### PR TITLE
体检路径映射红项的修复指引讲清两条真正省事的出路

### DIFF
--- a/apps/web/components/downloader-config-section.tsx
+++ b/apps/web/components/downloader-config-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
@@ -77,6 +77,21 @@ export function DownloaderConfigSection() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // 体检修复卡跳转带来的映射建议（?suggest_mapping=/xx）：自动展开默认
+  // 下载器的编辑表单并预填一条映射的本机侧，用户只需补下载器视角的路径
+  const [suggestMapping, setSuggestMapping] = useState<string | null>(null);
+  useEffect(() => {
+    const suggested = new URLSearchParams(window.location.search).get("suggest_mapping");
+    if (suggested) setSuggestMapping(suggested);
+  }, []);
+  const suggestConsumed = useRef(false);
+  useEffect(() => {
+    if (!suggestMapping || loading || suggestConsumed.current || downloaders.length === 0) return;
+    suggestConsumed.current = true;
+    const target = downloaders.find((d) => d.is_default) ?? downloaders[0];
+    setEditing(target.id);
+  }, [suggestMapping, loading, downloaders]);
 
   // 有下载器处于 pending/verifying 时轮询刷新，直到全部落定
   const hasInProgress = downloaders.some((d) => IN_PROGRESS.includes(d.status));
