### PR TITLE
fix(移动端): 子页面顶栏 logo 闪现修复 + 图标键放大到 iOS 原生比例

### DIFF
--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -360,13 +360,14 @@ function MobileTopBar({
   return (
     <header className="mobile-topbar pointer-events-none absolute inset-x-0 top-0 z-40">
       <div className="pointer-events-auto flex h-[52px] items-center gap-2 px-3">
+        {/* size-11（44px）：iOS HIG 最小可点目标，与子页面 PageNav 的键径一致 */}
         <button
           type="button"
           onClick={onMenu}
           aria-label="打开侧边栏"
-          className="grid size-9 shrink-0 place-items-center rounded-full text-white/85 transition active:scale-95 active:bg-white/10"
+          className="grid size-11 shrink-0 place-items-center rounded-full text-white/85 transition active:scale-95 active:bg-white/10"
         >
-          <MenuIcon className="size-[20px]" />
+          <MenuIcon className="size-[22px]" />
         </button>
         <button
           type="button"

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -238,38 +238,51 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   // 只有一次都没加载成功过才整页报错；已有数据在手时，瞬时失败只在页内
   // 挂提示条（stale-while-error）——为一次网络抖动把整面海报墙换成错误屏，
   // 用户看到的就是"页面闪没了"
+  // 兜底态（加载中/失败/不存在）也渲染 PageNav（库名未知，末项留空）：向外壳
+  // 登记「本页自带顶栏」，否则移动端全局顶栏（☰ + logo）会先显示再消失、顶部闪一下。
+  const fallbackTrail = [{ label: "媒体库", href: "/library" }, { label: "" }];
+
   if (failed && libraries === null) {
     return (
-      <CenteredNote>
-        <p className="text-[13.5px] text-[var(--text-muted)]">媒体库加载失败</p>
-        <button
-          type="button"
-          onClick={reload}
-          className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
-        >
-          重试
-        </button>
-      </CenteredNote>
+      <div className="flex-1">
+        <PageNav items={fallbackTrail} />
+        <CenteredNote>
+          <p className="text-[13.5px] text-[var(--text-muted)]">媒体库加载失败</p>
+          <button
+            type="button"
+            onClick={reload}
+            className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+          >
+            重试
+          </button>
+        </CenteredNote>
+      </div>
     );
   }
 
   if (libraries === null) {
     return (
-      <CenteredNote>
-        <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
-        <p className="text-[13px] text-[var(--text-muted)]">正在加载媒体库…</p>
-      </CenteredNote>
+      <div className="flex-1">
+        <PageNav items={fallbackTrail} />
+        <CenteredNote>
+          <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
+          <p className="text-[13px] text-[var(--text-muted)]">正在加载媒体库…</p>
+        </CenteredNote>
+      </div>
     );
   }
 
   if (library === null) {
     return (
-      <CenteredNote>
-        <p className="text-[13.5px] text-[var(--text-muted)]">这个媒体库不存在（可能已被删除）</p>
-        <Link href={"/library" as Route} className="btn-glass px-4 py-2 text-[13px] font-medium">
-          返回媒体库
-        </Link>
-      </CenteredNote>
+      <div className="flex-1">
+        <PageNav items={fallbackTrail} />
+        <CenteredNote>
+          <p className="text-[13.5px] text-[var(--text-muted)]">这个媒体库不存在（可能已被删除）</p>
+          <Link href={"/library" as Route} className="btn-glass px-4 py-2 text-[13px] font-medium">
+            返回媒体库
+          </Link>
+        </CenteredNote>
+      </div>
     );
   }
 

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -612,7 +612,7 @@ function LibraryActionsMenu({
           // 长在顶栏里，与返回键并排：共用顶栏控件形状，不再是页面里的胶囊按钮
           className={`${PAGE_NAV_BUTTON_CLASS} relative data-[state=open]:bg-black/55 data-[state=open]:text-white`}
         >
-          <MoreIcon className="size-[18px]" />
+          <MoreIcon className="size-[18px] max-md:size-[22px]" />
           {/* 收起的长任务在跑：触发按钮点一个小点，不至于被菜单藏住 */}
           {running && (
             <span className="absolute right-1 top-1 size-1.5 animate-pulse rounded-full bg-[#7dd3fc]" />

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -495,7 +495,7 @@ function ItemActionsMenu({
           aria-label="更多操作"
           className={`${PAGE_NAV_BUTTON_CLASS} relative data-[state=open]:bg-black/55 data-[state=open]:text-white`}
         >
-          <MoreIcon className="size-[18px]" />
+          <MoreIcon className="size-[18px] max-md:size-[22px]" />
           {/* 任务在跑时给触发键点一个小点：菜单收起后也知道后台还在忙 */}
           {running && (
             <span className="absolute right-1 top-1 size-1.5 animate-pulse rounded-full bg-[#7dd3fc]" />

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -149,31 +149,46 @@ export function LibraryItemDetailView({
     return () => clearTimeout(timer);
   }, [detail, libraryId, mediaItemId]);
 
+  // 兜底态（加载中/失败）的顶栏：条目标题未知，末项留空——渲染 PageNav 是为了
+  // 向外壳登记「本页自带顶栏」，否则移动端全局顶栏（☰ + logo）会先显示再消失，
+  // 顶部闪一下；同时转圈期间就有返回键可点。祖先链路与正文的 trail 保持一致。
+  const fallbackTrail = [
+    { label: "媒体库", href: "/library" as Route },
+    { label: library?.name ?? "库存", href: `/library/${libraryId}` as Route },
+    { label: "" },
+  ];
+
   if (failed) {
     return (
       // ambient-fallback：同 MediaDetailView——本页豁免全局蒙版，兜底态没有沉浸
       // 背景可铺，文案会压在用户壁纸上，自己带一层底才读得清
-      <div className="ambient-fallback flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
-        <p className="text-[15px] font-semibold text-[var(--text)]">未能加载该条目</p>
-        <p className="max-w-sm text-[13px] leading-6 text-[var(--text-muted)]">
-          条目可能已被删除或重新识别为其他作品，请回库存页查看。
-        </p>
-        <Link
-          href={`/library/${libraryId}` as Route}
-          className="btn-glass flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-[var(--text)]"
-        >
-          <ArrowLeftIcon className="size-4" />
-          回到库存页
-        </Link>
+      <div className="ambient-fallback flex h-full flex-col">
+        <PageNav items={fallbackTrail} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+          <p className="text-[15px] font-semibold text-[var(--text)]">未能加载该条目</p>
+          <p className="max-w-sm text-[13px] leading-6 text-[var(--text-muted)]">
+            条目可能已被删除或重新识别为其他作品，请回库存页查看。
+          </p>
+          <Link
+            href={`/library/${libraryId}` as Route}
+            className="btn-glass flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+          >
+            <ArrowLeftIcon className="size-4" />
+            回到库存页
+          </Link>
+        </div>
       </div>
     );
   }
 
   if (!detail) {
     return (
-      <div className="ambient-fallback flex h-full items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
-        <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
-        正在读取本地刮削信息…
+      <div className="ambient-fallback flex h-full flex-col">
+        <PageNav items={fallbackTrail} />
+        <div className="flex flex-1 items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+          <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
+          正在读取本地刮削信息…
+        </div>
       </div>
     );
   }

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -126,9 +126,25 @@ export function MediaDetailView({
     return () => setOverrideBackdrop(null);
   }, [immersiveUrl, setOverrideBackdrop]);
 
+  // 来路祖先（与影片标题无关）：加载/失败兜底与正常内容共用同一条回跳链路。
+  // 兜底态也必须渲染 PageNav——它向外壳登记「本页自带顶栏」，否则移动端的
+  // 全局顶栏（☰ + logo）会在数据到达前先显示、随后又消失，顶部闪一下；
+  // 顺带让用户在转圈期间就有返回键可点。
+  const ancestors = getMediaOrigin(source, id) ?? [
+    (item?.type ?? type ?? "movie") === "movie"
+      ? { label: "发现电影", href: "/discover/movie" }
+      : { label: "发现剧集", href: "/discover/tv" },
+  ];
+
   // 无 seed 且详情尚未到达：直达链接的加载态（或失败兜底）。
   if (!item) {
-    return <DetailFallback failed={loadFailed} onBack={close} />;
+    return (
+      <div className="flex h-full flex-col">
+        {/* 当前页标题未知，末项留空——只为立起返回键并认领顶栏 */}
+        <PageNav items={[...ancestors, { label: "" }]} />
+        <DetailFallback failed={loadFailed} onBack={close} />
+      </div>
+    );
   }
 
   const info = detail?.info;
@@ -159,14 +175,7 @@ export function MediaDetailView({
     });
 
   // 来路：站内点进来按来的列表页作返回目标；直达/刷新按影片类型兜底
-  const trail = [
-    ...(getMediaOrigin(source, id) ?? [
-      isMovie
-        ? { label: "发现电影", href: "/discover/movie" }
-        : { label: "发现剧集", href: "/discover/tv" },
-    ]),
-    { label: item.title },
-  ];
+  const trail = [...ancestors, { label: item.title }];
 
   return (
     // rounded-2xl + overflow 裁切：内容渐变到底部是近实色的深色板，方角会与
@@ -577,8 +586,9 @@ function PhotoArrow({
 function DetailFallback({ failed, onBack }: { failed: boolean; onBack: () => void }) {
   return (
     // ambient-fallback：本页豁免了全局蒙版（isHome），而此刻还没有沉浸背景可铺，
-    // 文案会直接压在用户配的壁纸上——亮壁纸下就读不出来了，兜底态自己带一层底
-    <div className="ambient-fallback flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+    // 文案会直接压在用户配的壁纸上——亮壁纸下就读不出来了，兜底态自己带一层底。
+    // flex-1 而非 h-full：调用处在其上方叠了一条 PageNav（flex 纵向布局）。
+    <div className="ambient-fallback flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
       {failed ? (
         <>
           <p className="text-[15px] font-semibold text-[var(--text)]">未能加载该影片详情</p>

--- a/apps/web/components/page-nav.tsx
+++ b/apps/web/components/page-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import Link from "next/link";
 import type { Route } from "next";
 import { useRouter } from "next/navigation";
@@ -91,9 +91,12 @@ export function PageNav({
   // （见 lib/page-chrome.tsx）。登记与 items 是否为空无关——空 items 时本组件
   // 不渲染任何东西，也就没有认领顶栏，因此这个 effect 必须在早退之前声明，
   // 但真正登记要跟着「本次是否真的渲染了顶栏」走。
+  // 必须用 useLayoutEffect：登记要赶在浏览器绘制之前生效，用 useEffect（绘制后）
+  // 会让外壳的全局顶栏（☰ + 字标）先画出一帧再被撤掉——进入详情页时顶部 logo
+  // 会肉眼可见地闪一下。本组件只在 AuthGate 之后的纯客户端子树渲染，无 SSR 警告问题。
   const registerPageNav = chrome?.registerPageNav;
   const rendersNav = items.length > 0;
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!registerPageNav || !rendersNav) return;
     return registerPageNav();
   }, [registerPageNav, rendersNav]);

--- a/apps/web/components/page-nav.tsx
+++ b/apps/web/components/page-nav.tsx
@@ -29,9 +29,13 @@ const REVEAL_END = 82;
  * 顶栏控件的统一形状：圆形深色玻璃键。返回键与页面操作（⋯）并排在同一行，
  * 必须是同一副长相，否则一边圆一边胶囊会像两套控件凑在一起。
  * 页面侧的操作按钮（见 library-detail-view 的 ⋯ 菜单）复用这个类名。
+ *
+ * 尺寸分两档：移动端 44px（iOS HIG 的最小可点目标，导航栏图标键的原生比例，
+ * 触屏上 36px 的键会显得局促难点）；桌面端保持 36px（鼠标精度高，44px 反而笨重）。
+ * 图标同比例缩放（约为键径的一半），改动时两档要一起看。
  */
 export const PAGE_NAV_BUTTON_CLASS =
-  "grid size-9 shrink-0 place-items-center rounded-full border border-white/[0.09] bg-black/30 text-white/85 backdrop-blur-md transition hover:bg-black/50 hover:text-white active:scale-[0.94]";
+  "grid size-9 shrink-0 place-items-center rounded-full border border-white/[0.09] bg-black/30 text-white/85 backdrop-blur-md transition hover:bg-black/50 hover:text-white active:scale-[0.94] max-md:size-11";
 
 /**
  * 找到本组件所在的滚动容器（全站页面都是「外壳固定 + 内层 overflow-y-auto」，
@@ -155,12 +159,12 @@ export function PageNav({
               aria-label="打开侧边栏"
               className={backClass}
             >
-              <MenuIcon className="size-[18px]" />
+              <MenuIcon className="size-[18px] max-md:size-[22px]" />
             </button>
           )}
           {parent ? (
             <Link href={parent.href as Route} aria-label={backLabel} title={backLabel} className={backClass}>
-              <ChevronLeftIcon className="size-[18px]" />
+              <ChevronLeftIcon className="size-[18px] max-md:size-[22px]" />
             </Link>
           ) : (
             <button
@@ -170,7 +174,7 @@ export function PageNav({
               title={backLabel}
               className={backClass}
             >
-              <ChevronLeftIcon className="size-[18px]" />
+              <ChevronLeftIcon className="size-[18px] max-md:size-[22px]" />
             </button>
           )}
         </div>

--- a/apps/web/components/person-detail-view.tsx
+++ b/apps/web/components/person-detail-view.tsx
@@ -49,14 +49,25 @@ export function PersonDetailView({ tmdbPersonId }: { tmdbPersonId: number | stri
 
   usePageTitle(person?.name);
 
+  // 兜底态也要渲染 PageNav（姓名未知，标签留空）：向外壳登记「本页自带顶栏」，
+  // 否则移动端全局顶栏（☰ + logo）会先显示再消失、顶部闪一下；无 href 的
+  // 单节点回退为浏览器后退，与正文态的返回行为一致。
   if (failure !== null) {
-    return <PersonFallback failure={failure} />;
+    return (
+      <div className="flex h-full flex-col">
+        <PageNav items={[{ label: "" }]} />
+        <PersonFallback failure={failure} />
+      </div>
+    );
   }
   if (person === null) {
     return (
-      <div className="flex h-full items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
-        <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
-        正在读取影人档案…
+      <div className="flex h-full flex-col">
+        <PageNav items={[{ label: "" }]} />
+        <div className="flex flex-1 items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+          <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
+          正在读取影人档案…
+        </div>
       </div>
     );
   }
@@ -194,7 +205,8 @@ function CreditCard({ credit, showCharacter }: { credit: PersonCredit; showChara
  */
 function PersonFallback({ failure }: { failure: "missing" | "error" }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+    // flex-1 而非 h-full：调用处在其上方叠了一条 PageNav（flex 纵向布局）
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
       {failure === "missing" ? (
         <>
           <p className="text-[15px] font-semibold text-[var(--text)]">库内没有这位影人的作品</p>

--- a/apps/web/components/search-command.tsx
+++ b/apps/web/components/search-command.tsx
@@ -125,7 +125,8 @@ function groupHistory(items: SearchHistoryItem[]): HistoryGroup[] {
 
 export function SearchCommand({
   onSearch,
-  triggerClassName = "glass-row !size-8 shrink-0 justify-center !p-0 max-md:!size-9",
+  // 移动端 44px：iOS HIG 最小可点目标（触屏），桌面保持 32px 紧凑图标键
+  triggerClassName = "glass-row !size-8 shrink-0 justify-center !p-0 max-md:!size-11",
 }: SearchCommandProps) {
   const [open, setOpen] = useState(false);
   // 面板是全屏浮层，Portal 到 body：避免被 sidebar 玻璃面板的 isolation:isolate
@@ -162,7 +163,7 @@ export function SearchCommand({
         title="搜索（⌘K 或 Ctrl+K）"
         className={triggerClassName}
       >
-        <SearchIcon className="size-[18px]" />
+        <SearchIcon className="size-[18px] max-md:size-[22px]" />
       </button>
 
       {/* 面板按需挂载：每次打开都是全新实例，状态（模式/分类/输入）自然重置，

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -258,9 +258,11 @@ function CollapseToggle({ collapsed, onClick }: { collapsed: boolean; onClick: (
       onClick={onClick}
       aria-label={label}
       title={label}
-      className="glass-row !size-8 shrink-0 justify-center !p-0"
+      // 移动端 44px：这颗键在抽屉里就是「收起抽屉」，iOS HIG 的最小可点目标；
+      // 桌面保持 32px 紧凑图标键
+      className="glass-row !size-8 shrink-0 justify-center !p-0 max-md:!size-11"
     >
-      <PanelLeftIcon className="size-[18px]" />
+      <PanelLeftIcon className="size-[18px] max-md:size-[22px]" />
     </button>
   );
 }

--- a/apps/web/components/subscription-inspector-view.tsx
+++ b/apps/web/components/subscription-inspector-view.tsx
@@ -77,23 +77,33 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
   );
   usePageTitle(detail?.media.title);
 
+  // 兜底态（加载中/失败）也渲染 PageNav（片名未知，末项留空）：向外壳登记
+  // 「本页自带顶栏」，否则移动端全局顶栏（☰ + logo）会先显示再消失、顶部闪一下。
+  const fallbackTrail = [{ label: "我的订阅", href: "/subscriptions" }, { label: "" }];
+
   if (failed) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-4">
-        <p className="text-[14px] text-[var(--text-muted)]">未能加载该订阅，可能已被删除。</p>
-        <Link href="/subscriptions" className="btn-glass px-4 py-2 text-[13px] font-medium">
-          <ArrowLeftIcon className="size-4" />
-          返回订阅列表
-        </Link>
+      <div className="flex h-full flex-col">
+        <PageNav items={fallbackTrail} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4">
+          <p className="text-[14px] text-[var(--text-muted)]">未能加载该订阅，可能已被删除。</p>
+          <Link href="/subscriptions" className="btn-glass px-4 py-2 text-[13px] font-medium">
+            <ArrowLeftIcon className="size-4" />
+            返回订阅列表
+          </Link>
+        </div>
       </div>
     );
   }
 
   if (!detail) {
     return (
-      <div className="flex h-full items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
-        <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
-        正在加载订阅详情…
+      <div className="flex h-full flex-col">
+        <PageNav items={fallbackTrail} />
+        <div className="flex flex-1 items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+          <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
+          正在加载订阅详情…
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## 改动内容

### 1. 进入子页面时顶部全局顶栏(logo)不再闪现

移动端全局顶栏的撤除依赖 PageNav 挂载后向外壳登记,存在两个时序缺口:

- **登记发生在绘制之后**:`PageNav` 用 `useEffect` 登记,全局顶栏会先画出一帧再被撤掉。改用 `useLayoutEffect`,登记在绘制前完成,顶栏显隐与主区让位(`data-topbar`)在同一帧内一起切换。
- **加载态没有认领顶栏**:影片/条目/影人/订阅/媒体库五类详情页的加载与失败兜底态没有渲染 PageNav,数据到达前 logo 顶栏会完整显示数百毫秒后才消失。兜底态补渲染 PageNav(标题未知时末项留空),用户在转圈期间即有返回键可点。

### 2. 顶栏图标键放大到 iOS 原生比例(44pt 可点目标)

子页面的返回/搜索/⋯ 菜单键、全局顶栏的汉堡键、抽屉的收起键此前是 32-36px,触屏上明显小于 iOS 原生导航键。按 iOS HIG 最小可点目标(44×44pt)统一放大移动端(< 768px)到 44px、图标 22px;桌面端通过 `max-md` 变体分档,保持原有紧凑尺寸不变。

## 验证

- `tsc --noEmit` 通过
- ESLint 改动文件无新增问题
- `next build` 生产构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLud4UmsMWE4Qr6FmtdHJu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLud4UmsMWE4Qr6FmtdHJu)_