### PR TITLE
feat: 海报卡片订阅状态统一——已订阅影片悬浮展示「已订阅」徽标

### DIFF
--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -11,6 +11,7 @@ import {
   LIBRARY_KIND_META,
   LibraryFormDialog,
   effectiveLibraryId,
+  libraryCardAction,
 } from "@/components/library-view";
 import { PosterCardVisual, type PosterVisualItem } from "@/components/poster-card";
 import {
@@ -346,7 +347,7 @@ function InventoryCell({ item }: { item: LibraryItem }) {
         <PosterCardVisual
           item={visual}
           href={`/media/${item.kind}/${item.tmdb_id}` as Route}
-          action="owned"
+          action={libraryCardAction(item)}
         />
       </div>
       <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-[11px] text-[var(--text-muted)]">

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -9,6 +9,7 @@ import { createPortal } from "react-dom";
 import { DirectoryPicker } from "@/components/directory-picker";
 import { FilmIcon, FolderIcon, MoreIcon, PlusIcon, TvIcon, XIcon } from "@/components/icons";
 import { MediaRow } from "@/components/media-row";
+import type { PosterCardAction } from "@/components/poster-card";
 import { Tooltip } from "@/components/tooltip";
 import {
   type LibraryItem,
@@ -33,6 +34,20 @@ export const LIBRARY_KIND_META: Record<MediaType, { label: string; Icon: typeof 
   movie: { label: "电影", Icon: FilmIcon },
   tv: { label: "剧集", Icon: TvIcon },
 };
+
+/**
+ * 库存条目的悬浮操作三分支（库首页「最近添加」行与单库库存墙共用）：
+ *   - 在播剧 → 订阅追新（还会有新集，转化价值最高；已订阅时卡片自动显「已订阅」）；
+ *   - 完结剧且已播集有缺口 → 补齐缺集（整季没下过的内容不在文件台账里，
+ *     「缺失重下」够不着，建订阅是唯一补齐路径；订阅按 E−H 只补缺的集）；
+ *   - 其余（电影 / 完结齐全 / 播出状态未知）→ 静态「已入库」标识，不给死按钮。
+ */
+export function libraryCardAction(item: LibraryItem): PosterCardAction {
+  if (item.kind !== "tv") return "owned";
+  if (item.air_status === "airing") return "follow";
+  if (item.air_status === "ended" && item.missing_episode_count > 0) return "backfill";
+  return "owned";
+}
 
 /**
  * 订阅的实际归属库：显式指定优先，否则该类型的默认库。
@@ -95,16 +110,24 @@ export function LibraryView() {
     return () => clearInterval(timer);
   }, [scanningAny, reload]);
 
-  // 每个非空库一行「最近添加」：按最近入账时间倒序取前 20，
-  // 复用发现页的横滚海报行（点击进详情、悬浮可订阅），把首页铺满
+  // 每个非空库一行「最近添加」：按最近入账时间倒序取前 20，复用发现页的
+  // 横滚海报行；悬浮动作按条目三分支（追新/补齐/已入库，见 libraryCardAction）
   const recentRows = useMemo(
     () =>
       (libraries ?? [])
         .map((library) => {
-          const items = [...(itemsByLibrary.get(library.id) ?? [])]
+          const recent = [...(itemsByLibrary.get(library.id) ?? [])]
             .sort((a, b) => (b.added_at ?? "").localeCompare(a.added_at ?? ""))
             .slice(0, 20);
-          return { library, items: items.map(libraryItemToMediaItem) };
+          // MediaItem.id 即 tmdb_id 字符串，库类型固定故同行内唯一，可作动作映射键
+          const actions = new Map(
+            recent.map((it) => [String(it.tmdb_id), libraryCardAction(it)]),
+          );
+          return {
+            library,
+            items: recent.map(libraryItemToMediaItem),
+            actionOf: (m: MediaItem) => actions.get(m.id) ?? ("owned" as const),
+          };
         })
         .filter((row) => row.items.length > 0),
     [libraries, itemsByLibrary],
@@ -175,7 +198,7 @@ export function LibraryView() {
       {/* —— 最近添加：Emby 首页式分区，每个非空库一行横滚海报 —— */}
       {recentRows.length > 0 && (
         <div className="mt-10 space-y-8">
-          {recentRows.map(({ library, items }) => (
+          {recentRows.map(({ library, items, actionOf }) => (
             <MediaRow
               key={library.id}
               row={{
@@ -185,7 +208,7 @@ export function LibraryView() {
               }}
               moreHref={`/library/${library.id}` as Route}
               moreLabel="查看全部"
-              cardAction="owned"
+              cardAction={actionOf}
             />
           ))}
         </div>

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -22,7 +22,7 @@ import {
   type MediaDetailData,
   type MediaImage,
 } from "@/lib/api/discover";
-import { listSubscriptions, type Subscription } from "@/lib/api/subscriptions";
+import { useSubscribeEntry } from "@/components/subscribe-entry";
 import { useBackdrop } from "@/lib/backdrop";
 import { getMediaSeed, useMediaDetail } from "@/lib/media-detail";
 import type { MediaSource, MediaType } from "@/lib/media-types";
@@ -59,29 +59,12 @@ export function MediaDetailView({
   const [detail, setDetail] = useState<MediaDetailData | null>(null);
   // 详情拉取失败状态：仅在无 seed（硬刷新/分享直达）时才需要整页兜底
   const [loadFailed, setLoadFailed] = useState(false);
-  // 该条目的订阅（从订阅列表按外部 ID 匹配；订阅/取消后重新拉取）
-  const [sub, setSub] = useState<Subscription | undefined>(undefined);
+  // 该条目的订阅：与海报卡片同一份全站订阅状态（subscribe-entry 收口），
+  // 订阅/取消后 refresh 一次，详情页与所有卡片同步更新
+  const { subscriptionOf, refresh: refreshSubscriptions } = useSubscribeEntry();
+  const sub = subscriptionOf({ id, source, type: type ?? "movie" });
   // 订阅弹层的打开参数；null = 关闭
   const [subscribeTarget, setSubscribeTarget] = useState<SubscribeTarget | null>(null);
-
-  const reloadSubscription = useCallback(() => {
-    listSubscriptions()
-      .then((rows) =>
-        setSub(
-          rows.find((s) =>
-            source === "douban"
-              ? s.media.douban_id === id
-              : s.media.kind === (type ?? "movie") && String(s.media.tmdb_id) === id,
-          ),
-        ),
-      )
-      .catch(() => setSub(undefined));
-  }, [id, source, type]);
-
-  useEffect(() => {
-    setSub(undefined);
-    reloadSubscription();
-  }, [reloadSubscription]);
   // 站内点卡片跳转时预存的列表字段（标题/海报/简介），用于首屏零白屏；
   // 硬刷新 / 分享链接直达时为空，此时全靠 /discover/{type}/{id} 拉取。
   const listItem = getMediaSeed(source, id);
@@ -267,7 +250,7 @@ export function MediaDetailView({
       <SubscribeDialog
         target={subscribeTarget}
         onClose={() => setSubscribeTarget(null)}
-        onChanged={reloadSubscription}
+        onChanged={refreshSubscriptions}
       />
 
       {/* —— 3. 剧情简介 + 词条信息 —— */}

--- a/apps/web/components/media-row.tsx
+++ b/apps/web/components/media-row.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { ChevronLeftIcon, ChevronRightIcon } from "@/components/icons";
 import { PosterCard, type PosterCardAction } from "@/components/poster-card";
-import type { MediaRowData } from "@/lib/media-types";
+import type { MediaItem, MediaRowData } from "@/lib/media-types";
 
 /**
  * 横滚海报行（Netflix 式分类行）。
@@ -26,8 +26,11 @@ export function MediaRow({
   row: MediaRowData;
   moreHref?: Route;
   moreLabel?: string;
-  /** 卡片悬浮操作区变体（媒体库场景传 "owned"），缺省为「订阅影片」 */
-  cardAction?: PosterCardAction;
+  /**
+   * 卡片悬浮操作区变体，缺省为「订阅影片」。媒体库「最近添加」行的动作
+   * 因条目而异（在播剧追新/完结缺集补齐/齐全已入库），支持传函数逐条目决定。
+   */
+  cardAction?: PosterCardAction | ((item: MediaItem) => PosterCardAction);
 }) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [canLeft, setCanLeft] = useState(false);
@@ -83,7 +86,11 @@ export function MediaRow({
                 row.ranked ? "w-[188px]" : "w-[152px] xl:w-[164px]"
               }`}
             >
-              <PosterCard item={item} rank={row.ranked ? i + 1 : undefined} action={cardAction} />
+              <PosterCard
+                item={item}
+                rank={row.ranked ? i + 1 : undefined}
+                action={typeof cardAction === "function" ? cardAction(item) : cardAction}
+              />
             </div>
           ))}
         </div>

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -3,7 +3,7 @@
 import type { Route } from "next";
 import Link from "next/link";
 
-import { PlayIcon, StarIcon } from "@/components/icons";
+import { CheckIcon, PlayIcon, StarIcon } from "@/components/icons";
 import { PosterImage } from "@/components/poster-image";
 import { useSubscribeEntry } from "@/components/subscribe-entry";
 import { useMediaDetail } from "@/lib/media-detail";
@@ -30,7 +30,9 @@ export interface PosterCardProps {
 
 /**
  * 悬浮层操作区的三种形态，按内容与用户的关系选择：
- * - subscribe：还没拥有（发现页/搜索），给「订阅影片」入口；
+ * - subscribe：还没拥有（发现页/搜索），给「订阅影片」入口；该影片已存在订阅时
+ *   自动切换为「已订阅」状态徽标（点击进入订阅管理弹层），状态来自
+ *   SubscribeEntryProvider 的全站订阅列表，卡片自身不发请求；
  * - owned：已在媒体库（库首页最近添加、单库库存墙），订阅无意义，改为「已入库」标识；
  * - none：已订阅但尚未落地（单库页「追踪中」），再给订阅按钮是重复操作，不显示。
  */
@@ -109,7 +111,9 @@ function PosterCardContent({
   rank?: number;
   action?: PosterCardAction;
 }) {
-  const { open: openSubscribe } = useSubscribeEntry();
+  const { open: openSubscribe, subscriptionOf } = useSubscribeEntry();
+  // 仅 subscribe 变体需要判断订阅状态；owned/none 场景（媒体库）不查询
+  const existingSub = action === "subscribe" ? subscriptionOf(item) : undefined;
   const badges = item.badges ?? [];
   const genres = item.genres ?? [];
   const overview = item.overview ?? "";
@@ -172,13 +176,16 @@ function PosterCardContent({
             {action !== "none" && (
               <div className="mt-2.5 flex items-center gap-2">
                 {action === "subscribe" ? (
-                  /* 未拥有的内容才给订阅入口（打开订阅弹层）。外层整卡是
-                     button/Link，内层不能再嵌 button，用 role=button 的 span 承载；
+                  /* 订阅入口（打开订阅弹层）。已订阅时切换为状态徽标，点击进入
+                     同一弹层的管理态（可调整/取消订阅）。外层整卡是 button/Link，
+                     内层不能再嵌 button，用 role=button 的 span 承载；
                      preventDefault 拦掉 Link 跳转，stopPropagation 拦掉整卡 onClick。 */
                   <span
                     role="button"
                     tabIndex={0}
-                    aria-label={`订阅《${item.title}》`}
+                    aria-label={
+                      existingSub ? `管理《${item.title}》的订阅` : `订阅《${item.title}》`
+                    }
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -191,10 +198,23 @@ function PosterCardContent({
                         void openSubscribe(item);
                       }
                     }}
-                    className="btn-accent flex h-7 items-center gap-1 rounded-full px-3 text-[11px] font-semibold"
+                    className={
+                      existingSub
+                        ? "flex h-7 items-center gap-1.5 rounded-full bg-white/[0.14] px-3 text-[11px] font-semibold text-white/90 backdrop-blur-sm transition-colors hover:bg-white/[0.22]"
+                        : "btn-accent flex h-7 items-center gap-1 rounded-full px-3 text-[11px] font-semibold"
+                    }
                   >
-                    <PlayIcon className="size-3" />
-                    订阅影片
+                    {existingSub ? (
+                      <>
+                        <CheckIcon className="size-3 text-[#4ade80]" />
+                        已订阅
+                      </>
+                    ) : (
+                      <>
+                        <PlayIcon className="size-3" />
+                        订阅影片
+                      </>
+                    )}
                   </span>
                 ) : (
                   /* 已入库标识：非交互，与库存格下方的绿点语言一致 */

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -3,7 +3,7 @@
 import type { Route } from "next";
 import Link from "next/link";
 
-import { CheckIcon, PlayIcon, StarIcon } from "@/components/icons";
+import { BellIcon, CheckIcon, DownloadIcon, PlayIcon, StarIcon } from "@/components/icons";
 import { PosterImage } from "@/components/poster-image";
 import { useSubscribeEntry } from "@/components/subscribe-entry";
 import { useMediaDetail } from "@/lib/media-detail";
@@ -29,14 +29,26 @@ export interface PosterCardProps {
 }
 
 /**
- * 悬浮层操作区的三种形态，按内容与用户的关系选择：
- * - subscribe：还没拥有（发现页/搜索），给「订阅影片」入口；该影片已存在订阅时
- *   自动切换为「已订阅」状态徽标（点击进入订阅管理弹层），状态来自
- *   SubscribeEntryProvider 的全站订阅列表，卡片自身不发请求；
- * - owned：已在媒体库（库首页最近添加、单库库存墙），订阅无意义，改为「已入库」标识；
+ * 悬浮层操作区的形态，按内容与用户的关系选择：
+ * - subscribe：还没拥有（发现页/搜索），给「订阅影片」入口；
+ * - follow：已在库的在播剧（还会有新集），给「订阅追新」入口；
+ * - backfill：已在库的完结剧但已播集有缺口，给「补齐缺集」入口
+ *   （订阅创建按 E−H 跳过库里已有的集，只为缺的集生成工单）；
+ * - owned：已在媒体库且无后续动作（电影/完结齐全剧），静态「已入库」标识；
  * - none：已订阅但尚未落地（单库页「追踪中」），再给订阅按钮是重复操作，不显示。
+ *
+ * 前三种都是订阅入口，仅文案/图标不同；该影片已存在订阅时自动切换为
+ * 「已订阅」状态徽标（点击进入订阅管理弹层），状态来自 SubscribeEntryProvider
+ * 的全站订阅列表，卡片自身不发请求。
  */
-export type PosterCardAction = "subscribe" | "owned" | "none";
+export type PosterCardAction = "subscribe" | "follow" | "backfill" | "owned" | "none";
+
+/** 三种订阅入口的文案与图标（已订阅时统一切换为状态徽标，不走这张表）。 */
+const SUBSCRIBE_ACTION_META = {
+  subscribe: { label: "订阅影片", Icon: PlayIcon },
+  follow: { label: "订阅追新", Icon: BellIcon },
+  backfill: { label: "补齐缺集", Icon: DownloadIcon },
+} as const;
 
 /**
  * 海报卡片的最小视觉契约。搜索结果不含年份和类型，缺失字段保持不显示，
@@ -112,8 +124,12 @@ function PosterCardContent({
   action?: PosterCardAction;
 }) {
   const { open: openSubscribe, subscriptionOf } = useSubscribeEntry();
-  // 仅 subscribe 变体需要判断订阅状态；owned/none 场景（媒体库）不查询
-  const existingSub = action === "subscribe" ? subscriptionOf(item) : undefined;
+  // 订阅入口类动作（subscribe/follow/backfill）才需要判断订阅状态；owned/none 不查询
+  const subscribeMeta =
+    action === "subscribe" || action === "follow" || action === "backfill"
+      ? SUBSCRIBE_ACTION_META[action]
+      : null;
+  const existingSub = subscribeMeta ? subscriptionOf(item) : undefined;
   const badges = item.badges ?? [];
   const genres = item.genres ?? [];
   const overview = item.overview ?? "";
@@ -175,7 +191,7 @@ function PosterCardContent({
             )}
             {action !== "none" && (
               <div className="mt-2.5 flex items-center gap-2">
-                {action === "subscribe" ? (
+                {subscribeMeta ? (
                   /* 订阅入口（打开订阅弹层）。已订阅时切换为状态徽标，点击进入
                      同一弹层的管理态（可调整/取消订阅）。外层整卡是 button/Link，
                      内层不能再嵌 button，用 role=button 的 span 承载；
@@ -184,7 +200,9 @@ function PosterCardContent({
                     role="button"
                     tabIndex={0}
                     aria-label={
-                      existingSub ? `管理《${item.title}》的订阅` : `订阅《${item.title}》`
+                      existingSub
+                        ? `管理《${item.title}》的订阅`
+                        : `${subscribeMeta.label}《${item.title}》`
                     }
                     onClick={(e) => {
                       e.preventDefault();
@@ -211,8 +229,8 @@ function PosterCardContent({
                       </>
                     ) : (
                       <>
-                        <PlayIcon className="size-3" />
-                        订阅影片
+                        <subscribeMeta.Icon className="size-3" />
+                        {subscribeMeta.label}
                       </>
                     )}
                   </span>

--- a/apps/web/components/subscribe-entry.tsx
+++ b/apps/web/components/subscribe-entry.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -12,13 +13,19 @@ import {
 import type { PosterVisualItem } from "@/components/poster-card";
 import { SubscribeDialog, type SubscribeTarget } from "@/components/subscribe-dialog";
 import { fetchDoubanMediaDetail } from "@/lib/api/discover";
+import { listSubscriptions, type Subscription } from "@/lib/api/subscriptions";
+import type { MediaType } from "@/lib/media-types";
 
 /**
- * 海报卡片「订阅影片」按钮的全站入口。
+ * 海报卡片「订阅影片」入口 + 全站订阅状态的唯一数据源。
  *
  * 海报卡片散落在搜索影视 / 发现电影 / 发现剧集 / Top250 / 订阅页等多层组件里，
  * 订阅弹层（SubscribeDialog）没必要每页各挂一份——这里在应用外壳挂唯一一份，
  * 卡片通过 useSubscribeEntry().open(item) 触发，与 useMediaDetail 的模式一致。
+ *
+ * 订阅状态同理收口在这里：应用启动拉取一次订阅列表，卡片与详情页都通过
+ * subscriptionOf(item) 判断「该影片是否已订阅」，避免每张卡片各自发请求；
+ * 弹层里订阅/取消订阅成功后（onChanged）自动刷新，所有消费方即时同步。
  *
  * kind（电影/剧集）是订阅预检的必填参数：发现页与 TMDB 搜索结果的卡片自带
  * type；豆瓣轻量搜索结果没有 type，点击时补拉一次豆瓣详情由后端识别类型
@@ -28,6 +35,38 @@ import { fetchDoubanMediaDetail } from "@/lib/api/discover";
 interface SubscribeEntryValue {
   /** 打开订阅弹层；豆瓣来源缺 type 时先补拉详情识别类型，故为异步 */
   open: (item: PosterVisualItem) => Promise<void>;
+  /** 查找该影片已存在的订阅；未订阅（或列表尚未加载完成）返回 undefined */
+  subscriptionOf: (item: SubscriptionLookupKey) => Subscription | undefined;
+  /** 重新拉取订阅列表（订阅/取消订阅后调用，卡片状态即时刷新） */
+  refresh: () => void;
+}
+
+/** 订阅状态查询的最小键：来源 + 外部 ID（TMDB 来源还需 type 消除电影/剧集撞号）。 */
+export interface SubscriptionLookupKey {
+  id: string;
+  source?: "tmdb" | "douban";
+  type?: MediaType;
+}
+
+/**
+ * 按外部 ID 在订阅列表中匹配条目（详情页与海报卡片共用的同一判断口径）：
+ *   - 豆瓣来源：按 douban_id 匹配（订阅从 TMDB 入口建立且未关联豆瓣 ID 时
+ *     匹配不到，属已知限制——两边没有可靠的对齐键，不按标题猜）；
+ *   - TMDB 来源：按 tmdb_id 匹配；电影和剧集的 TMDB ID 是两个独立号段，
+ *     卡片带 type 时用它消歧，缺失时（历史快照数据）仅按 ID 匹配。
+ */
+export function findSubscription(
+  subs: Subscription[],
+  key: SubscriptionLookupKey,
+): Subscription | undefined {
+  if ((key.source ?? "tmdb") === "douban") {
+    return subs.find((s) => s.media.douban_id === key.id);
+  }
+  return subs.find(
+    (s) =>
+      String(s.media.tmdb_id) === key.id &&
+      (key.type === undefined || s.media.kind === key.type),
+  );
 }
 
 const SubscribeEntryContext = createContext<SubscribeEntryValue | null>(null);
@@ -42,6 +81,19 @@ export function useSubscribeEntry(): SubscribeEntryValue {
 
 export function SubscribeEntryProvider({ children }: { children: ReactNode }) {
   const [target, setTarget] = useState<SubscribeTarget | null>(null);
+  // 全站订阅列表：启动拉取一次；失败保持空数组——状态判断降级为「都未订阅」，
+  // 不影响订阅入口本身（弹层预检有自己的错误提示）
+  const [subs, setSubs] = useState<Subscription[]>([]);
+
+  const refresh = useCallback(() => {
+    listSubscriptions()
+      .then(setSubs)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
   const open = useCallback(async (item: PosterVisualItem) => {
     const source = item.source ?? "tmdb";
@@ -61,12 +113,24 @@ export function SubscribeEntryProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const value = useMemo(() => ({ open }), [open]);
+  const subscriptionOf = useCallback(
+    (key: SubscriptionLookupKey) => findSubscription(subs, key),
+    [subs],
+  );
+
+  const value = useMemo(
+    () => ({ open, subscriptionOf, refresh }),
+    [open, subscriptionOf, refresh],
+  );
 
   return (
     <SubscribeEntryContext.Provider value={value}>
       {children}
-      <SubscribeDialog target={target} onClose={() => setTarget(null)} />
+      <SubscribeDialog
+        target={target}
+        onClose={() => setTarget(null)}
+        onChanged={refresh}
+      />
     </SubscribeEntryContext.Provider>
   );
 }

--- a/apps/web/components/subscription-inspector-view.tsx
+++ b/apps/web/components/subscription-inspector-view.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ArrowLeftIcon } from "@/components/icons";
 import { PosterImage } from "@/components/poster-image";
+import { useSubscribeEntry } from "@/components/subscribe-entry";
 import {
   deleteSubscription,
   getSubscription,
@@ -37,6 +38,8 @@ import { formatDateTime, formatRelativeTime } from "@/lib/time";
  */
 export function SubscriptionInspectorView({ id }: { id: number }) {
   const router = useRouter();
+  // 暂停/取消订阅会改变全站订阅状态（海报卡片的「已订阅」徽标），操作后同步刷新
+  const { refresh: refreshSubscriptions } = useSubscribeEntry();
   const [detail, setDetail] = useState<SubscriptionDetail | null>(null);
   const [activities, setActivities] = useState<SubscriptionActivity[]>([]);
   const [ruleSets, setRuleSets] = useState<RuleSet[]>([]);
@@ -95,6 +98,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
     try {
       await pauseSubscription(detail.id, detail.status !== "paused");
       reload();
+      refreshSubscriptions();
     } finally {
       setBusy(false);
     }
@@ -105,6 +109,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
     setBusy(true);
     try {
       await deleteSubscription(detail.id);
+      refreshSubscriptions();
       router.push("/subscriptions");
     } finally {
       setBusy(false);

--- a/apps/web/components/subscriptions-view.tsx
+++ b/apps/web/components/subscriptions-view.tsx
@@ -123,11 +123,12 @@ function MediaTypeSwitcher({
   );
 }
 
-/** 把订阅条目摘要适配成海报卡片的视觉契约。 */
+/** 把订阅条目摘要适配成海报卡片的视觉契约（带 type，悬浮层自动显示「已订阅」）。 */
 function toVisualItem(sub: Subscription): PosterVisualItem {
   return {
     id: String(sub.media.tmdb_id),
     source: "tmdb",
+    type: sub.media.kind,
     title: sub.media.title,
     year: sub.media.year ?? undefined,
     rating: 0,

--- a/apps/web/lib/api/libraries.ts
+++ b/apps/web/lib/api/libraries.ts
@@ -86,6 +86,10 @@ export interface LibraryItem {
   resolutions: string[];
   /** 标记 missing 的文件数（>0 时提示） */
   missing_count: number;
+  /** 剧集播出状态：airing=在播 / ended=完结；电影或状态未知为 null */
+  air_status: "airing" | "ended" | null;
+  /** 已播出但库里没有的正季集数（电影恒 0）——「补齐缺集」的依据 */
+  missing_episode_count: number;
   /** 最近一次文件入账时间（ISO 字符串），首页「最近添加」排序依据 */
   added_at: string | null;
 }

--- a/src/movieclaw_api/api/routes/libraries.py
+++ b/src/movieclaw_api/api/routes/libraries.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date
+
 from fastapi import APIRouter, BackgroundTasks, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -20,6 +22,7 @@ from movieclaw_api.schemas.library import (
     ScanResultView,
     UnidentifiedClearPayload,
     UnidentifiedFileView,
+    derive_air_status,
 )
 from movieclaw_api.schemas.response import ApiResponse, ok
 from movieclaw_api.services.library_config import LibraryConfigService
@@ -32,7 +35,7 @@ from movieclaw_api.services.library_scan import (
 from movieclaw_api.services.media_discover import get_tmdb_client
 from movieclaw_api.services.media_library import MediaLibraryService
 from movieclaw_db.engine import get_session
-from movieclaw_db.models import LibraryFile, MediaItem
+from movieclaw_db.models import LibraryFile, MediaItem, MediaSeason, utcnow
 from movieclaw_db.repositories.library_file_repo import LibraryFileRepository
 from movieclaw_media.models import MediaKind
 
@@ -269,10 +272,48 @@ async def list_library_items(
         assert item.id is not None
         grouped.setdefault(item.id, (item, []))[1].append(file)
 
+    # 剧集的已播单元集合：海报悬浮操作（订阅追新/补齐缺集）的判断依据。
+    # 季集结构在条目建档时已落库（media_season），一次批量查询本地即得，
+    # 不打 TMDB。特别季不参与缺集统计——订阅默认也不追特别季，口径一致。
+    tv_item_ids = [i for i, (item, _) in grouped.items() if item.kind == "tv"]
+    aired_by_item: dict[int, set[tuple[int, int]]] = {}
+    if tv_item_ids:
+        season_rows = (
+            (
+                await session.execute(
+                    select(MediaSeason).where(MediaSeason.media_item_id.in_(tv_item_ids))  # type: ignore[attr-defined]
+                )
+            )
+            .scalars()
+            .all()
+        )
+        today = utcnow().date()
+        for season in season_rows:
+            if season.season_number == 0:
+                continue
+            aired = aired_by_item.setdefault(season.media_item_id, set())
+            for episode in season.episodes:
+                number = episode.get("episode_number")
+                raw = episode.get("air_date")
+                try:
+                    if number is not None and raw and date.fromisoformat(raw) <= today:
+                        aired.add((season.season_number, number))
+                except ValueError:
+                    continue
+
     base = get_settings().tmdb_image_base_url.rstrip("/")
     views = []
     for item, files in grouped.values():
         units = {(f.season_number, f.episode_number) for f in files}
+        if item.kind == "tv":
+            # 缺集口径与订阅创建的 E−H 一致：已播 − 在位（missing 的文件不算拥有），
+            # 因此「补齐缺集」建订阅后恰好只为这些集生成工单
+            present = {
+                (f.season_number, f.episode_number) for f in files if f.missing_since is None
+            }
+            missing_episodes = len(aired_by_item.get(item.id, set()) - present)  # type: ignore[arg-type]
+        else:
+            missing_episodes = 0
         views.append(
             LibraryItemView(
                 media_item_id=item.id,  # type: ignore[arg-type]
@@ -287,6 +328,8 @@ async def list_library_items(
                 episode_count=len(units) if item.kind == "tv" else 0,
                 resolutions=sorted({f.resolution for f in files if f.resolution}, reverse=True),
                 missing_count=sum(1 for f in files if f.missing_since is not None),
+                air_status=derive_air_status(item.status) if item.kind == "tv" else None,
+                missing_episode_count=missing_episodes,
                 added_at=max(f.created_at for f in files),
             )
         )

--- a/src/movieclaw_api/schemas/library.py
+++ b/src/movieclaw_api/schemas/library.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -102,6 +103,22 @@ class LibraryView(BaseModel):
         )
 
 
+# TMDB status 原值 → 播出状态两分类（剧集海报悬浮操作的判断依据）。
+# 映射外的未知值不猜——返回 None，前端降级为静态「已入库」标识，
+# 不给出错误的「订阅追新 / 补齐缺集」入口。
+_AIRING_STATUSES = frozenset({"Returning Series", "In Production", "Planned", "Pilot"})
+_ENDED_STATUSES = frozenset({"Ended", "Canceled"})
+
+
+def derive_air_status(status: str | None) -> Literal["airing", "ended"] | None:
+    """剧集 TMDB status 原值收敛为 airing（还会有新集）/ ended（不会再有）。"""
+    if status in _AIRING_STATUSES:
+        return "airing"
+    if status in _ENDED_STATUSES:
+        return "ended"
+    return None
+
+
 class LibraryItemView(BaseModel):
     """库内一个媒体条目的库存聚合（单库海报墙的一格）。"""
 
@@ -119,6 +136,16 @@ class LibraryItemView(BaseModel):
     # 去重的介质规格标签（如 ["2160p","1080p"]），探测不到为空
     resolutions: list[str]
     missing_count: int = Field(description="标记 missing 的文件数（>0 时前端提示）")
+    # 剧集海报悬浮操作的两个判断依据（前端三分支：在播→订阅追新 /
+    # 完结缺集→补齐缺集 / 完结齐全或电影→已入库）
+    air_status: Literal["airing", "ended"] | None = Field(
+        default=None,
+        description="剧集播出状态：airing=在播 / ended=完结；电影或状态未知为 NULL",
+    )
+    missing_episode_count: int = Field(
+        default=0,
+        description="已播出但库里没有的正季集数（电影恒 0）——「补齐缺集」的依据",
+    )
     added_at: datetime | None = Field(
         default=None, description="最近一次文件入账时间（首页「最近添加」排序依据）"
     )

--- a/tests/api/test_library_items.py
+++ b/tests/api/test_library_items.py
@@ -1,0 +1,151 @@
+"""库存聚合接口的播出状态与缺集统计：海报悬浮三分支（追新/补齐/已入库）的数据依据。"""
+
+from __future__ import annotations
+
+import pytest_asyncio
+
+from movieclaw_api.api.routes.libraries import list_library_items
+from movieclaw_api.core.config import get_settings
+from movieclaw_api.schemas.library import derive_air_status
+from movieclaw_db.engine import dispose_db, get_database, init_db
+from movieclaw_db.migrations import run_migrations
+from movieclaw_db.models import FileSource, LibraryFile, MediaItem, MediaSeason, utcnow
+from movieclaw_db.repositories.library_repo import LibraryRepository
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{tmp_path / 'items.db'}")
+    get_settings.cache_clear()
+    init_db(get_settings().database_url, echo=False)
+    await run_migrations()
+    yield get_database()
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+def _season(item_id: int, number: int, air_dates: list[str | None]) -> MediaSeason:
+    """构造一季：按顺序给每集编号 1..N，air_date 逐集指定（None=未定档）。"""
+    return MediaSeason(
+        media_item_id=item_id,
+        season_number=number,
+        episodes=[
+            {"episode_number": i + 1, "name": "", "air_date": d}
+            for i, d in enumerate(air_dates)
+        ],
+    )
+
+
+def _file(
+    library_id: int, item_id: int, season: int, episode: int, *, missing: bool = False
+) -> LibraryFile:
+    return LibraryFile(
+        library_id=library_id,
+        media_item_id=item_id,
+        season_number=season,
+        episode_number=episode,
+        file_path=f"/tv/{item_id}/S{season:02d}E{episode:02d}.mkv",
+        size_bytes=1,
+        source=FileSource.SCANNED,
+        missing_since=utcnow() if missing else None,
+    )
+
+
+async def test_items_air_status_and_missing_episodes(db) -> None:
+    """三分支数据齐备：在播剧带 airing；完结缺集算已播−在位；齐全为 0。"""
+    async with db.session() as session:
+        library = await LibraryRepository(session).create(
+            name="剧集库", kind="tv", root_paths=["/tv"]
+        )
+        airing = MediaItem(
+            kind="tv", tmdb_id=301, title="在播剧", original_title="A", status="Returning Series"
+        )
+        ended_gap = MediaItem(
+            kind="tv", tmdb_id=302, title="完结缺集剧", original_title="B", status="Ended"
+        )
+        ended_full = MediaItem(
+            kind="tv", tmdb_id=303, title="完结齐全剧", original_title="C", status="Canceled"
+        )
+        session.add_all([airing, ended_gap, ended_full])
+        await session.flush()
+        assert library.id and airing.id and ended_gap.id and ended_full.id
+
+        session.add_all(
+            [
+                # 在播剧：S1 已播 3 集，库里在位 2 集
+                _season(airing.id, 1, ["2020-01-01", "2020-01-08", "2020-01-15"]),
+                _file(library.id, airing.id, 1, 1),
+                _file(library.id, airing.id, 1, 2),
+                # 完结缺集剧：S1 已播 2 集 + 1 集未定档；在位 1 集，另 1 集文件缺失
+                # （missing 不算拥有）→ 缺 1 集。特别季 0 有已播集但不参与统计。
+                _season(ended_gap.id, 1, ["2020-01-01", "2020-01-08", None]),
+                _season(ended_gap.id, 0, ["2020-06-01"]),
+                _file(library.id, ended_gap.id, 1, 1),
+                _file(library.id, ended_gap.id, 1, 2, missing=True),
+                # 完结齐全剧：S1 已播 2 集全在位
+                _season(ended_full.id, 1, ["2020-01-01", "2020-01-08"]),
+                _file(library.id, ended_full.id, 1, 1),
+                _file(library.id, ended_full.id, 1, 2),
+            ]
+        )
+        await session.flush()
+
+        resp = await list_library_items(library.id, session)
+        rows = {r.media_item_id: r for r in resp.data}
+
+        assert rows[airing.id].air_status == "airing"
+        assert rows[airing.id].missing_episode_count == 1
+
+        assert rows[ended_gap.id].air_status == "ended"
+        assert rows[ended_gap.id].missing_episode_count == 1
+
+        assert rows[ended_full.id].air_status == "ended"
+        assert rows[ended_full.id].missing_episode_count == 0
+
+
+async def test_items_movie_and_unknown_status(db) -> None:
+    """电影不参与播出状态判断；剧集 status 未知/映射外时不猜（None）。"""
+    async with db.session() as session:
+        library = await LibraryRepository(session).create(
+            name="电影库", kind="movie", root_paths=["/movies"]
+        )
+        movie = MediaItem(
+            kind="movie", tmdb_id=401, title="某电影", original_title="M", status="Released"
+        )
+        unknown = MediaItem(kind="tv", tmdb_id=402, title="无状态剧", original_title="U")
+        session.add_all([movie, unknown])
+        await session.flush()
+        assert library.id and movie.id and unknown.id
+
+        session.add_all(
+            [
+                LibraryFile(
+                    library_id=library.id,
+                    media_item_id=movie.id,
+                    season_number=0,
+                    episode_number=0,
+                    file_path="/movies/M/M.mkv",
+                    size_bytes=1,
+                    source=FileSource.SCANNED,
+                ),
+                _season(unknown.id, 1, ["2020-01-01"]),
+                _file(library.id, unknown.id, 1, 1),
+            ]
+        )
+        await session.flush()
+
+        resp = await list_library_items(library.id, session)
+        rows = {r.media_item_id: r for r in resp.data}
+
+        assert rows[movie.id].air_status is None
+        assert rows[movie.id].missing_episode_count == 0
+        assert rows[unknown.id].air_status is None
+
+
+def test_derive_air_status_mapping() -> None:
+    assert derive_air_status("Returning Series") == "airing"
+    assert derive_air_status("In Production") == "airing"
+    assert derive_air_status("Ended") == "ended"
+    assert derive_air_status("Canceled") == "ended"
+    assert derive_air_status("莫名其妙的值") is None
+    assert derive_air_status(None) is None


### PR DESCRIPTION
订阅状态收口到 SubscribeEntryProvider：应用启动拉取一次订阅列表，
海报卡片（发现页/搜索影视/Top250/订阅页）与影片详情页共用同一份
状态与同一套外部 ID 匹配口径（豆瓣按 douban_id，TMDB 按 tmdb_id+kind），
卡片自身不再各自发请求。

- poster-card：subscribe 变体自动判断——已订阅时「订阅影片」按钮切换
  为「已订阅」徽标，点击进入同一订阅弹层的管理态（可调整/取消）
- subscriptions-view：卡片补 type，订阅页悬浮不再出现重复的订阅按钮
- media-detail-view：删除自己的 listSubscriptions 匹配逻辑，改用共享状态
- subscription-inspector-view：暂停/取消订阅后刷新全站订阅状态
- 订阅弹层（全站入口）onChanged 接通刷新，订阅/取消后卡片即时同步

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A6oNE5rFFJbDNrSSQidjRM