@@ -181,6 +196,7 @@ export function DownloaderConfigSection() {
             <DownloaderCard
               key={downloader.id}
               downloader={downloader}
+              suggestMapping={suggestMapping}
               expanded={editing === downloader.id}
               onToggleForm={(open) => setEditing(open ? downloader.id : null)}
               onChanged={upsert}
@@ -204,6 +220,8 @@ export function DownloaderConfigSection() {
 
 interface DownloaderCardProps {
   downloader: ConfiguredDownloader;
+  /** 体检跳转建议预填的映射本机侧路径（无建议时为 null） */
+  suggestMapping: string | null;
   expanded: boolean;
   onToggleForm: (open: boolean) => void;
   onChanged: (downloader: ConfiguredDownloader) => void;
@@ -215,6 +233,7 @@ interface DownloaderCardProps {
 
 function DownloaderCard({
   downloader,
+  suggestMapping,
   expanded,
   onToggleForm,
   onChanged,
@@ -336,6 +355,7 @@ function DownloaderCard({
         <div className="border-t border-white/[0.06] p-4">
           <DownloaderForm
             downloader={downloader}
+            suggestMapping={suggestMapping}
             onSubmit={async (payload) => {
               onChanged(await updateDownloader(downloader.id, payload));
               onToggleForm(false);
@@ -440,12 +460,32 @@ function DownloaderActionsMenu({
 interface DownloaderFormProps {
   /** 编辑对象；null 表示新增 */
   downloader: ConfiguredDownloader | null;
+  /** 体检跳转建议预填的映射本机侧路径（无建议时不传） */
+  suggestMapping?: string | null;
   onSubmit: (payload: DownloaderPayload) => Promise<void>;
   onCancel: () => void;
   onError: (message: string) => void;
 }
 
-function DownloaderForm({ downloader, onSubmit, onCancel, onError }: DownloaderFormProps) {
+/** 已有映射按前缀已覆盖建议路径时不再追加，避免预填出冗余行。 */
+function withSuggestedMapping(existing: PathMapping[], suggest: string | null): PathMapping[] {
+  if (!suggest) return existing;
+  const norm = (p: string) => p.trim().replace(/\/+$/, "") || "/";
+  const target = norm(suggest);
+  const covered = existing.some((m) => {
+    const local = norm(m.local);
+    return local !== "/" && (target === local || target.startsWith(local + "/"));
+  });
+  return covered ? existing : [...existing, { local: suggest, remote: "" }];
+}
+
+function DownloaderForm({
+  downloader,
+  suggestMapping = null,
+  onSubmit,
+  onCancel,
+  onError,
+}: DownloaderFormProps) {
   const [busy, setBusy] = useState(false);
   const [clientType, setClientType] = useState<DownloaderClientType>(
     downloader?.client_type ?? "qbittorrent",
@@ -456,10 +496,15 @@ function DownloaderForm({ downloader, onSubmit, onCancel, onError }: DownloaderF
   // 出于安全后端不回传密码，编辑时留空需重新填写（未开鉴权则保持留空）
   const [password, setPassword] = useState("");
   const [savePath, setSavePath] = useState(downloader?.save_path ?? "");
-  // 路径映射：跨容器部署时 movieclaw 与下载器看同一块盘的两个名字
-  const [mappings, setMappings] = useState<PathMapping[]>(downloader?.path_mappings ?? []);
-  // 已有映射的编辑态默认展开，否则折叠（绝大多数部署用不到）
-  const [mappingsOpen, setMappingsOpen] = useState((downloader?.path_mappings?.length ?? 0) > 0);
+  // 路径映射：跨容器部署时 movieclaw 与下载器看同一块盘的两个名字。
+  // 体检跳转带建议时预填一行本机侧（右侧留给用户按下载器视角补齐）
+  const [mappings, setMappings] = useState<PathMapping[]>(
+    withSuggestedMapping(downloader?.path_mappings ?? [], suggestMapping),
+  );
+  // 已有映射的编辑态或带预填建议时默认展开，否则折叠（绝大多数部署用不到）
+  const [mappingsOpen, setMappingsOpen] = useState(
+    (downloader?.path_mappings?.length ?? 0) > 0 || suggestMapping !== null,
+  );
   // 目录弹窗当前服务的字段："save" = 默认保存目录，数字 = 第 N 条映射的左列
   const [pickerTarget, setPickerTarget] = useState<"save" | number | null>(null);
 
@@ -643,6 +688,12 @@ function DownloaderForm({ downloader, onSubmit, onCancel, onError }: DownloaderF
               否则会拒绝投递以防下载进下载器容器内的孤立路径；下载器能以相同路径直达的目录，
               添加一条两边相同的映射即可。
             </p>
+            {suggestMapping && (
+              <p className="rounded-lg bg-[var(--accent-soft)] px-3 py-2 text-[11.5px] leading-relaxed text-[var(--accent)]">
+                已按体检建议预填映射的本机侧 {suggestMapping}——右侧填下载器视角的对应路径；
+                下载器可直达同名路径时，点中间的 → 把左侧复制过去即可。
+              </p>
+            )}
             {mappings.map((mapping, index) => (
               <div key={index} className="flex items-center gap-2">
                 <button

--- a/apps/web/components/import-watch-section.tsx
+++ b/apps/web/components/import-watch-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DirectoryPicker } from "@/components/directory-picker";
 import { FolderIcon, PlusIcon, XIcon } from "@/components/icons";
@@ -72,6 +72,23 @@ export function ImportWatchSection() {
   useEffect(() => {
     reload();
   }, [reload]);
+
+  // 体检修复卡跳转（?suggest=auto&kinds=movie,tv）：自动打开新建规则弹窗并
+  // 预选「自动路由」目标；多个类型排成队列，保存一条后接着预填下一条
+  const [suggestKinds, setSuggestKinds] = useState<("movie" | "tv")[]>([]);
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("suggest") !== "auto") return;
+    const kinds = (params.get("kinds") ?? "")
+      .split(",")
+      .filter((k): k is "movie" | "tv" => k === "movie" || k === "tv");
+    setSuggestKinds(kinds.length > 0 ? kinds : ["movie"]);
+    setEditing("new");
+  }, []);
+  const suggestTarget = useMemo(
+    () => (suggestKinds[0] ? ({ type: "auto", kind: suggestKinds[0] } as const) : null),
+    [suggestKinds],
+  );
 
   const remove = (rule: ImportWatchRule) => {
     if (
@@ -163,10 +180,21 @@ export function ImportWatchSection() {
         state={editing}
         libraries={libraries}
         downloaderDirs={downloaderDirs}
-        onClose={() => setEditing(null)}
-        onSaved={() => {
+        initialTarget={suggestTarget}
+        onClose={() => {
           setEditing(null);
+          setSuggestKinds([]); // 用户中途关闭即放弃剩余预填队列
+        }}
+        onSaved={() => {
           reload();
+          if (suggestKinds.length > 1) {
+            // 还有下一个类型要建：弹窗保持打开，initialTarget 变化触发表单
+            // 重置为下一类型的预填（如电影规则建完接着建剧集）
+            setSuggestKinds((prev) => prev.slice(1));
+          } else {
+            setSuggestKinds([]);
+            setEditing(null);
+          }
         }}
       />
     </div>
@@ -179,6 +207,7 @@ function RuleFormDialog({
   state,
   libraries,
   downloaderDirs,
+  initialTarget,
   onClose,
   onSaved,
 }: {
@@ -186,6 +215,8 @@ function RuleFormDialog({
   libraries: MediaLibrary[];
   /** 下载器的本地目录候选：源目录大概率就是其中之一（或其子目录） */
   downloaderDirs: DownloaderDirOption[];
+  /** 新建时的目标预选（体检修复卡跳转预填「自动路由 + 类型」；变化会重置表单） */
+  initialTarget?: { type: "auto"; kind: "movie" | "tv" } | null;
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -210,11 +241,13 @@ function RuleFormDialog({
       setTarget({ type: "library", id: rule.library_id });
     } else if (rule?.kind) {
       setTarget({ type: "auto", kind: rule.kind });
+    } else if (initialTarget) {
+      setTarget(initialTarget);
     } else {
       setTarget(libraries[0] ? { type: "library", id: libraries[0].id } : null);
     }
     setPickerOpen(false);
-  }, [state, rule, libraries]);
+  }, [state, rule, libraries, initialTarget]);
 
   if (state === null) return null;
 

--- a/apps/web/components/subscription-settings-section.tsx
+++ b/apps/web/components/subscription-settings-section.tsx
@@ -10,9 +10,11 @@ import {
   getPipelineHealth,
   listRuleSets,
   type DispatchPreview,
+  type FixOption,
   type LibraryPipeline,
   type PipelineCheck,
   type PipelineHealth,
+  type PipelineIssue,
   type RuleSet,
 } from "@/lib/api/subscriptions";
 
@@ -55,6 +57,14 @@ function fixTarget(section: string | null): { href: string; label: string } | nu
   if (section === "import-watch") return { href: "/settings/import-watch", label: "去监听导入" };
   if (section === "libraries") return { href: "/library", label: "去媒体库" };
   return null;
+}
+
+/** 修复选项 → 带预填参数的跳转地址（目标设置页读取参数自动填表单）。 */
+function fixOptionHref(option: FixOption): string | null {
+  const target = fixTarget(option.fix_section);
+  if (!target) return null;
+  if (!option.fix_params) return target.href;
+  return `${target.href}?${new URLSearchParams(option.fix_params)}`;
 }
 
 function worst(statuses: Status[]): Status {
@@ -105,6 +115,9 @@ function PipelineHealthPanel() {
     health !== null &&
     (!health.sites_configured || !health.downloaders_configured || health.libraries.length === 0);
 
+  // 已聚合成修复卡的检查项 key：库卡片默认不再重复其红项文字（状态点保留）
+  const issueKeys = new Set((health?.issues ?? []).map((i) => i.key));
+
   return (
     <section>
       <div className="mb-2 flex items-center justify-between">
@@ -143,10 +156,17 @@ function PipelineHealthPanel() {
 
       {health !== null && !setupNeeded && (
         <div className="space-y-3">
+          {/* 修复卡置顶：按根因聚合，「需要处理 N 件事」——一个根因一张卡，
+              不随受影响的库数膨胀；库卡片里对应的红项文字随之隐藏（状态点保留） */}
+          {health.issues.length > 0 && <IssueCardList issues={health.issues} />}
           {/* 公共段：资源搜索 + 下载器（所有库共享，不逐库重复） */}
-          <SharedSegmentsRow health={health} />
+          <SharedSegmentsRow health={health} hiddenKeys={issueKeys} />
           {health.libraries.map((pipeline) => (
-            <LibraryPipelineCard key={pipeline.library_id} pipeline={pipeline} />
+            <LibraryPipelineCard
+              key={pipeline.library_id}
+              pipeline={pipeline}
+              hiddenKeys={issueKeys}
+            />
           ))}
         </div>
       )}
@@ -224,6 +244,94 @@ function SetupChecklist({ health }: { health: PipelineHealth }) {
   );
 }
 
+/**
+ * 修复卡列表：「需要处理 N 件事」。
+ * 一张卡 = 一个根因，卡内列出受影响的库与结构化的修复选项（多选项时
+ * 由用户按自己的部署取舍，每个选项讲清做什么/为什么/跳到哪）。
+ */
+function IssueCardList({ issues }: { issues: PipelineIssue[] }) {
+  return (
+    <div className="space-y-2.5">
+      <p className="text-[13px] font-medium text-white/90">
+        需要处理 {issues.length} 件事（下方库卡片的红黄点都来自这里）：
+      </p>
+      {issues.map((issue) => (
+        <IssueCard key={issue.key + issue.title} issue={issue} />
+      ))}
+    </div>
+  );
+}
+
+function IssueCard({ issue }: { issue: PipelineIssue }) {
+  const isError = issue.status === "error";
+  return (
+    <div
+      className={`rounded-xl border p-4 ${
+        isError ? "border-[#ff6b6b]/30 bg-[#ff6b6b]/[0.06]" : "border-amber-400/25 bg-amber-500/[0.06]"
+      }`}
+    >
+      <div className="flex items-start gap-2.5">
+        <span className={`mt-[5px] size-2 shrink-0 rounded-full ${STATUS_META[issue.status].dot}`} />
+        <div className="min-w-0 flex-1">
+          <p className="text-[13.5px] font-semibold text-white/95">{issue.title}</p>
+          {issue.affected_libraries.length > 0 && (
+            <p className="mt-1 text-[11.5px] text-[var(--text-faint)]">
+              影响 {issue.affected_libraries.length} 个库：{issue.affected_libraries.join("、")}
+            </p>
+          )}
+          <p className="mt-1.5 text-[12.5px] leading-relaxed text-[var(--text-muted)]">
+            {issue.detail}
+          </p>
+        </div>
+      </div>
+      {issue.options.length > 0 && (
+        <div
+          className={`mt-3 grid gap-2.5 ${issue.options.length > 1 ? "md:grid-cols-2" : ""}`}
+        >
+          {issue.options.map((option, i) => (
+            <FixOptionBlock
+              key={option.title}
+              option={option}
+              ordinal={issue.options.length > 1 ? i + 1 : null}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 修复卡里的一个选项块：做什么 / 为什么 / 带预填参数的跳转。 */
+function FixOptionBlock({ option, ordinal }: { option: FixOption; ordinal: number | null }) {
+  const href = fixOptionHref(option);
+  return (
+    <div className="flex flex-col rounded-lg bg-white/[0.04] p-3">
+      <p className="text-[12.5px] font-semibold text-white/90">
+        {ordinal !== null && (
+          <span className="mr-1.5 inline-flex size-4.5 items-center justify-center rounded-full bg-white/10 text-[10.5px] text-white/70">
+            {ordinal}
+          </span>
+        )}
+        {option.title}
+      </p>
+      {option.why && (
+        <p className="mt-1.5 text-[11.5px] leading-relaxed text-[var(--text-faint)]">{option.why}</p>
+      )}
+      <p className="mt-1.5 flex-1 text-[12px] leading-relaxed text-[var(--text-muted)]">
+        {option.steps}
+      </p>
+      {href && (
+        <Link
+          href={href as never}
+          className="btn-glass mt-2.5 self-start px-3 py-1.5 text-[12px] font-medium"
+        >
+          {option.fix_label} →
+        </Link>
+      )}
+    </div>
+  );
+}
+
 /** 流水线上的一个节点（步骤条渲染单元）。 */
 interface FlowNode {
   key: string;
@@ -268,7 +376,14 @@ function FlowStepper({ nodes }: { nodes: FlowNode[] }) {
 }
 
 /** 公共段（资源搜索 + 下载器）：所有库共享，单独一行不逐库重复。 */
-function SharedSegmentsRow({ health }: { health: PipelineHealth }) {
+function SharedSegmentsRow({
+  health,
+  hiddenKeys,
+}: {
+  health: PipelineHealth;
+  /** 已被修复卡聚合的检查项 key：红项文字不再重复（状态点保留） */
+  hiddenKeys: Set<string>;
+}) {
   const downloaderCheck = health.libraries[0]?.checks.find((c) => c.key === "downloader");
   const nodes: FlowNode[] = [
     {
@@ -286,7 +401,9 @@ function SharedSegmentsRow({ health }: { health: PipelineHealth }) {
       checks: downloaderCheck ? [downloaderCheck] : [],
     },
   ];
-  const problems = nodes.flatMap((n) => n.checks).filter((c) => c.status !== "ok");
+  const problems = nodes
+    .flatMap((n) => n.checks)
+    .filter((c) => c.status !== "ok" && !hiddenKeys.has(c.key));
   return (
     <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-3">
       <div className="flex items-center gap-3">
@@ -300,8 +417,15 @@ function SharedSegmentsRow({ health }: { health: PipelineHealth }) {
   );
 }
 
-/** 一个库的流水线卡片：步骤条 + 红黄项详情（全绿则只有一行）。 */
-function LibraryPipelineCard({ pipeline }: { pipeline: LibraryPipeline }) {
+/** 一个库的流水线卡片：步骤条 + 叙事 + 红黄项详情（已聚合的红项让位给修复卡）。 */
+function LibraryPipelineCard({
+  pipeline,
+  hiddenKeys,
+}: {
+  pipeline: LibraryPipeline;
+  /** 已被修复卡聚合的检查项 key：红项文字不再逐库重复（状态点保留） */
+  hiddenKeys: Set<string>;
+}) {
   const [showAll, setShowAll] = useState(false);
 
   const byKey = (keys: string[]) => pipeline.checks.filter((c) => keys.includes(c.key));
@@ -337,8 +461,8 @@ function LibraryPipelineCard({ pipeline }: { pipeline: LibraryPipeline }) {
     checks: [],
   });
 
-  // 卡片下方默认只列红黄项；「查看全部」展开每一段的事实陈述
-  const problems = pipeline.checks.filter((c) => c.status !== "ok");
+  // 卡片下方默认只列**未被修复卡聚合**的红黄项；「查看全部」仍展开全部事实
+  const problems = pipeline.checks.filter((c) => c.status !== "ok" && !hiddenKeys.has(c.key));
   const listed = showAll ? pipeline.checks.filter((c) => c.key !== "downloader") : problems;
   const meta = STATUS_META[pipeline.status];
 
@@ -359,6 +483,12 @@ function LibraryPipelineCard({ pipeline }: { pipeline: LibraryPipeline }) {
             {pipeline.library_name}
           </p>
           <FlowStepper nodes={nodes} />
+          {/* 正向叙事：订阅命中本库会发生什么——全绿时的可预期，不用去玩模拟一单 */}
+          {pipeline.narrative && (
+            <p className="mt-1.5 text-[11.5px] leading-relaxed text-[var(--text-faint)]">
+              {pipeline.narrative}
+            </p>
+          )}
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1">
           <span className={`text-[12px] font-medium ${meta.text}`}>{meta.label}</span>

--- a/apps/web/lib/api/subscriptions.ts
+++ b/apps/web/lib/api/subscriptions.ts
@@ -197,7 +197,34 @@ export interface LibraryPipeline {
   /** 库主根（入库节点的落点展示） */
   library_root: string | null;
   status: "ok" | "warn" | "error";
+  /** 「订阅命中本库会发生什么」的一句话叙事（全绿时的正向可预期） */
+  narrative: string;
   checks: PipelineCheck[];
+}
+
+/** 修复卡里的一个可选修法。 */
+export interface FixOption {
+  title: string;
+  /** 为什么这么做 / 适合谁（帮用户在多个选项间取舍；可为空串） */
+  why: string;
+  /** 具体做什么，含建议值 */
+  steps: string;
+  /** 修复去处（与 PipelineCheck.fix_section 同词表，前端映射到路由） */
+  fix_section: string;
+  fix_label: string;
+  /** 跳转预填参数：目标设置页读取后自动填表单，免去誊写路径 */
+  fix_params: Record<string, string> | null;
+}
+
+/** 按根因聚合的问题卡：一个根因 = 一张卡，不随受影响的库数膨胀。 */
+export interface PipelineIssue {
+  /** 与被聚合检查项的 PipelineCheck.key 同词表（库卡片据此隐藏重复红项） */
+  key: string;
+  status: "warn" | "error";
+  title: string;
+  detail: string;
+  affected_libraries: string[];
+  options: FixOption[];
 }
 
 /** 订阅链路体检整体结论（订阅设定页与订阅列表警示横幅共用）。 */
@@ -215,6 +242,8 @@ export interface PipelineHealth {
   sites_configured: boolean;
   /** 是否配置过下载器（同上语义） */
   downloaders_configured: boolean;
+  /** 按根因聚合的问题卡（error 在前）——置顶展示为「需要处理 N 件事」 */
+  issues: PipelineIssue[];
   libraries: LibraryPipeline[];
 }
 

--- a/src/movieclaw_api/schemas/subscription.py
+++ b/src/movieclaw_api/schemas/subscription.py
@@ -385,7 +385,34 @@ class LibraryPipelineView(BaseModel):
     path: str | None = Field(default=None, description="投递基底目录（movieclaw 视角）")
     library_root: str | None = Field(default=None, description="库主根（入库节点的落点）")
     status: Literal["ok", "warn", "error"] = Field(description="全链路最坏状态")
+    narrative: str = Field(
+        default="", description="「订阅命中本库会发生什么」的一句话叙事（正向可预期）"
+    )
     checks: list[HealthCheckView]
+
+
+class FixOptionView(BaseModel):
+    """修复卡里的一个可选修法。"""
+
+    title: str = Field(description="选项标题（如「补一条公共父目录映射」）")
+    why: str = Field(default="", description="为什么这么做 / 适合谁（帮用户在多个选项间取舍）")
+    steps: str = Field(description="具体做什么，含建议值")
+    fix_section: str = Field(description="修复去处：设置分区 id 或 libraries（前端映射到路由）")
+    fix_label: str = Field(description="跳转按钮文案")
+    fix_params: dict[str, str] | None = Field(
+        default=None, description="跳转预填参数（目标设置页读取后自动填表单）"
+    )
+
+
+class HealthIssueView(BaseModel):
+    """按根因聚合的问题卡：一个根因 = 一张卡，不随受影响的库数膨胀。"""
+
+    key: str = Field(description="与被聚合检查项的 HealthCheck.key 同词表")
+    status: Literal["warn", "error"]
+    title: str = Field(description="一句话根因")
+    detail: str = Field(description="根因的事实陈述与后果")
+    affected_libraries: list[str] = Field(default_factory=list, description="受影响的库名")
+    options: list[FixOptionView] = Field(description="结构化修复选项（多个时由用户取舍）")
 
 
 class PipelineHealthView(BaseModel):
@@ -403,6 +430,10 @@ class PipelineHealthView(BaseModel):
         "配置过但失效的老用户看到的是体检红项而非新手清单"
     )
     downloaders_configured: bool = Field(description="是否配置过下载器（同上语义）")
+    issues: list[HealthIssueView] = Field(
+        default_factory=list,
+        description="按根因聚合的问题卡（error 在前）——前端置顶展示为「需要处理 N 件事」",
+    )
     libraries: list[LibraryPipelineView]
 
 

--- a/src/movieclaw_api/services/subscription/dispatch.py
+++ b/src/movieclaw_api/services/subscription/dispatch.py
@@ -252,7 +252,8 @@ async def preview_dispatch_route(
         ok = False
         warning = (
             f"目录 {base} 不在下载器「{downloader.name}」的路径映射覆盖范围内，"
-            "届时投递会被拒绝——请为该目录补一条路径映射，或为这个库配置监听导入规则"
+            "届时投递会被拒绝——请补一条覆盖该目录的路径映射（映射按前缀匹配，"
+            "映射公共父目录即可覆盖其下所有库），或为这个库配置监听导入规则"
         )
     return {
         "mode": mode,

--- a/src/movieclaw_api/services/subscription/health.py
+++ b/src/movieclaw_api/services/subscription/health.py
@@ -58,7 +58,45 @@ class LibraryPipeline:
     path: str | None  # 投递基底目录（movieclaw 视角）
     library_root: str | None  # 库主根（入库节点的落点展示）
     status: str  # 全链路最坏状态
+    narrative: str = ""  # 「订阅命中本库会发生什么」的一句话叙事（全绿时的正向可预期）
     checks: list[HealthCheck] = field(default_factory=list)
+
+
+@dataclass
+class FixOption:
+    """修复卡里的一个可选修法：做什么 / 为什么 / 跳到哪。
+
+    fix_section 沿用 HealthCheck 的词表（前端负责映射到路由），fix_params
+    是跳转要携带的预填参数（如建议的映射路径）——目标设置页读取后自动
+    填好表单，用户不必凭记忆誊写路径。
+    """
+
+    title: str  # 选项标题（如「补一条公共父目录映射」）
+    why: str  # 为什么这么做 / 适合谁（帮用户二选一）
+    steps: str  # 具体做什么，含建议值
+    fix_section: str  # 修复去处（sites / downloaders / import-watch / libraries）
+    fix_label: str  # 跳转按钮文案
+    fix_params: dict[str, str] | None = None  # 跳转预填参数
+
+
+@dataclass
+class HealthIssue:
+    """按根因聚合的问题卡：一个根因 = 一张卡，不随受影响的库数膨胀。
+
+    体检按库逐条报告事实（``LibraryPipeline.checks``，保持不变），但同一个
+    根因（如下载器映射没覆盖媒体库）会在每个库上各亮一条红项——用户看到
+    的是 N 个问题，实际要修的只有一处。这里把红黄项按根因归并，给出
+    受影响的库和结构化的修复选项，前端置顶展示为「需要处理 N 件事」。
+    ``key`` 与被归并检查项的 ``HealthCheck.key`` 一致，前端据此在库卡片里
+    隐藏已被聚合的红项文字、只保留状态点。
+    """
+
+    key: str  # 与聚合来源的 HealthCheck.key 同词表
+    status: str  # error / warn
+    title: str  # 一句话根因
+    detail: str  # 根因的事实陈述与后果
+    affected_libraries: list[str] = field(default_factory=list)
+    options: list[FixOption] = field(default_factory=list)
 
 
 def _worst(statuses: list[str]) -> str:
@@ -187,6 +225,190 @@ def _check_transfer(
             )
         )
     return checks
+
+
+def _narrative(mode: str, base: str | None, library: Library, rule: ImportWatch | None) -> str:
+    """「订阅命中本库会发生什么」的一句话叙事。
+
+    体检的红黄项讲"哪里会坏"，这句话讲"正常时会发生什么"——把模拟一单
+    的结论常驻到每个库卡片上，全绿时用户也能对订阅后的行为有明确预期。
+    """
+    root = library.primary_root
+    if mode == "watch" and rule is not None:
+        if not root:
+            return f"投递到监听导入目录 {base}，但库没有根路径，下载完成后无法入库。"
+        if rule.strategy == "hardlink":
+            return (
+                f"订阅命中本库的影片会投递到 {base}，下载完成后自动识别并硬链接进 "
+                f"{root} 的「片名 (年份)」目录——源文件留在下载目录继续做种，删种不删片。"
+            )
+        return (
+            f"订阅命中本库的影片会投递到 {base}，下载完成后自动识别并复制进 "
+            f"{root} 的「片名 (年份)」目录——源文件保留在下载目录。"
+        )
+    if mode == "inplace":
+        return (
+            f"订阅命中本库的影片会以「片名 (年份)」目录直接下载进 {base}，"
+            "下载完成即在库内，扫描自动入账。"
+        )
+    return "库没有根路径：下载会落到下载器默认目录，不会自动入库。"
+
+
+# 修复去处 → 默认跳转按钮文案（与前端 fixTarget 的词表一致）
+_FIX_LABELS = {
+    "sites": "去接入站点",
+    "downloaders": "去下载器设置",
+    "import-watch": "去监听导入",
+    "libraries": "去媒体库",
+}
+
+
+def _aggregate_issues(
+    pipelines: list[LibraryPipeline],
+    site_check: HealthCheck,
+    downloader: DownloaderClient | None,
+    common_root: str | None,
+) -> list[HealthIssue]:
+    """把逐库的红黄项按根因归并成修复卡（error 在前，warn 在后）。
+
+    专门聚合的两类：全局段（站点/下载器，本就与库无关）与路径映射
+    （同一个根因逐库开花的重灾区，给出二选一的结构化修法）；其余红黄项
+    按（key, detail）归并——detail 相同即同一根因，受影响库合并列出。
+    """
+    issues: list[HealthIssue] = []
+
+    if site_check.status != "ok":
+        issues.append(
+            HealthIssue(
+                key="sites",
+                status=site_check.status,
+                title="资源站点不可用",
+                detail=site_check.detail,
+                options=[
+                    FixOption(
+                        title="接入或修复资源站点",
+                        why="订阅的一切从站点搜索开始，没有可用站点就搜不到任何资源。",
+                        steps="到「资源站点」接入站点，或修复失效的登录态（如更新 Cookie）。",
+                        fix_section="sites",
+                        fix_label=_FIX_LABELS["sites"],
+                    )
+                ],
+            )
+        )
+
+    if downloader is None:
+        issues.append(
+            HealthIssue(
+                key="downloader",
+                status="error",
+                title="没有可用的默认下载器",
+                detail="订阅只能记录想要的内容，无法真实下载。",
+                options=[
+                    FixOption(
+                        title="接入下载器并设为默认",
+                        why="找到的资源要交给 qBittorrent / Transmission 完成下载。",
+                        steps="到「下载器」添加实例，确保连接测试通过并设为默认。",
+                        fix_section="downloaders",
+                        fix_label=_FIX_LABELS["downloaders"],
+                    )
+                ],
+            )
+        )
+
+    # —— 路径映射：同一根因逐库开花的重灾区，归并成一张二选一的修复卡
+    mapping_hits = [
+        (p, c) for p in pipelines for c in p.checks if c.key == "mapping" and c.status != "ok"
+    ]
+    if mapping_hits and downloader is not None:
+        names = [p.library_name for p, _ in mapping_hits]
+        # 受影响的类型（去重保序）：监听导入选项据此建议建几条 auto 规则
+        kinds = list(dict.fromkeys(p.kind for p, _ in mapping_hits))
+        kind_labels = "、".join("电影" if k == "movie" else "剧集" for k in kinds)
+        anchor = common_root or mapping_hits[0][0].path or ""
+        issues.append(
+            HealthIssue(
+                key="mapping",
+                status="error",
+                title=f"下载器「{downloader.name}」的路径映射没有覆盖媒体库目录",
+                detail=(
+                    f"{len(names)} 个库的投递目录都不在映射覆盖范围内——这是同一个"
+                    "原因，修一处即可，不需要逐库配置。修复前投递会被拒绝"
+                    "（工单不会丢，修好后自动重试）。"
+                ),
+                affected_libraries=names,
+                options=[
+                    FixOption(
+                        title="补一条公共父目录映射（改动最小）",
+                        why=(
+                            "映射按目录前缀覆盖：一条公共父目录的映射即可覆盖其下"
+                            "所有库。适合下载器能直接访问媒体库目录、愿意让下载"
+                            "文件直接落在库内的部署。"
+                        ),
+                        steps=(
+                            f"添加映射：本机 {anchor} → 下载器视角的对应路径"
+                            "（下载器可直达同名路径时，两边填相同的即可）。"
+                        ),
+                        fix_section="downloaders",
+                        fix_label="去补映射",
+                        fix_params={"suggest_mapping": anchor} if anchor else None,
+                    ),
+                    FixOption(
+                        title="改用监听导入（下载区与库分离）",
+                        why=(
+                            "投递改走独立的下载目录，映射只需覆盖下载目录，媒体库"
+                            "分得再细也不影响下载器配置；下载完成后硬链接/复制进库，"
+                            "源文件继续做种、删种不删片——PT 保种推荐。"
+                        ),
+                        steps=(
+                            f"为{kind_labels}各建一条「自动路由」规则，源目录选"
+                            "下载器的下载目录（不能在媒体库根路径之下）。"
+                        ),
+                        fix_section="import-watch",
+                        fix_label="去建规则",
+                        fix_params={"suggest": "auto", "kinds": ",".join(kinds)},
+                    ),
+                ],
+            )
+        )
+
+    # —— 其余红黄项：detail 相同即同一根因，受影响库合并成一张单选项卡。
+    # 标题按 (key, status) 给人话版本，兜底退回检查项的段落名
+    titles = {
+        ("dispatch_dir", "error"): "媒体库没有根路径，无法自动入库",
+        ("transfer_disk", "error"): "硬链接无法跨文件系统工作",
+        ("transfer_disk", "warn"): "硬链接同盘暂时无法检测",
+        ("watch_active", "warn"): "目录监听未生效，入库会不及时",
+    }
+    grouped: dict[tuple[str, str], list[tuple[LibraryPipeline, HealthCheck]]] = {}
+    for pipeline in pipelines:
+        for check in pipeline.checks:
+            if check.status == "ok" or check.key in ("mapping", "downloader"):
+                continue
+            grouped.setdefault((check.key, check.detail), []).append((pipeline, check))
+    for (key, detail), hits in grouped.items():
+        check = hits[0][1]
+        section = check.fix_section or "libraries"
+        issues.append(
+            HealthIssue(
+                key=key,
+                status=check.status,
+                title=titles.get((key, check.status), check.label),
+                detail=detail,
+                affected_libraries=[p.library_name for p, _ in hits],
+                options=[
+                    FixOption(
+                        title=f"处理「{check.label}」",
+                        why="",
+                        steps=detail,
+                        fix_section=section,
+                        fix_label=_FIX_LABELS.get(section, "去处理"),
+                    )
+                ],
+            )
+        )
+
+    issues.sort(key=lambda i: -_SEVERITY.get(i.status, 0))
+    return issues
 
 
 async def pipeline_health(session: AsyncSession) -> dict:
@@ -320,6 +542,7 @@ async def pipeline_health(session: AsyncSession) -> dict:
                 path=base,
                 library_root=library.primary_root,
                 status=status,
+                narrative=_narrative(mode, base, library, rule),  # type: ignore[arg-type]
                 checks=checks,
             )
         )
@@ -329,6 +552,7 @@ async def pipeline_health(session: AsyncSession) -> dict:
     overall = _worst([p.status for p in pipelines] + [site_check.status])
     if downloader is None:
         overall = "error"
+    issues = _aggregate_issues(pipelines, site_check, downloader, common_root)
     return {
         "status": overall,
         "error_count": sum(1 for p in pipelines if p.status == "error"),
@@ -337,5 +561,6 @@ async def pipeline_health(session: AsyncSession) -> dict:
         "downloader_ok": downloader is not None,
         "sites_configured": sites_configured,
         "downloaders_configured": downloaders_configured,
+        "issues": [asdict(i) for i in issues],
         "libraries": [asdict(p) for p in pipelines],
     }

--- a/src/movieclaw_api/services/subscription/health.py
+++ b/src/movieclaw_api/services/subscription/health.py
@@ -203,6 +203,17 @@ async def pipeline_health(session: AsyncSession) -> dict:
     watched = _watched_dirs()
     libraries = await LibraryRepository(session).list_all()
 
+    # 映射修复建议的锚点：全部库根的公共父目录。映射按前缀覆盖，一条公共
+    # 父目录的映射即可覆盖其下所有库——建议里给出这个目录，避免用户把
+    # 逐库报警误读成"每个库都要单独配一条映射"
+    all_roots = [root for lib in libraries for root in lib.root_paths if root]
+    try:
+        common_root: str | None = os.path.commonpath(all_roots) if all_roots else None
+    except ValueError:  # 根路径混入了相对路径等异常形态：放弃建议锚点即可
+        common_root = None
+    if common_root == "/":
+        common_root = None  # 公共父目录退化到根：建议映射 / 没有意义
+
     pipelines: list[LibraryPipeline] = []
     for library in libraries:
         assert library.id is not None
@@ -282,9 +293,13 @@ async def pipeline_health(session: AsyncSession) -> dict:
                         status="error",
                         detail=(
                             f"目录 {base} 不在下载器「{downloader.name}」的路径映射"
-                            f"覆盖范围内，投递会被拒绝。建议映射：本机 {base} → "
-                            "下载器视角的对应路径（下载器可直达同名路径时，"
-                            "两边填相同的即可）"
+                            "覆盖范围内，投递会被拒绝。修复二选一：① 补一条路径"
+                            "映射——映射按目录前缀覆盖，映射公共父目录（本机 "
+                            f"{common_root or base} → 下载器视角的对应路径，下载器"
+                            "可直达同名路径时两边填相同的）即可一条覆盖其下所有库，"
+                            "无需逐库配置；② 为库配置监听导入规则（自动路由）——"
+                            "投递会改走独立的下载目录，路径映射只需覆盖那个下载"
+                            "目录，媒体库分得再细也不影响下载器配置"
                         ),
                         fix_section="downloaders",
                     )

--- a/tests/api/test_subscription_health.py
+++ b/tests/api/test_subscription_health.py
@@ -176,6 +176,21 @@ async def test_mapping_coverage_verdicts(db, tmp_path) -> None:
     assert str(tmp_path) in mapping["detail"]
     assert "监听导入规则" in mapping["detail"]
 
+    # 根因聚合：两个库同因映射不覆盖 → 一张修复卡，不随库数膨胀；
+    # 卡上给二选一的结构化修法，且父目录映射选项带跳转预填参数
+    mapping_issues = [i for i in result["issues"] if i["key"] == "mapping"]
+    assert len(mapping_issues) == 1
+    issue = mapping_issues[0]
+    assert issue["status"] == "error"
+    assert set(issue["affected_libraries"]) == {"电影库", "剧集库"}
+    assert len(issue["options"]) == 2
+    by_section = {o["fix_section"]: o for o in issue["options"]}
+    assert by_section["downloaders"]["fix_params"] == {"suggest_mapping": str(tmp_path)}
+    assert by_section["import-watch"]["fix_params"] == {
+        "suggest": "auto",
+        "kinds": "movie,tv",
+    }
+
     # 补上覆盖后：整链全绿
     async with db.session() as session:
         from sqlmodel import select
@@ -186,6 +201,9 @@ async def test_mapping_coverage_verdicts(db, tmp_path) -> None:
         result = await pipeline_health(session)
     assert result["status"] == "ok" and result["error_count"] == 0
     assert _check(result["libraries"][0], "mapping")["status"] == "ok"
+    # 全绿后修复卡清空；每库带「订阅后会发生什么」的正向叙事（inplace 口径）
+    assert result["issues"] == []
+    assert "直接下载进" in result["libraries"][0]["narrative"]
 
 
 @pytest.mark.asyncio
@@ -207,6 +225,11 @@ async def test_watch_mode_transfer_segments(db, tmp_path) -> None:
     active = _check(pipeline, "watch_active")
     assert active["status"] == "warn" and "兜底巡检" in active["detail"]
     assert result["status"] == "warn"  # 降级不算故障
+    # watch + 硬链接的叙事讲清分离布局的行为：投监听目录 → 硬链进库 → 继续做种
+    assert str(watch) in pipeline["narrative"] and "硬链接" in pipeline["narrative"]
+    # warn 也聚合成修复卡（监听未生效），指向监听导入设置
+    watch_issues = [i for i in result["issues"] if i["key"] == "watch_active"]
+    assert len(watch_issues) == 1 and watch_issues[0]["status"] == "warn"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_subscription_health.py
+++ b/tests/api/test_subscription_health.py
@@ -162,6 +162,7 @@ async def test_no_downloader_is_error(db, tmp_path) -> None:
 async def test_mapping_coverage_verdicts(db, tmp_path) -> None:
     root = tmp_path / "movies"
     await _make_library(db, root=root)
+    await _make_library(db, name="剧集库", kind="tv", root=tmp_path / "tv")
     await _make_site(db)
     # 映射不覆盖库根：error + 指向下载器设置（与真实投递被拒同口径）
     await _make_downloader(db, mappings=[{"local": "/somewhere/else", "remote": "/dl"}])
@@ -170,6 +171,10 @@ async def test_mapping_coverage_verdicts(db, tmp_path) -> None:
     mapping = _check(result["libraries"][0], "mapping")
     assert mapping["status"] == "error" and mapping["fix_section"] == "downloaders"
     assert str(root) in mapping["detail"]
+    # 修复指引必须给出两条出路：公共父目录映射（前缀覆盖，不必逐库配）
+    # 与监听导入规则——而不是让用户误以为要为每个库单独配一条映射
+    assert str(tmp_path) in mapping["detail"]
+    assert "监听导入规则" in mapping["detail"]
 
     # 补上覆盖后：整链全绿
     async with db.session() as session:


### PR DESCRIPTION
原文案「建议映射：本机 <库目录> → 下载器对应路径」逐库报警，容易被
误读成每个细分库都要单独配一条映射。实际上：

- 映射按目录前缀覆盖（最长前缀匹配），补一条全部库根公共父目录的
  映射即可一次覆盖所有库；
- 配置监听导入规则（自动路由）后投递改走独立下载目录，媒体库分得
  再细也不影响下载器配置。

体检现在计算全部库根的公共父目录作为建议锚点，红项文案给出上述
二选一指引；订阅弹窗预检的同款警告同步补充前缀覆盖说明。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CbjDFhjeVYm9UhYWCk4o9y