### PR TITLE
fix(移动端): 消除 iOS PWA 底部安全区黑边，内容改为穿过 Home 指示条

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -352,6 +352,20 @@ a {
   display: none;
 }
 
+/*
+ * 页面级滚动容器的底部安全区让位（配合上文「主区底部不整体让位」的约定）：
+ * 给「直接铺满主区、一滚到底」的那层 overflow-y-auto 加本类，在滚动内容
+ * 末尾追加一段 Home 指示条高度的空白——内容照常从指示条下方穿过（原生
+ * App 的观感），滚到头时最后一行又能完全露出、不被指示条压住。
+ * 用 ::after 占位而非改 padding：不与各页自己的 pb-* 打架；
+ * 非全面屏设备与桌面端 env() 解析为 0，占位高度为零、无副作用。
+ */
+.scroll-safe::after {
+  content: "";
+  display: block;
+  height: var(--safe-bottom);
+}
+
 /* —— 细滚动条 —— */
 .scroll-thin {
   scrollbar-width: thin;
@@ -868,17 +882,22 @@ body.cmdk-open .app-shell {
 /*
  * 移动端主区让位：顶栏是浮在内容之上的 absolute 雾层，主区必须自己空出
  * 「安全区 + 顶栏」这一段，否则页面第一屏会被压在汉堡和字标下面。
- * 三条横向/底部内边距同理吃安全区（横屏刘海、底部指示条）。
+ * 两条横向内边距同理吃安全区（横屏刘海）。
  *
  * 收口在这一条规则里、而不是逐页写 pt-14：全站十几个路由页都是
  * 「外层 h-full + 内层 overflow-y-auto」的同一形状，主区的内边距会自然
  * 传导给每一个页面，新增路由无需登记、不会漏。
+ *
+ * 注意：底部**不在这里让位**。主区整体抬高 safe-bottom 会把滚动视口在
+ * Home 指示条上方截断——内容被硬裁一刀、下面露出一条空底「黑边」
+ * （iPhone 全面屏 PWA 实测）。原生 App 的做法是内容一直滚到屏幕物理底边、
+ * 从指示条下方穿过，只在滚动内容末尾留出安全区高度的空白，
+ * 由页面级滚动容器的 .scroll-safe 承担（见下方）。
  */
 @media (max-width: 767px) {
   .app-shell > main {
     padding-top: calc(var(--safe-top) + var(--mobile-topbar-h));
     padding-right: var(--safe-right);
-    padding-bottom: var(--safe-bottom);
     padding-left: var(--safe-left);
   }
 

--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -110,8 +110,10 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
         </div>
       </div>
 
-      {/* 底部输入：生成中可继续打字，发送键变停止键 */}
-      <div className="shrink-0 px-4 pb-5 pt-2 max-md:px-3 max-md:pb-3">
+      {/* 底部输入：生成中可继续打字，发送键变停止键。
+          移动端主区不再整体让位底部安全区（见 globals.css），贴底的输入行
+          要自己把 Home 指示条的高度让出来，否则发送键会被指示条压住 */}
+      <div className="shrink-0 px-4 pb-5 pt-2 max-md:px-3 max-md:pb-[calc(0.75rem+var(--safe-bottom))]">
         <div className="mx-auto max-w-3xl">
           <Composer
             flat

--- a/apps/web/components/discover-view.tsx
+++ b/apps/web/components/discover-view.tsx
@@ -143,7 +143,7 @@ export function DiscoverView({
     );
   }
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto pb-10">
+    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       {toolbar}
       {page.hero.length > 0 && (
         <div className="px-6 max-md:px-4">

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -352,7 +352,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   );
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto pb-10">
+    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       {/* 顶栏：返回媒体库 + 吸顶库名 + 库操作 ⋯（无 pt——顶边与侧栏卡片顶边齐平） */}
       <PageNav
         items={[{ label: "媒体库", href: "/library" }, { label: library.name }]}

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -244,7 +244,7 @@ export function LibraryItemDetailView({
   return (
     // rounded-2xl + overflow 裁切：内容渐变到底部是近实色的深色板，方角
     // 会与全站"浮起圆角卡片"的形状语言冲突——按侧栏同规格圆角收尾
-    <div className="scroll-thin h-full overflow-y-auto rounded-2xl">
+    <div className="scroll-thin scroll-safe h-full overflow-y-auto rounded-2xl">
       {/* —— 顶部：不再有任何 hero 卡片图层——全站背景此刻就是本片剧照
           （沉浸覆盖 + 本页豁免全局蒙版，见 app-shell 的 isHome），大图
           直出、零边界。顶栏首屏只有一颗圆形返回键浮在剧照上（吸顶蒙版

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -303,7 +303,7 @@ export function LibraryView() {
   );
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto pb-10">
+    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       <div className="flex items-start justify-between gap-4 px-6 pt-2 max-md:flex-col max-md:items-stretch max-md:gap-3 max-md:px-4">
         <div>
           <h2 className="text-on-image text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[21px]">

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -180,7 +180,7 @@ export function MediaDetailView({
   return (
     // rounded-2xl + overflow 裁切：内容渐变到底部是近实色的深色板，方角会与
     // 全站「浮起圆角卡片」的形状语言冲突——按侧栏同规格圆角收尾
-    <div className="scroll-thin h-full overflow-y-auto rounded-2xl">
+    <div className="scroll-thin scroll-safe h-full overflow-y-auto rounded-2xl">
       {/* min-h-full + flex 纵向：内容不足一屏时（简介/演职员/剧照都缺的小众条目）
           内容层仍要撑满剩余高度。否则渐变板只到内容底部就断了，下面直接露出
           沉浸背景，板子底边成了一道硬边界——正是这套「无缝渐入」要避免的东西。

--- a/apps/web/components/media-search-results.tsx
+++ b/apps/web/components/media-search-results.tsx
@@ -148,7 +148,7 @@ export function MediaSearchResults({
         </div>
       </header>
 
-      <div className="scroll-thin relative min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
+      <div className="scroll-thin scroll-safe relative min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
         {allEmpty ? (
           <MediaSearchEmpty
             title={anyError ? "影视搜索出错" : "没有找到相关影视条目"}

--- a/apps/web/components/person-detail-view.tsx
+++ b/apps/web/components/person-detail-view.tsx
@@ -76,7 +76,7 @@ export function PersonDetailView({ tmdbPersonId }: { tmdbPersonId: number | stri
   const directed = person.credits.filter((c) => c.department === "director");
 
   return (
-    <div className="scroll-thin h-full overflow-y-auto pb-12">
+    <div className="scroll-thin scroll-safe h-full overflow-y-auto pb-12">
       {/* 来路交给浏览器后退：进人物页的入口是各处演职员条，来路不固定，
           写死「返回媒体库」会把用户带到他没来过的地方。
           不补负边距——本页的横向内边距在各分区上，滚动容器自身没有 px，

--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -813,7 +813,7 @@ export function SearchResults({ query, onResearch }: SearchResultsProps) {
       </header>
 
       {/* 主体：结果随 site_result 事件渐进出现，首批结果到达前保持骨架屏 */}
-      <div className="scroll-thin relative z-0 min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
+      <div className="scroll-thin scroll-safe relative z-0 min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
         {streaming && items.length === 0 && (
           <SkeletonList siteCount={siteProgress.length} />
         )}

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -115,7 +115,7 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
     // 无外框、无玻璃卡片：内容直接铺在全屏深色蒙版（.page-scrim）之上，
     // 背景透明，让蒙版透上来。沉浸式深色底，不再有圆角/描边/透出雪原的大卡片。
     // 头部与内容同列（同一 max-w 容器内），避免「标题贴左上、内容居中」的割裂感。
-    <div className="scroll-thin h-full overflow-y-auto">
+    <div className="scroll-thin scroll-safe h-full overflow-y-auto">
       {/* 日志分区放宽到 4xl：日志行信息密度高，窄容器折行太碎 */}
       <div
         className={`mx-auto w-full px-6 pb-20 pt-12 max-md:px-4 max-md:pb-12 max-md:pt-6 ${

--- a/apps/web/components/subscription-inspector-view.tsx
+++ b/apps/web/components/subscription-inspector-view.tsx
@@ -136,7 +136,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
   };
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto px-6 pb-12 max-md:px-4">
+    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto px-6 pb-12 max-md:px-4">
       {/* 顶栏：返回订阅列表 + 吸顶片名（容器已有 px-6，用 -mx-6 让吸顶蒙版铺满） */}
       <PageNav
         items={[{ label: "我的订阅", href: "/subscriptions" }, { label: detail.media.title }]}

--- a/apps/web/components/subscriptions-view.tsx
+++ b/apps/web/components/subscriptions-view.tsx
@@ -51,7 +51,7 @@ export function SubscriptionsView() {
   const visible = (subscriptions ?? []).filter((s) => s.media.kind === mediaType);
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto pb-10">
+    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       <div className="flex items-start justify-between gap-4 px-6 pt-2 max-md:flex-col max-md:items-stretch max-md:gap-3 max-md:px-4">
         <div>
           <h2 className="text-on-image text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[21px]">

--- a/apps/web/components/top250-view.tsx
+++ b/apps/web/components/top250-view.tsx
@@ -102,7 +102,7 @@ export function Top250View() {
   };
 
   return (
-    <div className="scroll-thin flex-1 overflow-y-auto px-6 pb-12 max-md:px-4">
+    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto px-6 pb-12 max-md:px-4">
       {/* 顶栏：返回发现电影（保留豆瓣数据源视角）+ 吸顶榜单名；
           容器已有 px-6，用 -mx-6 让吸顶蒙版铺满整宽 */}
       <PageNav


### PR DESCRIPTION
## 问题

iOS PWA（添加到主屏幕）在全面屏 iPhone 上，页面底部有一条黑边：滚动内容在 Home 指示条上方被硬裁一刀，下面露出一条安全区高度的空底（iPhone Air 实测截图确认，所有全面屏机型均受影响）。

## 根因

移动端主区 `.app-shell > main` 整体加了 `padding-bottom: var(--safe-bottom)`，把滚动视口从 Home 指示条上方截断——内容无法像原生 App 那样延伸到屏幕物理底边。

## 修复

- **主区不再为底部安全区整体让位**（globals.css）：滚动内容一直铺到屏幕物理底边、从 Home 指示条下方穿过，黑边消失；
- **新增 `.scroll-safe` 工具类**（`::after` 占位 `var(--safe-bottom)` 高度），加在全站 12 个页面级滚动容器上（发现页 / 媒体库 / 各详情页 / 搜索结果 / 设置等）：滚到底时最后一行内容仍能完全露出、不被指示条压住。用 `::after` 而非改 padding，不与各页已有的 `pb-*` 打架；非全面屏设备与桌面端 `env()` 解析为 0、无副作用；
- **Agent 对话页贴底的输入行**自行让位安全区（`max-md:pb-[calc(0.75rem+var(--safe-bottom))]`），发送键不被指示条压住。

弹窗（Modal 底部抽屉）与侧边抽屉原本就自带安全区处理，未改动。

## 验证

- `pnpm web:build` 构建通过；
- 产物 CSS 确认：`.scroll-safe:after{content:"";height:var(--safe-bottom);display:block}` 与主区新的 padding 规则均正确编译。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rz1YQ1hW2Z2WLpnkAa5gq

---
_Generated by [Claude Code](https://claude.ai/code/session_017rz1YQ1hW2Z2WLpnkAa5gq)_