### PR TITLE
修复 OpenAI 兼容端点被 Cloudflare AI Bot 误拦截

### DIFF
--- a/src/movieclaw_llm/protocols/openai_chat.py
+++ b/src/movieclaw_llm/protocols/openai_chat.py
@@ -47,6 +47,14 @@ from movieclaw_net import egress_transport
 
 logger = logging.getLogger(__name__)
 
+# 部分启用 Cloudflare AI Bot 防护的 OpenAI 兼容端点会将 SDK 默认的
+# ``AsyncOpenAI/Python`` User-Agent 误判为抓取机器人。统一使用常规浏览器标识，
+# 只改变客户端身份特征，不影响 Authorization 与 OpenAI 线协议。
+_BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+
 # OpenAI 的 finish_reason → 统一枚举；未知值按 stop 兜底
 _FINISH_REASON_MAP: dict[str, FinishReason] = {
     "stop": "stop",
@@ -62,7 +70,10 @@ _CONTENT_FILTER_CODES = {"data_inspection_failed", "content_filter"}
 class OpenAIChatProtocol(BaseLlmProtocol):
     def __init__(self, config: LlmProviderConfig, preset: ProviderPreset) -> None:
         super().__init__(config, preset)
-        kwargs: dict[str, Any] = {"api_key": config.api_key}
+        kwargs: dict[str, Any] = {
+            "api_key": config.api_key,
+            "default_headers": {"User-Agent": _BROWSER_UA},
+        }
         base_url = config.base_url or preset.base_url
         if base_url:
             kwargs["base_url"] = base_url

--- a/tests/llm/unit/test_openai_chat.py
+++ b/tests/llm/unit/test_openai_chat.py
@@ -5,6 +5,7 @@ import openai
 import pytest
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
+import movieclaw_llm.protocols.openai_chat as openai_chat_module
 from movieclaw_llm import (
     ChatMessage,
     ChatRequest,
@@ -27,6 +28,54 @@ from movieclaw_llm.providers import get_preset
 def make_protocol(provider_type: str = "bailian") -> OpenAIChatProtocol:
     config = LlmProviderConfig(name="测试实例", provider_type=provider_type, api_key="sk-test")
     return OpenAIChatProtocol(config, get_preset(provider_type))
+
+
+async def test_protocol_sends_browser_user_agent(monkeypatch):
+    captured_user_agent = ""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_user_agent
+        captured_user_agent = request.headers["user-agent"]
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "cmpl-ua",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "pong"},
+                    }
+                ],
+            },
+        )
+
+    monkeypatch.setattr(
+        openai_chat_module,
+        "egress_transport",
+        lambda _service: httpx.MockTransport(handler),
+    )
+    config = LlmProviderConfig(
+        name="测试实例",
+        provider_type="openai_compat",
+        api_key="sk-test",
+        base_url="https://example.test/v1",
+    )
+    protocol = OpenAIChatProtocol(config, get_preset("openai_compat"))
+    try:
+        await protocol.chat(
+            ChatRequest(messages=[ChatMessage(role="user", content="ping")]),
+            "test-model",
+        )
+    finally:
+        await protocol.close()
+
+    assert captured_user_agent.startswith("Mozilla/5.0")
+    assert "OpenAI/Python" not in captured_user_agent
 
 
 # -- 请求转换 ---------------------------------------------------------------


### PR DESCRIPTION
## 问题

部分经过 Cloudflare 代理的 OpenAI 兼容端点启用了 AI Bot 防护。

OpenAI Python SDK 默认发送：

`User-Agent: AsyncOpenAI/Python <version>`

Cloudflare 的 `Manage AI bots` 托管规则可能将其误判为 AI 抓取机器人，返回：

`HTTP 403: Your request was blocked.`

该响应随后被 SDK 转换为 `PermissionDeniedError`，最终在 MovieClaw 中显示为 API Key 认证失败，导致供应商连接验证和正常 LLM 请求无法使用。

## 修改

- 通过 `AsyncOpenAI.default_headers` 将 LLM 请求统一设置为常规浏览器 User-Agent。
- 保持请求 URL、Authorization、请求体和出口代理逻辑不变。
- 增加基于 `httpx.MockTransport` 的回归测试，检查实际线上请求：
  - User-Agent 以 `Mozilla/5.0` 开头。
  - User-Agent 不再包含 `OpenAI/Python`。

## 验证

- `pytest tests/llm/unit tests/api/test_llm.py -q`
  - 56 项测试通过。
- `ruff check src/movieclaw_llm/protocols/openai_chat.py tests/llm/unit/test_openai_chat.py`
  - 检查通过。
- 使用占位 API Key 请求受影响的兼容端点：
  - 修改前：Cloudflare 返回 `403 Your request was blocked.`
  - 修改后：请求正常到达上游鉴权，返回预期的 `401 valid api key is required`。
