### PR TITLE
发现页全量扩充（豆瓣+TMDB 榜单）与海报页渲染性能优化

### DIFF
--- a/apps/web/components/h-scroller.tsx
+++ b/apps/web/components/h-scroller.tsx
@@ -61,7 +61,11 @@ export function HScroller({
   };
 
   return (
-    <div className="group/hscroll relative">
+    // onPointerEnter 重测：行被 content-visibility 跳过渲染时挂载测量读到的
+    // 尺寸全是 0，滚入视口浏览器恢复渲染但不会触发 React 重渲染——翻页钮
+    // 只在悬停时浮现，进场先重测一次即可保证钮的可用性正确；测量已并帧，
+    // 重复触发无额外开销
+    <div className="group/hscroll relative" onPointerEnter={updateEdges}>
       <div
         ref={scrollerRef}
         onScroll={updateEdges}

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -818,7 +818,9 @@ function PendingCell({ sub }: { sub: Subscription }) {
     posterUrl: sub.media.poster_url ? cachedImageUrl(sub.media.poster_url) : "",
   };
   return (
-    <div className="opacity-80 transition hover:opacity-100">
+    // content-visibility 与库存格同款：追踪中的订阅一多（批量订阅季播剧），
+    // 视口外的格子同样不该参与布局与绘制
+    <div className="opacity-80 transition [contain-intrinsic-size:auto_270px] [content-visibility:auto] hover:opacity-100">
       {/* 已是订阅产物，悬浮层不再给「订阅影片」重复入口 */}
       <PosterCardVisual item={visual} href={`/subscriptions/${sub.id}` as Route} action="none" />
       <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-[11px] text-[var(--text-muted)]">

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -43,17 +43,24 @@ export const LIBRARY_KIND_META: Record<MediaType, { label: string; Icon: typeof 
   tv: { label: "剧集", Icon: TvIcon },
 };
 
+/** 收藏范围可选项的模块级缓存：这是后端静态常量，但 useRoutingOptions 被
+ *  每张库卡片和表单弹窗各自调用——不缓存的话库首页一次挂载就打出 N 个
+ *  相同请求。失败时清空缓存，下一个调用方重试。 */
+let routingOptionsPromise: Promise<RoutingOptions> | null = null;
+
 /** 收藏范围可选项（后端静态常量）；加载失败降级为 null（相关 UI 不渲染）。 */
 function useRoutingOptions(): RoutingOptions | null {
   const [options, setOptions] = useState<RoutingOptions | null>(null);
   useEffect(() => {
     let cancelled = false;
-    void getRoutingOptions()
+    routingOptionsPromise ??= getRoutingOptions();
+    void routingOptionsPromise
       .then((o) => {
         if (!cancelled) setOptions(o);
       })
       .catch(() => {
         /* 静默降级：收藏范围区显示加载失败提示 */
+        routingOptionsPromise = null;
       });
     return () => {
       cancelled = true;

--- a/apps/web/components/media-row.tsx
+++ b/apps/web/components/media-row.tsx
@@ -33,7 +33,10 @@ export function MediaRow({
   cardHref?: (item: MediaItem) => Route | undefined;
 }) {
   return (
-    <section className="relative">
+    // content-visibility：视口外的整行（标题 + 几十张海报卡）跳过布局与绘制，
+    // 发现页 16 行 / 库首页多行「最近添加」的首帧与滚动成本只与可见行相关；
+    // intrinsic-size 先占住一行的近似高度（auto 记住实测值），滚动条不跳
+    <section className="relative [contain-intrinsic-size:auto_330px] [content-visibility:auto]">
       <div className="mb-3 flex items-center justify-between gap-4 px-6 max-md:mb-2 max-md:px-4">
         <h3 className="text-on-image text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
           {row.title}

--- a/src/movieclaw_api/api/routes/discover.py
+++ b/src/movieclaw_api/api/routes/discover.py
@@ -157,7 +157,7 @@ async def _record_media_history(
 async def get_discover_page(
     kind: MediaKind,
     source: DiscoverSource = Query(
-        default=DiscoverSource.TMDB, description="数据来源：tmdb（热门榜单）/ douban（豆瓣 Top250）"
+        default=DiscoverSource.TMDB, description="数据来源：tmdb（热门榜单）/ douban（豆瓣榜单）"
     ),
 ) -> ApiResponse[DiscoverPage]:
     """返回一个完整发现页：kind=movie 发现电影，kind=tv 发现剧集。

--- a/src/movieclaw_media/douban.py
+++ b/src/movieclaw_media/douban.py
@@ -260,20 +260,39 @@ class _Collection:
     count: int = 30
 
 
+# 行序参考 Netflix 的发现页编排：实时趋势（大数字排名行）打头，随后是时效性
+# 内容（院线/热门），再到口碑榜，最后是常青的经典与分类榜——越靠上时效性越强。
 _MOVIE_COLLECTIONS = (
     _Collection("movie_real_time_hotest", "豆瓣实时热门电影", True),
+    _Collection("movie_showing", "影院热映"),
+    _Collection("movie_soon", "即将上映"),
+    _Collection("movie_hot_gaia", "豆瓣热门电影"),
     _Collection("movie_weekly_best", "豆瓣一周口碑电影榜", True),
+    _Collection("EC7Q5H2QI", "近期高分电影"),
     # 豆瓣接口支持单次返回完整 250 条；普通榜单仍只取首屏 30 条，避免无谓传输。
     _Collection("movie_top250", "豆瓣电影 Top 250", True, 250),
-    _Collection("EC7Q5H2QI", "近期高分电影"),
+    _Collection("movie_classic", "经典电影"),
+    _Collection("movie_scifi", "高分经典科幻片榜"),
+    _Collection("movie_comedy", "高分经典喜剧片榜"),
+    _Collection("movie_action", "高分经典动作片榜"),
+    _Collection("movie_love", "高分经典爱情片榜"),
 )
+# 剧集侧同理：实时榜与全量热门在前，口碑榜居中，地区细分行随后，动画与综艺
+# 垫底自成品类区。地区行使用豆瓣官方命名榜单 ID（tv_domestic 等），不再用内容
+# 等价但含义不透明的 EC 自定义榜单 ID。综艺/动画条目在豆瓣侧 type 同为 tv，
+# 可直接通过 _to_card 的类型过滤。
 _TV_COLLECTIONS = (
+    _Collection("tv_real_time_hotest", "豆瓣实时热门剧集", True),
+    _Collection("tv_hot", "近期热门剧集"),
     _Collection("tv_chinese_best_weekly", "华语口碑剧集榜", True),
     _Collection("tv_global_best_weekly", "全球口碑剧集榜", True),
-    _Collection("EC74443FY", "近期热门大陆剧"),
-    _Collection("ECFA5DI7Q", "近期热门美剧"),
-    _Collection("ECNA46YBA", "近期热门日剧"),
-    _Collection("ECBE5CBEI", "近期热门韩剧"),
+    _Collection("tv_domestic", "近期热门国产剧"),
+    _Collection("tv_american", "近期热门美剧"),
+    _Collection("tv_japanese", "近期热门日剧"),
+    _Collection("tv_korean", "近期热门韩剧"),
+    _Collection("tv_animation", "近期热门动画"),
+    _Collection("show_domestic", "近期热门国内综艺"),
+    _Collection("show_foreign", "近期热门国外综艺"),
 )
 
 

--- a/src/movieclaw_media/service.py
+++ b/src/movieclaw_media/service.py
@@ -85,44 +85,119 @@ class _RowSpec:
 
 
 def _movie_rows(region: str) -> tuple[_RowSpec, ...]:
+    # 行序参考 Netflix 发现页编排：趋势排名行打头，院线时效内容随后，热门与
+    # 口碑居中，地区行与类型行垫后。discover 查询统一带 vote_count 下限挡住
+    # 冷门残缺条目；类型 ID（878 科幻、28 动作等）是 TMDB 官方文档的稳定常量。
     return (
         _RowSpec("trending-day", "今日热榜 Top 10", "trending/movie/day", ranked=True, limit=10),
-        _RowSpec("popular", "热门电影", "movie/popular"),
         _RowSpec("now-playing", "正在热映", "movie/now_playing", {"region": region}),
-        _RowSpec("top-rated", "高分经典", "movie/top_rated"),
         _RowSpec("upcoming", "即将上映", "movie/upcoming", {"region": region}),
+        _RowSpec("popular", "热门电影", "movie/popular"),
+        _RowSpec("top-rated", "高分经典", "movie/top_rated"),
         _RowSpec(
             "chinese", "华语佳片", "discover/movie",
             {"with_original_language": "zh", "sort_by": "popularity.desc", "vote_count.gte": 50},
         ),
         _RowSpec(
+            "japanese", "日本电影", "discover/movie",
+            {"with_origin_country": "JP", "sort_by": "popularity.desc", "vote_count.gte": 100},
+        ),
+        _RowSpec(
+            "korean", "韩国电影", "discover/movie",
+            {"with_origin_country": "KR", "sort_by": "popularity.desc", "vote_count.gte": 100},
+        ),
+        _RowSpec(
             "scifi", "科幻巨制", "discover/movie",
             {"with_genres": "878", "sort_by": "popularity.desc", "vote_count.gte": 300},
+        ),
+        # with_genres 里的竖线是「或」（逗号才是「且」）：28|12 = 动作或冒险
+        _RowSpec(
+            "action", "动作与冒险", "discover/movie",
+            {"with_genres": "28|12", "sort_by": "popularity.desc", "vote_count.gte": 300},
+        ),
+        _RowSpec(
+            "thriller", "悬疑惊悚", "discover/movie",
+            {"with_genres": "53|9648", "sort_by": "popularity.desc", "vote_count.gte": 300},
+        ),
+        _RowSpec(
+            "comedy", "喜剧佳作", "discover/movie",
+            {"with_genres": "35", "sort_by": "popularity.desc", "vote_count.gte": 200},
+        ),
+        _RowSpec(
+            "romance", "爱情电影", "discover/movie",
+            {"with_genres": "10749", "sort_by": "popularity.desc", "vote_count.gte": 200},
+        ),
+        _RowSpec(
+            "horror", "恐怖片", "discover/movie",
+            {"with_genres": "27", "sort_by": "popularity.desc", "vote_count.gte": 200},
         ),
         _RowSpec(
             "animation", "动画电影", "discover/movie",
             {"with_genres": "16", "sort_by": "popularity.desc", "vote_count.gte": 200},
         ),
+        _RowSpec(
+            "documentary", "纪录片", "discover/movie",
+            {"with_genres": "99", "sort_by": "popularity.desc", "vote_count.gte": 50},
+        ),
     )
 
 
 def _tv_rows() -> tuple[_RowSpec, ...]:
+    # 剧集侧同理：趋势与在播内容在前，热门/口碑居中，然后是地区行与播出平台
+    # 品牌行（Netflix/HBO 是发现页里辨识度最高的两块金字招牌），类型行垫后。
     return (
         _RowSpec("trending-day", "今日热榜 Top 10", "trending/tv/day", ranked=True, limit=10),
-        _RowSpec("popular", "热门剧集", "tv/popular"),
         _RowSpec("on-the-air", "正在播出", "tv/on_the_air"),
+        _RowSpec("popular", "热门剧集", "tv/popular"),
         _RowSpec("top-rated", "高分神剧", "tv/top_rated"),
         _RowSpec(
             "chinese", "华语剧集", "discover/tv",
             {"with_original_language": "zh", "sort_by": "popularity.desc", "vote_count.gte": 20},
         ),
         _RowSpec(
+            "us", "热门美剧", "discover/tv",
+            {"with_origin_country": "US", "sort_by": "popularity.desc", "vote_count.gte": 50},
+        ),
+        _RowSpec(
+            "japanese", "热门日剧", "discover/tv",
+            {"with_origin_country": "JP", "sort_by": "popularity.desc", "vote_count.gte": 20},
+        ),
+        _RowSpec(
+            "korean", "热门韩剧", "discover/tv",
+            {"with_origin_country": "KR", "sort_by": "popularity.desc", "vote_count.gte": 20},
+        ),
+        # 播出平台行：with_networks 的 213=Netflix、49=HBO（TMDB network ID）
+        _RowSpec(
+            "netflix", "Netflix 出品", "discover/tv",
+            {"with_networks": "213", "sort_by": "popularity.desc", "vote_count.gte": 50},
+        ),
+        _RowSpec(
+            "hbo", "HBO 出品", "discover/tv",
+            {"with_networks": "49", "sort_by": "popularity.desc", "vote_count.gte": 50},
+        ),
+        _RowSpec(
             "scifi-fantasy", "科幻与奇幻", "discover/tv",
             {"with_genres": "10765", "sort_by": "popularity.desc", "vote_count.gte": 100},
         ),
         _RowSpec(
+            "crime-mystery", "悬疑罪案", "discover/tv",
+            {"with_genres": "80|9648", "sort_by": "popularity.desc", "vote_count.gte": 50},
+        ),
+        _RowSpec(
+            "comedy", "喜剧剧集", "discover/tv",
+            {"with_genres": "35", "sort_by": "popularity.desc", "vote_count.gte": 100},
+        ),
+        _RowSpec(
             "animation", "动画剧集", "discover/tv",
             {"with_genres": "16", "sort_by": "popularity.desc", "vote_count.gte": 100},
+        ),
+        _RowSpec(
+            "reality", "真人秀", "discover/tv",
+            {"with_genres": "10764", "sort_by": "popularity.desc", "vote_count.gte": 20},
+        ),
+        _RowSpec(
+            "documentary", "纪录片", "discover/tv",
+            {"with_genres": "99", "sort_by": "popularity.desc", "vote_count.gte": 20},
         ),
     )
 

--- a/tests/media/test_discover_service.py
+++ b/tests/media/test_discover_service.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from movieclaw_media.models import MediaKind
-from movieclaw_media.service import MediaDiscoverService
+from movieclaw_media.service import MediaDiscoverService, _movie_rows, _tv_rows
 from movieclaw_media.tmdb import TmdbError
 
 _IMAGE_BASE = "https://image.tmdb.org/t/p"
@@ -128,6 +128,40 @@ async def test_ranked_row_limits_to_top10() -> None:
     top = next(r for r in page.rows if r.id == "trending-day")
     assert top.ranked is True
     assert len(top.items) == 10
+
+
+async def test_pages_render_all_configured_rows_in_order() -> None:
+    """全部端点有数据时，电影/剧集页的行序应与行定义完整一致（含地区/平台/类型行）。"""
+    enough = {"results": [_movie(i) for i in range(1, 8)]}
+    movie_svc = _service(
+        {
+            path: enough
+            for path in (
+                "trending/movie/day", "movie/now_playing", "movie/upcoming",
+                "movie/popular", "movie/top_rated", "discover/movie",
+            )
+        }
+    )
+    movie_page = await movie_svc.discover_page(MediaKind.MOVIE)
+    assert [r.id for r in movie_page.rows] == [s.row_id for s in _movie_rows("CN")]
+
+    tv_item = {
+        "id": 9,
+        "name": "剧集9",
+        "first_air_date": "2025-03-01",
+        "vote_average": 8.0,
+        "poster_path": "/tv9.jpg",
+    }
+    tv_svc = _service(
+        {
+            path: {"results": [dict(tv_item, id=i) for i in range(1, 8)]}
+            for path in (
+                "trending/tv/day", "tv/on_the_air", "tv/popular", "tv/top_rated", "discover/tv",
+            )
+        }
+    )
+    tv_page = await tv_svc.discover_page(MediaKind.TV)
+    assert [r.id for r in tv_page.rows] == [s.row_id for s in _tv_rows()]
 
 
 async def test_single_row_failure_is_isolated() -> None:

--- a/tests/media/test_douban_discover.py
+++ b/tests/media/test_douban_discover.py
@@ -7,7 +7,13 @@ from typing import Any
 import httpx
 import pytest
 
-from movieclaw_media.douban import DoubanClient, DoubanDiscoverService, DoubanError
+from movieclaw_media.douban import (
+    _MOVIE_COLLECTIONS,
+    _TV_COLLECTIONS,
+    DoubanClient,
+    DoubanDiscoverService,
+    DoubanError,
+)
 from movieclaw_media.models import MediaKind, MediaSource
 
 
@@ -213,17 +219,27 @@ async def test_top250_requests_and_returns_full_collection() -> None:
     assert ("movie_real_time_hotest", 30) in client.calls
 
 
-async def test_all_collections_failure_raises_readable_error() -> None:
+async def test_tv_page_requests_all_configured_collections_in_order() -> None:
+    """剧集页应按配置顺序请求全部榜单，行序与配置一致（含动画与综艺行）。"""
     client = StubDoubanClient(
         {
-            key: DoubanError("豆瓣不可用")
-            for key in (
-                "movie_real_time_hotest",
-                "movie_weekly_best",
-                "movie_top250",
-                "EC7Q5H2QI",
-            )
+            spec.collection_id: {
+                "subject_collection_items": [_item(i, type="tv") for i in range(1, 6)]
+            }
+            for spec in _TV_COLLECTIONS
         }
+    )
+    page = await DoubanDiscoverService(client).discover_page(MediaKind.TV)  # type: ignore[arg-type]
+
+    assert [row.id for row in page.rows] == [
+        f"douban-{spec.collection_id}" for spec in _TV_COLLECTIONS
+    ]
+    assert page.rows[0].ranked
+
+
+async def test_all_collections_failure_raises_readable_error() -> None:
+    client = StubDoubanClient(
+        {spec.collection_id: DoubanError("豆瓣不可用") for spec in _MOVIE_COLLECTIONS}
     )
     with pytest.raises(DoubanError, match="豆瓣不可用"):
         await DoubanDiscoverService(client).discover_page(MediaKind.MOVIE)  # type: ignore[arg-type]


### PR DESCRIPTION
## 概要

三个递进的改动，把发现页的内容供给和承载性能一起升级：

### 1. 豆瓣发现页扩充（`a6adbb1`）

- 电影页 4 行 → 12 行：新增影院热映、即将上映、豆瓣热门、经典电影与科幻/喜剧/动作/爱情四个高分经典分类榜
- 剧集页 6 行 → 11 行：新增实时热门剧集、近期热门剧集、热门动画与国内/国外综艺
- 地区剧集行从内容等价的 EC 自定义榜单 ID 换成豆瓣官方命名 ID（`tv_domestic` 等），语义更清晰也更稳定
- 全部新榜单 ID 均已实测可用，条目字段能通过现有 `_to_card` 过滤

### 2. TMDB 发现页扩充（`66d2595`）

- 电影页 8 行 → 16 行：新增日本/韩国电影地区行与动作冒险、悬疑惊悚、喜剧、爱情、恐怖、纪录片类型行
- 剧集页 7 行 → 16 行：新增美剧/日剧/韩剧地区行（`with_origin_country`）、Netflix 与 HBO 播出平台品牌行（`with_networks`）及悬疑罪案、喜剧、真人秀、纪录片类型行
- 两个数据源统一 Netflix 式行序：趋势排名行打头，时效内容随后，热门口碑居中，地区/平台/类型行垫后

### 3. 前端渲染性能（`5275e64`）

- `MediaRow` 行容器加 `content-visibility: auto`：视口外整行跳过布局与绘制，发现页 16 行与库首页「最近添加」行同时受益
- `HScroller` 在 `pointerenter` 时重测边缘：修复被跳过渲染的行翻页钮缺席的问题
- 库详情页「追踪中」网格补上与库存格同款的视口外裁剪
- 库首页收藏范围可选项改为模块级缓存，消除每张库卡片一个的重复请求

## 测试

- 豆瓣/TMDB 发现服务与缓存、发现页 API 共 57 个测试通过，新增行序完整性用例 3 条
- `ruff check` 通过（2 处基线遗留报错未动）；`eslint` 0 错误；`next build` 全量构建通过
- `tests/api` 中 3 个失败用例经 stash 验证为基线预先存在，与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDBcSEo25tzRUiLoSSCD9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDBcSEo25tzRUiLoSSCD9g)_