### PR TITLE
perf(web): 修复液态玻璃持续重绘并全面优化前端性能

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1048,14 +1048,19 @@ body.cmdk-open .app-shell {
   /* 各骨架行通过 --stagger 错峰，扫光斜向依次掠过，比整片同步呼吸更有"加载中"的动感 */
   animation-delay: var(--stagger, 0ms);
 }
+/* 扫光动画走 transform 而非 left：left 是布局属性，每帧都要重排重绘；
+   transform 在合成器上执行，搜索期间常驻的动画不该持续占用主线程。
+   translateX 以自身宽度（父宽 40%）为基准：-100% 自身 = 原 left:-40%，
+   250% 自身 = 原 left:100%。 */
 @keyframes search-progress-sweep {
   from {
-    left: -40%;
+    transform: translateX(-100%);
   }
   to {
-    left: 100%;
+    transform: translateX(250%);
   }
 }
 .progress-sweep {
+  left: 0;
   animation: search-progress-sweep 1.1s ease-in-out infinite;
 }

--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import { Composer } from "@/components/composer";
 import { HighlightedCode } from "@/components/highlighted-code";
@@ -134,7 +134,10 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
 
 /* —— 单轮：用户气泡 + Agent 回应块 —— */
 
-function TurnView({ turn }: { turn: AgentTurn }) {
+/** memo：流式更新只替换正在生成那一轮的 turn 对象（store 是逐轮不可变更新），
+ *  历史轮次引用不变、比对通过即整轮跳过——长会话里没有它，每次增量都要
+ *  重建全部历史轮次的元素树。 */
+const TurnView = memo(function TurnView({ turn }: { turn: AgentTurn }) {
   return (
     <div className="space-y-4">
       {/* 用户消息：右侧玻璃气泡 */}
@@ -197,7 +200,7 @@ function TurnView({ turn }: { turn: AgentTurn }) {
       </div>
     </div>
   );
-}
+});
 
 /** 进行中的处理块此刻在做什么：取末尾条目推导实时状态。 */
 function processStatus(items: AgentProcessItem[]): string {
@@ -224,7 +227,7 @@ function processSummary(items: AgentProcessItem[]): string {
  * 处理过程折叠块（仿 Claude）：头部进行中显示实时状态、完成后显示一句话
  * 总结；点击展开思考与工具调用的混合列表（按实际发生顺序）。
  */
-function ProcessBlock({ segment, active }: { segment: AgentTurnSegment & { kind: "process" }; active: boolean }) {
+const ProcessBlock = memo(function ProcessBlock({ segment, active }: { segment: AgentTurnSegment & { kind: "process" }; active: boolean }) {
   const [open, setOpen] = useState(false);
   return (
     <div>
@@ -256,7 +259,7 @@ function ProcessBlock({ segment, active }: { segment: AgentTurnSegment & { kind:
       )}
     </div>
   );
-}
+});
 
 /**
  * 从定稿的 label（形如 `name({...json...})`）还原参数明细：
@@ -277,8 +280,15 @@ function toolInput(tool: AgentTurnToolCall): { lang: CodeLang; code: string } | 
   }
 }
 
-/** 单次工具调用卡片：参数完整展示（shiki 高亮）+ 生成/执行中/回执三种状态。 */
-function ToolCallCard({ tool }: { tool: AgentTurnToolCall }) {
+/** 单次工具调用卡片：参数完整展示（shiki 高亮）+ 生成/执行中/回执三种状态。
+ *  memo：store 对工具条目也是不可变更新，未被触碰的卡片整卡跳过；
+ *  参数明细的 JSON.parse/stringify（大参数可达几 KB）按 tool 缓存，
+ *  不再在每次渲染中内联执行。 */
+const ToolCallCard = memo(function ToolCallCard({ tool }: { tool: AgentTurnToolCall }) {
+  const input = useMemo(
+    () => (tool.argsDone === false ? null : toolInput(tool)),
+    [tool],
+  );
   return (
     <div className="rounded-lg border border-white/[0.05] bg-white/[0.02] px-2.5 py-1.5">
       {tool.argsDone === false ? (
@@ -295,10 +305,7 @@ function ToolCallCard({ tool }: { tool: AgentTurnToolCall }) {
       ) : (
         <>
           <p className="font-mono text-[11px] text-[var(--accent-2)]">⚙ {tool.name}</p>
-          {(() => {
-            const input = toolInput(tool);
-            return input && <HighlightedCode code={input.code} lang={input.lang} />;
-          })()}
+          {input && <HighlightedCode code={input.code} lang={input.lang} />}
         </>
       )}
       {tool.argsDone === false ? (
@@ -317,7 +324,7 @@ function ToolCallCard({ tool }: { tool: AgentTurnToolCall }) {
       )}
     </div>
   );
-}
+});
 
 /** 流式光标：正文尾部的呼吸圆点。 */
 function StreamingCursor() {

--- a/apps/web/components/avatar-badge.tsx
+++ b/apps/web/components/avatar-badge.tsx
@@ -21,7 +21,12 @@ export function AvatarBadge({
       className={`brand-badge flex shrink-0 items-center justify-center overflow-hidden rounded-full font-bold ${className}`}
     >
       {avatarUrl ? (
-        <img src={avatarUrl} alt={`${nickname} 的头像`} className="h-full w-full object-cover" />
+        <img
+          src={avatarUrl}
+          alt={`${nickname} 的头像`}
+          decoding="async"
+          className="h-full w-full object-cover"
+        />
       ) : (
         initialsOf(nickname)
       )}

--- a/apps/web/components/discover-view.tsx
+++ b/apps/web/components/discover-view.tsx
@@ -269,6 +269,8 @@ const HERO_INTERVAL = 8000;
  * Hero 大横幅：精选影片自动轮播。
  * 所有帧常驻 DOM 叠放，靠 opacity 交叉淡入淡出（避免切换时图片重新加载闪白）；
  * 文字区跟随当前帧一起淡入。两侧箭头与右下角圆点均可手动切换并重置计时。
+ * 图片按需装载：帧壳常驻，但 w1280 大图只有轮到（当前帧/下一帧）才写入 src，
+ * 首屏不必一次下载解码全部 6 张；已展示过的帧保持已加载，交叉淡出不闪白。
  */
 function HeroBanner({ items }: { items: MediaItem[] }) {
   const [index, setIndex] = useState(0);
@@ -280,16 +282,19 @@ function HeroBanner({ items }: { items: MediaItem[] }) {
   useEffect(() => {
     if (items.length <= 1) return;
     const timer = setInterval(() => {
+      // 后台标签页不推进轮播：推进了也没人看，白白解码下一张大图并重渲染
+      if (document.hidden) return;
       setIndex((i) => (i + 1) % items.length);
     }, HERO_INTERVAL);
     return () => clearInterval(timer);
     // index 作为依赖：手动切换后重置轮播计时，避免刚点完就被自动切走
   }, [items.length, index]);
 
+  const next = (index + 1) % items.length;
   return (
     <div className="group relative h-[46vh] min-h-[320px] w-full overflow-hidden rounded-2xl shadow-[0_24px_70px_-18px_rgba(0,0,0,0.62)] ring-1 ring-white/10 max-md:h-[38vh] max-md:min-h-[230px]">
       {items.map((item, i) => (
-        <HeroSlide key={item.id} item={item} active={i === index} />
+        <HeroSlide key={item.id} item={item} active={i === index} preload={i === index || i === next} />
       ))}
 
       {/* 手动切换按钮：首尾相连，触摸设备也保留足够大的点击区域。 */}
@@ -334,8 +339,22 @@ function HeroBanner({ items }: { items: MediaItem[] }) {
   );
 }
 
-function HeroSlide({ item, active }: { item: MediaItem; active: boolean }) {
+function HeroSlide({
+  item,
+  active,
+  preload,
+}: {
+  item: MediaItem;
+  active: boolean;
+  /** 是否该装载大图（当前帧或下一帧）；一旦装载过就保持，淡出时不闪白 */
+  preload: boolean;
+}) {
   const { open } = useMediaDetail();
+  // 「粘性」装载：轮到过一次就永久保留 src（浏览器已缓存，重复挂载无成本）
+  const [revealed, setRevealed] = useState(preload);
+  useEffect(() => {
+    if (preload) setRevealed(true);
+  }, [preload]);
   // Hero 占满首屏，手机上「向下滑看海报墙」几乎必然从这块起手，
   // 「更多信息」正落在起手区里，同样过一遍误触判定。
   const tapGuard = useTapGuard(() => open(item));
@@ -348,7 +367,7 @@ function HeroSlide({ item, active }: { item: MediaItem; active: boolean }) {
     >
       {/* 宽幅剧照 + 双层渐变蒙版：左侧压暗保文字可读，底部渐隐融入页面 */}
       <PosterImage
-        src={item.backdropUrl}
+        src={revealed ? item.backdropUrl : undefined}
         alt={`${item.title} 剧照`}
         className={`absolute inset-0 size-full object-cover object-top transition-transform duration-[9000ms] ease-linear ${
           active ? "scale-[1.06]" : "scale-100"

--- a/apps/web/components/downloader-config-section.tsx
+++ b/apps/web/components/downloader-config-section.tsx
@@ -22,6 +22,7 @@ import {
   updateDownloader,
 } from "@/lib/api/downloaders";
 import { formatRelativeTime } from "@/lib/time";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 import { LiquidGlassButton } from "@/vendor/liquid-glass";
 
 /** 连接状态 → 展示文案与颜色（与站点配置同语言） */
@@ -93,19 +94,18 @@ export function DownloaderConfigSection() {
     setEditing(target.id);
   }, [suggestMapping, loading, downloaders]);
 
-  // 有下载器处于 pending/verifying 时轮询刷新，直到全部落定
+  // 有下载器处于 pending/verifying 时轮询刷新，直到全部落定（页面隐藏时暂停）
   const hasInProgress = downloaders.some((d) => IN_PROGRESS.includes(d.status));
-  useEffect(() => {
-    if (!hasInProgress) return;
-    const timer = setInterval(() => {
+  useVisiblePolling(
+    () => {
       void listDownloaders()
         .then(setDownloaders)
         .catch(() => {
           /* 轮询失败静默重试，不打断页面 */
         });
-    }, 2000);
-    return () => clearInterval(timer);
-  }, [hasInProgress]);
+    },
+    hasInProgress ? 2000 : null,
+  );
 
   // 原地替换已有条目、新条目追加到末尾（保持列表顺序稳定，避免操作后跳位）
   const upsert = useCallback((next: ConfiguredDownloader) => {

--- a/apps/web/components/h-scroller.tsx
+++ b/apps/web/components/h-scroller.tsx
@@ -25,23 +25,34 @@ export function HScroller({
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [canLeft, setCanLeft] = useState(false);
   const [canRight, setCanRight] = useState(false);
+  const edgeFrame = useRef(0);
 
-  /** 根据当前滚动位置更新两侧按钮的可用性（含 1px 容差，避免亚像素误差） */
+  /** 根据当前滚动位置更新两侧按钮的可用性（含 1px 容差，避免亚像素误差）。
+   *  测量合并进下一帧统一执行：scroll 事件每帧可触发多次，事件回调里直接读
+   *  scrollLeft/clientWidth 会强制同步布局；发现页一屏多个横滚行叠加起来，
+   *  滑动时的布局抖动很可感。rAF 内读取则每帧至多量一次、且在布局干净时执行 */
   const updateEdges = useCallback(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    setCanLeft(el.scrollLeft > 1);
-    setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    if (edgeFrame.current) return;
+    edgeFrame.current = window.requestAnimationFrame(() => {
+      edgeFrame.current = 0;
+      const el = scrollerRef.current;
+      if (!el) return;
+      setCanLeft(el.scrollLeft > 1);
+      setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    });
   }, []);
 
   // 无依赖数组：子项异步加载（如媒体库列表）后内容宽度会变，每次渲染后都重量
   // 一次最省心；两个 state 未变时 React 自行短路，不会引起额外渲染
   useEffect(updateEdges);
 
-  // 视口尺寸变化会改变可视宽度，跟着重算
+  // 视口尺寸变化会改变可视宽度，跟着重算；卸载时取消未执行的测量帧
   useEffect(() => {
     window.addEventListener("resize", updateEdges);
-    return () => window.removeEventListener("resize", updateEdges);
+    return () => {
+      window.removeEventListener("resize", updateEdges);
+      window.cancelAnimationFrame(edgeFrame.current);
+    };
   }, [updateEdges]);
 
   const page = (dir: -1 | 1) => {

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
@@ -58,6 +58,8 @@ import { listSubscriptions, type Subscription } from "@/lib/api/subscriptions";
 import { formatBytes } from "@/lib/format";
 import { formatRelativeTime } from "@/lib/time";
 import { cachedImageUrl, imageUrl } from "@/lib/image-proxy";
+import { keepIfEqual, reconcileList } from "@/lib/poll-reconcile";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 import {
   subscriptionProgressNote,
   subscriptionStatusMeta,
@@ -119,13 +121,16 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
       .then(([libs, libraryItems, unknown, reviewGroups, ignoredGroups, missingItems, subs]) => {
         if (seq !== reloadSeq.current) return;
         setFailed(false);
-        setLibraries(libs);
-        setItems(libraryItems);
-        setUnidentified(unknown);
-        setReview(reviewGroups);
-        setIgnored(ignoredGroups);
-        setMissing(missingItems);
-        setSubscriptions(subs);
+        // 轮询快照内容没变时复用旧引用：库存墙逐条目复用（配合 InventoryCell
+        // 的 memo，只有真正变化的格子重渲染），其余列表整体复用。否则扫描期间
+        // 每 3 秒就把几百个格子全部重画一遍，表现为周期性卡顿
+        setLibraries((prev) => (prev ? keepIfEqual(prev, libs) : libs));
+        setItems((prev) => reconcileList(prev, libraryItems, (i) => i.media_item_id));
+        setUnidentified((prev) => keepIfEqual(prev, unknown));
+        setReview((prev) => keepIfEqual(prev, reviewGroups));
+        setIgnored((prev) => keepIfEqual(prev, ignoredGroups));
+        setMissing((prev) => keepIfEqual(prev, missingItems));
+        setSubscriptions((prev) => keepIfEqual(prev, subs));
         // 整库刷新可能是别处（首页卡片/其他设备）发起的：库列表响应里带着
         // 状态，据此补种进度面板——否则只有挂载时那一次探测，之后发起的
         // 刷新这个页面永远看不见。已有进行中的状态时不覆盖（专用轮询更新鲜）
@@ -154,21 +159,21 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   // 2 秒是"阶段文字跟得上"与"别把接口打太密"的折中：单部片的一个阶段
   // 常在数秒内走完，轮询再慢就只能看到最后一个阶段
   const refreshingMeta = Boolean(metaRefresh?.refreshing);
-  useEffect(() => {
-    if (!refreshingMeta) return;
-    const timer = setInterval(() => {
+  useVisiblePolling(
+    () => {
       getMetadataRefreshProgress(libraryId)
         .then((p) => {
-          setMetaRefresh(p);
+          // 阶段没推进时复用旧引用，别让 2 秒一次的轮询白白重渲染页面
+          setMetaRefresh((prev) => keepIfEqual(prev, p));
           if (!p.refreshing) reload();
         })
         // 瞬时失败保留旧状态、下一轮继续：这里一旦清空，refreshingMeta 变
         // false 会把本轮询连根停掉，后台还在跑的刷新从此在界面上失踪
         // （曾是线上实况）。刷新真结束时成功响应会带 refreshing=false 收尾
         .catch(() => {});
-    }, 2000);
-    return () => clearInterval(timer);
-  }, [refreshingMeta, libraryId, reload]);
+    },
+    refreshingMeta ? 2000 : null,
+  );
 
   const library = libraries?.find((l) => l.id === libraryId) ?? null;
   usePageTitle(library?.name);
@@ -190,15 +195,13 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
     const timer = setTimeout(() => setRecentlyBusy(false), 12_000);
     return () => clearTimeout(timer);
   }, [busy, recentlyBusy]);
-  useEffect(() => {
-    // 忙时快轮询；有文件入库中 / 元数据刷新中中速跟进（刷新会边跑边换海报，
-    // 让墙上的图逐步更新）；空闲低频兜底——后台自发的扫描（实时监控/定时
-    // 对账）页面开着不动也能感知到
-    const interval =
-      busy || recentlyBusy ? 3000 : importing > 0 || refreshingMeta ? 10_000 : 30_000;
-    const timer = setInterval(reload, interval);
-    return () => clearInterval(timer);
-  }, [busy, recentlyBusy, importing, refreshingMeta, reload]);
+  // 忙时快轮询；有文件入库中 / 元数据刷新中中速跟进（刷新会边跑边换海报，
+  // 让墙上的图逐步更新）；空闲低频兜底——后台自发的扫描（实时监控/定时
+  // 对账）页面开着不动也能感知到。页面隐藏时暂停、恢复可见立即补一次
+  useVisiblePolling(
+    reload,
+    busy || recentlyBusy ? 3000 : importing > 0 || refreshingMeta ? 10_000 : 30_000,
+  );
 
   // 待识别的文件总数（清单按条目目录分组，一组可能是一部剧的几十集）
   const unidentifiedFiles = unidentified.reduce((n, g) => n + g.file_count, 0);
@@ -723,8 +726,12 @@ function MetadataRefreshPanel({
 }
 
 /** 库存格：真实拥有的作品。点击进**媒体库条目详情**（本地刮削信息 +
- *  片源规格 + 条目操作），不再复用发现页的 TMDB 详情；格下标注库存概况。 */
-function InventoryCell({
+ *  片源规格 + 条目操作），不再复用发现页的 TMDB 详情；格下标注库存概况。
+ *
+ *  memo 化 + reload 的逐条目引用复用（见 lib/poll-reconcile.ts）：轮询快照
+ *  里没变化的条目沿用旧对象，这里比对通过就整格跳过——大库轮询时只有真正
+ *  变化的格子会重渲染。 */
+const InventoryCell = memo(function InventoryCell({
   item,
   libraryId,
   workingLabel,
@@ -761,7 +768,9 @@ function InventoryCell({
   if (dead) parts.splice(0, parts.length, "文件已全部缺失");
   else if (item.missing_count > 0) parts.push(`${item.missing_count} 个文件缺失`);
   return (
-    <div>
+    // content-visibility：视口外的格子跳过布局与绘制，大库海报墙的滚动/更新
+    // 成本只与可见格数相关；intrinsic-size 占住尺寸，滚动条不跳
+    <div className="[contain-intrinsic-size:auto_270px] [content-visibility:auto]">
       {/* 后台正在处理的那一格自己点亮：进度面板/胶囊列的是总数或片名，
           海报墙上也要能一眼看到"正在弄这部"，否则用户得在两处之间对片名 */}
       <div className="relative">
@@ -775,7 +784,8 @@ function InventoryCell({
         {workingLabel && (
           <>
             <span className="pointer-events-none absolute inset-0 rounded-xl ring-2 ring-[#7dd3fc] ring-offset-0" />
-            <span className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center gap-1.5 rounded-b-xl bg-[rgba(7,12,20,0.82)] px-2 py-1.5 text-[10.5px] font-medium text-[#7dd3fc] backdrop-blur-sm">
+            {/* 不用 backdrop-blur：海报墙每格一个模糊合成层会放大滚动时的 GPU 压力，底色加实即可 */}
+            <span className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center gap-1.5 rounded-b-xl bg-[rgba(7,12,20,0.92)] px-2 py-1.5 text-[10.5px] font-medium text-[#7dd3fc]">
               <span className="size-2.5 shrink-0 animate-spin rounded-full border-[1.5px] border-[#7dd3fc]/30 border-t-[#7dd3fc]" />
               <span className="truncate">{workingLabel}</span>
             </span>
@@ -794,7 +804,7 @@ function InventoryCell({
       )}
     </div>
   );
-}
+});
 
 /** 追踪中格：订阅状态行沿用订阅页语言，点击进订阅详情。 */
 function PendingCell({ sub }: { sub: Subscription }) {
@@ -1503,6 +1513,8 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
         <img
           src={cachedImageUrl(info.poster_url)}
           alt=""
+          loading="lazy"
+          decoding="async"
           className="h-[54px] w-9 shrink-0 rounded-md object-cover"
         />
       ) : (
@@ -1700,6 +1712,8 @@ function ClaimConfirmPanel({
           <img
             src={posterUrl}
             alt={title}
+            loading="lazy"
+            decoding="async"
             className="h-[104px] w-[70px] shrink-0 rounded-lg bg-white/[0.05] object-cover"
           />
         ) : (
@@ -1874,9 +1888,11 @@ function ClaimSearchPanel({
                 className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition hover:bg-white/[0.06]"
               >
                 {it.posterUrl ? (
-                          <img
+                  <img
                     src={it.posterUrl}
                     alt={it.title}
+                    loading="lazy"
+                    decoding="async"
                     className="h-12 w-8 shrink-0 rounded bg-white/[0.05] object-cover"
                   />
                 ) : (

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -45,6 +45,7 @@ import { resolveRequestUrl } from "@/lib/http";
 import { cachedImageUrl } from "@/lib/image-proxy";
 import { formatRelativeTime } from "@/lib/time";
 import { usePageTitle } from "@/lib/use-page-title";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 
 /**
  * 媒体库条目详情页（/library/[id]/item/[mediaItemId]）——与发现页详情
@@ -122,15 +123,14 @@ export function LibraryItemDetailView({
   // **无论刷新是从这个页面发起的、还是别处发起后你才打开这一页**，都会
   // 看到"正在刷新"并在结束时自动呈现新档案/新图；离开页面也不影响后台跑完
   const scrapingNow = Boolean(detail?.scraping) || kicking;
-  useEffect(() => {
-    if (!detail?.scraping) return;
-    const timer = setInterval(() => {
+  useVisiblePolling(
+    () => {
       getLibraryItemDetail(libraryId, mediaItemId)
         .then(setDetail)
         .catch(() => {});
-    }, 2000);
-    return () => clearInterval(timer);
-  }, [detail?.scraping, libraryId, mediaItemId]);
+    },
+    detail?.scraping ? 2000 : null,
+  );
 
   // 介质规格的静默补拉：后端把 ffprobe 补探挪到了响应之后的后台任务
   // （网络挂载上探测是秒级/文件，不能拖首屏），"尚未探测"的文件在页面

--- a/apps/web/components/library-organize-dialog.tsx
+++ b/apps/web/components/library-organize-dialog.tsx
@@ -14,6 +14,7 @@ import {
   startLibraryOrganize,
 } from "@/lib/api/libraries";
 import { formatBytes } from "@/lib/format";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 
 /**
  * 整理文件名对话框：预览 → 确认 → 执行 → 结果，四段式流程。
@@ -92,10 +93,10 @@ export function LibraryOrganizeDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [libraryId]);
 
-  // 执行中轮询单库详情：画进度，结束后取整理结论进结果页
-  useEffect(() => {
-    if (phase !== "running" || libraryId === null) return;
-    const timer = setInterval(() => {
+  // 执行中轮询单库详情：画进度，结束后取整理结论进结果页（页面隐藏时暂停）
+  useVisiblePolling(
+    () => {
+      if (libraryId === null) return;
       void getLibrary(libraryId)
         .then((lib) => {
           if (lib.organizing) {
@@ -113,9 +114,9 @@ export function LibraryOrganizeDialog({
           // 两个凭据都没有：任务还没起跑，继续等下一轮
         })
         .catch(() => {});
-    }, 1500);
-    return () => clearInterval(timer);
-  }, [phase, libraryId, onChanged]);
+    },
+    phase === "running" && libraryId !== null ? 1500 : null,
+  );
 
   // 预览按条目分组：同一部作品的文件放在一起看，比平铺清单好核对得多
   const groups = useMemo(() => {

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -35,6 +35,7 @@ import type { Subscription } from "@/lib/api/subscriptions";
 import { formatBytes } from "@/lib/format";
 import { imageUrl } from "@/lib/image-proxy";
 import type { MediaItem, MediaType } from "@/lib/media-types";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 
 /** 库类型 → 展示名与图标 */
 export const LIBRARY_KIND_META: Record<MediaType, { label: string; Icon: typeof FilmIcon }> = {
@@ -201,13 +202,20 @@ export function LibraryView() {
   // 轮询乱序守卫：扫描期间后端响应时间抖动大，上一轮的慢响应可能晚于
   // 下一轮到达，不作废就会用旧快照覆盖新状态（进度回跳、卡片状态闪烁）
   const reloadSeq = useRef(0);
+  // 上一轮已拉过条目时的库列表快照：库状态（扫描/整理/入账数/刷新进度）
+  // 没有任何变化，说明库存也不会变，封面拼图不必再逐库全量拉一遍条目
+  // ——否则空闲时每 30 秒也要打出 1 + N 个请求
+  const lastLibsSnapshot = useRef<string | null>(null);
   const reload = useCallback(() => {
     const seq = ++reloadSeq.current;
     listLibraries()
       .then(async (libs) => {
         if (seq !== reloadSeq.current) return;
         setFailed(false);
-        setLibraries(libs);
+        const snapshot = JSON.stringify(libs);
+        // 内容没变就复用旧引用，跳过整页卡片的无谓重渲染
+        setLibraries((prev) => (prev && JSON.stringify(prev) === snapshot ? prev : libs));
+        if (snapshot === lastLibsSnapshot.current) return;
         // 封面拼图需要各库的条目海报；库的数量级很小，并发拉取即可
         const entries = await Promise.all(
           libs.map(
@@ -215,6 +223,7 @@ export function LibraryView() {
           ),
         );
         if (seq !== reloadSeq.current) return;
+        lastLibsSnapshot.current = snapshot;
         setItemsByLibrary(new Map(entries));
       })
       // 瞬时失败不清已有数据：failed 只决定提示条，卡片继续用上一份快照，
@@ -253,12 +262,11 @@ export function LibraryView() {
     const timer = setTimeout(() => setRecentlyBusy(false), 12_000);
     return () => clearTimeout(timer);
   }, [busyAny, recentlyBusy]);
-  useEffect(() => {
-    const interval =
-      busyAny || recentlyBusy ? 3000 : refreshingAny ? 5000 : importingAny ? 10_000 : 30_000;
-    const timer = setInterval(reload, interval);
-    return () => clearInterval(timer);
-  }, [busyAny, recentlyBusy, refreshingAny, importingAny, reload]);
+  // 页面隐藏时暂停轮询、恢复可见立即补一次（useVisiblePolling）
+  useVisiblePolling(
+    reload,
+    busyAny || recentlyBusy ? 3000 : refreshingAny ? 5000 : importingAny ? 10_000 : 30_000,
+  );
 
   // 新建的库进入列表后滚进视野（依赖 libraries：创建到列表刷新之间隔着
   // 一次请求，元素这时才存在），高亮 2.5 秒后自行褪去
@@ -747,12 +755,13 @@ function LibraryCardMenu({
     if (!open) return;
     const close = () => setMenuPos(null);
     document.addEventListener("mousedown", close);
-    document.addEventListener("scroll", close, true);
+    // passive：只做关闭动作、不会 preventDefault，别让浏览器为它放弃滚动快路径
+    document.addEventListener("scroll", close, { capture: true, passive: true });
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && close();
     document.addEventListener("keydown", onKey);
     return () => {
       document.removeEventListener("mousedown", close);
-      document.removeEventListener("scroll", close, true);
+      document.removeEventListener("scroll", close, { capture: true });
       document.removeEventListener("keydown", onKey);
     };
   }, [open]);

--- a/apps/web/components/llm-config-section.tsx
+++ b/apps/web/components/llm-config-section.tsx
@@ -17,6 +17,7 @@ import {
   saveLlmProvider,
 } from "@/lib/api/llm";
 import { formatRelativeTime } from "@/lib/time";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 
 /** 连接状态 → 展示文案与颜色（与站点/下载器配置同语言） */
 const STATUS_META: Record<LlmProviderStatus, { label: string; color: string }> = {
@@ -64,19 +65,18 @@ export function LlmConfigSection() {
       .catch((e) => setError((e as Error).message));
   }, [load]);
 
-  // 处于 pending/verifying 时轮询刷新，直到落定
+  // 处于 pending/verifying 时轮询刷新，直到落定（页面隐藏时暂停）
   const inProgress = config != null && IN_PROGRESS.includes(config.status);
-  useEffect(() => {
-    if (!inProgress) return;
-    const timer = setInterval(() => {
+  useVisiblePolling(
+    () => {
       void getLlmProvider()
         .then(setConfig)
         .catch(() => {
           /* 轮询失败静默重试，不打断页面 */
         });
-    }, 2000);
-    return () => clearInterval(timer);
-  }, [inProgress]);
+    },
+    inProgress ? 2000 : null,
+  );
 
   async function guard(fn: () => Promise<void>) {
     setBusy(true);

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -457,19 +457,28 @@ function PhotoWall({
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [canLeft, setCanLeft] = useState(false);
   const [canRight, setCanRight] = useState(false);
+  const edgeFrame = useRef(0);
 
-  /** 与 MediaRow 同款的边缘检测：到达两端时隐藏对应方向的翻页钮 */
+  /** 与 HScroller 同款的边缘检测：到达两端时隐藏对应方向的翻页钮。
+   *  测量合并进 rAF：scroll 回调里直接读布局会强制同步布局（见 h-scroller.tsx） */
   const updateEdges = useCallback(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    setCanLeft(el.scrollLeft > 1);
-    setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    if (edgeFrame.current) return;
+    edgeFrame.current = window.requestAnimationFrame(() => {
+      edgeFrame.current = 0;
+      const el = scrollerRef.current;
+      if (!el) return;
+      setCanLeft(el.scrollLeft > 1);
+      setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    });
   }, []);
 
   useEffect(() => {
     updateEdges();
     window.addEventListener("resize", updateEdges);
-    return () => window.removeEventListener("resize", updateEdges);
+    return () => {
+      window.removeEventListener("resize", updateEdges);
+      window.cancelAnimationFrame(edgeFrame.current);
+    };
   }, [updateEdges, activeId]);
 
   const page = (dir: -1 | 1) => {

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -222,15 +222,17 @@ function PosterCardContent({
             className="absolute inset-0 size-full transition-transform duration-500 ease-out group-hover/card:scale-[1.06]"
           />
 
-          {/* 左上：资源最高清晰度徽章（无资源信息时不渲染） */}
+          {/* 左上：资源最高清晰度徽章（无资源信息时不渲染）。
+              徽章不用 backdrop-blur：海报墙每张卡 2~3 个模糊合成层会显著放大
+              滚动时的 GPU 压力（几百张卡叠加），加实底色观感几乎无差 */}
           {badges[0] && (
-            <span className="absolute left-2 top-2 rounded-md bg-black/55 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-[var(--accent)] backdrop-blur-sm">
+            <span className="absolute left-2 top-2 rounded-md bg-black/70 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-[var(--accent)]">
               {badges[0]}
             </span>
           )}
           {/* 右上：评分徽章（暂无评分时不渲染，避免展示 0.0） */}
           {item.rating > 0 && (
-            <span className="tnum absolute right-2 top-2 flex items-center gap-1 rounded-md bg-black/55 px-1.5 py-0.5 text-[11px] font-semibold text-white backdrop-blur-sm">
+            <span className="tnum absolute right-2 top-2 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-[11px] font-semibold text-white">
               <StarIcon className="size-3 text-[#f5c451]" />
               {item.rating.toFixed(1)}
             </span>
@@ -306,7 +308,7 @@ function PosterCardActionButton({
   if (!subscribeMeta) {
     // 已入库标识：非交互，与库存格下方的绿点语言一致。
     return (
-      <span className="flex h-7 items-center gap-1.5 rounded-full bg-white/[0.14] px-3 text-[11px] font-semibold text-white/90 backdrop-blur-sm">
+      <span className="flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-[11px] font-semibold text-white/90">
         <span className="size-1.5 rounded-full bg-[#4ade80]" />
         已入库
       </span>
@@ -341,7 +343,7 @@ function PosterCardActionButton({
       }}
       className={
         existingSub
-          ? "flex h-7 items-center gap-1.5 rounded-full bg-white/[0.14] px-3 text-[11px] font-semibold text-white/90 backdrop-blur-sm transition-colors hover:bg-white/[0.22]"
+          ? "flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-[11px] font-semibold text-white/90 transition-colors hover:bg-white/[0.26]"
           : "btn-accent flex h-7 items-center gap-1 rounded-full px-3 text-[11px] font-semibold"
       }
     >

--- a/apps/web/components/poster-image.tsx
+++ b/apps/web/components/poster-image.tsx
@@ -45,6 +45,7 @@ export function PosterImage({
       src={src}
       alt={alt}
       loading="lazy"
+      decoding="async"
       referrerPolicy="no-referrer"
       onError={() => setBroken(true)}
       className={`bg-[#141824] object-cover ${className}`}

--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import { ImageLightbox } from "@/components/image-lightbox";
 import { LayersIcon, ListIcon, PhotoIcon } from "@/components/icons";
@@ -413,9 +413,17 @@ function collectFacetMaps(items: TorrentHit[], filters: Filters | null): FacetMa
     // only 非空 = 这条结果只挂在该维度上，仅计入它；全通过时保持 null（计入所有维度）
     let only: FilterDim | null = null;
     if (filters) {
-      const failed = FILTER_DIMENSIONS.filter((d) => !d.pass(hit, filters));
-      if (failed.length > 1) continue;
-      if (failed.length === 1) only = failed[0].dim;
+      // 手写循环而非 filter()：这里在每条结果上执行，千条结果 × 每批流式
+      // 重算,避免每条都分配一个临时数组;失败超过 1 个维度即可提前退出
+      let failedCount = 0;
+      for (const d of FILTER_DIMENSIONS) {
+        if (d.pass(hit, filters)) continue;
+        failedCount += 1;
+        if (failedCount > 1) break;
+        only = d.dim;
+      }
+      if (failedCount > 1) continue;
+      if (failedCount === 0) only = null;
     }
     const want = (dim: FilterDim) => only === null || only === dim;
 
@@ -664,14 +672,16 @@ export function SearchResults({ query, onResearch }: SearchResultsProps) {
   );
   const sorted = useMemo(() => {
     const dir = sort.dir === "asc" ? 1 : -1;
-    return [...filtered].sort((x, y) => {
-      const vx = sortVector(x, sort.key);
-      const vy = sortVector(y, sort.key);
-      for (let i = 0; i < vx.length; i++) {
-        if (vx[i] !== vy[i]) return (vx[i] - vy[i]) * dir;
+    // 先逐条算好排序向量再排序：比较函数里现算会在 N·logN 次比较中反复
+    // 分配数组（千条结果约数万次），流式进结果期间每批都要全量重排，很可感
+    const decorated = filtered.map((hit) => ({ hit, vector: sortVector(hit, sort.key) }));
+    decorated.sort((x, y) => {
+      for (let i = 0; i < x.vector.length; i++) {
+        if (x.vector[i] !== y.vector[i]) return (x.vector[i] - y.vector[i]) * dir;
       }
       return 0;
     });
+    return decorated.map((d) => d.hit);
   }, [filtered, sort]);
 
   // 智能排序键的动态注入：按全量结果（而非筛选后）的类型构成决定——
@@ -923,23 +933,27 @@ function GroupedResults({
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
   const [uncapped, setUncapped] = useState<Set<string>>(() => new Set());
 
-  const buckets: { key: string; rows: TorrentHit[] }[] = [];
-  const indexOf = new Map<string, number>();
-  for (const hit of hits) {
-    const key = entityKeyOf(hit);
-    const i = indexOf.get(key);
-    if (i === undefined) {
-      indexOf.set(key, buckets.length);
-      buckets.push({ key, rows: [hit] });
-    } else {
-      buckets[i].rows.push(hit);
+  // 分桶按 hits 缓存：折叠/展开等本地状态变化不必重新遍历全量结果
+  const buckets = useMemo(() => {
+    const buckets: { key: string; rows: TorrentHit[] }[] = [];
+    const indexOf = new Map<string, number>();
+    for (const hit of hits) {
+      const key = entityKeyOf(hit);
+      const i = indexOf.get(key);
+      if (i === undefined) {
+        indexOf.set(key, buckets.length);
+        buckets.push({ key, rows: [hit] });
+      } else {
+        buckets[i].rows.push(hit);
+      }
     }
-  }
-  const unparsedAt = indexOf.get(ENTITY_UNPARSED);
-  if (unparsedAt !== undefined && unparsedAt !== buckets.length - 1) {
-    const [u] = buckets.splice(unparsedAt, 1);
-    buckets.push(u);
-  }
+    const unparsedAt = indexOf.get(ENTITY_UNPARSED);
+    if (unparsedAt !== undefined && unparsedAt !== buckets.length - 1) {
+      const [u] = buckets.splice(unparsedAt, 1);
+      buckets.push(u);
+    }
+    return buckets;
+  }, [hits]);
 
   return (
     <div className="space-y-4">
@@ -1786,8 +1800,13 @@ function SiteStatusSummary({
  * 全部结果都无海报时不渲染空网格，整页自然退化为普通列表。
  */
 function PosterResults({ hits }: { hits: TorrentHit[] }) {
-  const withPoster = hits.filter((h) => h.poster_url);
-  const withoutPoster = hits.filter((h) => !h.poster_url);
+  // 流式期间每批结果都重渲染本组件，分桶结果按 hits 缓存
+  const { withPoster, withoutPoster } = useMemo(() => {
+    const withPoster: TorrentHit[] = [];
+    const withoutPoster: TorrentHit[] = [];
+    for (const h of hits) (h.poster_url ? withPoster : withoutPoster).push(h);
+    return { withPoster, withoutPoster };
+  }, [hits]);
   return (
     <div className="space-y-5">
       {withPoster.length > 0 && (
@@ -1826,8 +1845,9 @@ function PosterResults({ hits }: { hits: TorrentHit[] }) {
 /**
  * 海报卡片左上角的促销徽标（免费 / 折扣 / 双倍上传 / H&R）。
  *
- * 与列表模式的 PromoBadges 同一判断口径，但样式为海报适配：用较实的底色 +
- * backdrop-blur，保证叠在明亮海报上依然清晰；免费最醒目（实绿底深字），
+ * 与列表模式的 PromoBadges 同一判断口径，但样式为海报适配：用较实的底色
+ * 保证叠在明亮海报上依然清晰（不用 backdrop-blur——海报墙每张卡多个模糊
+ * 合成层会放大滚动 GPU 压力）；免费最醒目（实绿底深字），
  * 因为「是否免费」是海报模式下用户最关心的下载决策依据。
  */
 function posterPromoBadges(hit: TorrentHit): { text: string; cls: string }[] {
@@ -1857,7 +1877,8 @@ function posterPromoBadges(hit: TorrentHit): { text: string; cls: string }[] {
   return badges;
 }
 
-function TorrentPosterCard({ hit }: { hit: TorrentHit }) {
+// memo：与 TorrentRow 同理，流式进结果时已有卡片的 hit 引用不变，整卡跳过
+const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: TorrentHit }) {
   const [viewerOpen, setViewerOpen] = useState(false);
   const size = hit.size ?? formatBytes(hit.size_bytes);
   const name = parsedName(hit);
@@ -1903,7 +1924,7 @@ function TorrentPosterCard({ hit }: { hit: TorrentHit }) {
             {posterPromoBadges(hit).map((b) => (
               <span
                 key={b.text}
-                className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold backdrop-blur-sm ${b.cls}`}
+                className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold ${b.cls}`}
               >
                 {b.text}
               </span>
@@ -1912,7 +1933,7 @@ function TorrentPosterCard({ hit }: { hit: TorrentHit }) {
           {/* 张数常显（含 1 张）：点开前就知道里面有几张图，只有一张时不必特意点开 */}
           <span
             title={`共 ${gallery.length} 张图片，点击卡片浏览`}
-            className="tnum flex shrink-0 items-center gap-1 rounded-md bg-black/55 px-1.5 py-0.5 text-[10px] font-medium text-white/85 backdrop-blur-sm"
+            className="tnum flex shrink-0 items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-[10px] font-medium text-white/85"
           >
             <PhotoIcon className="size-3" />
             {gallery.length}
@@ -1977,7 +1998,7 @@ function TorrentPosterCard({ hit }: { hit: TorrentHit }) {
       )}
     </li>
   );
-}
+});
 
 /* —— 单条种子 —— */
 
@@ -2100,8 +2121,11 @@ function specSummary(attrs: TorrentAttrs): string | null {
  * 体积/做种/完成/时间锁定在固定宽度的 2×2 网格里右对齐，跨行位置完全一致——
  * 眼睛沿一条垂直线扫下来即可完成全列表对比（Kayak/qBittorrent 式扫描列），
  * 不再混在自由流动的 meta 文本里逐行找数字。
+ *
+ * memo 化：流式搜索每批新结果都会重渲染整个列表，已有行的 hit 引用不变，
+ * 比对通过即整行跳过——上千行时这是流式期间卡顿与否的分界。
  */
-function TorrentRow({
+const TorrentRow = memo(function TorrentRow({
   hit,
   grouped = false,
   showRawTitles = false,
@@ -2118,7 +2142,11 @@ function TorrentRow({
   const asSpecRow = grouped && name !== null;
   const spec = asSpecRow && hit.attrs ? specSummary(hit.attrs) : null;
   return (
-    <li className="group relative rounded-2xl border border-white/[0.06] bg-[rgba(14,16,22,0.42)] px-4 py-3.5 backdrop-blur-xl transition-all hover:-translate-y-px hover:border-white/[0.13] hover:bg-[rgba(20,23,31,0.58)] hover:shadow-[0_12px_30px_-18px_rgba(0,0,0,0.8)]">
+    // 行底不用 backdrop-filter：结果动辄上千行，每行一个独立的实时模糊合成层，
+    // 滚动时 GPU 要逐层重采样背后内容，是搜索页掉帧的主因；页面蒙版本就压暗了
+    // 背景，行底改用更实的半透明底色，观感几乎一致。content-visibility 让
+    // 视口外的行跳过布局与绘制，长列表滚动/更新只付可见行的成本。
+    <li className="group relative rounded-2xl border border-white/[0.06] bg-[rgba(16,18,25,0.82)] px-4 py-3.5 transition-all [contain-intrinsic-size:auto_72px] [content-visibility:auto] hover:-translate-y-px hover:border-white/[0.13] hover:bg-[rgba(22,25,33,0.9)] hover:shadow-[0_12px_30px_-18px_rgba(0,0,0,0.8)]">
       <div className="flex items-center gap-5">
         {/* 标题优先，来源和属性下沉为辅助信息，避免徽标抢走首屏注意力。 */}
         <div className="min-w-0 flex-1">
@@ -2211,7 +2239,7 @@ function TorrentRow({
       </div>
     </li>
   );
-}
+});
 
 /** 列表指标单元：固定标签 + 数值的两级层次，让密集数字仍然可快速扫读。 */
 function Metric({

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -566,6 +566,8 @@ function BackdropGroup() {
             <img
               src={backdrop}
               alt="当前首页背景预览"
+              loading="lazy"
+              decoding="async"
               className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.03]"
             />
             {/* 底部信息渐变 + 当前背景名 */}
@@ -909,7 +911,13 @@ function BackdropTile({
             : "cursor-pointer border-white/[0.14] group-hover/tile:border-white/[0.35]"
         }`}
       >
-        <img src={src} alt={`${label}背景缩略图`} className="h-full w-full object-cover" />
+        <img
+          src={src}
+          alt={`${label}背景缩略图`}
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover"
+        />
         {active && (
           <span className="absolute right-1.5 top-1.5 flex size-[18px] items-center justify-center rounded-full bg-[var(--accent-strong)] text-[#141821] shadow">
             <CheckIcon className="size-3" />

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -329,11 +329,12 @@ function RunRow({
     };
     document.addEventListener("mousedown", onPointer);
     document.addEventListener("keydown", onKey);
-    document.addEventListener("scroll", close, true);
+    // passive：只做关闭动作、不会 preventDefault，别让浏览器为它放弃滚动快路径
+    document.addEventListener("scroll", close, { capture: true, passive: true });
     return () => {
       document.removeEventListener("mousedown", onPointer);
       document.removeEventListener("keydown", onKey);
-      document.removeEventListener("scroll", close, true);
+      document.removeEventListener("scroll", close, { capture: true });
     };
   }, [open]);
 

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/api/sites";
 import { formatBytes, formatCompact, formatDuration, formatRatio } from "@/lib/format";
 import { formatDateTime, formatRelativeTime } from "@/lib/time";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
 import { LiquidGlassButton, LiquidGlassInput } from "@/vendor/liquid-glass";
 
 /** 站点验证状态 → 展示文案与颜色 */
@@ -135,19 +136,18 @@ export function SiteConfigSection() {
     void load();
   }, [load]);
 
-  // 有站点处于 pending/verifying 时轮询刷新，直到全部落定
+  // 有站点处于 pending/verifying 时轮询刷新，直到全部落定（页面隐藏时暂停）
   const hasInProgress = configured.some((s) => IN_PROGRESS.includes(s.status));
-  useEffect(() => {
-    if (!hasInProgress) return;
-    const timer = setInterval(() => {
+  useVisiblePolling(
+    () => {
       void listConfiguredSites()
         .then(setConfigured)
         .catch(() => {
           /* 轮询失败静默重试，不打断页面 */
         });
-    }, 2500);
-    return () => clearInterval(timer);
-  }, [hasInProgress]);
+    },
+    hasInProgress ? 2500 : null,
+  );
 
   // 原地替换已有站点、新站点追加到末尾。
   // 注意：切换启用开关等操作也会走这里，必须保持列表顺序不变，否则被操作的站点会跳位，体验割裂。

--- a/apps/web/components/subscribe-entry.tsx
+++ b/apps/web/components/subscribe-entry.tsx
@@ -51,27 +51,6 @@ export interface SubscriptionLookupKey {
   type?: MediaType;
 }
 
-/**
- * 按外部 ID 在订阅列表中匹配条目（详情页与海报卡片共用的同一判断口径）：
- *   - 豆瓣来源：按 douban_id 匹配（订阅从 TMDB 入口建立且未关联豆瓣 ID 时
- *     匹配不到，属已知限制——两边没有可靠的对齐键，不按标题猜）；
- *   - TMDB 来源：按 tmdb_id 匹配；电影和剧集的 TMDB ID 是两个独立号段，
- *     卡片带 type 时用它消歧，缺失时（历史快照数据）仅按 ID 匹配。
- */
-export function findSubscription(
-  subs: Subscription[],
-  key: SubscriptionLookupKey,
-): Subscription | undefined {
-  if ((key.source ?? "tmdb") === "douban") {
-    return subs.find((s) => s.media.douban_id === key.id);
-  }
-  return subs.find(
-    (s) =>
-      String(s.media.tmdb_id) === key.id &&
-      (key.type === undefined || s.media.kind === key.type),
-  );
-}
-
 const SubscribeEntryContext = createContext<SubscribeEntryValue | null>(null);
 
 export function useSubscribeEntry(): SubscribeEntryValue {
@@ -119,9 +98,37 @@ export function SubscribeEntryProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  // 查表索引：subscriptionOf 在海报墙的每张卡片渲染时都会被调用，线性查找
+  // 是 O(卡片数 × 订阅数)；列表变化时建一次索引，单次查询 O(1)，同键保留首条。
+  // 匹配口径（详情页与海报卡片共用）：
+  //   - 豆瓣来源：按 douban_id 匹配（订阅从 TMDB 入口建立且未关联豆瓣 ID 时
+  //     匹配不到，属已知限制——两边没有可靠的对齐键，不按标题猜）；
+  //   - TMDB 来源：按 tmdb_id 匹配；电影和剧集的 TMDB ID 是两个独立号段，
+  //     卡片带 type 时用它消歧，缺失时（历史快照数据）仅按 ID 匹配。
+  const subscriptionIndex = useMemo(() => {
+    const byDouban = new Map<string, Subscription>();
+    const byTmdbTyped = new Map<string, Subscription>();
+    const byTmdb = new Map<string, Subscription>();
+    for (const s of subs ?? []) {
+      if (s.media.douban_id && !byDouban.has(s.media.douban_id)) {
+        byDouban.set(s.media.douban_id, s);
+      }
+      const id = String(s.media.tmdb_id);
+      const typed = `${id}:${s.media.kind}`;
+      if (!byTmdbTyped.has(typed)) byTmdbTyped.set(typed, s);
+      if (!byTmdb.has(id)) byTmdb.set(id, s);
+    }
+    return { byDouban, byTmdbTyped, byTmdb };
+  }, [subs]);
+
   const subscriptionOf = useCallback(
-    (key: SubscriptionLookupKey) => findSubscription(subs ?? [], key),
-    [subs],
+    (key: SubscriptionLookupKey) => {
+      if ((key.source ?? "tmdb") === "douban") return subscriptionIndex.byDouban.get(key.id);
+      return key.type === undefined
+        ? subscriptionIndex.byTmdb.get(key.id)
+        : subscriptionIndex.byTmdbTyped.get(`${key.id}:${key.type}`);
+    },
+    [subscriptionIndex],
   );
 
   const value = useMemo(

--- a/apps/web/components/top250-view.tsx
+++ b/apps/web/components/top250-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 
 import { PageNav } from "@/components/page-nav";
 import { SearchIcon } from "@/components/icons";
@@ -48,8 +48,18 @@ export function Top250View() {
     return [...counts].sort((a, b) => b[1] - a[1]);
   }, [items]);
 
+  // 排名查表：渲染时用 items.indexOf 是每格 O(n) 的线性扫描，250 格一轮渲染
+  // 就是数万次比较；榜单加载后排名固定，建一次 Map 终身使用
+  const rankById = useMemo(
+    () => new Map((items ?? []).map((item, index) => [item.id, index + 1])),
+    [items],
+  );
+
+  // 搜索输入用延迟值参与过滤：连续敲字时先渲染输入框本身，网格的全量
+  // 过滤与重渲染放到浏览器空闲时批量跟上，输入不再一字一卡
+  const deferredQuery = useDeferredValue(query);
   const filtered = useMemo(() => {
-    const keyword = query.trim().toLocaleLowerCase();
+    const keyword = deferredQuery.trim().toLocaleLowerCase();
     if (!items) return [];
     return items.filter((item) => {
       // 同一筛选维度采用「或」逻辑：选择科幻 + 动画即显示任一类型命中的影片。
@@ -62,7 +72,7 @@ export function Top250View() {
         item.originalTitle.toLocaleLowerCase().includes(keyword);
       return matchesGenre && matchesKeyword;
     });
-  }, [items, query, selectedGenres]);
+  }, [items, deferredQuery, selectedGenres]);
 
   const hasMore = visibleCount < filtered.length;
 
@@ -197,7 +207,7 @@ export function Top250View() {
           ) : (
             <div className="grid grid-cols-2 gap-x-4 gap-y-7 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8">
               {filtered.slice(0, visibleCount).map((item) => {
-                const rank = items.indexOf(item) + 1;
+                const rank = rankById.get(item.id) ?? 0;
                 return (
                   <div key={item.id} className="relative min-w-0">
                     <RankBadge rank={rank} />

--- a/apps/web/lib/agent-conversations.tsx
+++ b/apps/web/lib/agent-conversations.tsx
@@ -408,10 +408,12 @@ export function AgentConversationsProvider({ children }: { children: React.React
         console.warn("加载 Agent 会话列表失败", error);
       });
     const activeControllers = controllers.current;
+    const activeFlushTimer = flushTimer;
     return () => {
       cancelled = true;
       for (const controller of activeControllers.values()) controller.abort();
       activeControllers.clear();
+      if (activeFlushTimer.current !== null) window.clearTimeout(activeFlushTimer.current);
     };
   }, []);
 
@@ -436,6 +438,64 @@ export function AgentConversationsProvider({ children }: { children: React.React
     [],
   );
 
+  /* —— SSE 事件的批量合并 ——
+   * 流式生成时 text_delta / thinking_delta 每秒可达几十次，逐个 setState 会让
+   * 所有 context 消费者（侧栏、会话页的整条时间线）以同样频率重渲染，生成一条
+   * 长回复就是数千次 React diff。这里按轮次缓冲事件、每 80ms 合并应用一次
+   * （视觉上仍是流畅的打字机效果）；终态事件（完成/出错/取消）立即冲刷，
+   * 状态切换不吃这 80ms 延迟。 */
+  const eventBuffers = useRef(
+    new Map<string, { conversationId: string; turnId: string; events: AgentEvent[] }>(),
+  );
+  const flushTimer = useRef<number | null>(null);
+
+  const flushEvents = useCallback(() => {
+    if (flushTimer.current !== null) {
+      window.clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    if (eventBuffers.current.size === 0) return;
+    const buffers = [...eventBuffers.current.values()];
+    eventBuffers.current.clear();
+    setConversations((previous) =>
+      previous.map((conversation) => {
+        const mine = buffers.filter((buffer) => buffer.conversationId === conversation.id);
+        if (mine.length === 0) return conversation;
+        let turns = conversation.turns;
+        for (const buffer of mine) {
+          turns = turns.map((turn) =>
+            turn.id === buffer.turnId ? buffer.events.reduce(applyAgentEvent, turn) : turn,
+          );
+        }
+        return {
+          ...conversation,
+          updatedAt: Date.now(),
+          running: turns.some((turn) => turn.status === "running"),
+          turns,
+        };
+      }),
+    );
+  }, []);
+
+  const enqueueEvent = useCallback(
+    (conversationId: string, turnId: string, event: AgentEvent) => {
+      const key = `${conversationId}:${turnId}`;
+      const buffer = eventBuffers.current.get(key) ?? { conversationId, turnId, events: [] };
+      buffer.events.push(event);
+      eventBuffers.current.set(key, buffer);
+      const terminal =
+        event.type === "agent_done" ||
+        event.type === "agent_error" ||
+        event.type === "agent_cancelled";
+      if (terminal) {
+        flushEvents();
+      } else if (flushTimer.current === null) {
+        flushTimer.current = window.setTimeout(flushEvents, 80);
+      }
+    },
+    [flushEvents],
+  );
+
   /** 连接一个已存在的后台运行；HTTP 错误才会结束，网络抖动由 API 层续传。 */
   const connectRun = useCallback(
     (conversationId: string, turnId: string, runId: string) => {
@@ -446,7 +506,7 @@ export function AgentConversationsProvider({ children }: { children: React.React
       void streamAgentRun(
         runId,
         (event) => {
-          updateTurn(conversationId, turnId, (turn) => applyAgentEvent(turn, event));
+          enqueueEvent(conversationId, turnId, event);
         },
         { signal: controller.signal },
       )
@@ -456,6 +516,8 @@ export function AgentConversationsProvider({ children }: { children: React.React
             error instanceof HttpError && error.status === 404
               ? "运行记录不存在或已过期，可能是服务已重启，请重新发起任务"
               : (error as Error).message;
+          // 先冲刷缓冲中的事件再落错误态，保证时间线不乱序
+          flushEvents();
           updateTurn(conversationId, turnId, (turn) => ({
             ...turn,
             status: "error",
@@ -468,7 +530,7 @@ export function AgentConversationsProvider({ children }: { children: React.React
           }
         });
     },
-    [updateTurn],
+    [enqueueEvent, flushEvents, updateTurn],
   );
 
   /** 打开会话：已加载则直接返回；否则拉详情回放，running 时重挂 SSE。

--- a/apps/web/lib/poll-reconcile.ts
+++ b/apps/web/lib/poll-reconcile.ts
@@ -1,0 +1,47 @@
+/**
+ * 轮询快照的引用复用工具。
+ *
+ * 背景：媒体库页面靠周期轮询保持新鲜（扫描时 3 秒一轮），每轮响应都是全新
+ * 反序列化的对象。即使内容一字未变，直接 setState 也会换掉引用，导致整面
+ * 海报墙（可能几百个格子）重新渲染一遍——这是轮询期间周期性卡顿的主因之一。
+ *
+ * 这里在写入 state 前与上一份快照做**内容比对**：
+ *   - 整体没变 → 返回旧引用，React 跳过本次更新；
+ *   - 部分变了 → 逐条复用没变的条目对象，配合列表项的 React.memo，
+ *     只有真正变化的格子会重新渲染。
+ *
+ * 比对用 JSON.stringify：轮询数据本就来自 JSON 反序列化（无函数/undefined/
+ * 循环引用），序列化比对是准确的；几百条媒体数据的开销在毫秒级，远小于
+ * 一次整墙 React 重渲染。
+ */
+
+/** 内容相等时返回旧引用（配合 setState 使用可跳过重渲染），否则返回新值。 */
+export function keepIfEqual<T>(prev: T, next: T): T {
+  if (prev === next) return next;
+  return JSON.stringify(prev) === JSON.stringify(next) ? prev : next;
+}
+
+/**
+ * 按主键逐条复用列表：内容没变的条目沿用旧对象引用；全部没变（含顺序）时
+ * 直接返回旧数组。用于大列表（海报墙），让 memo 化的格子逐条跳过渲染。
+ */
+export function reconcileList<T>(
+  prev: readonly T[],
+  next: T[],
+  keyOf: (item: T) => string | number,
+): T[] {
+  if ((prev as unknown) === (next as unknown)) return next;
+  const prevByKey = new Map<string | number, T>();
+  for (const item of prev) prevByKey.set(keyOf(item), item);
+  let unchanged = prev.length === next.length;
+  const merged = next.map((item, index) => {
+    const old = prevByKey.get(keyOf(item));
+    if (old !== undefined && JSON.stringify(old) === JSON.stringify(item)) {
+      if (prev[index] !== old) unchanged = false; // 内容同但位置变了（重新排序）
+      return old;
+    }
+    unchanged = false;
+    return item;
+  });
+  return unchanged ? (prev as T[]) : merged;
+}

--- a/apps/web/lib/use-media-query.ts
+++ b/apps/web/lib/use-media-query.ts
@@ -17,10 +17,26 @@ import { useCallback, useSyncExternalStore } from "react";
  * 用 useSyncExternalStore 而非 useEffect + useState：订阅外部数据源的标准做法，
  * 服务端快照恒为 false（按桌面渲染），客户端首帧即读到真实值，不会闪一帧错版式。
  */
+/**
+ * MediaQueryList 按查询串缓存：getSnapshot 在每次渲染（以及 React 校验 store
+ * 时）都会被调用，每次都 window.matchMedia() 会不停新建 MQL 对象——海报墙
+ * 里几百张卡片同时用 useMediaQuery 时尤其浪费。同一查询串全站共享一个实例。
+ */
+const mqlCache = new Map<string, MediaQueryList>();
+
+function mediaQueryList(query: string): MediaQueryList {
+  let mql = mqlCache.get(query);
+  if (!mql) {
+    mql = window.matchMedia(query);
+    mqlCache.set(query, mql);
+  }
+  return mql;
+}
+
 export function useMediaQuery(query: string): boolean {
   const subscribe = useCallback(
     (onChange: () => void) => {
-      const mql = window.matchMedia(query);
+      const mql = mediaQueryList(query);
       mql.addEventListener("change", onChange);
       return () => mql.removeEventListener("change", onChange);
     },
@@ -28,7 +44,7 @@ export function useMediaQuery(query: string): boolean {
   );
   return useSyncExternalStore(
     subscribe,
-    () => window.matchMedia(query).matches,
+    () => mediaQueryList(query).matches,
     () => false, // SSR：按桌面渲染
   );
 }

--- a/apps/web/lib/use-visible-polling.ts
+++ b/apps/web/lib/use-visible-polling.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * 页面可见时才执行的周期轮询（system-logs-section 的写法抽成通用 hook）。
+ *
+ * 全站各处的状态轮询（下载器/LLM/站点验证、扫描进度、媒体库刷新等）此前
+ * 都是裸 setInterval：标签页切到后台仍按原频率发请求 + 重渲染组件树，
+ * 既费电费流量，也让后端白白挨打。这里统一为：
+ *   - 页面隐藏时跳过本 tick（定时器保留，省去重建逻辑）；
+ *   - 重新可见时立即补一次，不让用户干等下个周期。
+ *
+ * @param callback 轮询体；引用变化不重建定时器（内部走 ref）
+ * @param intervalMs 轮询间隔；null/0 表示停止轮询
+ * @param leading 挂载（或 intervalMs 变化）时是否立即先执行一次，默认 false
+ */
+export function useVisiblePolling(
+  callback: () => void,
+  intervalMs: number | null,
+  { leading = false }: { leading?: boolean } = {},
+) {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    if (!intervalMs) return;
+    const tick = () => {
+      if (!document.hidden) callbackRef.current();
+    };
+    if (leading) tick();
+    const timer = setInterval(tick, intervalMs);
+    document.addEventListener("visibilitychange", tick);
+    return () => {
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", tick);
+    };
+  }, [intervalMs, leading]);
+}

--- a/apps/web/vendor/liquid-glass/core/LiquidGlassRenderer.ts
+++ b/apps/web/vendor/liquid-glass/core/LiquidGlassRenderer.ts
@@ -30,6 +30,12 @@ private sampleBackground = 0;
   };
   private disposed = false;
   private positionFrame = 0;
+  /**
+   * 失效标记：参数 setter 只置位，真正的绘制统一由 watchPosition 的 RAF 消费。
+   * 一次 ResizeObserver 回调里连改采样/尺寸/设置/几何四项参数时，从四次全量
+   * 绘制合并为下一帧的一次；静止页面上没有失效就完全不绘制（见 watchPosition）。
+   */
+  private needsDraw = false;
   private lastViewport = { width: 0, height: 0 };
   private lastScroll = { x: Number.NaN, y: Number.NaN };
   private lastRect = { left: Number.NaN, top: Number.NaN, width: Number.NaN, height: Number.NaN };
@@ -166,7 +172,11 @@ private sampleBackground = 0;
       viewport.width !== this.lastViewport.width ||
       viewport.height !== this.lastViewport.height;
 
-    if (moved || ((this.sampleBackground || this.video) && visible)) {
+    // 重绘条件：位置/尺寸/滚动变化（采样对齐会失效）、参数更新标了脏、或视频
+    // 背景在可见中播放（纹理逐帧变化）。静态图片背景不满足任何条件时一帧都不画
+    // ——此前这里对 sampleBackground>0 的实例无条件逐帧全量绘制，是空闲页面
+    // 持续吃 GPU 的根源（侧栏/登录面板都开着背景采样）。
+    if (moved || this.needsDraw || (this.video && visible)) {
       this.lastRect = {
         left: rect.left,
         top: rect.top,
@@ -175,16 +185,22 @@ private sampleBackground = 0;
       };
       this.lastViewport = viewport;
       this.lastScroll = scroll;
+      this.needsDraw = false;
       this.draw();
     }
     this.positionFrame = window.requestAnimationFrame(this.watchPosition);
   };
 
+  /** 标记需要重绘：合并到下一帧统一执行，多次参数更新只触发一次绘制。 */
+  private requestDraw() {
+    this.needsDraw = true;
+  }
+
   setImage(url: string) {
     if (this.video?.currentSrc === url || this.video?.src === url || this.image.currentSrc === url || this.image.src === url) return;
     this.loadSource(url);
   }
-  setSettings(settings: LiquidGlassSettings) { this.settings = settings; this.size = { width: settings.lensWidth, height: settings.lensHeight }; this.draw(); }
+  setSettings(settings: LiquidGlassSettings) { this.settings = settings; this.size = { width: settings.lensWidth, height: settings.lensHeight }; this.requestDraw(); }
   setGeometry(
     x: number,
     y: number,
@@ -200,21 +216,21 @@ private sampleBackground = 0;
     this.button = button;
     this.morph = Math.max(0, Math.min(1, morph));
     this.materialMorph = Math.max(0, Math.min(1, materialMorph));
-    this.draw();
+    this.requestDraw();
   }
   setTrack(start: number, end: number, y: number, value: number, radius = 2.5) {
     this.track = { start, end, y, value, radius };
-    this.draw();
+    this.requestDraw();
   }
   setTrackColors(base: [number, number, number], fill: [number, number, number]) {
     this.trackColors = { base, fill };
-    this.draw();
+    this.requestDraw();
   }
   setBackgroundSampling(amount: boolean | number) {
     // 兼容旧的布尔开关；数值则按 0~1 夹取，作为 shader 里中性玻璃与背景的混合系数
     this.sampleBackground =
       typeof amount === "number" ? Math.max(0, Math.min(1, amount)) : amount ? 1 : 0;
-    this.draw();
+    this.requestDraw();
   }
   dispose() {
     this.disposed = true;
@@ -228,13 +244,27 @@ private sampleBackground = 0;
   }
   resize(width: number, height: number) {
     const deviceScale = window.devicePixelRatio || 1;
-    const compactSupersampling = height <= 80 ? 3 : height <= 140 ? 2.5 : 2;
-    const renderScale = Math.min(4, Math.max(deviceScale, compactSupersampling));
-    this.canvas.width = Math.max(1, Math.round(width * renderScale));
-    this.canvas.height = Math.max(1, Math.round(height * renderScale));
+    // 超采样只对小控件有意义（边缘占比大，锯齿明显）；大面板（侧栏/登录面板）
+    // 边缘只占极小比例，高倍率的视觉收益有限而像素成本按平方增长，压到 1.5。
+    const compactSupersampling = height <= 80 ? 3 : height <= 140 ? 2.5 : 1.5;
+    let renderScale = Math.min(4, Math.max(deviceScale, compactSupersampling));
+    // 像素面积上限：防止「大面板 × 高 DPR」相乘出数百万像素的 backing buffer，
+    // 着色器是每像素几十次纹理采样的重路径，面积必须封顶。
+    const MAX_PIXELS = 2_400_000;
+    const area = width * height;
+    if (area > 0 && area * renderScale * renderScale > MAX_PIXELS) {
+      renderScale = Math.max(1, Math.sqrt(MAX_PIXELS / area));
+    }
+    const pixelWidth = Math.max(1, Math.round(width * renderScale));
+    const pixelHeight = Math.max(1, Math.round(height * renderScale));
+    // 尺寸没变就不重设 canvas.width/height——赋值本身会清空并重分配缓冲区
+    if (this.canvas.width !== pixelWidth || this.canvas.height !== pixelHeight) {
+      this.canvas.width = pixelWidth;
+      this.canvas.height = pixelHeight;
+    }
     this.canvas.style.width = `${width}px`;
     this.canvas.style.height = `${height}px`;
-    this.draw();
+    this.requestDraw();
   }
   draw() {
     if (!this.ready) return;

--- a/apps/web/vendor/liquid-glass/core/shaders.ts
+++ b/apps/web/vendor/liquid-glass/core/shaders.ts
@@ -77,6 +77,10 @@ vec3 sampleBlur(vec2 uv, float amount) {
 }
 vec3 spectralSample(vec2 base, vec2 axis, float blurAmount, float mixAmount) {
   vec3 neutral = sampleBlur(base, blurAmount);
+  // 色散混合量很小（面板主体，远离边缘）时光谱贡献不可见，但 7 路 sampleBlur
+  // 的 63 次纹理采样照付不误——大面板绝大多数像素都落在这条快速路径上，
+  // 每像素从 72 次采样降到 9 次。阈值 3% 的混合量在视觉上无法分辨。
+  if (mixAmount < 0.03) return neutral;
   vec3 red = sampleBlur(base + axis * 3.0, blurAmount) * vec3(1.0, 0.0, 0.0);
   vec3 orange = sampleBlur(base + axis * 2.0, blurAmount) * vec3(1.0, 0.45, 0.0);
   vec3 yellow = sampleBlur(base + axis, blurAmount) * vec3(1.0, 1.0, 0.0);
@@ -181,17 +185,21 @@ float thickness = hC * mix(2.0, 1.1, press);
   vec2 chromaAxis = normalize(normal.xy + vec2(.0001))
     * chromaSpread * pxToUV * u_bgScale;
   float prismMix = min(.32, u_chroma * 3.6 * (.25 + edge));
-  vec3 sampledBackground = spectralSample(
-    backgroundUV,
-    chromaAxis,
-    u_blurAmount,
-    prismMix
-  );
-  sampledBackground = adjustColor(sampledBackground);
-
   float glassLight = .032 + depth * .018 + lowerBody * .018 + topSheen * .055;
   vec3 neutralGlass = vec3(glassLight, glassLight + .004, glassLight + .01);
-  vec3 color = mix(neutralGlass, sampledBackground, u_sampleBackground);
+  // 采样强度为 0（纯中性玻璃底）时整条背景采样路径都不必执行。u_sampleBackground
+  // 是运行时 uniform，编译器无法静态消除死代码，必须显式分支跳过。
+  vec3 color = neutralGlass;
+  if (u_sampleBackground > 0.004) {
+    vec3 sampledBackground = spectralSample(
+      backgroundUV,
+      chromaAxis,
+      u_blurAmount,
+      prismMix
+    );
+    sampledBackground = adjustColor(sampledBackground);
+    color = mix(neutralGlass, sampledBackground, u_sampleBackground);
+  }
   color = mix(color, color * u_tintColor, u_tintStrength);
   color *= 1.0 - u_darkTint * (.62 + edge * .38);
   if (u_tint >= 0.0) {


### PR DESCRIPTION
修复 #19 报告的全部问题，并对前端做了一轮全面性能扫描与优化。

## Issue #19（液态玻璃与媒体库轮询）

- **P0**：渲染器改为失效驱动重绘——只有位置/尺寸/滚动变化、参数标脏或视频背景可见时才 `draw()`。静态图片背景（侧栏、登录面板）空闲时不再逐帧全量绘制，后台标签页随 RAF 节流自然停止
- **P1 着色器**：`u_sampleBackground=0` 时跳过整条采样路径；色散只在玻璃边缘执行，大面板主体每像素从 72 次纹理采样降到 9 次
- **P1 超采样**：大面板从 2 倍降到 1.5 倍，新增 240 万像素 backing buffer 面积上限
- **P2**：参数 setter 标脏合并，一次设置变化从四次全量绘制降为一次；resize 尺寸未变不再重分配缓冲区
- **P2 轮询**：轮询快照做内容比对、逐条目复用引用 + `InventoryCell` memo，扫描期间只重渲染真正变化的格子；海报墙加 `content-visibility:auto`；媒体库总览修复空闲时每 30 秒的 1+N 请求
- **P3**：海报徽章移除每卡多个 backdrop-blur 合成层，改用更实的半透明底色

## 全面扫描的额外修复

- **搜索结果页**：结果行去掉行级 `backdrop-blur-xl`（上千行各一个实时模糊合成层，滚动掉帧主因）+ 行/卡 memo + `content-visibility`；排序向量预计算；facet/分组/分桶去重复计算
- **Agent 流式输出**：SSE delta 事件按 80ms 批量合并（终态立即冲刷），对话轮次组件链 memo 化，长回复不再每秒几十次驱动全站重渲染
- **轮询统一**：新增 `useVisiblePolling`，7 处状态轮询在后台标签页暂停、恢复可见立即补一次
- 横滚容器边缘检测合并进 rAF（消除滚动时强制同步布局）；Hero 轮播大图按需装载；Top250 排名 O(n²)→Map 查表 + 搜索输入 `useDeferredValue`；`useMediaQuery` 缓存 MediaQueryList；订阅状态查询建索引；进度扫光动画 `left`→`transform`；弹层 scroll 监听补 passive；零散 `img` 补懒加载

## 验证

- `pnpm web:typecheck` 通过
- `pnpm web:lint` 0 错误（仅剩 2 个改动前已存在的警告）
- `pnpm web:build` 通过，包体不变（Shared First Load JS 102 kB）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGnzWbSsDNJmU8jA1T6nrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGnzWbSsDNJmU8jA1T6nrf)_