### PR TITLE
feat(web): 语义字号 token 体系 + 移动端字号/触控目标对齐 iOS HIG

### DIFF
--- a/apps/web/app/(app)/search/page.tsx
+++ b/apps/web/app/(app)/search/page.tsx
@@ -141,7 +141,7 @@ function SearchVerticals({
                   role="tab"
                   aria-selected={active}
                   onClick={() => !active && onSwitch(tab.id)}
-                  className={`rounded-full px-3.5 py-1 text-[12px] font-medium transition-colors ${
+                  className={`rounded-full px-3.5 py-1 text-sub font-medium transition-colors ${
                     active
                       ? "bg-white/[0.16] text-white"
                       : "text-[rgba(243,245,249,0.72)] hover:bg-white/[0.08] hover:text-white"
@@ -239,7 +239,7 @@ function ScopeChip({
       role="radio"
       aria-checked={active}
       onClick={() => !active && onClick()}
-      className={`rounded-full px-2.5 py-1 text-[12px] transition-colors ${
+      className={`rounded-full px-2.5 py-1 text-sub transition-colors ${
         active
           ? "bg-white/[0.16] font-medium text-white"
           : "text-[rgba(243,245,249,0.68)] hover:bg-white/[0.08] hover:text-white"

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,64 @@
 @import "tailwindcss";
 
 /*
+ * —— 语义字号 token（全站唯一的字号来源） ——
+ *
+ * 全站文字一律使用下面这套语义档位（text-micro / text-caption / … / text-title-lg），
+ * 不要再写 text-[13px] 这类任意 px 值：任意值是孤立的魔法数字，无法统一适配终端。
+ *
+ * 工作原理：@theme 里的 --text-* 会生成同名工具类（如 text-ui），且编译产物是
+ * font-size: var(--text-ui) 的变量引用（Tailwind v4 行为，已实测验证）——因此
+ * 只需在下方移动端媒体查询里覆盖 :root 变量，即可让全站字号整体换档，
+ * 组件无需逐处写 max-md: 断点。
+ *
+ * 两档取值：
+ * - 桌面档：延续原先的紧凑排版（信息密度优先，鼠标 + 大屏近距离阅读）；
+ * - 移动档：对齐 iOS 人机界面规范（HIG）的动态字体默认档——正文 Body 17pt、
+ *   Callout 16pt、Footnote 13pt、最小可读 Caption2 11pt（Web 上 1pt ≈ 1 CSS px）。
+ *
+ * 档位语义（桌面 → 移动）：
+ * - text-micro    10 → 11   徽标、角标、分组小标题等最小信息（移动端不允许再小）
+ * - text-caption  11 → 13   次要说明、时间戳、元数据
+ * - text-sub      12 → 14   辅助正文、表单说明、次级标签
+ * - text-ui       13 → 16   导航项、菜单项、按钮、列表行标题（UI 控件主文字）
+ * - text-body     14 → 16   正文基准（body 默认字号、气泡、输入框）
+ * - text-body-lg  15 → 17   阅读正文（Markdown、详情简介），移动端对齐 iOS Body
+ * - text-title-sm 16 → 17   小标题
+ * - text-title    17 → 20   区块 / 弹窗标题
+ * - text-title-lg 19 → 22   页面大标题
+ *
+ * 注意：这里刻意不定义 --text-*--line-height 配套变量——定义了工具类就会
+ * 同时输出 line-height，与现状「行高继承 body 1.5 或由 leading-* 显式指定」
+ * 的排版行为不一致，会引起全站布局抖动。
+ */
+@theme {
+  --text-micro: 10px;
+  --text-caption: 11px;
+  --text-sub: 12px;
+  --text-ui: 13px;
+  --text-body: 14px;
+  --text-body-lg: 15px;
+  --text-title-sm: 16px;
+  --text-title: 17px;
+  --text-title-lg: 19px;
+}
+
+/* 移动端换档：整体抬到 iOS HIG 的可读标准（断点与全站移动端约定一致，767px） */
+@media (max-width: 767px) {
+  :root {
+    --text-micro: 11px;
+    --text-caption: 13px;
+    --text-sub: 14px;
+    --text-ui: 16px;
+    --text-body: 16px;
+    --text-body-lg: 17px;
+    --text-title-sm: 17px;
+    --text-title: 20px;
+    --text-title-lg: 22px;
+  }
+}
+
+/*
  * Movieclaw 控制台 —— 冷调「银玻璃」主题（液态玻璃 · Bing 式氛围底）
  * ------------------------------------------------------------------
  * 设计语言：沉浸式左右分区（参考 Codex 桌面端）+ 半透明「液态玻璃」表面。
@@ -99,7 +157,7 @@ body {
   margin: 0;
   color: var(--text);
   font-family: var(--font-sans);
-  font-size: 14px;
+  font-size: var(--text-body);
   line-height: 1.5;
   letter-spacing: -0.005em;
   background: var(--bg);
@@ -123,10 +181,26 @@ body {
  *    生效，于是所有「悬停才浮现」的操作（列表行的下载/详情按钮、卡片上的
  *    订阅入口、会话行的更多菜单）在手机上永远点不到。给这些元素补一个
  *    .touch-reveal，在无悬停设备上恒定可见——这是移动端可用性的硬要求。
+ * 3) 触控目标 44pt：iOS HIG 的最小可点面积。视觉上不便放大到 44px 的小按钮
+ *    （会话行的 ⋯、composer 的发送键等）挂 .touch-target，用伪元素在移动端
+ *    把命中区悄悄撑到 44×44——伪元素参与父按钮的点击判定，外观不变。
  */
 @media (max-width: 767px) {
   :where(input, textarea, select) {
     font-size: 16px;
+  }
+
+  .touch-target {
+    position: relative;
+  }
+  .touch-target::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
   }
 }
 
@@ -375,10 +449,11 @@ a {
 /*
  * —— AI 回复正文的 Markdown 排版（components/markdown.tsx） ——
  * 颜色全部走 CSS 变量，在 .immersive-theme 内自动切到中性灰阶。
- * 字号/行高与原纯文本正文一致（15px/28px），保证切换渲染器不跳版式。
+ * 字号走语义 token 的阅读正文档（桌面 15px / 移动 17px），行高 28px 两档通用
+ * （15px 下约 1.85、17px 下约 1.65，均在舒适阅读区间），保证切换渲染器不跳版式。
  */
 .markdown {
-  font-size: 15px;
+  font-size: var(--text-body-lg);
   line-height: 28px;
   color: var(--text);
   word-break: break-word;
@@ -463,7 +538,7 @@ a {
   background: none;
   border-radius: 0;
   padding: 0;
-  font-size: 12.5px;
+  font-size: var(--text-sub);
 }
 .markdown blockquote {
   border-left: 3px solid rgba(255, 255, 255, 0.14);
@@ -503,7 +578,7 @@ a {
   padding: 4px 0;
   background: transparent !important;
   font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 11px;
+  font-size: var(--text-caption);
   line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
@@ -726,7 +801,7 @@ a {
 
 /* 分组小标题 */
 .group-label {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   font-weight: 650;
   letter-spacing: 0.13em;
   text-transform: uppercase;

--- a/apps/web/app/health/page.tsx
+++ b/apps/web/app/health/page.tsx
@@ -71,16 +71,16 @@ export default function HealthPage() {
   return (
     <div className="grid gap-6 lg:grid-cols-[0.78fr_1.22fr]">
       <section className="rounded-[32px] border border-[var(--line)] bg-[#111111] p-8 text-white shadow-[var(--shadow)]">
-        <p className="text-xs font-semibold tracking-[0.24em] text-[#ffb89e] uppercase">
+        <p className="text-sub font-semibold tracking-[0.24em] text-[#ffb89e] uppercase">
           Live contract check
         </p>
         <h1 className="mt-5 text-3xl font-semibold">Backend health status</h1>
-        <p className="mt-4 max-w-xl text-sm leading-7 text-white/72">
+        <p className="mt-4 max-w-xl text-body leading-7 text-white/72">
           This page validates the base frontend contract: the web console talks to FastAPI through
           the shared client layer instead of calling ad hoc endpoints from the UI.
         </p>
         <div className="mt-8 rounded-[24px] border border-white/10 bg-white/6 p-5">
-          <p className="text-sm text-white/60">State</p>
+          <p className="text-body text-white/60">State</p>
           <p className="mt-2 text-2xl font-semibold">
             {state.status === "loading" && "Loading"}
             {state.status === "success" && "Healthy"}
@@ -104,11 +104,11 @@ export default function HealthPage() {
 
         {state.status === "error" ? (
           <div className="rounded-[24px] border border-[color:rgba(153,27,27,0.14)] bg-[color:rgba(153,27,27,0.06)] p-6">
-            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--danger)]">
+            <p className="text-body font-semibold uppercase tracking-[0.18em] text-[var(--danger)]">
               Request failed
             </p>
-            <p className="mt-3 text-sm leading-7 text-[var(--foreground)]">{state.error}</p>
-            <p className="mt-4 text-sm text-[var(--muted)]">
+            <p className="mt-3 text-body leading-7 text-[var(--foreground)]">{state.error}</p>
+            <p className="mt-4 text-body text-[var(--muted)]">
               Check whether FastAPI is running on port `8000`, or override the frontend env if the
               API lives elsewhere.
             </p>
@@ -118,25 +118,25 @@ export default function HealthPage() {
         {state.status === "success" ? (
           <div className="space-y-5">
             <div className="flex items-center gap-3">
-              <span className="inline-flex rounded-full bg-[color:rgba(22,101,52,0.1)] px-3 py-1 text-sm font-semibold text-[var(--success)]">
+              <span className="inline-flex rounded-full bg-[color:rgba(22,101,52,0.1)] px-3 py-1 text-body font-semibold text-[var(--success)]">
                 {state.data.status}
               </span>
-              <span className="text-sm text-[var(--muted)]">
+              <span className="text-body text-[var(--muted)]">
                 Backend contract from `/api/v1/health`
               </span>
             </div>
 
             <div className="grid gap-4 sm:grid-cols-3">
               <article className="rounded-[24px] border border-[var(--line)] bg-white/80 p-5">
-                <p className="text-sm text-[var(--muted)]">Service</p>
+                <p className="text-body text-[var(--muted)]">Service</p>
                 <p className="mt-2 text-xl font-semibold">{state.data.service}</p>
               </article>
               <article className="rounded-[24px] border border-[var(--line)] bg-white/80 p-5">
-                <p className="text-sm text-[var(--muted)]">Environment</p>
+                <p className="text-body text-[var(--muted)]">Environment</p>
                 <p className="mt-2 text-xl font-semibold">{state.data.environment}</p>
               </article>
               <article className="rounded-[24px] border border-[var(--line)] bg-white/80 p-5">
-                <p className="text-sm text-[var(--muted)]">Protocol</p>
+                <p className="text-body text-[var(--muted)]">Protocol</p>
                 <p className="mt-2 text-xl font-semibold">HTTP JSON</p>
               </article>
             </div>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -93,7 +93,7 @@ export default function LoginPage() {
           onChange={(e) => setPassword(e.target.value)}
           autoComplete="current-password"
         />
-        <label className="flex cursor-pointer items-center gap-2 text-[12px] text-[var(--text-muted)]">
+        <label className="flex cursor-pointer items-center gap-2 text-sub text-[var(--text-muted)]">
           <input
             type="checkbox"
             checked={remember}
@@ -106,7 +106,7 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={busy || !username.trim() || !password}
-          className="btn-accent w-full rounded-full px-4.5 py-2.5 text-[13px] font-semibold disabled:opacity-40"
+          className="btn-accent w-full rounded-full px-4.5 py-2.5 text-ui font-semibold disabled:opacity-40"
         >
           {busy ? "登录中…" : "登录"}
         </button>

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -105,7 +105,7 @@ export default function SetupPage() {
         <button
           type="submit"
           disabled={busy || !username.trim() || !password || !confirm}
-          className="btn-accent w-full rounded-full px-4.5 py-2.5 text-[13px] font-semibold disabled:opacity-40"
+          className="btn-accent w-full rounded-full px-4.5 py-2.5 text-ui font-semibold disabled:opacity-40"
         >
           {busy ? "创建中…" : "创建账号并进入"}
         </button>

--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -53,8 +53,8 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
     return (
       <div className="immersive-theme flex h-full items-center justify-center px-6">
         <div className="max-w-sm text-center">
-          <p className="text-sm font-medium text-[var(--text)]">无法打开会话</p>
-          <p className="mt-2 text-xs leading-5 text-[var(--text-muted)]">{loadError}</p>
+          <p className="text-body font-medium text-[var(--text)]">无法打开会话</p>
+          <p className="mt-2 text-sub leading-5 text-[var(--text-muted)]">{loadError}</p>
         </div>
       </div>
     );
@@ -63,7 +63,7 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
   if (!conversation?.loaded) {
     return (
       <div className="immersive-theme flex h-full items-center justify-center px-6">
-        <p className="animate-pulse text-sm text-[var(--text-muted)]">正在加载会话…</p>
+        <p className="animate-pulse text-body text-[var(--text-muted)]">正在加载会话…</p>
       </div>
     );
   }
@@ -82,10 +82,10 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
       {/* 顶部条：会话标题 + 运行状态 */}
       <header className="flex h-14 shrink-0 items-center px-5 max-md:h-11 max-md:px-4">
         <div className="flex min-w-0 items-center gap-2.5">
-          <h1 className="truncate text-[14px] font-semibold tracking-[-0.01em]">
+          <h1 className="truncate text-body font-semibold tracking-[-0.01em]">
             {conversation.title}
           </h1>
-          <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-[11px] text-[var(--text-muted)]">
+          <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-white/[0.06] px-2.5 py-0.5 text-caption text-[var(--text-muted)]">
             <span
               className={`size-1.5 rounded-full ${running ? "animate-pulse bg-[#6aa7ff]" : "bg-[#4ade80]"}`}
             />
@@ -142,7 +142,7 @@ const TurnView = memo(function TurnView({ turn }: { turn: AgentTurn }) {
     <div className="space-y-4">
       {/* 用户消息：右侧玻璃气泡 */}
       <div className="flex justify-end">
-        <div className="max-w-[80%] whitespace-pre-wrap rounded-2xl bg-[var(--glass-fill-active)] px-4 py-3 text-sm leading-6 text-[var(--text)]">
+        <div className="max-w-[80%] whitespace-pre-wrap rounded-2xl bg-[var(--glass-fill-active)] px-4 py-3 text-body leading-6 text-[var(--text)]">
           {turn.input}
         </div>
       </div>
@@ -176,20 +176,20 @@ const TurnView = memo(function TurnView({ turn }: { turn: AgentTurn }) {
           })}
 
           {turn.status === "running" && turn.segments.length === 0 && (
-            <p className="text-[13px] text-[var(--text-faint)]">
+            <p className="text-ui text-[var(--text-faint)]">
               正在启动
               <StreamingCursor />
             </p>
           )}
 
           {turn.status === "error" && (
-            <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-3.5 py-2.5 text-[13px] leading-5 text-[#ff6b6b]">
+            <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-3.5 py-2.5 text-ui leading-5 text-[#ff6b6b]">
               {turn.error}
             </div>
           )}
 
           {turn.status === "done" && (
-            <p className="text-[11px] text-[var(--text-faint)]">
+            <p className="text-caption text-[var(--text-faint)]">
               {turn.stopped
                 ? "已停止生成"
                 : turn.result &&
@@ -234,7 +234,7 @@ const ProcessBlock = memo(function ProcessBlock({ segment, active }: { segment: 
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 text-[12px] font-medium text-[var(--text-faint)] transition-colors hover:text-[var(--text-muted)]"
+        className="flex items-center gap-1 text-sub font-medium text-[var(--text-faint)] transition-colors hover:text-[var(--text-muted)]"
       >
         <ChevronRightIcon className={`size-3.5 transition-transform ${open ? "rotate-90" : ""}`} />
         <span className={active ? "animate-pulse" : undefined}>
@@ -247,7 +247,7 @@ const ProcessBlock = memo(function ProcessBlock({ segment, active }: { segment: 
             item.kind === "thinking" ? (
               <p
                 key={index}
-                className="whitespace-pre-wrap text-[12px] leading-5 text-[var(--text-faint)]"
+                className="whitespace-pre-wrap text-sub leading-5 text-[var(--text-faint)]"
               >
                 {item.text}
               </p>
@@ -294,7 +294,7 @@ const ToolCallCard = memo(function ToolCallCard({ tool }: { tool: AgentTurnToolC
       {tool.argsDone === false ? (
         // 参数生成中：工具名固定，参数区右锚定滚动显示最新生成的尾部——
         // 长参数溢出时新字符持续从右侧推入，肉眼可见任务仍在进行
-        <p className="flex font-mono text-[11px] text-[var(--accent-2)]">
+        <p className="flex font-mono text-caption text-[var(--accent-2)]">
           <span className="shrink-0">⚙ {tool.name}(</span>
           <span className="flex min-w-0 flex-1 justify-end overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_24px)]">
             <span className="whitespace-nowrap">
@@ -304,17 +304,18 @@ const ToolCallCard = memo(function ToolCallCard({ tool }: { tool: AgentTurnToolC
         </p>
       ) : (
         <>
-          <p className="font-mono text-[11px] text-[var(--accent-2)]">⚙ {tool.name}</p>
+          <p className="font-mono text-caption text-[var(--accent-2)]">⚙ {tool.name}</p>
           {input && <HighlightedCode code={input.code} lang={input.lang} />}
         </>
       )}
       {tool.argsDone === false ? (
-        <p className="mt-0.5 animate-pulse text-[11px] text-[var(--text-faint)]">生成参数中…</p>
+        <p className="mt-0.5 animate-pulse text-caption text-[var(--text-faint)]">生成参数中…</p>
       ) : tool.output === undefined ? (
-        <p className="mt-0.5 text-[11px] text-[var(--text-faint)]">执行中…</p>
+        <p className="mt-0.5 text-caption text-[var(--text-faint)]">执行中…</p>
       ) : (
         <div
-          className={`scroll-thin mt-1 max-h-44 overflow-y-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-4 ${
+          // 行高用相对值：字号随语义 token 在移动端换档（11→13px），固定 16px 行高会挤死多行日志
+          className={`scroll-thin mt-1 max-h-44 overflow-y-auto whitespace-pre-wrap break-words font-mono text-caption leading-[1.45] ${
             tool.isError ? "text-[#ff6b6b]" : "text-[var(--text-muted)]"
           }`}
         >

--- a/apps/web/components/artwork-picker-dialog.tsx
+++ b/apps/web/components/artwork-picker-dialog.tsx
@@ -82,8 +82,8 @@ export function ArtworkPickerDialog({
     >
       <div className="flex items-center justify-between gap-4 border-b border-white/[0.08] px-6 py-4 max-md:flex-col max-md:items-stretch max-md:gap-3 max-md:px-5 max-md:py-3.5">
         <div className="min-w-0">
-          <h3 className="text-[16px] font-semibold text-[var(--text)]">更换图片</h3>
-          <p className="mt-1 text-[12px] leading-5 text-[var(--text-muted)]">
+          <h3 className="text-title-sm font-semibold text-[var(--text)]">更换图片</h3>
+          <p className="mt-1 text-sub leading-5 text-[var(--text-muted)]">
             选中即生效，并同步写入媒体目录；此后刷新元数据不会覆盖你选的图
           </p>
         </div>
@@ -98,7 +98,7 @@ export function ArtworkPickerDialog({
               key={key}
               type="button"
               onClick={() => setTab(key)}
-              className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-medium transition ${
+              className={`rounded-full px-3.5 py-1.5 text-sub font-medium transition ${
                 tab === key ? "bg-white/[0.14] text-white" : "text-white/60 hover:text-white/85"
               }`}
             >
@@ -110,14 +110,14 @@ export function ArtworkPickerDialog({
 
       {locked && (
         <div className="flex items-center justify-between gap-3 border-b border-white/[0.08] bg-[#7dd3fc]/[0.07] px-6 py-2.5 max-md:px-5">
-          <span className="text-[12px] text-[#7dd3fc]">
+          <span className="text-sub text-[#7dd3fc]">
             当前{tab === "poster" ? "海报" : "背景"}由你手动选定，刷新元数据不会覆盖
           </span>
           <button
             type="button"
             disabled={applying !== null}
             onClick={() => void apply(null)}
-            className="shrink-0 text-[12px] font-medium text-[var(--accent-2)] hover:underline disabled:opacity-50"
+            className="shrink-0 text-sub font-medium text-[var(--accent-2)] hover:underline disabled:opacity-50"
           >
             恢复自动选图
           </button>
@@ -126,7 +126,7 @@ export function ArtworkPickerDialog({
 
       <div className="scroll-thin flex-1 overflow-y-auto p-6">
         {failed && (
-          <p className="py-10 text-center text-[13px] text-[#ff9f9f]">
+          <p className="py-10 text-center text-ui text-[#ff9f9f]">
             候选图加载失败（TMDB 可能不可达），
             <button type="button" onClick={load} className="ml-1 underline">
               重试
@@ -134,13 +134,13 @@ export function ArtworkPickerDialog({
           </p>
         )}
         {!failed && data === null && (
-          <div className="flex items-center justify-center gap-2 py-14 text-[13px] text-[var(--text-muted)]">
+          <div className="flex items-center justify-center gap-2 py-14 text-ui text-[var(--text-muted)]">
             <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
             正在拉取候选图…
           </div>
         )}
         {data !== null && candidates.length === 0 && (
-          <p className="py-14 text-center text-[13px] text-[var(--text-muted)]">
+          <p className="py-14 text-center text-ui text-[var(--text-muted)]">
             TMDB 上没有这个条目的{tab === "poster" ? "海报" : "背景图"}
           </p>
         )}
@@ -173,16 +173,16 @@ export function ArtworkPickerDialog({
                 />
                 {/* 标出正在用的那张，消除"我现在用的是哪张"的疑问 */}
                 {c.file_path === current && (
-                  <span className="absolute left-1.5 top-1.5 rounded bg-[var(--accent-2)] px-1.5 py-0.5 text-[10px] font-semibold text-black/85">
+                  <span className="absolute left-1.5 top-1.5 rounded bg-[var(--accent-2)] px-1.5 py-0.5 text-micro font-semibold text-black/85">
                     当前
                   </span>
                 )}
                 {tab === "backdrop" && c.language === null && (
-                  <span className="absolute right-1.5 top-1.5 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white/85">
+                  <span className="absolute right-1.5 top-1.5 rounded bg-black/70 px-1.5 py-0.5 text-micro text-white/85">
                     无文字
                   </span>
                 )}
-                <span className="tnum absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-1.5 pb-1 pt-4 text-left text-[10px] text-white/75">
+                <span className="tnum absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-1.5 pb-1 pt-4 text-left text-micro text-white/75">
                   {c.width}×{c.height}
                   {c.language ? ` · ${c.language}` : ""}
                 </span>
@@ -202,7 +202,7 @@ export function ArtworkPickerDialog({
           type="button"
           onClick={onClose}
           disabled={applying !== null}
-          className="btn-glass px-4 py-2 text-[13px] font-medium disabled:opacity-50"
+          className="btn-glass px-4 py-2 text-ui font-medium disabled:opacity-50"
         >
           完成
         </button>

--- a/apps/web/components/auth-screen.tsx
+++ b/apps/web/components/auth-screen.tsx
@@ -53,11 +53,11 @@ function AuthScreenInner({
           contentClassName="p-8"
         >
           <header className="mb-7">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-[var(--text-faint)]">
+            <p className="text-sub font-semibold uppercase tracking-[0.18em] text-[var(--text-faint)]">
               {publicEnv.appName}
             </p>
             <h1 className="mt-2 text-[22px] font-semibold text-[var(--text)]">{title}</h1>
-            <p className="mt-1.5 text-[13px] leading-relaxed text-[var(--text-muted)]">
+            <p className="mt-1.5 text-ui leading-relaxed text-[var(--text-muted)]">
               {subtitle}
             </p>
           </header>
@@ -75,10 +75,10 @@ export function AuthField({
 }: { label: string } & React.InputHTMLAttributes<HTMLInputElement>) {
   return (
     <div>
-      <label className="mb-1.5 block text-xs font-medium text-[var(--text-muted)]">{label}</label>
+      <label className="mb-1.5 block text-sub font-medium text-[var(--text-muted)]">{label}</label>
       <input
         {...inputProps}
-        className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+        className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
       />
     </div>
   );
@@ -88,7 +88,7 @@ export function AuthField({
 export function AuthError({ message }: { message: string | null }) {
   if (!message) return null;
   return (
-    <p className="rounded-xl border border-[rgba(255,107,107,0.25)] bg-[rgba(255,107,107,0.1)] px-3 py-2 text-[12px] leading-relaxed text-[var(--danger)]">
+    <p className="rounded-xl border border-[rgba(255,107,107,0.25)] bg-[rgba(255,107,107,0.1)] px-3 py-2 text-sub leading-relaxed text-[var(--danger)]">
       {message}
     </p>
   );

--- a/apps/web/components/avatar-badge.tsx
+++ b/apps/web/components/avatar-badge.tsx
@@ -5,7 +5,7 @@ import { initialsOf } from "@/lib/session";
 /**
  * 用户头像徽标：上传过头像显示图片（圆形裁切），否则回退到昵称首字的银色徽标。
  * 用户菜单、设置页个人信息等所有展示头像处共用本组件，保证换头像后观感一致。
- * 尺寸与字号由调用方通过 className 指定（如 "size-9 text-[13px]"）。
+ * 尺寸与字号由调用方通过 className 指定（如 "size-9 text-ui"）。
  */
 export function AvatarBadge({
   nickname,

--- a/apps/web/components/cast-row.tsx
+++ b/apps/web/components/cast-row.tsx
@@ -52,7 +52,7 @@ export function CastRow({ cast, title = "演职员" }: { cast: CastRowPerson[]; 
   if (cast.length === 0) return null;
   return (
     <section>
-      <h2 className="text-on-image mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+      <h2 className="text-on-image mb-3 text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
         {title}
       </h2>
       <HScroller className="-mx-1 gap-3 px-1 pb-1">
@@ -85,9 +85,9 @@ function CastCard({ person }: { person: CastRowPerson }) {
           }
         />
       </div>
-      <p className="mt-1.5 truncate text-[12px] font-medium text-[var(--text)]">{person.name}</p>
+      <p className="mt-1.5 truncate text-sub font-medium text-[var(--text)]">{person.name}</p>
       {person.role && (
-        <p className="truncate text-[11px] text-[var(--text-faint)]">饰 {person.role}</p>
+        <p className="truncate text-caption text-[var(--text-faint)]">饰 {person.role}</p>
       )}
     </>
   );

--- a/apps/web/components/composer.tsx
+++ b/apps/web/components/composer.tsx
@@ -70,7 +70,7 @@ export function Composer({
         }}
         placeholder={placeholder ?? (busy ? "生成中，可先输入下一条…" : "随心输入，描述一个新任务…")}
         // 锁定态的占位符是提示语（说明为何不可用）而非装饰，按 muted 档渲染保证可读
-        className={`scroll-thin block w-full resize-none bg-transparent px-4 pb-1 pt-3.5 text-[14px] leading-6 text-[var(--text)] focus:outline-none ${
+        className={`scroll-thin block w-full resize-none bg-transparent px-4 pb-1 pt-3.5 text-body leading-6 text-[var(--text)] focus:outline-none ${
           disabled ? "placeholder:text-[var(--text-muted)]" : "placeholder:text-[var(--text-faint)]"
         }`}
       />
@@ -78,12 +78,13 @@ export function Composer({
         <button
           type="button"
           aria-label="添加附件"
-          className="flex size-8 items-center justify-center rounded-xl text-[var(--text-muted)] transition-colors hover:bg-[var(--glass-fill-hover)] hover:text-[var(--text)]"
+          // 移动端 44px：iOS HIG 最小可点目标（桌面保持 32px 紧凑图标键）
+          className="flex size-8 items-center justify-center rounded-xl text-[var(--text-muted)] transition-colors hover:bg-[var(--glass-fill-hover)] hover:text-[var(--text)] max-md:size-11"
         >
-          <PlusIcon className="size-[18px]" />
+          <PlusIcon className="size-[18px] max-md:size-[22px]" />
         </button>
         <div className="flex items-center gap-2">
-          <span className="hidden text-[11px] text-[var(--text-faint)] sm:block">
+          <span className="hidden text-caption text-[var(--text-faint)] sm:block">
             {showStop ? (
               "生成中"
             ) : (
@@ -99,12 +100,13 @@ export function Composer({
               disabled={!showStop && !canSubmit}
               onClick={() => (showStop ? onStop?.() : submit())}
               aria-label={showStop ? "停止生成" : "发送"}
-              className="flex size-9 items-center justify-center rounded-[12px] bg-white/[0.1] text-[var(--text)] transition-colors hover:bg-white/[0.16] disabled:opacity-40 disabled:hover:bg-white/[0.1]"
+              // 移动端 44px：iOS HIG 最小可点目标
+              className="flex size-9 items-center justify-center rounded-[12px] bg-white/[0.1] text-[var(--text)] transition-colors hover:bg-white/[0.16] disabled:opacity-40 disabled:hover:bg-white/[0.1] max-md:size-11"
             >
               {showStop ? (
                 <span className="block size-[11px] rounded-[3px] bg-current" />
               ) : (
-                <SendIcon className="size-[18px]" />
+                <SendIcon className="size-[18px] max-md:size-[22px]" />
               )}
             </button>
           ) : (
@@ -119,7 +121,9 @@ export function Composer({
               disabled={!showStop && !canSubmit}
               onActiveChange={() => (showStop ? onStop?.() : submit())}
               aria-label={showStop ? "停止生成" : "发送"}
-              className="lg-send !size-9"
+              // WebGL 画布几何跟 width/height 入参走死 36px，视觉不便放大，
+              // 用 .touch-target 在移动端把命中区扩到 44px（iOS HIG）
+              className="lg-send touch-target !size-9"
             >
               {showStop ? (
                 // 停止：ChatGPT 同款实心方块

--- a/apps/web/components/directory-picker.tsx
+++ b/apps/web/components/directory-picker.tsx
@@ -116,7 +116,7 @@ export function DirectoryPicker({
       panelClassName="flex max-h-[76dvh] flex-col"
     >
         <div className="space-y-3 p-5 pb-3">
-          <h2 className="text-[15px] font-bold text-white">选择服务器目录</h2>
+          <h2 className="text-body-lg font-bold text-white">选择服务器目录</h2>
 
           {/* 面包屑 / 手动输入（铅笔切换） */}
           {editing ? (
@@ -130,7 +130,7 @@ export function DirectoryPicker({
               }}
               placeholder="输入绝对路径后回车跳转"
               spellCheck={false}
-              className="w-full rounded-xl border border-[var(--accent)]/60 bg-white/[0.04] px-3 py-2 font-mono text-[13px] text-[var(--text)] outline-none"
+              className="w-full rounded-xl border border-[var(--accent)]/60 bg-white/[0.04] px-3 py-2 font-mono text-ui text-[var(--text)] outline-none"
             />
           ) : (
             <div className="flex items-center gap-1.5">
@@ -141,7 +141,7 @@ export function DirectoryPicker({
                 <button
                   type="button"
                   onClick={() => void navigate("/")}
-                  className="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[13px] text-[var(--text-muted)] hover:bg-white/10 hover:text-white"
+                  className="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-ui text-[var(--text-muted)] hover:bg-white/10 hover:text-white"
                 >
                   /
                 </button>
@@ -151,7 +151,7 @@ export function DirectoryPicker({
                     <button
                       type="button"
                       onClick={() => void navigate(seg.path)}
-                      className={`rounded-md px-1.5 py-0.5 text-[13px] hover:bg-white/10 hover:text-white ${
+                      className={`rounded-md px-1.5 py-0.5 text-ui hover:bg-white/10 hover:text-white ${
                         seg.path === view?.path
                           ? "font-semibold text-white"
                           : "text-[var(--text-muted)]"
@@ -177,7 +177,7 @@ export function DirectoryPicker({
           )}
 
           {error && (
-            <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3 py-2 text-[12px] leading-5 text-red-200">
+            <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3 py-2 text-sub leading-5 text-red-200">
               {error}
             </p>
           )}
@@ -186,9 +186,9 @@ export function DirectoryPicker({
         {/* 子目录列表：单击下钻 */}
         <div ref={listRef} className="min-h-[240px] flex-1 overflow-y-auto px-3 pb-2">
           {loading && !view ? (
-            <p className="px-3 py-8 text-center text-[13px] text-[var(--text-muted)]">加载中…</p>
+            <p className="px-3 py-8 text-center text-ui text-[var(--text-muted)]">加载中…</p>
           ) : view && view.entries.length === 0 ? (
-            <p className="px-3 py-8 text-center text-[13px] text-[var(--text-muted)]">
+            <p className="px-3 py-8 text-center text-ui text-[var(--text-muted)]">
               该目录下没有子目录，可直接选择当前目录
             </p>
           ) : (
@@ -201,7 +201,7 @@ export function DirectoryPicker({
                 className="glass-row group flex w-full items-center gap-2.5 px-3 py-2 text-left disabled:opacity-50"
               >
                 <FolderIcon className="size-4 shrink-0 text-[var(--accent)]/80" />
-                <span className="min-w-0 flex-1 truncate text-[13px] text-[var(--text)]">
+                <span className="min-w-0 flex-1 truncate text-ui text-[var(--text)]">
                   {entry.name}
                 </span>
                 <ChevronRightIcon className="size-3.5 shrink-0 text-[var(--text-faint)] opacity-0 transition-opacity group-hover:opacity-100" />
@@ -215,19 +215,19 @@ export function DirectoryPicker({
           {/* 保尾截断（dir=rtl）：省略号在头部，当前目录名始终可见；LRM 防 "/" 跳位 */}
           <p
             dir="rtl"
-            className="min-w-0 flex-1 truncate text-left font-mono text-[12px] text-[var(--text-muted)]"
+            className="min-w-0 flex-1 truncate text-left font-mono text-sub text-[var(--text-muted)]"
             title={view?.path}
           >
             {view ? "‎" + view.path + "‎" : "…"}
           </p>
-          <button type="button" onClick={onClose} className="btn-glass h-8 shrink-0 px-3.5 text-[13px] font-medium">
+          <button type="button" onClick={onClose} className="btn-glass h-8 shrink-0 px-3.5 text-ui font-medium">
             取消
           </button>
           <button
             type="button"
             disabled={!view || loading}
             onClick={() => view && onSelect(view.path)}
-            className="btn-accent flex h-8 shrink-0 items-center gap-1.5 rounded-full px-4 text-[13px] font-semibold disabled:opacity-40"
+            className="btn-accent flex h-8 shrink-0 items-center gap-1.5 rounded-full px-4 text-ui font-semibold disabled:opacity-40"
           >
             <CheckIcon className="size-3.5" />
             选择此目录

--- a/apps/web/components/discover-view.tsx
+++ b/apps/web/components/discover-view.tsx
@@ -183,7 +183,7 @@ function SourceSwitcher({
             key={source}
             type="button"
             onClick={() => onChange(source)}
-            className={`rounded-full px-4 py-1.5 text-xs font-semibold transition ${
+            className={`rounded-full px-4 py-1.5 text-sub font-semibold transition ${
               value === source
                 ? "bg-white/15 text-white shadow-sm"
                 : "text-[var(--text-muted)] hover:text-white"
@@ -233,18 +233,18 @@ function DiscoverError({ error, onRetry }: { error: DiscoverErrorInfo; onRetry: 
             <GlobeIcon className="size-5" />
           </span>
         )}
-        <p className="text-[15px] font-semibold text-[var(--text)]">
+        <p className="text-body-lg font-semibold text-[var(--text)]">
           {unreachable ? "无法连接数据源" : "发现页加载失败"}
         </p>
-        <p className="mt-2 break-all text-[13px] leading-6 text-[var(--text-muted)]">{error.message}</p>
+        <p className="mt-2 break-all text-ui leading-6 text-[var(--text-muted)]">{error.message}</p>
         {unreachable && error.hint && (
-          <p className="mt-2 text-[12px] leading-6 text-[var(--text-faint)]">{error.hint}</p>
+          <p className="mt-2 text-sub leading-6 text-[var(--text-faint)]">{error.hint}</p>
         )}
         <div className="mt-5 flex items-center justify-center gap-3">
           {unreachable && (
             <Link
               href={"/settings/network" as Route}
-              className="btn-accent flex h-9 items-center rounded-full px-5 text-[13px] font-semibold"
+              className="btn-accent flex h-9 items-center rounded-full px-5 text-ui font-semibold"
             >
               前往网络设置
             </Link>
@@ -252,7 +252,7 @@ function DiscoverError({ error, onRetry }: { error: DiscoverErrorInfo; onRetry: 
           <button
             type="button"
             onClick={onRetry}
-            className={`${unreachable ? "btn-glass" : "btn-accent"} h-9 rounded-full px-5 text-[13px] font-semibold`}
+            className={`${unreachable ? "btn-glass" : "btn-accent"} h-9 rounded-full px-5 text-ui font-semibold`}
           >
             重试
           </button>
@@ -382,16 +382,16 @@ function HeroSlide({
           active ? "translate-y-0 opacity-100" : "translate-y-3 opacity-0"
         }`}
       >
-        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
+        <p className="text-caption font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
           今日精选 · {item.type === "movie" ? "电影" : "剧集"}
         </p>
         <h2 className="text-on-image mt-2 text-[34px] font-bold leading-[1.1] tracking-[-0.02em] text-white max-md:mt-1 max-md:text-[23px] sm:text-[40px]">
           {item.title}
         </h2>
-        <p className="text-on-image mt-1 truncate text-[13px] text-white/55 max-md:text-[11.5px]">{item.originalTitle}</p>
+        <p className="text-on-image mt-1 truncate text-ui text-white/55 max-md:text-caption">{item.originalTitle}</p>
 
         {/* 元信息行：评分 / 年份 / 类型 / 规模 / 质量徽章（空字段不占位） */}
-        <div className="tnum mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[12.5px] text-white/80">
+        <div className="tnum mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sub text-white/80">
           {item.rating > 0 && (
             <span className="flex items-center gap-1 font-semibold text-white">
               <StarIcon className="size-3.5 text-[#f5c451]" />
@@ -406,7 +406,7 @@ function HeroSlide({
               {item.badges.map((b) => (
                 <span
                   key={b}
-                  className="rounded border border-white/25 px-1.5 py-px text-[10px] font-semibold tracking-wide text-white/85"
+                  className="rounded border border-white/25 px-1.5 py-px text-micro font-semibold tracking-wide text-white/85"
                 >
                   {b}
                 </span>
@@ -415,14 +415,14 @@ function HeroSlide({
           )}
         </div>
 
-        <p className="text-on-image mt-3 line-clamp-2 max-w-lg text-[13px] leading-6 text-white/75 max-md:mt-2 max-md:text-[12px] max-md:leading-5 sm:line-clamp-3">
+        <p className="text-on-image mt-3 line-clamp-2 max-w-lg text-ui leading-6 text-white/75 max-md:mt-2 max-md:text-sub max-md:leading-5 sm:line-clamp-3">
           {item.overview}
         </p>
 
         <div className="mt-5 flex flex-wrap items-center gap-3 max-md:mt-3.5 max-md:gap-2">
           <button
             type="button"
-            className="btn-accent flex h-10 items-center gap-2 rounded-full px-5 text-[13px] font-semibold"
+            className="btn-accent flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold"
           >
             <BellIcon className="size-4" />
             订阅追踪
@@ -430,7 +430,7 @@ function HeroSlide({
           <button
             type="button"
             {...tapGuard}
-            className="btn-glass h-10 bg-white/10 px-5 text-[13px] font-medium backdrop-blur-md"
+            className="btn-glass h-10 bg-white/10 px-5 text-ui font-medium backdrop-blur-md"
           >
             <InfoIcon className="size-4" />
             更多信息

--- a/apps/web/components/download-target-dialog.tsx
+++ b/apps/web/components/download-target-dialog.tsx
@@ -205,10 +205,10 @@ export function DownloadTargetDialog({
   return (
     <Modal open onClose={onClose} label="选择保存位置">
       <div className="space-y-4 p-6">
-          <h2 className="text-[17px] font-bold text-white">选择保存位置</h2>
+          <h2 className="text-title font-bold text-white">选择保存位置</h2>
 
           {error && (
-            <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-[13px] leading-6 text-red-200">
+            <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
               {error}
             </p>
           )}
@@ -230,16 +230,16 @@ export function DownloadTargetDialog({
                 >
                   <FolderIcon className="mt-0.5 size-4 shrink-0 text-[var(--accent)]/80" />
                   <span className="min-w-0 flex-1">
-                    <span className="block truncate font-mono text-[13px] font-medium text-[var(--text)]">
+                    <span className="block truncate font-mono text-ui font-medium text-[var(--text)]">
                       {option.label}
                     </span>
                     {option.detail && (
-                      <span className="mt-0.5 block text-[11px] leading-relaxed text-[var(--text-faint)]">
+                      <span className="mt-0.5 block text-caption leading-relaxed text-[var(--text-faint)]">
                         {option.detail}
                       </span>
                     )}
                     {option.warning && (
-                      <span className="mt-1 block rounded-md bg-amber-500/10 px-2 py-1 text-[11px] leading-relaxed text-amber-200">
+                      <span className="mt-1 block rounded-md bg-amber-500/10 px-2 py-1 text-caption leading-relaxed text-amber-200">
                         {option.warning}
                       </span>
                     )}
@@ -249,7 +249,7 @@ export function DownloadTargetDialog({
             </div>
           )}
 
-          <p className="text-[11px] leading-relaxed text-[var(--text-faint)]">
+          <p className="text-caption leading-relaxed text-[var(--text-faint)]">
             movieclaw 与下载器不在同一容器/主机、看到的路径不同？到
             <Link href="/settings/downloaders" className="mx-0.5 text-[var(--accent)] hover:underline">
               设置 → 下载器
@@ -258,14 +258,14 @@ export function DownloadTargetDialog({
           </p>
 
           <div className="flex justify-end gap-3 pt-1">
-            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-[13px] font-medium">
+            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
               取消
             </button>
             <button
               type="button"
               onClick={submit}
               disabled={busy || loading || selected === null}
-              className="btn-accent h-9 rounded-full px-5 text-[13px] font-semibold disabled:opacity-40"
+              className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
             >
               {busy ? "提交中…" : "确认下载"}
             </button>

--- a/apps/web/components/downloader-config-section.tsx
+++ b/apps/web/components/downloader-config-section.tsx
@@ -123,13 +123,13 @@ export function DownloaderConfigSection() {
   return (
     <div className="space-y-5">
       {error && (
-        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-sm text-[#ff6b6b]">
+        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
           {error}
         </div>
       )}
 
       <div className="flex items-center justify-between gap-4">
-        <p className="text-xs text-[var(--text-muted)]">
+        <p className="text-sub text-[var(--text-muted)]">
           {loading
             ? "加载中…"
             : downloaders.length === 0
@@ -141,7 +141,7 @@ export function DownloaderConfigSection() {
             type="button"
             onClick={() => void load()}
             disabled={loading}
-            className="btn-glass px-3.5 py-1.5 text-xs font-medium"
+            className="btn-glass px-3.5 py-1.5 text-sub font-medium"
           >
             刷新
           </button>
@@ -149,7 +149,7 @@ export function DownloaderConfigSection() {
             type="button"
             onClick={() => setAdding((v) => !v)}
             disabled={loading}
-            className="btn-accent flex items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-xs font-semibold disabled:opacity-60"
+            className="btn-accent flex items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-sub font-semibold disabled:opacity-60"
           >
             <PlusIcon className="size-4" />
             添加下载器
@@ -185,8 +185,8 @@ export function DownloaderConfigSection() {
               <DownloadIcon className="size-6" />
             </span>
             <div>
-              <p className="text-sm font-medium text-[var(--text)]">还没有接入任何下载器</p>
-              <p className="mt-1 text-xs text-[var(--text-muted)]">
+              <p className="text-body font-medium text-[var(--text)]">还没有接入任何下载器</p>
+              <p className="mt-1 text-sub text-[var(--text-muted)]">
                 点击右上角「添加下载器」，支持 qBittorrent 和 Transmission。
               </p>
             </div>
@@ -276,21 +276,21 @@ function DownloaderCard({
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <p className="truncate text-sm font-semibold text-[var(--text)]">{downloader.name}</p>
+            <p className="truncate text-body font-semibold text-[var(--text)]">{downloader.name}</p>
             {downloader.is_default && (
-              <span className="shrink-0 rounded-full border border-white/[0.12] bg-[var(--accent-soft)] px-2 py-0.5 text-[11px] font-semibold text-[var(--accent)]">
+              <span className="shrink-0 rounded-full border border-white/[0.12] bg-[var(--accent-soft)] px-2 py-0.5 text-caption font-semibold text-[var(--accent)]">
                 默认
               </span>
             )}
             <span
-              className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium"
+              className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
               style={{ background: `${meta.color}1f`, color: meta.color }}
             >
               <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
               {meta.label}
             </span>
           </div>
-          <p className="mt-0.5 truncate text-[11px] text-[var(--text-faint)]" title={downloader.url}>
+          <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]" title={downloader.url}>
             {subtitle}
           </p>
         </div>
@@ -372,8 +372,8 @@ function DownloaderCard({
 function InfoStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <p className="text-[10px] text-[var(--text-faint)]">{label}</p>
-      <p className="mt-0.5 truncate text-[13px] font-semibold text-[var(--text)]">{value}</p>
+      <p className="text-micro text-[var(--text-faint)]">{label}</p>
+      <p className="mt-0.5 truncate text-ui font-semibold text-[var(--text)]">{value}</p>
     </div>
   );
 }
@@ -403,7 +403,7 @@ function DownloaderActionsMenu({
   onDelete,
 }: DownloaderActionsMenuProps) {
   const itemClass =
-    "glass-row nav-item cursor-pointer px-3 py-2 text-xs font-medium outline-none " +
+    "glass-row nav-item cursor-pointer px-3 py-2 text-sub font-medium outline-none " +
     "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)] " +
     "data-[disabled]:pointer-events-none data-[disabled]:opacity-40";
 
@@ -549,9 +549,9 @@ function DownloaderForm({
   }
 
   const inputClass =
-    "w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] " +
+    "w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui " +
     "text-[var(--text)] outline-none focus:border-[var(--accent)]/60";
-  const labelClass = "mb-1.5 block text-xs font-medium text-[var(--text-muted)]";
+  const labelClass = "mb-1.5 block text-sub font-medium text-[var(--text-muted)]";
 
   return (
     <div className="space-y-4">
@@ -565,7 +565,7 @@ function DownloaderForm({
               type="button"
               onClick={() => setClientType(t)}
               data-active={clientType === t}
-              className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+              className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
             >
               {TYPE_LABEL[t]}
             </button>
@@ -634,11 +634,11 @@ function DownloaderForm({
           >
             <FolderIcon className="size-4 shrink-0 text-[var(--accent)]/80" />
             {savePath ? (
-              <span dir="rtl" className="min-w-0 flex-1 truncate font-mono text-[13px] text-[var(--text)]">
+              <span dir="rtl" className="min-w-0 flex-1 truncate font-mono text-ui text-[var(--text)]">
                 {"‎" + savePath + "‎"}
               </span>
             ) : (
-              <span className="text-[13px] text-[var(--text-faint)]">浏览服务器目录并选择…</span>
+              <span className="text-ui text-[var(--text-faint)]">浏览服务器目录并选择…</span>
             )}
           </button>
           {savePath && (
@@ -652,7 +652,7 @@ function DownloaderForm({
             </button>
           )}
         </div>
-        <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+        <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
           提交下载时文件的保存位置，从 movieclaw 能看到的目录里选择；下载器看到的路径不同时，
           配合下方「路径映射」翻译。留空则使用下载器自己设置的默认下载目录
           ——下载器与 movieclaw 没有共享目录的部署请留空。
@@ -664,7 +664,7 @@ function DownloaderForm({
         <button
           type="button"
           onClick={() => setMappingsOpen((v) => !v)}
-          className="flex items-center gap-1.5 text-xs font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
+          className="flex items-center gap-1.5 text-sub font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
         >
           <span
             className="inline-block transition-transform"
@@ -679,7 +679,7 @@ function DownloaderForm({
         </button>
         {mappingsOpen && (
           <div className="mt-2.5 space-y-2.5">
-            <p className="text-[11px] leading-relaxed text-[var(--text-faint)]">
+            <p className="text-caption leading-relaxed text-[var(--text-faint)]">
               movieclaw 与下载器不在同一容器/主机、同一块盘两边路径不同时才需要：
               提交下载前会把保存目录按前缀翻译成下载器视角。例如 movieclaw 看到的下载区是
               <code className="mx-0.5 font-mono">/data/downloads</code>、下载器容器里是
@@ -689,7 +689,7 @@ function DownloaderForm({
               添加一条两边相同的映射即可。
             </p>
             {suggestMapping && (
-              <p className="rounded-lg bg-[var(--accent-soft)] px-3 py-2 text-[11.5px] leading-relaxed text-[var(--accent)]">
+              <p className="rounded-lg bg-[var(--accent-soft)] px-3 py-2 text-caption leading-relaxed text-[var(--accent)]">
                 已按体检建议预填映射的本机侧 {suggestMapping}——右侧填下载器视角的对应路径；
                 下载器可直达同名路径时，点中间的 → 把左侧复制过去即可。
               </p>
@@ -704,11 +704,11 @@ function DownloaderForm({
                 >
                   <FolderIcon className="size-4 shrink-0 text-[var(--accent)]/80" />
                   {mapping.local ? (
-                    <span dir="rtl" className="min-w-0 flex-1 truncate font-mono text-[13px] text-[var(--text)]">
+                    <span dir="rtl" className="min-w-0 flex-1 truncate font-mono text-ui text-[var(--text)]">
                       {"‎" + mapping.local + "‎"}
                     </span>
                   ) : (
-                    <span className="truncate text-[13px] text-[var(--text-faint)]">movieclaw 上的路径…</span>
+                    <span className="truncate text-ui text-[var(--text-faint)]">movieclaw 上的路径…</span>
                   )}
                 </button>
                 {/* 箭头即按钮：两边路径一致时点一下把左侧复制到右侧，省去手动输入 */}
@@ -743,17 +743,17 @@ function DownloaderForm({
             <button
               type="button"
               onClick={() => setMappings((prev) => [...prev, { local: "", remote: "" }])}
-              className="btn-glass flex items-center gap-1 px-3 py-1.5 text-xs font-medium"
+              className="btn-glass flex items-center gap-1 px-3 py-1.5 text-sub font-medium"
             >
               <PlusIcon className="size-3.5" />
               添加映射
             </button>
             {!mappingsComplete ? (
-              <p className="text-[11px] text-[#ffb46b]">
+              <p className="text-caption text-[#ffb46b]">
                 每条映射两边都要填：左边浏览选择，右边填下载器上以 / 开头的绝对路径；不需要的行请删除。
               </p>
             ) : !mappingsUnique ? (
-              <p className="text-[11px] text-[#ffb46b]">
+              <p className="text-caption text-[#ffb46b]">
                 映射的路径不能重复：同一 movieclaw 路径或同一下载器路径只能出现一次，请修改或删除重复的行。
               </p>
             ) : null}
@@ -762,14 +762,14 @@ function DownloaderForm({
       </div>
 
       <div className="flex items-center justify-end gap-3 pt-1">
-        <button type="button" onClick={onCancel} className="btn-glass px-3.5 py-2 text-[13px] font-medium">
+        <button type="button" onClick={onCancel} className="btn-glass px-3.5 py-2 text-ui font-medium">
           取消
         </button>
         <button
           type="button"
           onClick={submit}
           disabled={busy || !canSubmit}
-          className="btn-accent rounded-full px-4.5 py-2 text-[13px] font-semibold disabled:opacity-40"
+          className="btn-accent rounded-full px-4.5 py-2 text-ui font-semibold disabled:opacity-40"
         >
           {busy ? "保存中…" : "保存"}
         </button>

--- a/apps/web/components/extension-settings.tsx
+++ b/apps/web/components/extension-settings.tsx
@@ -42,14 +42,14 @@ export function ExtensionCard() {
             <PuzzleIcon className="size-5" />
           </span>
           <div>
-            <h2 className="text-[15px] font-semibold">MovieClaw 浏览器插件</h2>
-            <p className="mt-0.5 text-xs leading-5 text-[var(--text-muted)]">
+            <h2 className="text-body-lg font-semibold">MovieClaw 浏览器插件</h2>
+            <p className="mt-0.5 text-sub leading-5 text-[var(--text-muted)]">
               在站点页面一键读取登录 Cookie（含 httpOnly）并同步到本服务，免去手动复制粘贴，
               还能随 Cookie 变化自动保持最新。
             </p>
           </div>
         </div>
-        <span className="flex shrink-0 items-center gap-1.5 text-xs text-[var(--text-muted)]">
+        <span className="flex shrink-0 items-center gap-1.5 text-sub text-[var(--text-muted)]">
           <span
             className={`size-2 rounded-full ${installed === null ? "animate-pulse" : ""}`}
             style={{ background: badge.color }}
@@ -59,20 +59,20 @@ export function ExtensionCard() {
       </div>
 
       {installed ? (
-        <p className="mt-4 rounded-xl bg-white/[0.03] px-4 py-3 text-sm text-[var(--text-muted)]">
+        <p className="mt-4 rounded-xl bg-white/[0.03] px-4 py-3 text-body text-[var(--text-muted)]">
           <CheckIcon className="mr-1.5 inline size-4 text-[#4ade80]" />
           插件已就绪。打开支持的站点页面，点击浏览器工具栏的 MovieClaw
           图标即可同步该站 Cookie；首次使用请先点下方「同步令牌」生成并填入插件。
         </p>
       ) : (
-        <ol className="mt-4 space-y-2 rounded-xl bg-white/[0.03] px-4 py-3.5 text-[13px] leading-6 text-[var(--text-muted)]">
+        <ol className="mt-4 space-y-2 rounded-xl bg-white/[0.03] px-4 py-3.5 text-ui leading-6 text-[var(--text-muted)]">
           <li>
             <b className="text-[var(--text)]">1.</b> 点击下方按钮下载插件包，解压得到{" "}
-            <code className="rounded bg-white/[0.06] px-1 font-mono text-xs">chrome-mv3</code> 文件夹。
+            <code className="rounded bg-white/[0.06] px-1 font-mono text-sub">chrome-mv3</code> 文件夹。
           </li>
           <li>
             <b className="text-[var(--text)]">2.</b> 浏览器打开{" "}
-            <code className="rounded bg-white/[0.06] px-1 font-mono text-xs">chrome://extensions</code>
+            <code className="rounded bg-white/[0.06] px-1 font-mono text-sub">chrome://extensions</code>
             ，右上角开启「开发者模式」。
           </li>
           <li>
@@ -87,7 +87,7 @@ export function ExtensionCard() {
           <a
             href={EXTENSION_ZIP_URL}
             download
-            className="btn-accent flex items-center gap-1.5 rounded-full px-4 py-2 text-xs font-semibold"
+            className="btn-accent flex items-center gap-1.5 rounded-full px-4 py-2 text-sub font-semibold"
           >
             <DownloadIcon className="size-4" />
             下载插件包
@@ -96,13 +96,13 @@ export function ExtensionCard() {
         <button
           type="button"
           onClick={() => setTokenOpen(true)}
-          className="btn-glass flex items-center gap-1.5 px-4 py-2 text-xs font-medium"
+          className="btn-glass flex items-center gap-1.5 px-4 py-2 text-sub font-medium"
         >
           <ShieldIcon className="size-4" />
           同步令牌
         </button>
         {!installed && (
-          <p className="text-[11px] text-[var(--text-faint)]">
+          <p className="text-caption text-[var(--text-faint)]">
             支持 Chrome / Edge 等 Chromium 内核浏览器；安装检测同样仅对 Chromium 生效。
           </p>
         )}
@@ -174,8 +174,8 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
       <div className="space-y-4 p-6">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-[17px] font-bold text-[var(--text)]">同步令牌</h2>
-            <p className="mt-1 text-xs leading-5 text-[var(--text-muted)]">
+            <h2 className="text-title font-bold text-[var(--text)]">同步令牌</h2>
+            <p className="mt-1 text-sub leading-5 text-[var(--text-muted)]">
               在浏览器插件的设置里填入此令牌，即可把站点 Cookie 同步到本服务。令牌长期有效，除非你重新生成。
             </p>
           </div>
@@ -183,7 +183,7 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
         </div>
 
         {error && (
-          <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-sm text-[#ff6b6b]">
+          <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
             {error}
           </div>
         )}
@@ -193,7 +193,7 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
         ) : token?.enabled ? (
           <TokenRow token={token.token ?? ""} createdAt={token.created_at} />
         ) : (
-          <p className="rounded-xl bg-white/[0.03] px-4 py-3 text-sm text-[var(--text-muted)]">
+          <p className="rounded-xl bg-white/[0.03] px-4 py-3 text-body text-[var(--text-muted)]">
             尚未启用同步。点击下方「生成令牌」创建一个。
           </p>
         )}
@@ -203,7 +203,7 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
             type="button"
             onClick={onGenerate}
             disabled={busy || loading}
-            className="btn-accent rounded-full px-4 py-2 text-xs font-semibold disabled:opacity-60"
+            className="btn-accent rounded-full px-4 py-2 text-sub font-semibold disabled:opacity-60"
           >
             {token?.enabled ? "重新生成" : "生成令牌"}
           </button>
@@ -212,7 +212,7 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
               type="button"
               onClick={onRevoke}
               disabled={busy || loading}
-              className="btn-glass px-4 py-2 text-xs font-medium !text-[var(--danger)] hover:!border-[#ff6b6b]/40"
+              className="btn-glass px-4 py-2 text-sub font-medium !text-[var(--danger)] hover:!border-[#ff6b6b]/40"
             >
               关闭同步
             </button>
@@ -220,7 +220,7 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
           <button
             type="button"
             onClick={onClose}
-            className="btn-glass ml-auto px-4 py-2 text-xs font-medium"
+            className="btn-glass ml-auto px-4 py-2 text-sub font-medium"
           >
             完成
           </button>
@@ -232,7 +232,7 @@ function TokenModal({ open, onClose }: { open: boolean; onClose: () => void }) {
 
 function StatusDot({ on }: { on: boolean }) {
   return (
-    <span className="flex shrink-0 items-center gap-1.5 text-xs text-[var(--text-muted)]">
+    <span className="flex shrink-0 items-center gap-1.5 text-sub text-[var(--text-muted)]">
       <span
         className="size-2 rounded-full"
         style={{ background: on ? "#4ade80" : "#c0c4cc" }}
@@ -261,13 +261,13 @@ function TokenRow({ token, createdAt }: { token: string; createdAt: string | nul
   return (
     <div>
       <div className="flex items-center gap-2 rounded-xl bg-white/[0.04] px-3 py-2.5">
-        <code className="min-w-0 flex-1 truncate font-mono text-[13px] text-[var(--text)]">
+        <code className="min-w-0 flex-1 truncate font-mono text-ui text-[var(--text)]">
           {display}
         </code>
         <button
           type="button"
           onClick={() => setRevealed((v) => !v)}
-          className="btn-glass shrink-0 px-2.5 py-1 text-xs font-medium"
+          className="btn-glass shrink-0 px-2.5 py-1 text-sub font-medium"
         >
           {revealed ? "隐藏" : "显示"}
         </button>
@@ -275,13 +275,13 @@ function TokenRow({ token, createdAt }: { token: string; createdAt: string | nul
           type="button"
           onClick={copy}
           aria-label="复制令牌"
-          className="btn-glass shrink-0 px-2 py-1 text-xs font-medium"
+          className="btn-glass shrink-0 px-2 py-1 text-sub font-medium"
         >
           {copied ? <CheckIcon className="size-4 text-[#4ade80]" /> : <CopyIcon className="size-4" />}
         </button>
       </div>
       {createdAt && (
-        <p className="mt-1.5 text-[11px] text-[var(--text-faint)]">
+        <p className="mt-1.5 text-caption text-[var(--text-faint)]">
           生成于 {formatDateTime(createdAt)}
         </p>
       )}

--- a/apps/web/components/image-lightbox.tsx
+++ b/apps/web/components/image-lightbox.tsx
@@ -141,16 +141,16 @@ export function ImageLightbox({
     >
       {/* 顶栏：计数 + 标题 + 关闭 */}
       <div className="flex shrink-0 flex-wrap items-center gap-3 px-4 py-3 text-white/85 [padding-top:calc(0.75rem+var(--safe-top))] max-md:gap-2 max-md:px-3">
-        <span className="tnum shrink-0 rounded-full bg-white/[0.1] px-2.5 py-0.5 text-[12px]">
+        <span className="tnum shrink-0 rounded-full bg-white/[0.1] px-2.5 py-0.5 text-sub">
           {index + 1} / {images.length}
         </span>
-        {title && <p className="min-w-0 flex-1 truncate text-[13px] text-white/70">{title}</p>}
+        {title && <p className="min-w-0 flex-1 truncate text-ui text-white/70">{title}</p>}
 
         {/* 可选操作按钮（如「设为背景」）：busy 转菊花禁用，done 变对勾，错误就地提示 */}
         {action && (
           <div className="flex min-w-0 shrink-0 items-center gap-2">
             {actionError && (
-              <span className="max-w-[260px] truncate text-[12px] text-[#f2a4a4]" title={actionError}>
+              <span className="max-w-[260px] truncate text-sub text-[#f2a4a4]" title={actionError}>
                 {actionError}
               </span>
             )}
@@ -161,7 +161,7 @@ export function ImageLightbox({
                 e.stopPropagation();
                 void runAction();
               }}
-              className={`flex h-8 items-center gap-1.5 rounded-full px-3.5 text-[12.5px] font-medium transition-colors ${
+              className={`flex h-8 items-center gap-1.5 rounded-full px-3.5 text-sub font-medium transition-colors ${
                 actionStatus === "done"
                   ? "bg-white/[0.1] text-white/85"
                   : "bg-white/[0.12] text-white hover:bg-white/[0.2] disabled:cursor-default disabled:hover:bg-white/[0.12]"
@@ -211,10 +211,10 @@ export function ImageLightbox({
         {broken.has(index) ? (
           <div
             onClick={(e) => e.stopPropagation()}
-            className="rounded-2xl border border-white/[0.12] bg-white/[0.04] px-8 py-10 text-center text-[13px] text-white/60"
+            className="rounded-2xl border border-white/[0.12] bg-white/[0.04] px-8 py-10 text-center text-ui text-white/60"
           >
             这张图片加载失败
-            <span className="mt-1 block text-[11px] text-white/40">
+            <span className="mt-1 block text-caption text-white/40">
               图床可能已失效或拒绝外链访问
             </span>
           </div>

--- a/apps/web/components/import-watch-section.tsx
+++ b/apps/web/components/import-watch-section.tsx
@@ -105,7 +105,7 @@ export function ImportWatchSection() {
 
   return (
     <div className="space-y-5">
-      <p className="text-[13px] leading-6 text-[var(--text-muted)]">
+      <p className="text-ui leading-6 text-[var(--text-muted)]">
         监听下载目录，其中<strong className="font-medium text-white/80">下载完成</strong>
         的内容（下载器确认完成，或文件持续静默且探测通过）自动识别、按「标题 (年份)」规范命名
         搬进目标媒体库。源文件原地保留：硬链接零占用、可继续做种；复制适合跨盘。
@@ -113,15 +113,15 @@ export function ImportWatchSection() {
       </p>
 
       {error && (
-        <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-[13px] leading-6 text-red-200">
+        <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
           {error}
         </p>
       )}
 
       {failed && (
         <div className="flex items-center gap-3">
-          <p className="text-[13px] text-[var(--text-muted)]">监听导入配置加载失败</p>
-          <button type="button" onClick={reload} className="btn-glass px-3 py-1.5 text-[12.5px] font-medium">
+          <p className="text-ui text-[var(--text-muted)]">监听导入配置加载失败</p>
+          <button type="button" onClick={reload} className="btn-glass px-3 py-1.5 text-sub font-medium">
             重试
           </button>
         </div>
@@ -130,7 +130,7 @@ export function ImportWatchSection() {
       {rules !== null && !failed && (
         <div className="space-y-2">
           {rules.length === 0 && (
-            <p className="rounded-xl bg-white/[0.03] px-4 py-6 text-center text-[13px] text-[var(--text-muted)]">
+            <p className="rounded-xl bg-white/[0.03] px-4 py-6 text-center text-ui text-[var(--text-muted)]">
               还没有监听导入规则。不需要「下载区 → 库」自动搬运的话，这里保持为空即可。
             </p>
           )}
@@ -141,17 +141,17 @@ export function ImportWatchSection() {
             >
               <FolderIcon className="size-4 shrink-0 text-[var(--accent)]/80" />
               <div className="min-w-0 flex-1">
-                <p className="truncate font-mono text-[12.5px] text-[var(--text)]" title={rule.source_path}>
+                <p className="truncate font-mono text-sub text-[var(--text)]" title={rule.source_path}>
                   {rule.source_path}
                 </p>
-                <p className="mt-0.5 text-[11.5px] text-[var(--text-muted)]">
+                <p className="mt-0.5 text-caption text-[var(--text-muted)]">
                   {rule.strategy === "hardlink" ? "硬链接" : "复制"} → {rule.target_label}
                 </p>
               </div>
               <button
                 type="button"
                 onClick={() => setEditing(rule)}
-                className="btn-glass shrink-0 px-3 py-1.5 text-[12px] font-medium"
+                className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium"
               >
                 编辑
               </button>
@@ -168,7 +168,7 @@ export function ImportWatchSection() {
           <button
             type="button"
             onClick={() => setEditing("new")}
-            className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-white/15 px-3 py-2.5 text-[13px] font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--accent)]/50 hover:text-white"
+            className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-white/15 px-3 py-2.5 text-ui font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--accent)]/50 hover:text-white"
           >
             <PlusIcon className="size-4" />
             添加监听导入规则
@@ -269,18 +269,18 @@ function RuleFormDialog({
       .finally(() => setBusy(false));
   };
 
-  const labelClass = "mb-1.5 block text-xs font-medium text-[var(--text-muted)]";
+  const labelClass = "mb-1.5 block text-sub font-medium text-[var(--text-muted)]";
 
   return (
     <>
       <Modal open onClose={onClose} label={rule ? "编辑监听导入规则" : "添加监听导入规则"}>
         <div className="space-y-4 p-6">
-          <h2 className="text-[17px] font-bold text-white">
+          <h2 className="text-title font-bold text-white">
             {rule ? "编辑监听导入规则" : "添加监听导入规则"}
           </h2>
 
           {error && (
-            <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-[13px] leading-6 text-red-200">
+            <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
               {error}
             </p>
           )}
@@ -294,18 +294,18 @@ function RuleFormDialog({
             >
               <FolderIcon className="size-4 shrink-0 text-[var(--accent)]/80" />
               {sourcePath ? (
-                <span dir="rtl" className="min-w-0 flex-1 truncate font-mono text-[13px] text-[var(--text)]">
+                <span dir="rtl" className="min-w-0 flex-1 truncate font-mono text-ui text-[var(--text)]">
                   {"‎" + sourcePath + "‎"}
                 </span>
               ) : (
-                <span className="text-[13px] text-[var(--text-faint)]">浏览服务器目录并选择…</span>
+                <span className="text-ui text-[var(--text-faint)]">浏览服务器目录并选择…</span>
               )}
             </button>
             {/* 下载器目录快捷候选：源目录大概率就是下载器目录，点选直填；
                 想用其子目录（如 watch/）点选后再「浏览」，弹窗会从该目录起步 */}
             {downloaderDirs.length > 0 && (
               <div className="mt-2">
-                <p className="mb-1.5 text-[11px] text-[var(--text-faint)]">
+                <p className="mb-1.5 text-caption text-[var(--text-faint)]">
                   从下载器目录快速选择（选后可再浏览细化到子目录）：
                 </p>
                 <div className="flex flex-wrap gap-1.5">
@@ -316,7 +316,7 @@ function RuleFormDialog({
                       onClick={() => setSourcePath(option.path)}
                       data-active={sourcePath === option.path}
                       title={`${option.path}（来自下载器「${option.downloaderName}」）`}
-                      className="glass-row nav-item !w-auto max-w-full gap-1.5 px-2.5 py-1.5 text-[12px] font-medium"
+                      className="glass-row nav-item !w-auto max-w-full gap-1.5 px-2.5 py-1.5 text-sub font-medium"
                     >
                       <FolderIcon className="size-3.5 shrink-0 text-[var(--accent)]/80" />
                       <span dir="rtl" className="min-w-0 truncate font-mono">
@@ -327,7 +327,7 @@ function RuleFormDialog({
                 </div>
               </div>
             )}
-            <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+            <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
               不能与任何媒体库的根路径重叠（库根下的内容由库自己扫描管理）。
               订阅和手动下载会把种子投到这个目录（movieclaw 视角）；若下载器在另一个
               容器/主机上、看到的路径不同，请先到「设置 → 下载器」配置路径映射，
@@ -349,14 +349,14 @@ function RuleFormDialog({
                   type="button"
                   onClick={() => setStrategy(value)}
                   data-active={strategy === value}
-                  className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+                  className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
                   title={hint}
                 >
                   {label}
                 </button>
               ))}
             </div>
-            <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+            <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
               {strategy === "hardlink"
                 ? "保存时会检测源目录与目标库主根是否同一文件系统，跨盘会提示改用复制。"
                 : "复制适合源目录与库不在同一块盘的部署。"}
@@ -372,7 +372,7 @@ function RuleFormDialog({
                   type="button"
                   onClick={() => setTarget({ type: "library", id: lib.id })}
                   data-active={target?.type === "library" && target.id === lib.id}
-                  className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+                  className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
                   title={lib.primary_root ?? undefined}
                 >
                   {lib.name}
@@ -389,19 +389,19 @@ function RuleFormDialog({
                   type="button"
                   onClick={() => setTarget({ type: "auto", kind: k })}
                   data-active={target?.type === "auto" && target.kind === k}
-                  className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+                  className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
                   title="识别出作品后，按各库的收藏范围自动选库；未命中进该类型的默认库"
                 >
                   {label}
                 </button>
               ))}
               {libraries.length === 0 && (
-                <p className="text-[12px] text-[var(--text-faint)]">
+                <p className="text-sub text-[var(--text-faint)]">
                   还没有媒体库，请先在「媒体库」页创建。
                 </p>
               )}
             </div>
-            <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+            <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
               {target?.type === "auto"
                 ? "自动路由：识别出作品后按各媒体库的「收藏范围」分流（如动画进动漫库），未命中进该类型的默认库；订阅投递的内容始终进订阅指定的库。每个类型至多一条自动路由规则。"
                 : "指定库：这个目录里的内容固定导入所选库（落其主根）。"}
@@ -409,14 +409,14 @@ function RuleFormDialog({
           </div>
 
           <div className="flex items-center justify-end gap-3 pt-1">
-            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-[13px] font-medium">
+            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
               取消
             </button>
             <button
               type="button"
               onClick={submit}
               disabled={!canSubmit}
-              className="btn-accent h-9 rounded-full px-5 text-[13px] font-semibold disabled:opacity-40"
+              className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
             >
               {busy ? "保存中…" : "保存"}
             </button>

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -250,11 +250,11 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
       <div className="flex-1">
         <PageNav items={fallbackTrail} />
         <CenteredNote>
-          <p className="text-[13.5px] text-[var(--text-muted)]">媒体库加载失败</p>
+          <p className="text-ui text-[var(--text-muted)]">媒体库加载失败</p>
           <button
             type="button"
             onClick={reload}
-            className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+            className="btn-glass px-4 py-2 text-ui font-medium text-[var(--text)]"
           >
             重试
           </button>
@@ -269,7 +269,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
         <PageNav items={fallbackTrail} />
         <CenteredNote>
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
-          <p className="text-[13px] text-[var(--text-muted)]">正在加载媒体库…</p>
+          <p className="text-ui text-[var(--text-muted)]">正在加载媒体库…</p>
         </CenteredNote>
       </div>
     );
@@ -280,8 +280,8 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
       <div className="flex-1">
         <PageNav items={fallbackTrail} />
         <CenteredNote>
-          <p className="text-[13.5px] text-[var(--text-muted)]">这个媒体库不存在（可能已被删除）</p>
-          <Link href={"/library" as Route} className="btn-glass px-4 py-2 text-[13px] font-medium">
+          <p className="text-ui text-[var(--text-muted)]">这个媒体库不存在（可能已被删除）</p>
+          <Link href={"/library" as Route} className="btn-glass px-4 py-2 text-ui font-medium">
             返回媒体库
           </Link>
         </CenteredNote>
@@ -368,13 +368,13 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
             {library.name}
           </h2>
           {library.is_default && (
-            <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.12] px-2 py-0.5 text-[11px] font-semibold text-white/90">
+            <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.12] px-2 py-0.5 text-caption font-semibold text-white/90">
               默认
             </span>
           )}
         </div>
         <p
-          className="text-on-image mt-1.5 truncate text-[13px] text-[var(--text-muted)] max-md:text-[12px]"
+          className="text-on-image mt-1.5 truncate text-ui text-[var(--text-muted)] max-md:text-sub"
           title={library.root_paths.join("\n")}
         >
           {meta.label}库 · {stats.item_count} 部作品 · {stats.file_count} 个文件 ·{" "}
@@ -382,7 +382,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
           {library.primary_root ? ` · ${library.primary_root}` : ""}
         </p>
         {library.last_scan && !busy && (
-          <p className="mt-1 text-[12px] text-white/45">
+          <p className="mt-1 text-sub text-white/45">
             最近扫描 {formatRelativeTime(library.last_scan.finished_at)}
             {library.last_scan.cancelled ? "（手动停止，未扫完）" : ""} · 新入账{" "}
             {library.last_scan.scanned}（识别 {library.last_scan.identified} / 待识别{" "}
@@ -410,7 +410,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
           busy) && (
           <div className="mt-2.5 flex flex-wrap items-center gap-2">
             {busy && (
-              <span className="flex items-center gap-1.5 rounded-full border border-[#7dd3fc]/35 bg-[#7dd3fc]/[0.12] px-3 py-1 text-[12px] font-semibold text-[#7dd3fc]">
+              <span className="flex items-center gap-1.5 rounded-full border border-[#7dd3fc]/35 bg-[#7dd3fc]/[0.12] px-3 py-1 text-sub font-semibold text-[#7dd3fc]">
                 <span className="size-3 animate-spin rounded-full border-[1.5px] border-[#7dd3fc]/30 border-t-[#7dd3fc]" />
                 {busyText(
                   library.scanning ? library.scan_progress : library.organize_progress,
@@ -420,7 +420,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
             {/* 刷新元数据的按钮已收进 ⋯ 菜单；它是全量重刷、耗时长，
                 进度另用下方的面板完整展示（到哪部了、在做什么） */}
             {importing > 0 && (
-              <span className="flex items-center gap-1.5 rounded-full border border-[#7dd3fc]/35 bg-[#7dd3fc]/[0.12] px-3 py-1 text-[12px] font-semibold text-[#7dd3fc]">
+              <span className="flex items-center gap-1.5 rounded-full border border-[#7dd3fc]/35 bg-[#7dd3fc]/[0.12] px-3 py-1 text-sub font-semibold text-[#7dd3fc]">
                 <span className="size-1.5 animate-pulse rounded-full bg-[#7dd3fc]" />
                 已发现 {importing} 个新文件 · 写入完成后自动入库
               </span>
@@ -429,7 +429,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
               <button
                 type="button"
                 onClick={() => setIssueTab("missing")}
-                className="flex items-center gap-1.5 rounded-full border border-white/[0.14] bg-white/[0.06] px-3 py-1 text-[12px] font-semibold text-white/75 transition hover:bg-white/[0.12] hover:text-white"
+                className="flex items-center gap-1.5 rounded-full border border-white/[0.14] bg-white/[0.06] px-3 py-1 text-sub font-semibold text-white/75 transition hover:bg-white/[0.12] hover:text-white"
               >
                 <span className="size-1.5 rounded-full bg-white/40" />
                 {missing.length} 个条目缺失
@@ -439,7 +439,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
               <button
                 type="button"
                 onClick={() => setIssueTab("unidentified")}
-                className="flex items-center gap-1.5 rounded-full border border-[#f5c451]/35 bg-[#f5c451]/[0.12] px-3 py-1 text-[12px] font-semibold text-[#f5c451] transition hover:bg-[#f5c451]/[0.22]"
+                className="flex items-center gap-1.5 rounded-full border border-[#f5c451]/35 bg-[#f5c451]/[0.12] px-3 py-1 text-sub font-semibold text-[#f5c451] transition hover:bg-[#f5c451]/[0.22]"
               >
                 <span className="size-1.5 rounded-full bg-[#f5c451]" />
                 {unidentifiedFiles} 个文件待识别
@@ -450,7 +450,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
               <button
                 type="button"
                 onClick={() => setIssueTab("review")}
-                className="flex items-center gap-1.5 rounded-full border border-[#c4b5fd]/35 bg-[#c4b5fd]/[0.12] px-3 py-1 text-[12px] font-semibold text-[#c4b5fd] transition hover:bg-[#c4b5fd]/[0.22]"
+                className="flex items-center gap-1.5 rounded-full border border-[#c4b5fd]/35 bg-[#c4b5fd]/[0.12] px-3 py-1 text-sub font-semibold text-[#c4b5fd] transition hover:bg-[#c4b5fd]/[0.22]"
               >
                 <span className="size-1.5 rounded-full bg-[#c4b5fd]" />
                 {review.length} 个条目待复核身份
@@ -475,12 +475,12 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
           />
         )}
         {failed && (
-          <p className="mt-3 rounded-lg border border-amber-400/25 bg-amber-500/10 px-3.5 py-2 text-[12.5px] text-amber-200">
+          <p className="mt-3 rounded-lg border border-amber-400/25 bg-amber-500/10 px-3.5 py-2 text-sub text-amber-200">
             与后端通信失败，正在自动重试；下方显示的是最近一次成功加载的数据
           </p>
         )}
         {notice && (
-          <p className="mt-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2 text-[12.5px] text-red-200">
+          <p className="mt-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2 text-sub text-red-200">
             {notice}
           </p>
         )}
@@ -502,7 +502,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
 
       {/* —— 库存海报墙 —— */}
       {items.length === 0 && unidentified.length === 0 ? (
-        <p className="mt-16 text-center text-[13.5px] leading-7 text-[var(--text-muted)]">
+        <p className="mt-16 text-center text-ui leading-7 text-[var(--text-muted)]">
           这个库还没有内容。
           <br />
           点右上角 ⋯ 里的「扫描库」把根路径下已有的影片识别入库；订阅的内容下载完成后也会自动进来。
@@ -526,9 +526,9 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
       {/* —— 追踪中（订阅已指向本库、文件未落地）—— */}
       {pending.length > 0 && (
         <div className="mt-10 px-6 max-md:mt-7 max-md:px-4">
-          <h3 className="text-on-image text-[15px] font-semibold text-white/85">
+          <h3 className="text-on-image text-body-lg font-semibold text-white/85">
             追踪中
-            <span className="ml-2 text-[12px] font-normal text-[var(--text-faint)]">
+            <span className="ml-2 text-sub font-normal text-[var(--text-faint)]">
               已订阅、资源到位后自动入库
             </span>
           </h3>
@@ -598,7 +598,7 @@ function LibraryActionsMenu({
   // 与站点配置一致用 Radix DropdownMenu：Portal 到 body + 碰撞检测，
   // 不会被头部容器裁切；开合/外部点击/键盘导航全交给 Radix。
   const itemClass =
-    "glass-row nav-item cursor-pointer px-3 py-2 text-[13px] font-medium outline-none " +
+    "glass-row nav-item cursor-pointer px-3 py-2 text-ui font-medium outline-none " +
     "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)] " +
     "data-[disabled]:pointer-events-none data-[disabled]:opacity-40";
   const running = scanning || organizing || refreshingMeta;
@@ -683,7 +683,7 @@ function MetadataRefreshPanel({
   return (
     <div className="mt-3 rounded-xl border border-[#7dd3fc]/25 bg-[#7dd3fc]/[0.07] px-4 py-3">
       <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2 text-[12.5px] font-semibold text-[#7dd3fc]">
+        <div className="flex min-w-0 items-center gap-2 text-sub font-semibold text-[#7dd3fc]">
           <span className="size-3 shrink-0 animate-spin rounded-full border-[1.5px] border-[#7dd3fc]/30 border-t-[#7dd3fc]" />
           <span className="truncate">
             {state.stopping ? "正在停止刷新" : "正在刷新元数据"}
@@ -695,7 +695,7 @@ function MetadataRefreshPanel({
           type="button"
           onClick={onStop}
           disabled={state.stopping}
-          className="shrink-0 text-[12px] font-medium text-white/70 transition hover:text-white disabled:opacity-50"
+          className="shrink-0 text-sub font-medium text-white/70 transition hover:text-white disabled:opacity-50"
         >
           {state.stopping ? "收尾中…" : "停止"}
         </button>
@@ -710,14 +710,14 @@ function MetadataRefreshPanel({
       {state.active.length > 0 && (
         <div className="mt-2.5 space-y-1">
           {state.active.map((a) => (
-            <p key={a.media_item_id} className="flex gap-2 text-[12px] text-white/70">
+            <p key={a.media_item_id} className="flex gap-2 text-sub text-white/70">
               <span className="min-w-0 flex-1 truncate">{a.title}</span>
               <span className="shrink-0 text-white/45">{a.phase}</span>
             </p>
           ))}
         </div>
       )}
-      <p className="mt-2 text-[11.5px] text-white/40">
+      <p className="mt-2 text-caption text-white/40">
         全量重刷：重拉 TMDB 档案、按当前尺寸重下图片、覆盖媒体目录镜像；
         你手动选定的图不受影响
       </p>
@@ -785,7 +785,7 @@ const InventoryCell = memo(function InventoryCell({
           <>
             <span className="pointer-events-none absolute inset-0 rounded-xl ring-2 ring-[#7dd3fc] ring-offset-0" />
             {/* 不用 backdrop-blur：海报墙每格一个模糊合成层会放大滚动时的 GPU 压力，底色加实即可 */}
-            <span className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center gap-1.5 rounded-b-xl bg-[rgba(7,12,20,0.92)] px-2 py-1.5 text-[10.5px] font-medium text-[#7dd3fc]">
+            <span className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center gap-1.5 rounded-b-xl bg-[rgba(7,12,20,0.92)] px-2 py-1.5 text-micro font-medium text-[#7dd3fc]">
               <span className="size-2.5 shrink-0 animate-spin rounded-full border-[1.5px] border-[#7dd3fc]/30 border-t-[#7dd3fc]" />
               <span className="truncate">{workingLabel}</span>
             </span>
@@ -793,7 +793,7 @@ const InventoryCell = memo(function InventoryCell({
         )}
       </div>
       {parts.length > 0 && (
-        <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-[11px] text-[var(--text-muted)]">
+        <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-caption text-[var(--text-muted)]">
           {abnormal && (
             <span
               className={`size-1.5 shrink-0 rounded-full ${dead ? "bg-white/30" : "bg-[#f5c451]"}`}
@@ -823,7 +823,7 @@ function PendingCell({ sub }: { sub: Subscription }) {
     <div className="opacity-80 transition [contain-intrinsic-size:auto_270px] [content-visibility:auto] hover:opacity-100">
       {/* 已是订阅产物，悬浮层不再给「订阅影片」重复入口 */}
       <PosterCardVisual item={visual} href={`/subscriptions/${sub.id}` as Route} action="none" />
-      <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-[11px] text-[var(--text-muted)]">
+      <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-caption text-[var(--text-muted)]">
         <span
           className="size-1.5 shrink-0 rounded-full"
           style={{ backgroundColor: meta.color }}
@@ -920,7 +920,7 @@ function IssueDrawer({
   );
 
   const tabClass = (active: boolean) =>
-    `rounded-full px-3.5 py-1.5 text-[12.5px] font-semibold transition ${
+    `rounded-full px-3.5 py-1.5 text-sub font-semibold transition ${
       active ? "bg-white/[0.14] text-white" : "text-[var(--text-muted)] hover:text-white"
     }`;
 
@@ -985,7 +985,7 @@ function IssueDrawer({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={open === "missing" ? "按片名过滤…" : "按文件名过滤…"}
-            className="min-w-0 flex-1 rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-[12.5px] text-[var(--text)] outline-none placeholder:text-white/30 focus:border-[var(--accent)]/60"
+            className="min-w-0 flex-1 rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-sub text-[var(--text)] outline-none placeholder:text-white/30 focus:border-[var(--accent)]/60"
           />
           {open === "missing" && missing.length > 0 && (
             <button
@@ -1004,7 +1004,7 @@ function IssueDrawer({
                   .catch(() => {})
                   .finally(() => setBusy(false));
               }}
-              className="btn-glass shrink-0 px-3 py-1.5 text-[12px] font-medium disabled:opacity-50"
+              className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium disabled:opacity-50"
             >
               全部清理
             </button>
@@ -1026,7 +1026,7 @@ function IssueDrawer({
                   .catch(() => {})
                   .finally(() => setBusy(false));
               }}
-              className="btn-glass shrink-0 px-3 py-1.5 text-[12px] font-medium disabled:opacity-50"
+              className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium disabled:opacity-50"
             >
               全部忽略
             </button>
@@ -1034,7 +1034,7 @@ function IssueDrawer({
         </div>
 
         {/* 说明行 */}
-        <p className="px-5 pt-3 text-[11.5px] leading-5 text-[var(--text-muted)]">
+        <p className="px-5 pt-3 text-caption leading-5 text-[var(--text-muted)]">
           {open === "missing"
             ? "文件已不在磁盘；「重新下载」交给订阅管线补回，「清理记录」只删台账（都不动磁盘）；文件回归会自动恢复。"
             : open === "unidentified"
@@ -1046,7 +1046,7 @@ function IssueDrawer({
 
         {/* 「放错库了」修复引导：认领解决不了这一类，不给引导用户会在认领里打转 */}
         {open === "unidentified" && kindMismatchFiles > 0 && (
-          <p className="mx-5 mt-3 rounded-lg bg-[#f5c451]/[0.1] px-3 py-2 text-[11.5px] leading-5 text-[#f5c451]">
+          <p className="mx-5 mt-3 rounded-lg bg-[#f5c451]/[0.1] px-3 py-2 text-caption leading-5 text-[#f5c451]">
             有 {kindMismatchFiles} 个文件的实际类型与本库不符（
             {movie ? "剧集文件在电影库" : "电影文件在剧集库"}
             ），认领无法解决。个别文件放错了：把文件移到对应类型的库即可；整库类型建错了：
@@ -1086,7 +1086,7 @@ function IssueDrawer({
             (open === "unidentified" && unidentifiedShown.length === 0) ||
             (open === "review" && reviewShown.length === 0) ||
             (open === "ignored" && ignoredShown.length === 0)) && (
-            <p className="mt-12 text-center text-[13px] text-[var(--text-muted)]">
+            <p className="mt-12 text-center text-ui text-[var(--text-muted)]">
               {keyword
                 ? "没有匹配的条目"
                 : open === "ignored"
@@ -1140,13 +1140,13 @@ function MissingRow({
   return (
     <div className="rounded-xl bg-white/[0.03] px-3.5 py-2.5">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/85">
+        <span className="min-w-0 flex-1 truncate text-ui font-medium text-white/85">
           {item.title}
           {item.year ? ` (${item.year})` : ""}
-          <span className="ml-2 text-[12px] font-normal text-[var(--text-muted)]">{summary}</span>
+          <span className="ml-2 text-sub font-normal text-[var(--text-muted)]">{summary}</span>
         </span>
         {done ? (
-          <span className="text-[12px] text-[#4ade80]">{done}</span>
+          <span className="text-sub text-[#4ade80]">{done}</span>
         ) : (
           <span className="flex shrink-0 items-center gap-2">
             <button
@@ -1159,7 +1159,7 @@ function MissingRow({
                   }),
                 )
               }
-              className="btn-accent rounded-full px-3 py-1.5 text-[12px] font-semibold disabled:opacity-50"
+              className="btn-accent rounded-full px-3 py-1.5 text-sub font-semibold disabled:opacity-50"
             >
               重新下载
             </button>
@@ -1173,7 +1173,7 @@ function MissingRow({
                 if (!window.confirm(warning)) return;
                 act(() => clearMissing(libraryId, item.media_item_id));
               }}
-              className="btn-glass px-3 py-1.5 text-[12px] font-medium disabled:opacity-50"
+              className="btn-glass px-3 py-1.5 text-sub font-medium disabled:opacity-50"
             >
               清理记录
             </button>
@@ -1181,9 +1181,9 @@ function MissingRow({
         )}
       </div>
       {item.subscription_id && !done && (
-        <p className="mt-1 text-[11.5px] text-[#f5c451]/80">该条目有订阅在追踪</p>
+        <p className="mt-1 text-caption text-[#f5c451]/80">该条目有订阅在追踪</p>
       )}
-      {error && <p className="mt-1 text-[11.5px] text-red-300">{error}</p>}
+      {error && <p className="mt-1 text-caption text-red-300">{error}</p>}
     </div>
   );
 }
@@ -1246,7 +1246,7 @@ function GroupMoreMenu({
   onToggleFiles: () => void;
 }) {
   const itemClass =
-    "glass-row nav-item cursor-pointer px-3 py-2 text-[13px] font-medium outline-none " +
+    "glass-row nav-item cursor-pointer px-3 py-2 text-ui font-medium outline-none " +
     "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)] " +
     "data-[disabled]:pointer-events-none data-[disabled]:opacity-40";
   return (
@@ -1296,7 +1296,7 @@ function StatusBadge({ group }: { group: UnidentifiedGroup }) {
   return (
     <span
       title={group.reason ?? undefined}
-      className={`shrink-0 rounded-md px-1.5 py-0.5 text-[11px] ${
+      className={`shrink-0 rounded-md px-1.5 py-0.5 text-caption ${
         meta.tone === "warn"
           ? "bg-[#f5c451]/[0.16] text-[#f5c451]"
           : "bg-white/[0.07] text-[var(--text-muted)]"
@@ -1355,13 +1355,13 @@ function UnidentifiedGroupRow({
           title，次要动作收进 ⋯ 菜单——组多起来时这一行就是全部扫读内容 */}
       <div className="flex items-center gap-2">
         <span
-          className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/85"
+          className="min-w-0 flex-1 truncate text-ui font-medium text-white/85"
           title={`${group.label}\n${group.key}`}
         >
           {group.label}
         </span>
         <StatusBadge group={group} />
-        <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+        <span className="shrink-0 text-caption text-[var(--text-faint)]">
           {group.file_count} 个 · {formatBytes(group.total_size_bytes)}
         </span>
         {/* TMDB 不可达有确定解法，直接给按钮；其余给搜索入口 */}
@@ -1370,7 +1370,7 @@ function UnidentifiedGroupRow({
             type="button"
             disabled={busy}
             onClick={() => act(() => startLibraryScan(group.library_id))}
-            className="btn-glass shrink-0 px-2.5 py-1 text-[12px] font-medium disabled:opacity-40"
+            className="btn-glass shrink-0 px-2.5 py-1 text-sub font-medium disabled:opacity-40"
           >
             重新扫描
           </button>
@@ -1379,7 +1379,7 @@ function UnidentifiedGroupRow({
             type="button"
             disabled={busy}
             onClick={() => setPanel((p) => (p?.view === "search" ? null : { view: "search" }))}
-            className={`shrink-0 rounded-full px-2.5 py-1 text-[12px] font-medium transition disabled:opacity-40 ${
+            className={`shrink-0 rounded-full px-2.5 py-1 text-sub font-medium transition disabled:opacity-40 ${
               searchOpen ? "bg-white/[0.14] text-white" : "btn-glass"
             }`}
           >
@@ -1399,7 +1399,7 @@ function UnidentifiedGroupRow({
           （待识别行每次扫描本就自动重试），等不及可以自己去补录。不写清楚，
           用户会以为搜不到就只剩忽略一条路 */}
       {group.code === "no_match" && (
-        <p className="mt-1 text-[11px] leading-relaxed text-[var(--text-faint)]">
+        <p className="mt-1 text-caption leading-relaxed text-[var(--text-faint)]">
           每次扫描会自动重试识别。TMDB 是社区维护的数据库，确认缺这个条目可以
           <a
             href={`https://www.themoviedb.org/${movie ? "movie" : "tv"}/new`}
@@ -1437,7 +1437,7 @@ function UnidentifiedGroupRow({
                       },
                 )
               }
-              className={`rounded-lg border px-2.5 py-1 text-[12px] transition disabled:opacity-40 ${
+              className={`rounded-lg border px-2.5 py-1 text-sub transition disabled:opacity-40 ${
                 selectedId === c.tmdb_id
                   ? "border-[var(--accent)] bg-[var(--accent)]/[0.28] text-white"
                   : "border-[var(--accent)]/40 bg-[var(--accent)]/[0.12] text-white/90 hover:bg-[var(--accent)]/[0.24]"
@@ -1446,7 +1446,7 @@ function UnidentifiedGroupRow({
               {c.title}
               {c.year ? ` (${c.year})` : ""}
               {c.episode_count ? (
-                <span className="ml-1.5 text-[11px] text-[var(--text-muted)]">
+                <span className="ml-1.5 text-caption text-[var(--text-muted)]">
                   {c.episode_count} 集
                 </span>
               ) : null}
@@ -1455,7 +1455,7 @@ function UnidentifiedGroupRow({
         </div>
       )}
 
-      {error && <p className="mt-1.5 text-[11.5px] text-red-300">{error}</p>}
+      {error && <p className="mt-1.5 text-caption text-red-300">{error}</p>}
 
       {panel?.view === "search" && (
         <ClaimSearchPanel
@@ -1481,7 +1481,7 @@ function UnidentifiedGroupRow({
           {group.files.map((f) => (
             <li
               key={f.id}
-              className="truncate font-mono text-[11px] text-[var(--text-faint)]"
+              className="truncate font-mono text-caption text-[var(--text-faint)]"
               title={f.file_path}
             >
               {f.file_path}
@@ -1523,11 +1523,11 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
         <div className="h-[54px] w-9 shrink-0 rounded-md bg-white/[0.06]" />
       )}
       <div className="min-w-0">
-        <p className="text-[10.5px] font-semibold uppercase tracking-wide text-[var(--text-faint)]">
+        <p className="text-micro font-semibold uppercase tracking-wide text-[var(--text-faint)]">
           {tone === "current" ? "现身份" : "新识别结论"}
         </p>
         <p
-          className={`truncate text-[13px] font-medium ${
+          className={`truncate text-ui font-medium ${
             tone === "suggestion" ? "text-[#c4b5fd]" : "text-white/85"
           }`}
           title={info.title}
@@ -1536,7 +1536,7 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
           {info.year ? ` (${info.year})` : ""}
         </p>
         {info.tmdb_id != null && (
-          <p className="text-[11px] text-[var(--text-faint)]">tmdb {info.tmdb_id}</p>
+          <p className="text-caption text-[var(--text-faint)]">tmdb {info.tmdb_id}</p>
         )}
       </div>
     </div>
@@ -1545,10 +1545,10 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
   return (
     <div className="rounded-xl bg-white/[0.03] px-3.5 py-3">
       <div className="flex items-baseline gap-2">
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/85" title={group.key}>
+        <span className="min-w-0 flex-1 truncate text-ui font-medium text-white/85" title={group.key}>
           {group.label}
         </span>
-        <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+        <span className="shrink-0 text-caption text-[var(--text-faint)]">
           {group.file_count} 个文件 · {formatBytes(group.total_size_bytes)}
         </span>
       </div>
@@ -1556,7 +1556,7 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
       {/* 两个身份并排：看清是谁 vs 该是谁 */}
       <div className="mt-2.5 flex items-center gap-3">
         {side(group.current, "current")}
-        <span className="shrink-0 text-[15px] text-[var(--text-faint)]">→</span>
+        <span className="shrink-0 text-body-lg text-[var(--text-faint)]">→</span>
         {side(group.suggestion, "suggestion")}
       </div>
 
@@ -1565,7 +1565,7 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
           type="button"
           disabled={busy}
           onClick={() => act(true)}
-          className="rounded-full border border-[#c4b5fd]/45 bg-[#c4b5fd]/[0.14] px-3.5 py-1.5 text-[12px] font-semibold text-[#c4b5fd] transition hover:bg-[#c4b5fd]/[0.26] disabled:opacity-40"
+          className="rounded-full border border-[#c4b5fd]/45 bg-[#c4b5fd]/[0.14] px-3.5 py-1.5 text-sub font-semibold text-[#c4b5fd] transition hover:bg-[#c4b5fd]/[0.26] disabled:opacity-40"
         >
           采纳新结论
         </button>
@@ -1573,11 +1573,11 @@ function ReviewGroupRow({ group, onChanged }: { group: ReviewGroup; onChanged: (
           type="button"
           disabled={busy}
           onClick={() => act(false)}
-          className="btn-glass px-3.5 py-1.5 text-[12px] font-medium disabled:opacity-40"
+          className="btn-glass px-3.5 py-1.5 text-sub font-medium disabled:opacity-40"
         >
           维持现状
         </button>
-        {error && <span className="text-[11.5px] text-red-300">{error}</span>}
+        {error && <span className="text-caption text-red-300">{error}</span>}
       </div>
     </div>
   );
@@ -1600,12 +1600,12 @@ function IgnoredGroupRow({
     <div className="rounded-xl bg-white/[0.02] px-3.5 py-2.5">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
         <span
-          className="min-w-0 flex-1 truncate text-[13px] text-white/70"
+          className="min-w-0 flex-1 truncate text-ui text-white/70"
           title={group.key}
         >
           {group.label}
         </span>
-        <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+        <span className="shrink-0 text-caption text-[var(--text-faint)]">
           {group.file_count} 个文件 · {formatBytes(group.total_size_bytes)}
         </span>
         <button
@@ -1619,7 +1619,7 @@ function IgnoredGroupRow({
               .catch((e) => setError((e as Error).message))
               .finally(() => setBusy(false));
           }}
-          className="btn-glass shrink-0 px-3 py-1.5 text-[12px] font-medium disabled:opacity-40"
+          className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium disabled:opacity-40"
         >
           恢复
         </button>
@@ -1627,19 +1627,19 @@ function IgnoredGroupRow({
           <button
             type="button"
             onClick={() => setExpanded((v) => !v)}
-            className="text-[11.5px] text-[var(--text-muted)] transition hover:text-white/80"
+            className="text-caption text-[var(--text-muted)] transition hover:text-white/80"
           >
             {expanded ? "收起文件" : "查看文件"}
           </button>
         )}
       </div>
-      {error && <p className="mt-1 text-[11.5px] text-red-300">{error}</p>}
+      {error && <p className="mt-1 text-caption text-red-300">{error}</p>}
       {expanded && (
         <ul className="mt-2 space-y-1 border-t border-white/[0.06] pt-2">
           {group.files.map((f) => (
             <li
               key={f.id}
-              className="truncate font-mono text-[11px] text-[var(--text-faint)]"
+              className="truncate font-mono text-caption text-[var(--text-faint)]"
               title={f.file_path}
             >
               {f.file_path}
@@ -1723,38 +1723,38 @@ function ClaimConfirmPanel({
         )}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-            <span className="text-[13.5px] font-semibold text-white/95">{title}</span>
-            {year ? <span className="text-[12px] text-[var(--text-muted)]">{year}</span> : null}
+            <span className="text-ui font-semibold text-white/95">{title}</span>
+            {year ? <span className="text-sub text-[var(--text-muted)]">{year}</span> : null}
             {item?.extent ? (
-              <span className="text-[12px] text-[var(--text-muted)]">{item.extent}</span>
+              <span className="text-sub text-[var(--text-muted)]">{item.extent}</span>
             ) : null}
             {seed.episodeCount ? (
-              <span className="text-[12px] text-[var(--text-muted)]">
+              <span className="text-sub text-[var(--text-muted)]">
                 对应季 {seed.episodeCount} 集
               </span>
             ) : null}
             {item && item.rating > 0 ? (
-              <span className="text-[12px] text-[#f5c451]">★ {item.rating.toFixed(1)}</span>
+              <span className="text-sub text-[#f5c451]">★ {item.rating.toFixed(1)}</span>
             ) : null}
           </div>
           {seed.reasons && seed.reasons.length > 0 && (
-            <p className="mt-0.5 text-[11px] text-[var(--text-faint)]">
+            <p className="mt-0.5 text-caption text-[var(--text-faint)]">
               与本地文件的佐证：{seed.reasons.join("、")}
             </p>
           )}
           {item?.overview ? (
-            <p className="mt-1 line-clamp-3 text-[11.5px] leading-[1.55] text-[var(--text-muted)]">
+            <p className="mt-1 line-clamp-3 text-caption leading-[1.55] text-[var(--text-muted)]">
               {item.overview}
             </p>
           ) : failed ? (
-            <p className="mt-1 text-[11.5px] text-[var(--text-faint)]">
+            <p className="mt-1 text-caption text-[var(--text-faint)]">
               详情加载失败（不影响认领，可打开 TMDB 页面核对）
             </p>
           ) : (
-            <p className="mt-1 text-[11.5px] text-[var(--text-faint)]">正在加载详情…</p>
+            <p className="mt-1 text-caption text-[var(--text-faint)]">正在加载详情…</p>
           )}
           {credits && (
-            <p className="mt-1 truncate text-[11px] text-[var(--text-faint)]" title={credits}>
+            <p className="mt-1 truncate text-caption text-[var(--text-faint)]" title={credits}>
               {credits}
             </p>
           )}
@@ -1765,22 +1765,22 @@ function ClaimConfirmPanel({
           href={`https://www.themoviedb.org/${kind}/${seed.tmdbId}`}
           target="_blank"
           rel="noreferrer"
-          className="text-[11.5px] text-[var(--text-muted)] underline decoration-white/20 underline-offset-2 transition hover:text-white/80"
+          className="text-caption text-[var(--text-muted)] underline decoration-white/20 underline-offset-2 transition hover:text-white/80"
         >
           在 TMDB 打开核对 ↗
         </a>
         <span className="flex-1" />
         {movie && fileCount > 1 && (
-          <span className="text-[11px] text-[var(--text-faint)]">整组视为同一部片的多个版本</span>
+          <span className="text-caption text-[var(--text-faint)]">整组视为同一部片的多个版本</span>
         )}
-        <button type="button" disabled={busy} onClick={onCancel} className="btn-glass px-3 py-1.5 text-[12px] font-medium disabled:opacity-40">
+        <button type="button" disabled={busy} onClick={onCancel} className="btn-glass px-3 py-1.5 text-sub font-medium disabled:opacity-40">
           取消
         </button>
         <button
           type="button"
           disabled={busy}
           onClick={onConfirm}
-          className="btn-accent rounded-full px-3.5 py-1.5 text-[12px] font-semibold disabled:opacity-40"
+          className="btn-accent rounded-full px-3.5 py-1.5 text-sub font-semibold disabled:opacity-40"
         >
           认领{fileCount > 1 ? `全部 ${fileCount} 个文件` : ""}
         </button>
@@ -1835,13 +1835,13 @@ function ClaimSearchPanel({
           }}
           placeholder="片名关键词，或直接粘 TMDB ID"
           autoFocus
-          className="min-w-0 flex-1 rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-[12.5px] text-[var(--text)] outline-none placeholder:text-white/30 focus:border-[var(--accent)]/60"
+          className="min-w-0 flex-1 rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-sub text-[var(--text)] outline-none placeholder:text-white/30 focus:border-[var(--accent)]/60"
         />
         {idOnly ? (
           <button
             type="button"
             onClick={() => onPick({ tmdbId: Number(query.trim()), title: `TMDB #${query.trim()}` })}
-            className="btn-accent shrink-0 rounded-full px-3.5 py-1.5 text-[12px] font-semibold"
+            className="btn-accent shrink-0 rounded-full px-3.5 py-1.5 text-sub font-semibold"
           >
             查看该 ID
           </button>
@@ -1850,16 +1850,16 @@ function ClaimSearchPanel({
             type="button"
             disabled={searching || !query.trim()}
             onClick={search}
-            className="btn-glass shrink-0 px-3.5 py-1.5 text-[12px] font-medium disabled:opacity-40"
+            className="btn-glass shrink-0 px-3.5 py-1.5 text-sub font-medium disabled:opacity-40"
           >
             {searching ? "搜索中…" : "搜索"}
           </button>
         )}
       </div>
 
-      {error && <p className="mt-2 text-[11.5px] text-red-300">{error}</p>}
+      {error && <p className="mt-2 text-caption text-red-300">{error}</p>}
       {results !== null && results.length === 0 && !error && (
-        <p className="mt-2 text-[11.5px] leading-relaxed text-[var(--text-muted)]">
+        <p className="mt-2 text-caption leading-relaxed text-[var(--text-muted)]">
           没有找到{movie ? "电影" : "剧集"}结果，换个关键词试试（TMDB 对中文名支持有限时可试英文/原名）。
           确认 TMDB 没收录的话，可以
           <a
@@ -1900,14 +1900,14 @@ function ClaimSearchPanel({
                 ) : (
                   <div className="h-12 w-8 shrink-0 rounded bg-white/[0.05]" />
                 )}
-                <span className="min-w-0 flex-1 truncate text-[12.5px] text-white/90">
+                <span className="min-w-0 flex-1 truncate text-sub text-white/90">
                   {it.title}
                   {it.year ? (
-                    <span className="ml-1.5 text-[11.5px] text-[var(--text-muted)]">{it.year}</span>
+                    <span className="ml-1.5 text-caption text-[var(--text-muted)]">{it.year}</span>
                   ) : null}
                 </span>
                 {it.rating > 0 && (
-                  <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+                  <span className="shrink-0 text-caption text-[var(--text-faint)]">
                     ★ {it.rating.toFixed(1)}
                   </span>
                 )}

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -165,13 +165,13 @@ export function LibraryItemDetailView({
       <div className="ambient-fallback flex h-full flex-col">
         <PageNav items={fallbackTrail} />
         <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
-          <p className="text-[15px] font-semibold text-[var(--text)]">未能加载该条目</p>
-          <p className="max-w-sm text-[13px] leading-6 text-[var(--text-muted)]">
+          <p className="text-body-lg font-semibold text-[var(--text)]">未能加载该条目</p>
+          <p className="max-w-sm text-ui leading-6 text-[var(--text-muted)]">
             条目可能已被删除或重新识别为其他作品，请回库存页查看。
           </p>
           <Link
             href={`/library/${libraryId}` as Route}
-            className="btn-glass flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+            className="btn-glass flex items-center gap-2 px-4 py-2 text-ui font-medium text-[var(--text)]"
           >
             <ArrowLeftIcon className="size-4" />
             回到库存页
@@ -185,7 +185,7 @@ export function LibraryItemDetailView({
     return (
       <div className="ambient-fallback flex h-full flex-col">
         <PageNav items={fallbackTrail} />
-        <div className="flex flex-1 items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+        <div className="flex flex-1 items-center justify-center gap-2.5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在读取本地刮削信息…
         </div>
@@ -285,14 +285,14 @@ export function LibraryItemDetailView({
           <button
             type="button"
             onClick={() => setArtworkOpen(true)}
-            className="touch-reveal absolute inset-x-0 bottom-0 flex h-11 items-center justify-center bg-black/70 text-[12.5px] font-medium text-white opacity-0 backdrop-blur-sm transition group-hover/poster:opacity-100 max-md:h-8 max-md:text-[11px]"
+            className="touch-reveal absolute inset-x-0 bottom-0 flex h-11 items-center justify-center bg-black/70 text-sub font-medium text-white opacity-0 backdrop-blur-sm transition group-hover/poster:opacity-100 max-md:h-8 max-md:text-caption"
           >
             更换图片
           </button>
         </div>
 
         <div className="min-w-0 flex-1 pb-1">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
+          <p className="text-caption font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
             已入库 · {isMovie ? "电影" : "剧集"}
             {meta && meta.genres.length > 0 ? ` · ${meta.genres.join(" / ")}` : ""}
           </p>
@@ -300,16 +300,16 @@ export function LibraryItemDetailView({
             {detail.title}
           </h1>
           {detail.original_title && detail.original_title !== detail.title && (
-            <p className="text-on-image mt-1.5 truncate text-[14px] text-white/55">
+            <p className="text-on-image mt-1.5 truncate text-body text-white/55">
               {detail.original_title}
             </p>
           )}
 
-          <div className="tnum mt-3.5 flex flex-wrap items-center gap-x-3.5 gap-y-2 text-[13px] text-white/80 max-md:mt-2 max-md:gap-x-2.5 max-md:gap-y-1 max-md:text-[12px]">
+          <div className="tnum mt-3.5 flex flex-wrap items-center gap-x-3.5 gap-y-2 text-ui text-white/80 max-md:mt-2 max-md:gap-x-2.5 max-md:gap-y-1 max-md:text-sub">
             {meta?.rating != null && (
               <span className="flex items-center gap-1.5">
                 <StarIcon className="size-4 text-[#f5c451]" />
-                <span className="text-[16px] font-bold text-white">{meta.rating.toFixed(1)}</span>
+                <span className="text-title-sm font-bold text-white">{meta.rating.toFixed(1)}</span>
               </span>
             )}
             {detail.year && <span>{detail.year}</span>}
@@ -341,13 +341,13 @@ export function LibraryItemDetailView({
           {/* 刮削进行中的状态条：与库页的整库刷新面板同一套语言（阶段文案
               也同源），状态在服务端——离开页面/刷新浏览器回来照样看得到 */}
           {scrapingNow && (
-            <div className="mt-4 flex max-w-2xl items-center gap-2 rounded-xl border border-[#7dd3fc]/25 bg-[#7dd3fc]/[0.07] px-4 py-2.5 text-[12.5px] font-medium text-[#7dd3fc]">
+            <div className="mt-4 flex max-w-2xl items-center gap-2 rounded-xl border border-[#7dd3fc]/25 bg-[#7dd3fc]/[0.07] px-4 py-2.5 text-sub font-medium text-[#7dd3fc]">
               <span className="size-3 shrink-0 animate-spin rounded-full border-[1.5px] border-[#7dd3fc]/30 border-t-[#7dd3fc]" />
               <span className="truncate">
                 正在刷新元数据
                 {detail.scraping_phase ? ` · ${detail.scraping_phase}` : ""}
               </span>
-              <span className="ml-auto shrink-0 text-[11.5px] font-normal text-white/45">
+              <span className="ml-auto shrink-0 text-caption font-normal text-white/45">
                 完成后自动更新本页
               </span>
             </div>
@@ -355,7 +355,7 @@ export function LibraryItemDetailView({
 
           {/* 重新识别的结论横幅：结果与后续动作当场给出 */}
           {(reidentifyResult || reidentifyError) && (
-            <div className="mt-4 max-w-2xl rounded-xl border border-white/[0.1] bg-[rgba(14,16,22,0.6)] px-4 py-3 text-[12.5px] leading-6 text-white/85 backdrop-blur-md">
+            <div className="mt-4 max-w-2xl rounded-xl border border-white/[0.1] bg-[rgba(14,16,22,0.6)] px-4 py-3 text-sub leading-6 text-white/85 backdrop-blur-md">
               {reidentifyError ? (
                 <span className="text-[#ff9f9f]">{reidentifyError}</span>
               ) : (
@@ -398,9 +398,9 @@ export function LibraryItemDetailView({
         {/* —— 剧情简介（本地 NFO 优先，TMDB 兜底）—— */}
         {meta?.plot && (
           <section>
-            <h2 className="text-on-image mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+            <h2 className="text-on-image mb-3 text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
               剧情简介
-              <span className="ml-2 text-[11px] font-normal text-[var(--text-faint)]">
+              <span className="ml-2 text-caption font-normal text-[var(--text-faint)]">
                 {meta.source === "nfo"
                   ? `信息来自本地刮削（${meta.nfo_name}）`
                   : meta.source === "db"
@@ -408,7 +408,7 @@ export function LibraryItemDetailView({
                     : "信息来自 TMDB"}
               </span>
             </h2>
-            <p className="text-on-image max-w-3xl text-[14px] leading-7 text-white/78">
+            <p className="text-on-image max-w-3xl text-body leading-7 text-white/78">
               {meta.plot}
             </p>
           </section>
@@ -487,7 +487,7 @@ function ItemActionsMenu({
   onDelete: () => void;
 }) {
   const itemClass =
-    "glass-row nav-item cursor-pointer px-3 py-2 text-[13px] font-medium outline-none " +
+    "glass-row nav-item cursor-pointer px-3 py-2 text-ui font-medium outline-none " +
     "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)] " +
     "data-[disabled]:pointer-events-none data-[disabled]:opacity-40";
   const running = reidentifying || scraping;
@@ -688,7 +688,7 @@ function QualityBadges({ files }: { files: LibraryItemFile[] }) {
       {labels.map((b) => (
         <span
           key={b}
-          className="rounded border border-white/25 px-1.5 py-px text-[10px] font-semibold tracking-wide text-white/85"
+          className="rounded border border-white/25 px-1.5 py-px text-micro font-semibold tracking-wide text-white/85"
         >
           {b}
         </span>
@@ -723,7 +723,7 @@ function MovieVersionSpecs({ files }: { files: LibraryItemFile[] }) {
   return (
     <section>
       <div className="mb-3 flex items-center gap-3">
-        <h2 className="text-on-image text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+        <h2 className="text-on-image text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
           片源规格
         </h2>
         {versions.length > 1 && (
@@ -734,7 +734,7 @@ function MovieVersionSpecs({ files }: { files: LibraryItemFile[] }) {
                 type="button"
                 aria-pressed={f.id === active.id}
                 onClick={() => setActiveId(f.id)}
-                className={`tnum rounded-full px-3 py-1 text-[12px] font-medium transition-colors ${
+                className={`tnum rounded-full px-3 py-1 text-sub font-medium transition-colors ${
                   f.id === active.id
                     ? "bg-white/[0.14] text-white"
                     : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
@@ -762,17 +762,17 @@ function SpecRows({ file }: { file: LibraryItemFile }) {
         {videoBadges(file).length > 0 ? (
           videoBadges(file).map((b) => <SpecBadge key={b} text={b} />)
         ) : (
-          <span className="text-[12.5px] text-[var(--text-muted)]">未能探测（ffprobe 缺失或文件不可达）</span>
+          <span className="text-sub text-[var(--text-muted)]">未能探测（ffprobe 缺失或文件不可达）</span>
         )}
       </SpecRow>
       <SpecRow label="音频">
         {file.audio_streams === null ? (
-          <span className="text-[12.5px] text-[var(--text-muted)]">
+          <span className="text-sub text-[var(--text-muted)]">
             尚未探测——后台正在读取，稍候自动刷新；持续为空请检查文件是否可达，
             以及（源码部署时）是否装了 ffmpeg
           </span>
         ) : file.audio_streams.length === 0 ? (
-          <span className="text-[12.5px] text-[var(--text-muted)]">文件内没有音轨</span>
+          <span className="text-sub text-[var(--text-muted)]">文件内没有音轨</span>
         ) : (
           file.audio_streams.map((a, i) => (
             <SpecBadge key={i} text={audioLabel(a)} accent={a.default} />
@@ -781,7 +781,7 @@ function SpecRows({ file }: { file: LibraryItemFile }) {
       </SpecRow>
       <SpecRow label="字幕">
         {file.subtitle_streams.length === 0 ? (
-          <span className="text-[12.5px] text-[var(--text-muted)]">无内封或外挂字幕</span>
+          <span className="text-sub text-[var(--text-muted)]">无内封或外挂字幕</span>
         ) : (
           file.subtitle_streams.map((s, i) => (
             <SpecBadge
@@ -799,7 +799,7 @@ function SpecRows({ file }: { file: LibraryItemFile }) {
 function SpecRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex items-baseline gap-4">
-      <span className="w-10 shrink-0 text-[12px] text-[var(--text-faint)]">{label}</span>
+      <span className="w-10 shrink-0 text-sub text-[var(--text-faint)]">{label}</span>
       <div className="flex flex-wrap items-center gap-1.5">{children}</div>
     </div>
   );
@@ -816,7 +816,7 @@ function SpecBadge({
 }) {
   return (
     <span
-      className={`tnum inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11.5px] ${
+      className={`tnum inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-caption ${
         accent
           ? "border-white/30 bg-white/[0.1] text-white"
           : "border-white/[0.12] bg-white/[0.04] text-white/80"
@@ -824,7 +824,7 @@ function SpecBadge({
     >
       {text}
       {suffix && (
-        <span className="rounded-sm bg-white/[0.12] px-1 text-[10px] text-white/70">{suffix}</span>
+        <span className="rounded-sm bg-white/[0.12] px-1 text-micro text-white/70">{suffix}</span>
       )}
     </span>
   );
@@ -837,7 +837,7 @@ function SourceLink({ href, label }: { href: string; label: string }) {
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="text-[11.5px] text-[var(--text-muted)] underline decoration-white/20 underline-offset-2 transition hover:text-white/80"
+      className="text-caption text-[var(--text-muted)] underline decoration-white/20 underline-offset-2 transition hover:text-white/80"
     >
       {label} ↗
     </a>
@@ -896,14 +896,14 @@ function SeasonEpisodesSection({
   return (
     <section>
       <div className="mb-3 flex items-center gap-3">
-        <h2 className="text-on-image text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+        <h2 className="text-on-image text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
           分集
         </h2>
         {seasons.length > 1 ? (
           <select
             value={season}
             onChange={(e) => setSeason(Number(e.target.value))}
-            className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-[12.5px] text-white/90 outline-none focus:border-white/25 [&>option]:bg-[#181c28]"
+            className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-sub text-white/90 outline-none focus:border-white/25 [&>option]:bg-[#181c28]"
           >
             {seasons.map((s) => (
               <option key={s} value={s}>
@@ -912,22 +912,22 @@ function SeasonEpisodesSection({
             ))}
           </select>
         ) : (
-          <span className="text-[12.5px] text-[var(--text-muted)]">
+          <span className="text-sub text-[var(--text-muted)]">
             {season === 0 ? "特别篇" : `第 ${season} 季`}
           </span>
         )}
         {data && (
-          <span className="tnum text-[12px] text-[var(--text-faint)]">
+          <span className="tnum text-sub text-[var(--text-faint)]">
             在库 {ownedCount} / {data.episodes.length} 集
           </span>
         )}
       </div>
 
       {failed && (
-        <p className="text-[12.5px] text-[var(--text-muted)]">分集信息加载失败，请稍后重试。</p>
+        <p className="text-sub text-[var(--text-muted)]">分集信息加载失败，请稍后重试。</p>
       )}
       {!data && !failed && (
-        <div className="flex items-center gap-2.5 py-6 text-[12.5px] text-[var(--text-muted)]">
+        <div className="flex items-center gap-2.5 py-6 text-sub text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在读取分集信息…
         </div>
@@ -952,22 +952,22 @@ function SeasonEpisodesSection({
           {current && (
             <div className="mt-4 rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] p-6 backdrop-blur-xl">
               <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                <h3 className="text-[14.5px] font-semibold text-[var(--text)]">
+                <h3 className="text-body font-semibold text-[var(--text)]">
                   第 {current.episode_number} 集{current.name ? ` · ${current.name}` : ""}
                 </h3>
                 {current.air_date && (
-                  <span className="tnum text-[12px] text-[var(--text-faint)]">
+                  <span className="tnum text-sub text-[var(--text-faint)]">
                     {current.air_date} 播出
                   </span>
                 )}
                 {!current.owned && (
-                  <span className="rounded border border-[#f5c451]/40 px-1.5 py-px text-[10px] font-semibold text-[#f5c451]">
+                  <span className="rounded border border-[#f5c451]/40 px-1.5 py-px text-micro font-semibold text-[#f5c451]">
                     不在库中
                   </span>
                 )}
               </div>
               {current.overview && (
-                <p className="mt-2.5 max-w-3xl text-[13px] leading-6 text-white/70">
+                <p className="mt-2.5 max-w-3xl text-ui leading-6 text-white/70">
                   {current.overview}
                 </p>
               )}
@@ -981,28 +981,28 @@ function SeasonEpisodesSection({
                       <div className="flex items-center gap-4">
                         <Tooltip
                           content={
-                            <span className="tnum break-all font-mono text-[11.5px] leading-5">
+                            <span className="tnum break-all font-mono text-caption leading-5">
                               {file.file_path}
                             </span>
                           }
                           maxWidth={520}
                         >
-                          <p className="min-w-0 flex-1 truncate text-[13px] text-[var(--text)]">
+                          <p className="min-w-0 flex-1 truncate text-ui text-[var(--text)]">
                             {file.file_name}
                           </p>
                         </Tooltip>
                         {file.missing && (
-                          <span className="shrink-0 rounded border border-[#f5c451]/40 px-1.5 py-px text-[10px] font-semibold text-[#f5c451]">
+                          <span className="shrink-0 rounded border border-[#f5c451]/40 px-1.5 py-px text-micro font-semibold text-[#f5c451]">
                             文件缺失
                           </span>
                         )}
-                        <span className="shrink-0 rounded border border-white/[0.14] px-1.5 py-px text-[10px] text-white/55">
+                        <span className="shrink-0 rounded border border-white/[0.14] px-1.5 py-px text-micro text-white/55">
                           {file.source === "imported" ? "入库管线" : "扫描发现"}
                         </span>
-                        <span className="tnum shrink-0 text-[12.5px] text-[var(--text-muted)]">
+                        <span className="tnum shrink-0 text-sub text-[var(--text-muted)]">
                           {formatBytes(file.size_bytes)}
                         </span>
-                        <span className="tnum shrink-0 text-[11.5px] text-[var(--text-faint)]">
+                        <span className="tnum shrink-0 text-caption text-[var(--text-faint)]">
                           {formatRelativeTime(file.added_at)}
                         </span>
                       </div>
@@ -1013,7 +1013,7 @@ function SeasonEpisodesSection({
                   ))}
                 </div>
               ) : (
-                <p className="mt-3 text-[12.5px] text-[var(--text-muted)]">
+                <p className="mt-3 text-sub text-[var(--text-muted)]">
                   本集不在库中——可通过订阅追踪自动补齐。
                 </p>
               )}
@@ -1062,13 +1062,13 @@ function EpisodeCard({
           }
         />
         {!episode.owned && (
-          <span className="absolute right-1.5 top-1.5 rounded bg-black/60 px-1.5 py-px text-[10px] font-semibold text-[#f5c451]">
+          <span className="absolute right-1.5 top-1.5 rounded bg-black/60 px-1.5 py-px text-micro font-semibold text-[#f5c451]">
             缺
           </span>
         )}
       </div>
       <p
-        className={`tnum mt-1.5 truncate text-[12.5px] ${
+        className={`tnum mt-1.5 truncate text-sub ${
           selected ? "font-semibold text-white" : "text-[var(--text)]"
         }`}
       >
@@ -1105,15 +1105,15 @@ function FileSection({
 
   return (
     <section>
-      <h2 className="text-on-image mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+      <h2 className="text-on-image mb-3 text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
         {title}{" "}
-        <span className="tnum text-[13px] font-normal text-[var(--text-muted)]">{files.length}</span>
+        <span className="tnum text-ui font-normal text-[var(--text-muted)]">{files.length}</span>
       </h2>
       <div className="overflow-hidden rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] backdrop-blur-xl">
         {groups.map(([season, groupFiles]) => (
           <div key={season}>
             {!isMovie && groups.length > 1 && (
-              <p className="border-b border-white/[0.05] px-5 pb-2 pt-3.5 text-[12px] font-semibold text-[var(--text-muted)]">
+              <p className="border-b border-white/[0.05] px-5 pb-2 pt-3.5 text-sub font-semibold text-[var(--text-muted)]">
                 {season === 0 ? "未归集" : `第 ${season} 季`} · {groupFiles.length} 个文件
               </p>
             )}
@@ -1123,7 +1123,7 @@ function FileSection({
           </div>
         ))}
       </div>
-      <p className="mt-2 text-[11.5px] text-[var(--text-faint)]">
+      <p className="mt-2 text-caption text-[var(--text-faint)]">
         悬浮文件名可查看物理路径。规格探测自文件本体（ffprobe），不来自资源命名。
       </p>
     </section>
@@ -1149,15 +1149,15 @@ function FileRow({ file, isMovie }: { file: LibraryItemFile; isMovie: boolean })
         <div className="min-w-0 flex-1">
           <Tooltip
             content={
-              <span className="tnum break-all font-mono text-[11.5px] leading-5">
+              <span className="tnum break-all font-mono text-caption leading-5">
                 {file.file_path}
               </span>
             }
             maxWidth={520}
           >
-            <p className="truncate text-[13px] text-[var(--text)]">
+            <p className="truncate text-ui text-[var(--text)]">
               {!isMovie && (file.episode_number > 0 || file.season_number > 0) && (
-                <span className="tnum mr-2 text-[12px] font-semibold text-[var(--accent-2)]">
+                <span className="tnum mr-2 text-sub font-semibold text-[var(--accent-2)]">
                   S{String(file.season_number).padStart(2, "0")}E
                   {String(file.episode_number).padStart(2, "0")}
                 </span>
@@ -1165,7 +1165,7 @@ function FileRow({ file, isMovie }: { file: LibraryItemFile; isMovie: boolean })
               {file.file_name}
             </p>
           </Tooltip>
-          <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11.5px] text-[var(--text-muted)]">
+          <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-caption text-[var(--text-muted)]">
             {badges.length > 0 && <span className="tnum">{badges.join(" · ")}</span>}
             {audioSummary && <span className="tnum">{audioSummary}</span>}
             {file.subtitle_streams.length > 0 && (
@@ -1174,17 +1174,17 @@ function FileRow({ file, isMovie }: { file: LibraryItemFile; isMovie: boolean })
           </p>
         </div>
         {file.missing && (
-          <span className="shrink-0 rounded border border-[#f5c451]/40 px-1.5 py-px text-[10px] font-semibold text-[#f5c451]">
+          <span className="shrink-0 rounded border border-[#f5c451]/40 px-1.5 py-px text-micro font-semibold text-[#f5c451]">
             文件缺失
           </span>
         )}
-        <span className="shrink-0 rounded border border-white/[0.14] px-1.5 py-px text-[10px] text-white/55">
+        <span className="shrink-0 rounded border border-white/[0.14] px-1.5 py-px text-micro text-white/55">
           {file.source === "imported" ? "入库管线" : "扫描发现"}
         </span>
-        <span className="tnum w-20 shrink-0 text-right text-[12.5px] text-[var(--text-muted)]">
+        <span className="tnum w-20 shrink-0 text-right text-sub text-[var(--text-muted)]">
           {formatBytes(file.size_bytes)}
         </span>
-        <span className="tnum w-20 shrink-0 text-right text-[11.5px] text-[var(--text-faint)]">
+        <span className="tnum w-20 shrink-0 text-right text-caption text-[var(--text-faint)]">
           {formatRelativeTime(file.added_at)}
         </span>
       </div>
@@ -1245,34 +1245,34 @@ function DeleteDialog({
       <div className="p-6">
         {result ? (
           <>
-            <h3 className="text-[16px] font-semibold text-[var(--text)]">
+            <h3 className="text-title-sm font-semibold text-[var(--text)]">
               {result.errors.length > 0 ? "部分删除完成" : "已从磁盘彻底删除"}
             </h3>
             <div className="scroll-thin mt-4 max-h-56 overflow-y-auto rounded-xl border border-white/[0.08] bg-white/[0.03] p-3.5">
               {result.removed_paths.map((p) => (
-                <p key={p} className="tnum break-all py-0.5 font-mono text-[11.5px] leading-5 text-white/70">
+                <p key={p} className="tnum break-all py-0.5 font-mono text-caption leading-5 text-white/70">
                   {p}
                 </p>
               ))}
               {result.removed_paths.length === 0 && (
-                <p className="text-[12px] text-[var(--text-muted)]">没有删除任何磁盘路径</p>
+                <p className="text-sub text-[var(--text-muted)]">没有删除任何磁盘路径</p>
               )}
             </div>
             {result.errors.length > 0 && (
-              <div className="mt-3 space-y-1 text-[12px] leading-5 text-[#ff9f9f]">
+              <div className="mt-3 space-y-1 text-sub leading-5 text-[#ff9f9f]">
                 {result.errors.map((e) => (
                   <p key={e}>{e}</p>
                 ))}
               </div>
             )}
-            <p className="mt-3 text-[12.5px] text-[var(--text-muted)]">
+            <p className="mt-3 text-sub text-[var(--text-muted)]">
               已清理 {result.rows_deleted} 条台账，释放 {formatBytes(result.freed_bytes)}。
             </p>
             <div className="mt-5 flex justify-end">
               <button
                 type="button"
                 onClick={onDeleted}
-                className="btn-accent rounded-full px-5 py-2 text-[13px] font-semibold"
+                className="btn-accent rounded-full px-5 py-2 text-ui font-semibold"
               >
                 回到库存页
               </button>
@@ -1280,11 +1280,11 @@ function DeleteDialog({
           </>
         ) : (
           <>
-            <h3 className="flex items-center gap-2 text-[16px] font-semibold text-[var(--text)]">
+            <h3 className="flex items-center gap-2 text-title-sm font-semibold text-[var(--text)]">
               <TrashIcon className="size-4.5 text-[#ff9f9f]" />
               删除「{detail.title}」
             </h3>
-            <p className="mt-3 text-[13px] leading-6 text-white/80">
+            <p className="mt-3 text-ui leading-6 text-white/80">
               这不是「从列表移除」——将把下列目录从磁盘
               <span className="font-semibold text-[#ff9f9f]">彻底删除</span>
               ，包括视频文件、NFO、海报、字幕等全部刮削产物，共{" "}
@@ -1297,13 +1297,13 @@ function DeleteDialog({
                 ? detail.entry_dirs
                 : detail.files.map((f) => f.file_path)
               ).map((p) => (
-                <p key={p} className="tnum flex items-start gap-1.5 break-all py-0.5 font-mono text-[11.5px] leading-5 text-white/70">
+                <p key={p} className="tnum flex items-start gap-1.5 break-all py-0.5 font-mono text-caption leading-5 text-white/70">
                   <FolderIcon className="mt-0.5 size-3.5 shrink-0 text-white/40" />
                   {p}
                 </p>
               ))}
             </div>
-            <label className="mt-4 flex cursor-pointer items-start gap-2.5 text-[12.5px] leading-6 text-white/80">
+            <label className="mt-4 flex cursor-pointer items-start gap-2.5 text-sub leading-6 text-white/80">
               <input
                 type="checkbox"
                 checked={confirmed}
@@ -1312,13 +1312,13 @@ function DeleteDialog({
               />
               我已明白：以上目录及其中全部文件将被永久删除，无法恢复。
             </label>
-            {error && <p className="mt-3 text-[12.5px] text-[#ff9f9f]">{error}</p>}
+            {error && <p className="mt-3 text-sub text-[#ff9f9f]">{error}</p>}
             <div className="mt-5 flex justify-end gap-3">
               <button
                 type="button"
                 onClick={onClose}
                 disabled={busy}
-                className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+                className="btn-glass px-4 py-2 text-ui font-medium text-[var(--text)]"
               >
                 取消
               </button>
@@ -1326,7 +1326,7 @@ function DeleteDialog({
                 type="button"
                 onClick={run}
                 disabled={!confirmed || busy}
-                className="flex items-center gap-2 rounded-full bg-[#c73838] px-5 py-2 text-[13px] font-semibold text-white transition hover:bg-[#d64545] disabled:cursor-not-allowed disabled:opacity-40"
+                className="flex items-center gap-2 rounded-full bg-[#c73838] px-5 py-2 text-ui font-semibold text-white transition hover:bg-[#d64545] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {busy && (
                   <span className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />

--- a/apps/web/components/library-organize-dialog.tsx
+++ b/apps/web/components/library-organize-dialog.tsx
@@ -167,13 +167,13 @@ export function LibraryOrganizeDialog({
         {/* —— 头部 —— */}
         <div className="flex items-start justify-between gap-3 border-b border-white/[0.08] px-6 pb-4 pt-5">
           <div className="min-w-0">
-            <h2 className="text-[17px] font-bold text-white">
+            <h2 className="text-title font-bold text-white">
               整理文件名
-              <span className="ml-2 text-[13px] font-normal text-[var(--text-muted)]">
+              <span className="ml-2 text-ui font-normal text-[var(--text-muted)]">
                 {library.name}
               </span>
             </h2>
-            <p className="mt-1 text-[12px] leading-5 text-[var(--text-muted)]">
+            <p className="mt-1 text-sub leading-5 text-[var(--text-muted)]">
               按刮削结果把存量文件改名归位为「标题 (年份){library.kind === "tv" ? "/Season NN" : ""}
               /规范文件名」，Plex / Emby 零歧义识别；字幕等附属文件同步改名。
             </p>
@@ -192,15 +192,15 @@ export function LibraryOrganizeDialog({
         {phase === "loading" && (
           <div className="flex flex-col items-center gap-3 px-6 py-16">
             <span className="size-5 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
-            <p className="text-[13px] text-[var(--text-muted)]">
+            <p className="text-ui text-[var(--text-muted)]">
               正在核对台账与磁盘，生成整理预览…
             </p>
           </div>
         )}
         {phase === "failed" && (
           <div className="flex flex-col items-center gap-4 px-6 py-14">
-            <p className="max-w-md text-center text-[13px] leading-6 text-red-200">{error}</p>
-            <button type="button" onClick={onClose} className="btn-glass px-4 py-2 text-[13px] font-medium">
+            <p className="max-w-md text-center text-ui leading-6 text-red-200">{error}</p>
+            <button type="button" onClick={onClose} className="btn-glass px-4 py-2 text-ui font-medium">
               关闭
             </button>
           </div>
@@ -226,10 +226,10 @@ export function LibraryOrganizeDialog({
               </div>
 
               {renameCount === 0 ? (
-                <p className="rounded-xl bg-white/[0.03] px-4 py-8 text-center text-[13.5px] leading-7 text-[var(--text-muted)]">
+                <p className="rounded-xl bg-white/[0.03] px-4 py-8 text-center text-ui leading-7 text-[var(--text-muted)]">
                   这个库已经很规整了，没有需要改名的文件 🎉
                   {preview.skips.length > 0 && (
-                    <span className="block text-[12px] text-[var(--text-faint)]">
+                    <span className="block text-sub text-[var(--text-faint)]">
                       （{preview.skips.length} 个文件因下方原因未参与整理）
                     </span>
                   )}
@@ -238,8 +238,8 @@ export function LibraryOrganizeDialog({
                 <>
                   {/* 风险告知：批量改名是半不可逆操作，三条风险必须看到 */}
                   <div className="rounded-xl border border-[#f5c451]/30 bg-[#f5c451]/[0.08] px-4 py-3">
-                    <p className="text-[12.5px] font-semibold text-[#f5c451]">开始前请确认</p>
-                    <ul className="mt-1.5 list-disc space-y-1 pl-4 text-[12px] leading-5 text-[#f5c451]/85">
+                    <p className="text-sub font-semibold text-[#f5c451]">开始前请确认</p>
+                    <ul className="mt-1.5 list-disc space-y-1 pl-4 text-sub leading-5 text-[#f5c451]/85">
                       <li>
                         改名直接发生在磁盘上，<strong>无法一键撤销</strong>；下方清单就是将要发生的全部变更。
                       </li>
@@ -257,7 +257,7 @@ export function LibraryOrganizeDialog({
                   <div className="space-y-3">
                     {groups.map((group) => (
                       <div key={`${group.title}-${group.year}`} className="rounded-xl bg-white/[0.03]">
-                        <p className="border-b border-white/[0.06] px-3.5 py-2 text-[12.5px] font-semibold text-white/85">
+                        <p className="border-b border-white/[0.06] px-3.5 py-2 text-sub font-semibold text-white/85">
                           {group.title}
                           {group.year ? ` (${group.year})` : ""}
                           <span className="ml-2 font-normal text-[var(--text-faint)]">
@@ -268,23 +268,23 @@ export function LibraryOrganizeDialog({
                           {group.actions.map((action) => (
                             <div key={action.file_id} className="py-2">
                               <p
-                                className="truncate font-mono text-[11px] text-[var(--text-faint)] line-through decoration-white/25"
+                                className="truncate font-mono text-caption text-[var(--text-faint)] line-through decoration-white/25"
                                 title={action.source_path}
                               >
                                 {action.source_rel}
                               </p>
                               <p
-                                className="mt-0.5 flex items-center gap-1 font-mono text-[11.5px] text-white/90"
+                                className="mt-0.5 flex items-center gap-1 font-mono text-caption text-white/90"
                                 title={action.target_path}
                               >
                                 <ChevronRightIcon className="size-3 shrink-0 text-[var(--accent)]" />
                                 <span className="truncate">{action.target_rel}</span>
-                                <span className="ml-auto shrink-0 pl-2 font-sans text-[10.5px] text-[var(--text-faint)]">
+                                <span className="ml-auto shrink-0 pl-2 font-sans text-micro text-[var(--text-faint)]">
                                   {formatBytes(action.size_bytes)}
                                 </span>
                               </p>
                               {action.sidecars.length > 0 && (
-                                <p className="mt-0.5 pl-4 text-[10.5px] text-[var(--text-faint)]">
+                                <p className="mt-0.5 pl-4 text-micro text-[var(--text-faint)]">
                                   +{action.sidecars.length} 个附属文件（字幕等）同步改名
                                 </p>
                               )}
@@ -303,7 +303,7 @@ export function LibraryOrganizeDialog({
                   <button
                     type="button"
                     onClick={() => setShowSkips((v) => !v)}
-                    className="flex w-full items-center gap-1.5 px-3.5 py-2.5 text-left text-[12.5px] font-medium text-[var(--text-muted)] transition hover:text-white"
+                    className="flex w-full items-center gap-1.5 px-3.5 py-2.5 text-left text-sub font-medium text-[var(--text-muted)] transition hover:text-white"
                   >
                     <ChevronRightIcon
                       className={`size-3.5 transition-transform ${showSkips ? "rotate-90" : ""}`}
@@ -315,12 +315,12 @@ export function LibraryOrganizeDialog({
                       {preview.skips.map((skip) => (
                         <div key={skip.file_path} className="py-2">
                           <p
-                            className="truncate font-mono text-[11px] text-[var(--text-faint)]"
+                            className="truncate font-mono text-caption text-[var(--text-faint)]"
                             title={skip.file_path}
                           >
                             {skip.file_path}
                           </p>
-                          <p className="mt-0.5 text-[11.5px] text-[#f5c451]/80">{skip.reason}</p>
+                          <p className="mt-0.5 text-caption text-[#f5c451]/80">{skip.reason}</p>
                         </div>
                       ))}
                     </div>
@@ -332,13 +332,13 @@ export function LibraryOrganizeDialog({
             {/* —— 确认区 —— */}
             <div className="border-t border-white/[0.08] px-6 py-4">
               {error && (
-                <p className="mb-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2 text-[12.5px] text-red-200">
+                <p className="mb-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2 text-sub text-red-200">
                   {error}
                 </p>
               )}
               {renameCount > 0 ? (
                 <div className="flex flex-wrap items-center justify-between gap-3">
-                  <label className="flex cursor-pointer select-none items-center gap-2 text-[12.5px] text-[var(--text-muted)]">
+                  <label className="flex cursor-pointer select-none items-center gap-2 text-sub text-[var(--text-muted)]">
                     <input
                       type="checkbox"
                       checked={agreed}
@@ -348,14 +348,14 @@ export function LibraryOrganizeDialog({
                     我已核对清单并了解上述风险
                   </label>
                   <div className="flex items-center gap-3">
-                    <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-[13px] font-medium">
+                    <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
                       取消
                     </button>
                     <button
                       type="button"
                       disabled={!agreed}
                       onClick={start}
-                      className="btn-accent h-9 rounded-full px-5 text-[13px] font-semibold disabled:opacity-40"
+                      className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
                     >
                       开始整理 {renameCount} 个文件
                     </button>
@@ -363,7 +363,7 @@ export function LibraryOrganizeDialog({
                 </div>
               ) : (
                 <div className="flex justify-end">
-                  <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-[13px] font-medium">
+                  <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
                     关闭
                   </button>
                 </div>
@@ -381,13 +381,13 @@ export function LibraryOrganizeDialog({
                 style={{ width: `${pct ?? 8}%` }}
               />
             </div>
-            <p className="text-[13.5px] font-medium text-white">
+            <p className="text-ui font-medium text-white">
               正在整理…
               {progress && progress.total > 0
                 ? ` ${progress.processed} / ${progress.total}`
                 : ""}
             </p>
-            <p className="text-center text-[12px] leading-5 text-[var(--text-muted)]">
+            <p className="text-center text-sub leading-5 text-[var(--text-muted)]">
               每改名一个文件即同步台账，中断也不会账实不符；期间扫描自动让路。
               <br />
               关闭窗口不影响整理，库卡片上可继续查看进度。
@@ -402,8 +402,8 @@ export function LibraryOrganizeDialog({
               <span className="flex size-11 items-center justify-center rounded-full bg-[#4ade80]/15">
                 <CheckIcon className="size-5 text-[#4ade80]" />
               </span>
-              <p className="text-[15px] font-semibold text-white">整理完成</p>
-              <p className="text-center text-[13px] leading-6 text-[var(--text-muted)]">
+              <p className="text-body-lg font-semibold text-white">整理完成</p>
+              <p className="text-center text-ui leading-6 text-[var(--text-muted)]">
                 改名归位 {result?.renamed ?? 0} 个文件
                 {result && result.sidecars_renamed > 0
                   ? `，附属文件 ${result.sidecars_renamed} 个随迁`
@@ -416,10 +416,10 @@ export function LibraryOrganizeDialog({
               </p>
               {result && result.errors.length > 0 && (
                 <div className="w-full rounded-xl border border-[#f5c451]/30 bg-[#f5c451]/[0.08] px-4 py-3">
-                  <p className="text-[12.5px] font-semibold text-[#f5c451]">
+                  <p className="text-sub font-semibold text-[#f5c451]">
                     {result.errors.length} 个文件处理时遇到问题（未被改动）
                   </p>
-                  <ul className="mt-1.5 space-y-1 text-[11.5px] leading-5 text-[#f5c451]/85">
+                  <ul className="mt-1.5 space-y-1 text-caption leading-5 text-[#f5c451]/85">
                     {result.errors.map((message) => (
                       <li key={message} className="break-all">
                         {message}
@@ -431,7 +431,7 @@ export function LibraryOrganizeDialog({
               <button
                 type="button"
                 onClick={onClose}
-                className="btn-accent mt-2 h-9 rounded-full px-6 text-[13px] font-semibold"
+                className="btn-accent mt-2 h-9 rounded-full px-6 text-ui font-semibold"
               >
                 完成
               </button>
@@ -451,7 +451,7 @@ function StatChip({ tone, label }: { tone: "accent" | "ok" | "warn" | "muted"; l
     muted: "border-white/[0.1] bg-white/[0.05] text-[var(--text-muted)]",
   }[tone];
   return (
-    <span className={`rounded-full border px-3 py-1 text-[12px] font-semibold ${toneClass}`}>
+    <span className={`rounded-full border px-3 py-1 text-sub font-semibold ${toneClass}`}>
       {label}
     </span>
   );

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -324,14 +324,14 @@ export function LibraryView() {
           <h2 className="text-on-image text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[21px]">
             媒体库
           </h2>
-          <p className="text-on-image mt-1.5 text-[13px] text-[var(--text-muted)] max-md:mt-1 max-md:line-clamp-2 max-md:text-[12px]">
+          <p className="text-on-image mt-1.5 text-ui text-[var(--text-muted)] max-md:mt-1 max-md:line-clamp-2 max-md:text-sub">
             你的影视收藏在这里安家：订阅与下载的内容按「入库到哪个库」落盘，Plex / Emby 可直接识别
           </p>
         </div>
         <button
           type="button"
           onClick={() => setEditing("new")}
-          className="btn-accent flex shrink-0 items-center justify-center gap-1 rounded-full py-2 pl-3 pr-4 text-[13px] font-semibold max-md:self-start"
+          className="btn-accent flex shrink-0 items-center justify-center gap-1 rounded-full py-2 pl-3 pr-4 text-ui font-semibold max-md:self-start"
         >
           <PlusIcon className="size-4" />
           添加媒体库
@@ -339,7 +339,7 @@ export function LibraryView() {
       </div>
 
       {error && (
-        <div className="mx-6 mt-4 rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-sm text-[#ff6b6b] max-md:mx-4">
+        <div className="mx-6 mt-4 rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b] max-md:mx-4">
           {error}
         </div>
       )}
@@ -349,14 +349,14 @@ export function LibraryView() {
       {routingWarnings.map((w) => (
         <div
           key={w}
-          className="mx-6 mt-4 rounded-xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-[12.5px] leading-relaxed text-amber-200 max-md:mx-4"
+          className="mx-6 mt-4 rounded-xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sub leading-relaxed text-amber-200 max-md:mx-4"
         >
           {w}
         </div>
       ))}
 
       {libraries === null && !failed && (
-        <div className="mt-16 flex items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+        <div className="mt-16 flex items-center justify-center gap-2.5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在加载媒体库…
         </div>
@@ -366,11 +366,11 @@ export function LibraryView() {
           提示条（stale-while-error），卡片照常展示上一份快照 */}
       {failed && libraries === null && (
         <div className="mt-16 flex flex-col items-center gap-3 text-center">
-          <p className="text-[13.5px] text-[var(--text-muted)]">媒体库加载失败</p>
+          <p className="text-ui text-[var(--text-muted)]">媒体库加载失败</p>
           <button
             type="button"
             onClick={reload}
-            className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+            className="btn-glass px-4 py-2 text-ui font-medium text-[var(--text)]"
           >
             重试
           </button>
@@ -378,15 +378,15 @@ export function LibraryView() {
       )}
 
       {failed && libraries !== null && (
-        <div className="mx-6 mt-4 rounded-xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-[12.5px] text-amber-200 max-md:mx-4">
+        <div className="mx-6 mt-4 rounded-xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sub text-amber-200 max-md:mx-4">
           与后端通信失败，正在自动重试；下方显示的是最近一次成功加载的数据
         </div>
       )}
 
       {libraries !== null && libraries.length === 0 && (
         <div className="mt-20 flex flex-col items-center gap-4 px-6 text-center">
-          <p className="text-[15px] font-semibold text-[var(--text)]">还没有媒体库</p>
-          <p className="max-w-[440px] text-[13px] leading-relaxed text-[var(--text-muted)]">
+          <p className="text-body-lg font-semibold text-[var(--text)]">还没有媒体库</p>
+          <p className="max-w-[440px] text-ui leading-relaxed text-[var(--text-muted)]">
             媒体库定义「内容放在哪」：订阅和下载完成的影片会整理进对应库的根目录，
             Plex / Emby 指向同一目录即可识别。建议按类型分别创建，比如电影库、剧集库，
             根路径选到你的媒体盘（Docker 部署时是挂进容器的那个路径）。
@@ -394,7 +394,7 @@ export function LibraryView() {
           <button
             type="button"
             onClick={() => setEditing("new")}
-            className="btn-accent flex items-center gap-1 rounded-full py-2 pl-3 pr-4 text-[13px] font-semibold"
+            className="btn-accent flex items-center gap-1 rounded-full py-2 pl-3 pr-4 text-ui font-semibold"
           >
             <PlusIcon className="size-4" />
             创建第一个媒体库
@@ -551,13 +551,13 @@ function LibraryCard({
           {!busy && (importing > 0 || stats.unidentified_count > 0) && (
             <div className="absolute inset-x-2.5 bottom-2 flex flex-wrap items-center gap-1.5">
               {importing > 0 && (
-                <span className="flex items-center gap-1.5 rounded-full border border-[#7dd3fc]/35 bg-black/55 px-2 py-0.5 text-[10px] font-semibold text-[#7dd3fc] backdrop-blur-md">
+                <span className="flex items-center gap-1.5 rounded-full border border-[#7dd3fc]/35 bg-black/55 px-2 py-0.5 text-micro font-semibold text-[#7dd3fc] backdrop-blur-md">
                   <span className="size-1.5 animate-pulse rounded-full bg-[#7dd3fc]" />
                   {importing} 个新文件入库中
                 </span>
               )}
               {stats.unidentified_count > 0 && (
-                <span className="rounded-full border border-[#f5c451]/35 bg-black/55 px-2 py-0.5 text-[10px] font-semibold text-[#f5c451] backdrop-blur-md">
+                <span className="rounded-full border border-[#f5c451]/35 bg-black/55 px-2 py-0.5 text-micro font-semibold text-[#f5c451] backdrop-blur-md">
                   {stats.unidentified_count} 个待识别
                 </span>
               )}
@@ -578,7 +578,7 @@ function LibraryCard({
                   分阶段（盘点/入账/补图），阶段变了这里必须跟着变——否则
                   文件扫完后还要下几分钟图片，环停在 100% 配一句"扫描中"，
                   看起来就是卡死了 */}
-              <span className="text-[11px] font-semibold text-white/85">
+              <span className="text-caption font-semibold text-white/85">
                 {library.scanning
                   ? (SCAN_PHASE_LABELS[library.scan_progress?.phase ?? "ingesting"] ?? "扫描中")
                   : library.organizing
@@ -588,7 +588,7 @@ function LibraryCard({
               {/* 刷新是全量重刷、以分钟计，多给一行"到哪部了"（并发若干路
                   时取第一部即可，完整列表在单库页的面板里） */}
               {refreshingMeta && library.metadata_refresh?.active?.[0] && (
-                <span className="max-w-[86%] truncate text-[10.5px] text-white/60">
+                <span className="max-w-[86%] truncate text-micro text-white/60">
                   {library.metadata_refresh.active[0].title} ·{" "}
                   {library.metadata_refresh.active[0].phase}
                 </span>
@@ -600,16 +600,16 @@ function LibraryCard({
 
       {/* 库名：Emby 式放在封面下方居中，只与「默认」共处一行 */}
       <div className="mt-2.5 flex items-center justify-center gap-2 px-2">
-        <h3 className="truncate text-[15px] font-semibold text-white">{library.name}</h3>
+        <h3 className="truncate text-body-lg font-semibold text-white">{library.name}</h3>
         {library.is_default && (
-          <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.1] px-2 py-0.5 text-[10.5px] font-semibold text-white/80">
+          <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.1] px-2 py-0.5 text-micro font-semibold text-white/80">
             默认
           </span>
         )}
       </div>
       {collectSummary && (
         <p
-          className="mt-0.5 truncate px-2 text-center text-[11px] text-[var(--text-faint)]"
+          className="mt-0.5 truncate px-2 text-center text-caption text-[var(--text-faint)]"
           title={`收藏范围：${collectSummary}（订阅与监听导入按它自动选库）`}
         >
           收：{collectSummary}
@@ -667,7 +667,7 @@ function ScanProgressRing({ progress }: { progress: { processed: number; total: 
           className="transition-[stroke-dashoffset] duration-500 ease-out"
         />
       </svg>
-      <span className="absolute inset-0 flex items-center justify-center text-[13px] font-semibold text-white">
+      <span className="absolute inset-0 flex items-center justify-center text-ui font-semibold text-white">
         {pct === null ? "…" : `${pct}%`}
       </span>
     </div>
@@ -815,7 +815,7 @@ function LibraryCardMenu({
                 setMenuPos(null);
                 onEdit();
               }}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium disabled:opacity-40"
+              className="glass-row px-2.5 py-2 text-ui font-medium disabled:opacity-40"
             >
               编辑库
             </button>
@@ -835,7 +835,7 @@ function LibraryCardMenu({
                 }
                 onScan();
               }}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium disabled:opacity-40"
+              className="glass-row px-2.5 py-2 text-ui font-medium disabled:opacity-40"
             >
               {!library.scanning
                 ? "扫描库"
@@ -850,7 +850,7 @@ function LibraryCardMenu({
                 setMenuPos(null);
                 onOrganize();
               }}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium disabled:opacity-40"
+              className="glass-row px-2.5 py-2 text-ui font-medium disabled:opacity-40"
             >
               {library.organizing ? "正在整理…" : "整理文件名"}
             </button>
@@ -858,7 +858,7 @@ function LibraryCardMenu({
               type="button"
               disabled={library.is_default}
               onClick={() => guard(() => setDefaultLibrary(library.id))}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium disabled:opacity-40"
+              className="glass-row px-2.5 py-2 text-ui font-medium disabled:opacity-40"
             >
               设为默认库
             </button>
@@ -875,7 +875,7 @@ function LibraryCardMenu({
                   return;
                 guard(() => deleteLibrary(library.id));
               }}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium !text-[var(--danger)] hover:!bg-[rgba(255,107,107,0.12)] disabled:opacity-40"
+              className="glass-row px-2.5 py-2 text-ui font-medium !text-[var(--danger)] hover:!bg-[rgba(255,107,107,0.12)] disabled:opacity-40"
             >
               删除库
             </button>
@@ -961,9 +961,9 @@ export function LibraryFormDialog({
   };
 
   const inputClass =
-    "w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] " +
+    "w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui " +
     "text-[var(--text)] outline-none focus:border-[var(--accent)]/60";
-  const labelClass = "mb-1.5 block text-xs font-medium text-[var(--text-muted)]";
+  const labelClass = "mb-1.5 block text-sub font-medium text-[var(--text-muted)]";
 
   // 收藏范围的当前声明摘要（底栏常显）：切到基本信息页签也能看到已设了什么。
   // 区域折叠复用卡片摘要的 regionLabels（整组折叠 + 零散国家码兜底），
@@ -998,10 +998,10 @@ export function LibraryFormDialog({
       >
         {/* 头部：标题 + 分段页签 */}
         <div className="shrink-0 border-b border-white/[0.06] px-6 pt-5 max-md:px-5">
-          <h2 className="text-[17px] font-bold text-white">
+          <h2 className="text-title font-bold text-white">
             {library ? "编辑媒体库" : "添加媒体库"}
             {library && (
-              <span className="ml-2 text-[13px] font-normal text-[var(--text-muted)]">
+              <span className="ml-2 text-ui font-normal text-[var(--text-muted)]">
                 {library.name}
               </span>
             )}
@@ -1019,7 +1019,7 @@ export function LibraryFormDialog({
                 role="tab"
                 aria-selected={tab === key}
                 onClick={() => setTab(key)}
-                className={`relative pb-2.5 text-[13px] font-medium transition-colors ${
+                className={`relative pb-2.5 text-ui font-medium transition-colors ${
                   tab === key ? "text-white" : "text-[var(--text-muted)] hover:text-white"
                 }`}
               >
@@ -1053,7 +1053,7 @@ export function LibraryFormDialog({
                   disabled={library !== null}
                   onClick={() => setKind(k)}
                   data-active={(library?.kind ?? kind) === k}
-                  className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium disabled:opacity-60"
+                  className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium disabled:opacity-60"
                 >
                   {LIBRARY_KIND_META[k].label}
                 </button>
@@ -1091,7 +1091,7 @@ export function LibraryFormDialog({
                   <Tooltip
                     content={
                       <>
-                        <p className="mb-1 break-all font-mono text-[11px] text-[var(--text-muted)]">{root}</p>
+                        <p className="mb-1 break-all font-mono text-caption text-[var(--text-muted)]">{root}</p>
                         点击更改：从当前路径开始重新选择目录。
                       </>
                     }
@@ -1100,7 +1100,7 @@ export function LibraryFormDialog({
                       type="button"
                       dir="rtl"
                       onClick={() => setPickerTarget(i)}
-                      className="min-w-0 flex-1 truncate rounded text-left font-mono text-[13px] text-[var(--text)] transition-colors hover:text-[var(--accent)]"
+                      className="min-w-0 flex-1 truncate rounded text-left font-mono text-ui text-[var(--text)] transition-colors hover:text-[var(--accent)]"
                     >
                       {"‎" + root + "‎"}
                     </button>
@@ -1115,7 +1115,7 @@ export function LibraryFormDialog({
                         </>
                       }
                     >
-                      <span className="shrink-0 cursor-default rounded-full bg-[var(--accent)]/15 px-2 py-0.5 text-[10px] font-semibold text-[var(--accent)]">
+                      <span className="shrink-0 cursor-default rounded-full bg-[var(--accent)]/15 px-2 py-0.5 text-micro font-semibold text-[var(--accent)]">
                         主根
                       </span>
                     </Tooltip>
@@ -1124,7 +1124,7 @@ export function LibraryFormDialog({
                       <button
                         type="button"
                         onClick={() => setRoots([root, ...roots.filter((r) => r !== root)])}
-                        className="touch-reveal shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium text-[var(--text-faint)] opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover:opacity-100"
+                        className="touch-reveal shrink-0 rounded-full px-2 py-0.5 text-micro font-medium text-[var(--text-faint)] opacity-0 transition-opacity hover:bg-white/10 hover:text-white group-hover:opacity-100"
                       >
                         设为主根
                       </button>
@@ -1143,13 +1143,13 @@ export function LibraryFormDialog({
               <button
                 type="button"
                 onClick={() => setPickerTarget("add")}
-                className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-white/15 px-3 py-2.5 text-[13px] font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--accent)]/50 hover:text-white"
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-white/15 px-3 py-2.5 text-ui font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--accent)]/50 hover:text-white"
               >
                 <PlusIcon className="size-4" />
                 {roots.length === 0 ? "浏览服务器目录并添加" : "添加目录"}
               </button>
             </div>
-            <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+            <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
               新入库的内容落在<strong className="font-medium text-[var(--text-muted)]">主根</strong>下：主根/标题
               (年份)。其余为扩展根：扫描与监控照常覆盖，但不写入新内容。
             </p>
@@ -1162,12 +1162,12 @@ export function LibraryFormDialog({
               两个维度间是"且" */}
           {tab === "scope" && (
             <>
-          <p className="text-[12px] leading-relaxed text-[var(--text-muted)]">
+          <p className="text-sub leading-relaxed text-[var(--text-muted)]">
             可选：声明「本库收什么」后，订阅与监听导入按作品特征自动选进本库。
             全部留空 = 不声明，该类型的默认库承接未命中的作品；订阅时永远可以手动改库。
           </p>
           {routingOptions === null ? (
-            <p className="rounded-xl border border-white/[0.08] bg-white/[0.03] px-3 py-2.5 text-[12px] text-[var(--text-faint)]">
+            <p className="rounded-xl border border-white/[0.08] bg-white/[0.03] px-3 py-2.5 text-sub text-[var(--text-faint)]">
               正在加载可选项…
             </p>
           ) : (
@@ -1194,7 +1194,7 @@ export function LibraryFormDialog({
                             : [...prev, code],
                         )
                       }
-                      className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+                      className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
                     >
                       {name}
                     </button>
@@ -1202,7 +1202,7 @@ export function LibraryFormDialog({
                 </div>
                 {/* 预设组保留为快捷键：一键选中/取消整组，避免「欧美」要点十下 */}
                 <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                  <span className="text-[11px] text-[var(--text-faint)]">快捷组合</span>
+                  <span className="text-caption text-[var(--text-faint)]">快捷组合</span>
                   {routingOptions.region_presets.map((preset) => {
                     const active = preset.countries.every((c) => matchRegions.includes(c));
                     return (
@@ -1220,7 +1220,7 @@ export function LibraryFormDialog({
                               : [...new Set([...prev, ...preset.countries])],
                           )
                         }
-                        className="glass-row nav-item !w-auto px-2.5 py-1 text-[11px] font-medium"
+                        className="glass-row nav-item !w-auto px-2.5 py-1 text-caption font-medium"
                       >
                         {preset.label}
                       </button>
@@ -1243,7 +1243,7 @@ export function LibraryFormDialog({
                             : [...prev, g.id],
                         )
                       }
-                      className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+                      className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
                     >
                       {g.label}
                     </button>
@@ -1251,7 +1251,7 @@ export function LibraryFormDialog({
                 </div>
               </div>
               {matchRegions.length > 0 && matchGenres.length > 0 && (
-                <p className="text-[11px] leading-relaxed text-[var(--text-faint)]">
+                <p className="text-caption leading-relaxed text-[var(--text-faint)]">
                   区域与类型须<strong className="font-medium text-[var(--text-muted)]">同时满足</strong>
                   （如「日韩 + 动画」= 只收日韩的动画）。
                 </p>
@@ -1265,23 +1265,23 @@ export function LibraryFormDialog({
         {/* 底栏：错误 + 范围摘要 + 操作，任一页签下常显 */}
         <div className="shrink-0 border-t border-white/[0.06] px-6 py-4 max-md:px-5">
           {error && (
-            <p className="mb-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-[13px] leading-6 text-red-200">
+            <p className="mb-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
               {error}
             </p>
           )}
           <div className="flex items-center justify-between gap-3">
-            <p className="min-w-0 truncate text-[11px] text-[var(--text-faint)]">
+            <p className="min-w-0 truncate text-caption text-[var(--text-faint)]">
               {missingFields.length > 0 ? `还需填写：${missingFields.join("、")}` : scopeSummary}
             </p>
             <div className="flex shrink-0 items-center gap-3">
-              <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-[13px] font-medium">
+              <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
                 取消
               </button>
               <button
                 type="button"
                 onClick={submit}
                 disabled={!canSubmit}
-                className="btn-accent h-9 rounded-full px-5 text-[13px] font-semibold disabled:opacity-40"
+                className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
               >
                 {busy ? "保存中…" : "保存"}
               </button>

--- a/apps/web/components/llm-config-section.tsx
+++ b/apps/web/components/llm-config-section.tsx
@@ -95,12 +95,12 @@ export function LlmConfigSection() {
   return (
     <div className="space-y-5">
       {error && (
-        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-sm text-[#ff6b6b]">
+        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
           {error}
         </div>
       )}
 
-      <p className="text-xs text-[var(--text-muted)]">
+      <p className="text-sub text-[var(--text-muted)]">
         {loading
           ? "加载中…"
           : config == null
@@ -117,15 +117,15 @@ export function LlmConfigSection() {
             <SparkIcon className="size-6" />
           </span>
           <div>
-            <p className="text-sm font-medium text-[var(--text)]">还没有接入模型供应商</p>
-            <p className="mt-1 text-xs text-[var(--text-muted)]">
+            <p className="text-body font-medium text-[var(--text)]">还没有接入模型供应商</p>
+            <p className="mt-1 text-sub text-[var(--text-muted)]">
               支持 OpenAI、阿里云百炼，以及任何 OpenAI 兼容端点（如自建 vLLM / Ollama）。
             </p>
           </div>
           <button
             type="button"
             onClick={() => setEditing(true)}
-            className="btn-accent mt-1 rounded-full px-4 py-1.5 text-xs font-semibold"
+            className="btn-accent mt-1 rounded-full px-4 py-1.5 text-sub font-semibold"
           >
             接入模型供应商
           </button>
@@ -140,12 +140,12 @@ export function LlmConfigSection() {
               </span>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <p className="truncate text-sm font-semibold text-[var(--text)]">
+                  <p className="truncate text-body font-semibold text-[var(--text)]">
                     {preset?.display_name ?? config.provider_type}
                   </p>
                   <StatusPill status={config.status} />
                 </div>
-                <p className="mt-0.5 truncate text-[11px] text-[var(--text-faint)]">
+                <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]">
                   {config.status === "failed" && config.last_error
                     ? config.last_error
                     : [
@@ -160,7 +160,7 @@ export function LlmConfigSection() {
                 <button
                   type="button"
                   onClick={() => setEditing((v) => !v)}
-                  className="btn-glass px-3 py-1.5 text-xs font-medium"
+                  className="btn-glass px-3 py-1.5 text-sub font-medium"
                 >
                   {editing ? "收起" : "编辑"}
                 </button>
@@ -170,7 +170,7 @@ export function LlmConfigSection() {
                   onClick={() =>
                     void guard(async () => setConfig(await reverifyLlmProvider()))
                   }
-                  className="btn-glass px-3 py-1.5 text-xs font-medium disabled:opacity-40"
+                  className="btn-glass px-3 py-1.5 text-sub font-medium disabled:opacity-40"
                 >
                   重新测试
                 </button>
@@ -185,7 +185,7 @@ export function LlmConfigSection() {
                       setEditing(false);
                     })
                   }
-                  className="btn-glass px-3 py-1.5 text-xs font-medium !text-[#ff6b6b] disabled:opacity-40"
+                  className="btn-glass px-3 py-1.5 text-sub font-medium !text-[#ff6b6b] disabled:opacity-40"
                 >
                   删除
                 </button>
@@ -227,7 +227,7 @@ function StatusPill({ status }: { status: LlmProviderStatus }) {
   const meta = STATUS_META[status];
   return (
     <span
-      className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium"
+      className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
       style={{ background: `${meta.color}1f`, color: meta.color }}
     >
       <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
@@ -239,8 +239,8 @@ function StatusPill({ status }: { status: LlmProviderStatus }) {
 function InfoStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <p className="text-[10px] text-[var(--text-faint)]">{label}</p>
-      <p className="mt-0.5 truncate text-[13px] font-semibold text-[var(--text)]">{value}</p>
+      <p className="text-micro text-[var(--text-faint)]">{label}</p>
+      <p className="mt-0.5 truncate text-ui font-semibold text-[var(--text)]">{value}</p>
     </div>
   );
 }
@@ -388,9 +388,9 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
   }
 
   const inputClass =
-    "w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] " +
+    "w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui " +
     "text-[var(--text)] outline-none focus:border-[var(--accent)]/60";
-  const labelClass = "mb-1.5 block text-xs font-medium text-[var(--text-muted)]";
+  const labelClass = "mb-1.5 block text-sub font-medium text-[var(--text-muted)]";
 
   return (
     <div className="space-y-4">
@@ -410,10 +410,10 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
               data-active={providerType === p.id}
               className="glass-row nav-item !flex-col !items-start !gap-0.5 px-3.5 py-2.5 text-left"
             >
-              <span className="text-[13px] font-semibold text-[var(--text)]">
+              <span className="text-ui font-semibold text-[var(--text)]">
                 {p.display_name}
               </span>
-              <span className="truncate text-[11px] text-[var(--text-faint)]">
+              <span className="truncate text-caption text-[var(--text-faint)]">
                 {providerHint(p)}
               </span>
             </button>
@@ -437,7 +437,7 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
             {...NO_AUTOFILL}
           />
           {!needBaseUrl && (
-            <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+            <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
               留空使用官方端点；使用代理或镜像时填写完整地址。
             </p>
           )}
@@ -496,7 +496,7 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
           {isCustomEndpoint && <option value={NEW_MODEL}>＋ 新增模型（需填写参数）…</option>}
         </select>
         {selected && !isNew && (
-          <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+          <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
             {modelSpecs(selected) || "该模型的详细规格以官方文档为准。"}
           </p>
         )}
@@ -505,7 +505,7 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
       {/* 新增模型的参数子表单：这些参数是 agent 做上下文/思考预算决策的依据，必填 */}
       {isNew && (
         <div className="space-y-3.5 rounded-xl border border-white/[0.08] bg-white/[0.03] p-3.5">
-          <p className="text-xs font-medium text-[var(--text-muted)]">
+          <p className="text-sub font-medium text-[var(--text-muted)]">
             新模型参数
             <span className="ml-2 font-normal text-[var(--text-faint)]">
               按端点实际部署的模型规格填写，保存后计入本地模型目录
@@ -595,7 +595,7 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
                 className={inputClass}
                 {...NO_AUTOFILL}
               />
-              <p className="mt-1.5 text-[11px] leading-relaxed text-[var(--text-faint)]">
+              <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
                 思维链可用的最大 token 数（thinking_budget 上限），超配供应商会直接报错。
               </p>
             </div>
@@ -604,14 +604,14 @@ function LlmProviderForm({ config, presets, onSubmit, onCancel, onError }: LlmPr
       )}
 
       <div className="flex items-center justify-end gap-3 pt-1">
-        <button type="button" onClick={onCancel} className="btn-glass px-3.5 py-2 text-[13px] font-medium">
+        <button type="button" onClick={onCancel} className="btn-glass px-3.5 py-2 text-ui font-medium">
           取消
         </button>
         <button
           type="button"
           onClick={submit}
           disabled={busy || !canSubmit}
-          className="btn-accent rounded-full px-4.5 py-2 text-[13px] font-semibold disabled:opacity-40"
+          className="btn-accent rounded-full px-4.5 py-2 text-ui font-semibold disabled:opacity-40"
         >
           {busy ? "保存中…" : "保存并测试连接"}
         </button>
@@ -649,7 +649,7 @@ function CheckField({
 }) {
   return (
     <label
-      className={`flex cursor-pointer items-center gap-1.5 text-xs text-[var(--text-muted)] ${
+      className={`flex cursor-pointer items-center gap-1.5 text-sub text-[var(--text-muted)] ${
         disabled ? "cursor-not-allowed opacity-40" : ""
       }`}
     >

--- a/apps/web/components/llm-gate.tsx
+++ b/apps/web/components/llm-gate.tsx
@@ -37,7 +37,7 @@ export function useLlmConfigured(): boolean | null {
 /** 未配置模型时的引导提示：告知原因 + 一键跳转设置页。 */
 export function LlmSetupNotice() {
   return (
-    <p className="notice-surface mt-3 rounded-xl border border-[var(--line)] px-3.5 py-2.5 text-[13px] leading-5 text-[var(--text-muted)]">
+    <p className="notice-surface mt-3 rounded-xl border border-[var(--line)] px-3.5 py-2.5 text-ui leading-5 text-[var(--text-muted)]">
       尚未接入 AI 模型，暂时无法开始对话。请先前往
       <Link href="/settings/llm" className="mx-0.5 text-[var(--accent)] hover:underline">
         设置 → AI 模型

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -212,7 +212,7 @@ export function MediaDetailView({
         </div>
 
         <div className="min-w-0 flex-1 pb-1">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
+          <p className="text-caption font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
             {source === "douban" ? "豆瓣" : "TMDB"} · {isMovie ? "电影" : "剧集"}
             {item.genres.length > 0 ? ` · ${item.genres.join(" / ")}` : ""}
           </p>
@@ -222,19 +222,19 @@ export function MediaDetailView({
           {/* 原名：与中文标题相同就不渲染——国产片在 TMDB 的 original_title
               往往就是中文名本身，照原样渲染会在标题下面重复一行 */}
           {item.originalTitle && item.originalTitle !== item.title && (
-            <p className="text-on-image mt-1.5 truncate text-[14px] text-white/55 max-md:mt-0.5 max-md:text-[12px]">
+            <p className="text-on-image mt-1.5 truncate text-body text-white/55 max-md:mt-0.5 max-md:text-sub">
               {item.originalTitle}
             </p>
           )}
 
           {/* 元信息行：评分 / 年份 / 规模 / 质量徽章 */}
-          <div className="tnum mt-3.5 flex flex-wrap items-center gap-x-3.5 gap-y-2 text-[13px] text-white/80 max-md:mt-2 max-md:gap-x-2.5 max-md:gap-y-1 max-md:text-[12px]">
+          <div className="tnum mt-3.5 flex flex-wrap items-center gap-x-3.5 gap-y-2 text-ui text-white/80 max-md:mt-2 max-md:gap-x-2.5 max-md:gap-y-1 max-md:text-sub">
             {/* 评分 0 = 数据源暂无评分（新片/小众条目），不能照原样渲染成「0.0」
                 ——那读起来是「烂到 0 分」。海报卡片与条目详情页都是这个口径 */}
             {item.rating > 0 && (
               <span className="flex items-center gap-1.5">
                 <StarIcon className="size-4 text-[#f5c451]" />
-                <span className="text-[16px] font-bold text-white">{item.rating.toFixed(1)}</span>
+                <span className="text-title-sm font-bold text-white">{item.rating.toFixed(1)}</span>
               </span>
             )}
             {!!item.year && <span>{item.year}</span>}
@@ -249,7 +249,7 @@ export function MediaDetailView({
                 {item.badges.map((b) => (
                   <span
                     key={b}
-                    className="rounded border border-white/25 px-1.5 py-px text-[10px] font-semibold tracking-wide text-white/85"
+                    className="rounded border border-white/25 px-1.5 py-px text-micro font-semibold tracking-wide text-white/85"
                   >
                     {b}
                   </span>
@@ -276,7 +276,7 @@ export function MediaDetailView({
               <button
                 type="button"
                 onClick={openSubscribe}
-                className="btn-glass flex h-10 items-center gap-2 bg-white/10 px-5 text-[13px] font-medium backdrop-blur-md transition hover:bg-white/15"
+                className="btn-glass flex h-10 items-center gap-2 bg-white/10 px-5 text-ui font-medium backdrop-blur-md transition hover:bg-white/15"
               >
                 <CheckIcon
                   className="size-4"
@@ -288,14 +288,14 @@ export function MediaDetailView({
               <button
                 type="button"
                 onClick={openSubscribe}
-                className="btn-accent flex h-10 items-center gap-2 rounded-full px-5 text-[13px] font-semibold"
+                className="btn-accent flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold"
               >
                 <BellIcon className="size-4" />
                 订阅追踪
               </button>
             )}
             {sub && (
-              <span className="text-on-image flex items-center gap-1.5 text-[12.5px] text-[var(--text-muted)]">
+              <span className="text-on-image flex items-center gap-1.5 text-sub text-[var(--text-muted)]">
                 <span
                   className="size-1.5 rounded-full"
                   style={{ backgroundColor: subscriptionStatusMeta[sub.status].color }}
@@ -318,10 +318,10 @@ export function MediaDetailView({
       <div className="mt-9 space-y-8 px-12 max-md:mt-6 max-md:space-y-6 max-md:px-4">
         {item.overview && (
           <section>
-            <h2 className="text-on-image mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+            <h2 className="text-on-image mb-3 text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
               剧情简介
             </h2>
-            <p className="text-on-image max-w-3xl text-[14px] leading-7 text-white/78">
+            <p className="text-on-image max-w-3xl text-body leading-7 text-white/78">
               {item.overview}
             </p>
           </section>
@@ -334,7 +334,7 @@ export function MediaDetailView({
             很容易落到「每一格都是空」的状态，那时候留下的是一个空玻璃盒子 */}
         {hasFacts && info && (
           <section>
-            <h2 className="text-on-image mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+            <h2 className="text-on-image mb-3 text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
               词条信息
             </h2>
             <div className="rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] p-6 backdrop-blur-xl max-md:p-4">
@@ -390,7 +390,7 @@ function SourceLink({ href, label }: { href: string; label: string }) {
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="text-[12px] text-[var(--text-faint)] underline-offset-4 transition-colors hover:text-[var(--text)] hover:underline"
+      className="text-sub text-[var(--text-faint)] underline-offset-4 transition-colors hover:text-[var(--text)] hover:underline"
     >
       {label} ↗
     </a>
@@ -495,7 +495,7 @@ function PhotoWall({
   return (
     <section className="group/photos">
       <div className="mb-3 flex items-center gap-3">
-        <h2 className="text-on-image text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+        <h2 className="text-on-image text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
           剧照与海报
         </h2>
         {tabs.length > 1 && (
@@ -506,7 +506,7 @@ function PhotoWall({
                 type="button"
                 aria-pressed={tab.id === activeId}
                 onClick={() => switchTab(tab.id)}
-                className={`tnum rounded-full px-3 py-1 text-[12px] font-medium transition-colors ${
+                className={`tnum rounded-full px-3 py-1 text-sub font-medium transition-colors ${
                   tab.id === activeId
                     ? "bg-white/[0.14] text-white"
                     : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
@@ -603,21 +603,21 @@ function DetailFallback({ failed, onBack }: { failed: boolean; onBack: () => voi
     <div className="ambient-fallback flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
       {failed ? (
         <>
-          <p className="text-[15px] font-semibold text-[var(--text)]">未能加载该影片详情</p>
-          <p className="max-w-sm text-[13px] leading-6 text-[var(--text-muted)]">
+          <p className="text-body-lg font-semibold text-[var(--text)]">未能加载该影片详情</p>
+          <p className="max-w-sm text-ui leading-6 text-[var(--text-muted)]">
             资源可能已下线，或网络暂时不可达。请返回后重试。
           </p>
           <button
             type="button"
             onClick={onBack}
-            className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+            className="btn-glass px-4 py-2 text-ui font-medium text-[var(--text)]"
           >
             <ArrowLeftIcon className="size-4" />
             返回
           </button>
         </>
       ) : (
-        <div className="flex items-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+        <div className="flex items-center gap-2.5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在加载详情…
         </div>
@@ -630,8 +630,8 @@ function DetailFallback({ failed, onBack }: { failed: boolean; onBack: () => voi
 function Fact({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-[12px] text-[var(--text-faint)]">{label}</dt>
-      <dd className="mt-1 text-[13.5px] leading-6 text-[var(--text)]">{value}</dd>
+      <dt className="text-sub text-[var(--text-faint)]">{label}</dt>
+      <dd className="mt-1 text-ui leading-6 text-[var(--text)]">{value}</dd>
     </div>
   );
 }

--- a/apps/web/components/media-row.tsx
+++ b/apps/web/components/media-row.tsx
@@ -38,13 +38,13 @@ export function MediaRow({
     // intrinsic-size 先占住一行的近似高度（auto 记住实测值），滚动条不跳
     <section className="relative [contain-intrinsic-size:auto_330px] [content-visibility:auto]">
       <div className="mb-3 flex items-center justify-between gap-4 px-6 max-md:mb-2 max-md:px-4">
-        <h3 className="text-on-image text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+        <h3 className="text-on-image text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
           {row.title}
         </h3>
         {moreHref && (
           <Link
             href={moreHref}
-            className="shrink-0 text-xs font-semibold text-[var(--text-muted)] transition hover:text-[var(--text)]"
+            className="shrink-0 text-sub font-semibold text-[var(--text-muted)] transition hover:text-[var(--text)]"
           >
             {moreLabel}
           </Link>

--- a/apps/web/components/media-search-results.tsx
+++ b/apps/web/components/media-search-results.tsx
@@ -109,7 +109,7 @@ export function MediaSearchResults({
       {/* 状态行：与站点资源垂直的头部同构（关键词 + 快照提示） */}
       <header className="shrink-0 px-6 pb-3 pt-4 max-md:px-4 max-md:pt-3">
         <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
-          <h1 className="text-on-image text-[18px] font-semibold tracking-[-0.01em] text-white">
+          <h1 className="text-on-image text-title-lg font-semibold tracking-[-0.01em] text-white">
             “{keyword}”
           </h1>
 
@@ -118,7 +118,7 @@ export function MediaSearchResults({
             <div className="ml-auto flex items-center gap-2">
               <span
                 title="这是历史留存的结果快照，豆瓣数据（评分/海报）可能已变化"
-                className="flex items-center gap-1.5 rounded-full border border-[#6aa7ff]/30 bg-[#6aa7ff]/12 px-2.5 py-1 text-[11px] text-[#b9d4ff] backdrop-blur-sm"
+                className="flex items-center gap-1.5 rounded-full border border-[#6aa7ff]/30 bg-[#6aa7ff]/12 px-2.5 py-1 text-caption text-[#b9d4ff] backdrop-blur-sm"
               >
                 <svg
                   viewBox="0 0 24 24"
@@ -138,7 +138,7 @@ export function MediaSearchResults({
                 <button
                   type="button"
                   onClick={onResearch}
-                  className="btn-accent rounded-full px-2.5 py-1 text-[11px] font-medium"
+                  className="btn-accent rounded-full px-2.5 py-1 text-caption font-medium"
                 >
                   重新搜索
                 </button>
@@ -194,11 +194,11 @@ function MediaSourceSection({
   return (
     <section>
       <div className="mb-3 flex items-center gap-2.5">
-        <span className="rounded-full bg-black/30 px-2.5 py-0.5 text-[11px] text-[var(--accent)] backdrop-blur-sm">
+        <span className="rounded-full bg-black/30 px-2.5 py-0.5 text-caption text-[var(--accent)] backdrop-blur-sm">
           {label}
         </span>
         {items && items.length > 0 && (
-          <span className="text-on-image text-[12px] text-[rgba(243,245,249,0.75)]">
+          <span className="text-on-image text-sub text-[rgba(243,245,249,0.75)]">
             共 {items.length} 条结果
           </span>
         )}
@@ -206,12 +206,12 @@ function MediaSourceSection({
 
       {!items && !error && <MediaSearchSkeleton />}
       {error && (
-        <p className="text-on-image text-[12px] leading-relaxed text-[rgba(243,245,249,0.6)]">
+        <p className="text-on-image text-sub leading-relaxed text-[rgba(243,245,249,0.6)]">
           {error}
         </p>
       )}
       {items?.length === 0 && (
-        <p className="text-on-image text-[12px] text-[rgba(243,245,249,0.6)]">
+        <p className="text-on-image text-sub text-[rgba(243,245,249,0.6)]">
           该来源没有找到相关条目
         </p>
       )}
@@ -240,12 +240,12 @@ function MediaSearchEmpty({
 }) {
   return (
     <div className="flex flex-col items-center pt-24 text-center">
-      <p className="text-on-image text-[15px] font-semibold text-white">{title}</p>
-      <p className="text-on-image mt-1.5 text-[12px] text-[rgba(243,245,249,0.7)]">{hint}</p>
+      <p className="text-on-image text-body-lg font-semibold text-white">{title}</p>
+      <p className="text-on-image mt-1.5 text-sub text-[rgba(243,245,249,0.7)]">{hint}</p>
       <button
         type="button"
         onClick={onSwitchToTorrent}
-        className="btn-accent mt-5 rounded-full px-4 py-1.5 text-[12px] font-semibold"
+        className="btn-accent mt-5 rounded-full px-4 py-1.5 text-sub font-semibold"
       >
         搜索站点资源
       </button>

--- a/apps/web/components/network-config-section.tsx
+++ b/apps/web/components/network-config-section.tsx
@@ -139,15 +139,15 @@ export function NetworkConfigSection() {
   if (failed) {
     return (
       <div className="flex items-center gap-3">
-        <p className="text-[13px] text-[var(--text-muted)]">网络配置加载失败</p>
-        <button type="button" onClick={reload} className="btn-glass px-3 py-1.5 text-[12.5px] font-medium">
+        <p className="text-ui text-[var(--text-muted)]">网络配置加载失败</p>
+        <button type="button" onClick={reload} className="btn-glass px-3 py-1.5 text-sub font-medium">
           重试
         </button>
       </div>
     );
   }
   if (!view || !form) {
-    return <p className="text-[13px] text-[var(--text-muted)]">正在加载网络配置…</p>;
+    return <p className="text-ui text-[var(--text-muted)]">正在加载网络配置…</p>;
   }
 
   const proxyActive =
@@ -162,7 +162,7 @@ export function NetworkConfigSection() {
         {/* 保存状态挂在首个分组标题行右侧：不单占一行，避免页面顶部空隙 */}
         <div className="mb-2.5 flex h-5 items-center justify-between px-1">
           <h3 className="group-label">代理</h3>
-          <span className="text-[12px]">
+          <span className="text-sub">
             {saveState === "saving" && <span className="text-[var(--text-faint)]">保存中…</span>}
             {saveState === "saved" && (
               <span className="flex items-center gap-1 text-emerald-300/90">
@@ -201,7 +201,7 @@ export function NetworkConfigSection() {
                   key={value}
                   type="button"
                   onClick={() => commit({ ...form, proxy_mode: value as ProxyMode })}
-                  className={`rounded-full px-3.5 py-1.5 text-xs font-semibold transition ${
+                  className={`rounded-full px-3.5 py-1.5 text-sub font-semibold transition ${
                     form.proxy_mode === value
                       ? "bg-white/15 text-white shadow-sm"
                       : "text-[var(--text-muted)] hover:text-white"
@@ -215,11 +215,11 @@ export function NetworkConfigSection() {
 
           {form.proxy_mode === "env" && (
             <div className="flex items-center justify-between gap-4 px-5 py-3.5">
-              <span className="text-[12.5px] text-[var(--text-muted)]">环境变量探测</span>
+              <span className="text-sub text-[var(--text-muted)]">环境变量探测</span>
               {view.env_proxy_detected ? (
-                <span className="font-mono text-[12.5px] text-[var(--text)]">{view.env_proxy_detected}</span>
+                <span className="font-mono text-sub text-[var(--text)]">{view.env_proxy_detected}</span>
               ) : (
-                <span className="flex items-center gap-1.5 text-[12.5px] text-amber-300/90">
+                <span className="flex items-center gap-1.5 text-sub text-amber-300/90">
                   未发现代理地址
                   <HelpDot
                     content="未检测到 HTTPS_PROXY / HTTP_PROXY / ALL_PROXY。Docker 部署可通过 -e HTTPS_PROXY=… 传入；或改用「手动」直接填写。"
@@ -250,11 +250,11 @@ export function NetworkConfigSection() {
                   onBlur={(e) => commit({ ...form, proxy_url: e.target.value.trim() })}
                   onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
                   placeholder="socks5://192.168.1.2:7891"
-                  className="w-[300px] max-w-[55%] rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 font-mono text-[12.5px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/50 max-md:w-full max-md:max-w-none"
+                  className="w-[300px] max-w-[55%] rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 font-mono text-sub text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/50 max-md:w-full max-md:max-w-none"
                 />
               </div>
               {(proxyUrlError || !form.proxy_url.trim()) && (
-                <p className={`mt-1.5 text-right text-[11px] ${proxyUrlError ? "text-red-300" : "text-[var(--text-faint)]"}`}>
+                <p className={`mt-1.5 text-right text-caption ${proxyUrlError ? "text-red-300" : "text-[var(--text-faint)]"}`}>
                   {proxyUrlError ?? "填写地址后自动保存生效"}
                 </p>
               )}
@@ -280,7 +280,7 @@ export function NetworkConfigSection() {
             }
           />
           {!proxyActive && (
-            <span className="ml-auto text-[11px] text-[var(--text-faint)]">
+            <span className="ml-auto text-caption text-[var(--text-faint)]">
               当前无可用代理，开关已禁用（测试仍可用，测的是直连/镜像的连通性）
             </span>
           )}
@@ -354,8 +354,8 @@ export function NetworkConfigSection() {
               <ChevronRightIcon
                 className={`size-4 shrink-0 text-[var(--text-faint)] transition-transform ${advancedOpen ? "rotate-90" : ""}`}
               />
-              <span className="text-sm font-medium text-[var(--text)]">TMDB 镜像地址</span>
-              <span className="truncate text-[11.5px] text-[var(--text-faint)]">不走代理的替代方案</span>
+              <span className="text-body font-medium text-[var(--text)]">TMDB 镜像地址</span>
+              <span className="truncate text-caption text-[var(--text-faint)]">不走代理的替代方案</span>
             </button>
             <HelpDot
               content={
@@ -408,11 +408,11 @@ export function NetworkConfigSection() {
                       }}
                       onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
                       placeholder={view.mirror_defaults[field] ?? ""}
-                      className="w-[340px] max-w-[60%] rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 font-mono text-[12.5px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/50 max-md:w-full max-md:max-w-none"
+                      className="w-[340px] max-w-[60%] rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 font-mono text-sub text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/50 max-md:w-full max-md:max-w-none"
                     />
                   </div>
                   {mirrorErrors[field] && (
-                    <p className="mt-1.5 text-right text-[11px] text-red-300">{mirrorErrors[field]}</p>
+                    <p className="mt-1.5 text-right text-caption text-red-300">{mirrorErrors[field]}</p>
                   )}
                 </div>
               ))}
@@ -428,7 +428,7 @@ export function NetworkConfigSection() {
 function LabelWithHelp({ label, help }: { label: string; help: React.ReactNode }) {
   return (
     <span className="flex shrink-0 items-center gap-1.5">
-      <span className="text-sm font-medium text-[var(--text)]">{label}</span>
+      <span className="text-body font-medium text-[var(--text)]">{label}</span>
       <HelpDot content={help} />
     </span>
   );
@@ -476,15 +476,15 @@ function ServiceRow({
   return (
     <div className="flex items-center gap-3 px-5 py-3.5">
       <span className="flex min-w-0 items-center gap-1.5">
-        <span className="truncate text-sm font-medium text-[var(--text)]">{label}</span>
+        <span className="truncate text-body font-medium text-[var(--text)]">{label}</span>
         <HelpDot content={description} />
       </span>
       <span className="ml-auto flex items-center gap-3">
-        {pending && <span className="text-[12px] text-[var(--text-faint)]">测试中…</span>}
+        {pending && <span className="text-sub text-[var(--text-faint)]">测试中…</span>}
         {result && (
           <Tooltip content={result.message} placement="top">
             <span
-              className={`flex items-center gap-1.5 text-[12px] ${
+              className={`flex items-center gap-1.5 text-sub ${
                 result.ok ? "text-emerald-300/90" : "text-red-300/90"
               }`}
             >
@@ -499,7 +499,7 @@ function ServiceRow({
           type="button"
           onClick={onTest}
           disabled={pending}
-          className="btn-glass px-3 py-1.5 text-[12px] font-medium disabled:opacity-40"
+          className="btn-glass px-3 py-1.5 text-sub font-medium disabled:opacity-40"
         >
           测试
         </button>

--- a/apps/web/components/new-task.tsx
+++ b/apps/web/components/new-task.tsx
@@ -50,7 +50,7 @@ export function NewTask() {
           />
           {locked && <LlmSetupNotice />}
           {error && (
-            <p className="notice-surface mt-3 rounded-xl border border-[#ff6b6b]/35 px-3.5 py-2.5 text-[13px] leading-5 text-[#ff6b6b]">
+            <p className="notice-surface mt-3 rounded-xl border border-[#ff6b6b]/35 px-3.5 py-2.5 text-ui leading-5 text-[#ff6b6b]">
               创建会话失败：{error}
             </p>
           )}

--- a/apps/web/components/page-nav.tsx
+++ b/apps/web/components/page-nav.tsx
@@ -189,7 +189,7 @@ export function PageNav({
             对读屏隐藏，避免同一个标题被念两遍。 */}
         <span
           aria-hidden="true"
-          className="min-w-0 truncate text-[15px] font-semibold tracking-[-0.01em] text-white/90"
+          className="min-w-0 truncate text-body-lg font-semibold tracking-[-0.01em] text-white/90"
           style={{
             opacity: "var(--nav-reveal, 0)",
             transform: "translateY(calc((1 - var(--nav-reveal, 0)) * 5px))",

--- a/apps/web/components/person-detail-view.tsx
+++ b/apps/web/components/person-detail-view.tsx
@@ -64,7 +64,7 @@ export function PersonDetailView({ tmdbPersonId }: { tmdbPersonId: number | stri
     return (
       <div className="flex h-full flex-col">
         <PageNav items={[{ label: "" }]} />
-        <div className="flex flex-1 items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+        <div className="flex flex-1 items-center justify-center gap-2.5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在读取影人档案…
         </div>
@@ -101,18 +101,18 @@ export function PersonDetailView({ tmdbPersonId }: { tmdbPersonId: number | stri
           />
         </div>
         <div className="min-w-0 flex-1 pb-1">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
+          <p className="text-caption font-semibold uppercase tracking-[0.22em] text-[var(--accent-2)]">
             影人
           </p>
           <h1 className="text-on-image mt-2 text-[32px] font-bold leading-[1.12] tracking-[-0.02em] text-white max-md:mt-1 max-md:text-[20px]">
             {person.name}
           </h1>
           {person.originalName && person.originalName !== person.name && (
-            <p className="text-on-image mt-1 truncate text-[13.5px] text-white/55 max-md:text-[12px]">
+            <p className="text-on-image mt-1 truncate text-ui text-white/55 max-md:text-sub">
               {person.originalName}
             </p>
           )}
-          <p className="tnum mt-3 text-[13px] text-white/70 max-md:mt-2 max-md:text-[12px]">
+          <p className="tnum mt-3 text-ui text-white/70 max-md:mt-2 max-md:text-sub">
             库内 {person.credits.length} 部
             {cast.length > 0 && directed.length > 0
               ? `（参演 ${cast.length} · 执导 ${directed.length}）`
@@ -147,9 +147,9 @@ function CreditGrid({
   if (credits.length === 0) return null;
   return (
     <section>
-      <h2 className="text-on-image mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[var(--text)]">
+      <h2 className="text-on-image mb-3 text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
         {title}
-        <span className="tnum ml-2 text-[12px] font-normal text-[var(--text-faint)]">
+        <span className="tnum ml-2 text-sub font-normal text-[var(--text-faint)]">
           {credits.length}
         </span>
       </h2>
@@ -172,10 +172,10 @@ function CreditCard({ credit, showCharacter }: { credit: PersonCredit; showChara
           className="size-full object-cover"
         />
       </div>
-      <p className="text-on-image mt-1.5 truncate text-[12.5px] font-medium text-[var(--text)]">
+      <p className="text-on-image mt-1.5 truncate text-sub font-medium text-[var(--text)]">
         {credit.title}
       </p>
-      <p className="text-on-image tnum truncate text-[11px] text-[var(--text-faint)]">
+      <p className="text-on-image tnum truncate text-caption text-[var(--text-faint)]">
         {showCharacter && credit.character ? `饰 ${credit.character}` : credit.year || ""}
       </p>
     </>
@@ -209,20 +209,20 @@ function PersonFallback({ failure }: { failure: "missing" | "error" }) {
     <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
       {failure === "missing" ? (
         <>
-          <p className="text-[15px] font-semibold text-[var(--text)]">库内没有这位影人的作品</p>
-          <p className="max-w-md text-[13px] leading-6 text-[var(--text-muted)]">
+          <p className="text-body-lg font-semibold text-[var(--text)]">库内没有这位影人的作品</p>
+          <p className="max-w-md text-ui leading-6 text-[var(--text-muted)]">
             可能是他参演的片都已从库里移除；也可能这个库是早前扫描的——影人档案随入库刮削
             一并建立，对它执行一次「刷新元数据」即可补齐，之后这里就会列出他在库内的全部作品。
           </p>
-          <Link href={"/library" as Route} className="btn-glass px-4 py-2 text-[13px] font-medium">
+          <Link href={"/library" as Route} className="btn-glass px-4 py-2 text-ui font-medium">
             <ArrowLeftIcon className="size-4" />
             去媒体库
           </Link>
         </>
       ) : (
         <>
-          <p className="text-[15px] font-semibold text-[var(--text)]">未能加载影人档案</p>
-          <p className="max-w-sm text-[13px] leading-6 text-[var(--text-muted)]">
+          <p className="text-body-lg font-semibold text-[var(--text)]">未能加载影人档案</p>
+          <p className="max-w-sm text-ui leading-6 text-[var(--text-muted)]">
             请稍后重试；若持续失败，请查看系统日志。
           </p>
         </>

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -226,13 +226,13 @@ function PosterCardContent({
               徽章不用 backdrop-blur：海报墙每张卡 2~3 个模糊合成层会显著放大
               滚动时的 GPU 压力（几百张卡叠加），加实底色观感几乎无差 */}
           {badges[0] && (
-            <span className="absolute left-2 top-2 rounded-md bg-black/70 px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-[var(--accent)]">
+            <span className="absolute left-2 top-2 rounded-md bg-black/70 px-1.5 py-0.5 text-micro font-bold tracking-wide text-[var(--accent)]">
               {badges[0]}
             </span>
           )}
           {/* 右上：评分徽章（暂无评分时不渲染，避免展示 0.0） */}
           {item.rating > 0 && (
-            <span className="tnum absolute right-2 top-2 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-[11px] font-semibold text-white">
+            <span className="tnum absolute right-2 top-2 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-caption font-semibold text-white">
               <StarIcon className="size-3 text-[#f5c451]" />
               {item.rating.toFixed(1)}
             </span>
@@ -243,12 +243,12 @@ function PosterCardContent({
               与桌面 hover 是同一层——手机上不再另设常驻的角落圆键。 */}
           <div className="absolute inset-x-0 bottom-0 translate-y-3 bg-gradient-to-t from-black/90 via-black/60 to-transparent px-3 pb-3 pt-10 opacity-0 transition-all duration-300 ease-out group-hover/card:translate-y-0 group-hover/card:opacity-100 group-data-[revealed=true]/card:translate-y-0 group-data-[revealed=true]/card:opacity-100">
             {genres.length > 0 && (
-              <p className="text-[11px] font-medium text-[var(--accent-2)]">
+              <p className="text-caption font-medium text-[var(--accent-2)]">
                 {genres.join(" · ")}
               </p>
             )}
             {overview && (
-              <p className="mt-1 line-clamp-3 text-[11px] leading-4 text-white/75">
+              <p className="mt-1 line-clamp-3 text-caption leading-4 text-white/75">
                 {overview}
               </p>
             )}
@@ -263,12 +263,12 @@ function PosterCardContent({
 
       {/* 文字区：常显标题 + 元信息（压在背景大图上，需 text-on-image 投影保证可读） */}
       <div className={`mt-2 ${rank ? "pl-11 max-md:pl-9" : ""}`}>
-        <p className="text-on-image truncate text-[13px] font-semibold text-[var(--text)]">
+        <p className="text-on-image truncate text-ui font-semibold text-[var(--text)]">
           {item.title}
         </p>
         {/* year 用真值判断：媒体库条目缺失年份时以 0 占位，不应显示出来 */}
         {(!!item.year || item.extent) && (
-          <p className="text-on-image tnum mt-0.5 truncate text-[11px] text-[var(--text-muted)]">
+          <p className="text-on-image tnum mt-0.5 truncate text-caption text-[var(--text-muted)]">
             {item.year || ""}
             {!!item.year && item.extent ? " · " : ""}
             {item.extent}
@@ -308,7 +308,7 @@ function PosterCardActionButton({
   if (!subscribeMeta) {
     // 已入库标识：非交互，与库存格下方的绿点语言一致。
     return (
-      <span className="flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-[11px] font-semibold text-white/90">
+      <span className="flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-caption font-semibold text-white/90">
         <span className="size-1.5 rounded-full bg-[#4ade80]" />
         已入库
       </span>
@@ -343,8 +343,8 @@ function PosterCardActionButton({
       }}
       className={
         existingSub
-          ? "flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-[11px] font-semibold text-white/90 transition-colors hover:bg-white/[0.26]"
-          : "btn-accent flex h-7 items-center gap-1 rounded-full px-3 text-[11px] font-semibold"
+          ? "flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-caption font-semibold text-white/90 transition-colors hover:bg-white/[0.26]"
+          : "btn-accent flex h-7 items-center gap-1 rounded-full px-3 text-caption font-semibold"
       }
     >
       {existingSub ? (

--- a/apps/web/components/search-command.tsx
+++ b/apps/web/components/search-command.tsx
@@ -405,7 +405,7 @@ function SearchPalette({
             autoCapitalize="off"
             autoCorrect="off"
             spellCheck={false}
-            className="h-[52px] min-w-0 flex-1 bg-transparent text-[15px] text-[var(--text)] outline-none placeholder:text-[var(--text-faint)]"
+            className="h-[52px] min-w-0 flex-1 bg-transparent text-body-lg text-[var(--text)] outline-none placeholder:text-[var(--text-faint)]"
           />
           <ModeSwitch mode={mode} onChange={changeMode} />
         </div>
@@ -435,25 +435,25 @@ function SearchPalette({
         <div className="scroll-thin max-h-[336px] min-h-[96px] overflow-y-auto p-2 max-md:max-h-none max-md:min-h-0 max-md:flex-1">
           {items !== null && items.length > 0 && (
             <div className="flex items-center justify-between px-2.5 pb-1 pt-1">
-              <span className="text-[11px] font-medium tracking-wide text-[var(--text-faint)]">
+              <span className="text-caption font-medium tracking-wide text-[var(--text-faint)]">
                 最近搜索
               </span>
               <button
                 type="button"
                 onClick={removeAll}
-                className="rounded-md px-1.5 py-0.5 text-[11px] text-[var(--text-faint)] transition-colors hover:bg-white/[0.08] hover:text-[var(--text-muted)]"
+                className="rounded-md px-1.5 py-0.5 text-caption text-[var(--text-faint)] transition-colors hover:bg-white/[0.08] hover:text-[var(--text-muted)]"
               >
                 清空
               </button>
             </div>
           )}
           {items !== null && items.length === 0 && (
-            <p className="px-2.5 py-6 text-center text-[12px] text-[var(--text-faint)]">
+            <p className="px-2.5 py-6 text-center text-sub text-[var(--text-faint)]">
               还没有搜索记录，输入关键词回车开始搜索
             </p>
           )}
           {items !== null && items.length > 0 && filteredGroups.length === 0 && (
-            <p className="px-2.5 py-6 text-center text-[12px] text-[var(--text-faint)]">
+            <p className="px-2.5 py-6 text-center text-sub text-[var(--text-faint)]">
               没有匹配「{keyword.trim()}」的搜索记录，回车直接搜索
             </p>
           )}
@@ -479,10 +479,10 @@ function SearchPalette({
 
         {/* —— 页脚：左侧模式说明，右侧快捷键 —— */}
         <div className="flex h-10 shrink-0 items-center justify-between border-t border-white/[0.06] px-4">
-          <span className="text-[11px] text-[var(--text-faint)]">
+          <span className="text-caption text-[var(--text-faint)]">
             {mode === "media" ? "在豆瓣中搜索影视条目" : "跨全部已配置站点搜索种子"}
           </span>
-          <span className="flex items-center gap-3 text-[11px] text-[var(--text-faint)] max-md:hidden">
+          <span className="flex items-center gap-3 text-caption text-[var(--text-faint)] max-md:hidden">
             <span className="flex items-center gap-1">
               <Kbd>⏎</Kbd> 搜索
             </span>
@@ -534,7 +534,7 @@ function ModeSwitch({
             // mousedown 抢焦点会让输入框失焦，preventDefault 保持焦点常驻输入框
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => onChange(opt.id)}
-            className={`rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors ${
+            className={`rounded-md px-2.5 py-1 text-sub font-medium transition-colors ${
               active
                 ? "bg-white/[0.13] text-[var(--text)]"
                 : "text-[var(--text-muted)] hover:text-[var(--text)]"
@@ -563,7 +563,7 @@ function CategoryChip({
       type="button"
       onMouseDown={(event) => event.preventDefault()}
       onClick={onClick}
-      className={`rounded-full px-2.5 py-[3px] text-[12px] transition-colors ${
+      className={`rounded-full px-2.5 py-[3px] text-sub transition-colors ${
         active
           ? "bg-white/[0.14] font-medium text-[var(--text)]"
           : "text-[var(--text-muted)] hover:bg-white/[0.06] hover:text-[var(--text)]"
@@ -629,15 +629,15 @@ function HistoryGroupRow({
           onClick={onPick}
           className="flex min-w-0 flex-1 items-center gap-2.5 py-2 pl-2.5 text-left"
         >
-          <span className="min-w-0 flex-1 truncate text-[13px] leading-5 text-[var(--text)]/90">
+          <span className="min-w-0 flex-1 truncate text-ui leading-5 text-[var(--text)]/90">
             {group.keyword}
           </span>
           {group.items.length > 1 ? (
             <>
-              <span className="shrink-0 rounded-md bg-white/[0.07] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+              <span className="shrink-0 rounded-md bg-white/[0.07] px-1.5 py-0.5 text-micro text-[var(--text-muted)]">
                 {group.items.length} 种范围
               </span>
-              <span className="hidden shrink-0 text-[10px] text-[var(--text-faint)] sm:inline">
+              <span className="hidden shrink-0 text-micro text-[var(--text-faint)] sm:inline">
                 {mediaCount > 0 && `影视 ${mediaCount}`}
                 {mediaCount > 0 && torrentCount > 0 && " · "}
                 {torrentCount > 0 && `资源 ${torrentCount}`}
@@ -649,12 +649,12 @@ function HistoryGroupRow({
           {latest.has_snapshot && (
             <span
               title="最近一次搜索已有结果快照，点击秒开预览"
-              className="shrink-0 rounded-md bg-[#6aa7ff]/15 px-1.5 py-0.5 text-[10px] text-[#9cc2ff]"
+              className="shrink-0 rounded-md bg-[#6aa7ff]/15 px-1.5 py-0.5 text-micro text-[#9cc2ff]"
             >
               快照
             </span>
           )}
-          <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+          <span className="shrink-0 text-caption text-[var(--text-faint)]">
             {formatRelativeTime(latest.last_searched_at)}
           </span>
         </button>
@@ -729,19 +729,19 @@ function HistorySingleRow({
           active ? "bg-white/[0.07]" : ""
         }`}
       >
-        <span className="min-w-0 flex-1 truncate text-[13px] leading-5 text-[var(--text)]/90">
+        <span className="min-w-0 flex-1 truncate text-ui leading-5 text-[var(--text)]/90">
           {item.keyword}
         </span>
         <HistoryTypeBadges item={item} />
         {item.has_snapshot && (
           <span
             title="已留存结果快照，点击秒开预览"
-            className="shrink-0 rounded-md bg-[#6aa7ff]/15 px-1.5 py-0.5 text-[10px] text-[#9cc2ff]"
+            className="shrink-0 rounded-md bg-[#6aa7ff]/15 px-1.5 py-0.5 text-micro text-[#9cc2ff]"
           >
             快照
           </span>
         )}
-        <span className="shrink-0 text-[11px] text-[var(--text-faint)] transition-opacity group-hover/single:opacity-0">
+        <span className="shrink-0 text-caption text-[var(--text-faint)] transition-opacity group-hover/single:opacity-0">
           {formatRelativeTime(item.last_searched_at)}
         </span>
       </button>
@@ -771,15 +771,15 @@ function HistoryVariantRow({
         onClick={onPick}
         className="flex min-w-0 flex-1 items-center gap-2 py-1.5 pl-2 text-left"
       >
-        <span className="min-w-0 flex-1 truncate text-[12px] text-[var(--text-muted)]">
+        <span className="min-w-0 flex-1 truncate text-sub text-[var(--text-muted)]">
           {item.vertical === "media" ? "影视" : `资源 · ${item.label ?? "全部"}`}
         </span>
         {item.has_snapshot && (
-          <span className="shrink-0 rounded-md bg-[#6aa7ff]/15 px-1.5 py-0.5 text-[10px] text-[#9cc2ff]">
+          <span className="shrink-0 rounded-md bg-[#6aa7ff]/15 px-1.5 py-0.5 text-micro text-[#9cc2ff]">
             快照
           </span>
         )}
-        <span className="shrink-0 text-[10px] text-[var(--text-faint)]">
+        <span className="shrink-0 text-micro text-[var(--text-faint)]">
           {formatRelativeTime(item.last_searched_at)}
         </span>
       </button>
@@ -798,7 +798,7 @@ function HistoryTypeBadges({ item }: { item: SearchHistoryItem }) {
   return (
     <>
       <span
-        className={`shrink-0 rounded-md px-1.5 py-0.5 text-[10px] ${
+        className={`shrink-0 rounded-md px-1.5 py-0.5 text-micro ${
           isMedia
             ? "bg-[var(--accent-soft)] text-[var(--accent-2)]"
             : "bg-white/[0.07] text-[var(--text-muted)]"
@@ -807,7 +807,7 @@ function HistoryTypeBadges({ item }: { item: SearchHistoryItem }) {
         {isMedia ? "影视" : "资源"}
       </span>
       {!isMedia && item.label && (
-        <span className="shrink-0 rounded-md bg-white/[0.07] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+        <span className="shrink-0 rounded-md bg-white/[0.07] px-1.5 py-0.5 text-micro text-[var(--text-muted)]">
           {item.label}
         </span>
       )}
@@ -850,7 +850,7 @@ function DeleteHistoryButton({
 
 function Kbd({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="rounded bg-white/[0.07] px-1 py-px font-sans text-[10px] text-[var(--text-muted)]">
+    <kbd className="rounded bg-white/[0.07] px-1 py-px font-sans text-micro text-[var(--text-muted)]">
       {children}
     </kbd>
   );

--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -729,22 +729,22 @@ export function SearchResults({ query, onResearch }: SearchResultsProps) {
       {/* pt-4：上方还有 /search 页的垂直选项卡行（影视 | 站点资源），间距略收 */}
       <header className="relative z-20 shrink-0 px-6 pb-3 pt-4 max-md:px-4 max-md:pt-3">
         <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
-          <h1 className="text-on-image text-[18px] font-semibold tracking-[-0.01em] text-white">
+          <h1 className="text-on-image text-title-lg font-semibold tracking-[-0.01em] text-white">
             “{query.keyword}”
           </h1>
           {query.scope.label && (
-            <span className="rounded-full bg-black/30 px-2.5 py-0.5 text-[11px] text-[var(--accent)] backdrop-blur-sm">
+            <span className="rounded-full bg-black/30 px-2.5 py-0.5 text-caption text-[var(--accent)] backdrop-blur-sm">
               {query.scope.label}
             </span>
           )}
           {phase === "streaming" && (
-            <span className="text-on-image flex items-center gap-1.5 text-[12px] text-[rgba(243,245,249,0.75)]">
+            <span className="text-on-image flex items-center gap-1.5 text-sub text-[rgba(243,245,249,0.75)]">
               <span className="size-1.5 animate-pulse rounded-full bg-[var(--accent)]" />
               已找到 {items.length} 条
             </span>
           )}
           {phase === "done" && (
-            <span className="text-on-image text-[12px] text-[rgba(243,245,249,0.75)]">
+            <span className="text-on-image text-sub text-[rgba(243,245,249,0.75)]">
               {filtering
                 ? `筛选后 ${filtered.length} / 共 ${items.length} 条`
                 : `共 ${items.length} 条结果`}
@@ -757,7 +757,7 @@ export function SearchResults({ query, onResearch }: SearchResultsProps) {
               <>
                 <span
                   title="这是历史留存的结果快照，站点数据（做种数/促销/链接）可能已变化"
-                  className="flex items-center gap-1.5 rounded-full border border-[#6aa7ff]/30 bg-[#6aa7ff]/12 px-2.5 py-1 text-[11px] text-[#b9d4ff] backdrop-blur-sm"
+                  className="flex items-center gap-1.5 rounded-full border border-[#6aa7ff]/30 bg-[#6aa7ff]/12 px-2.5 py-1 text-caption text-[#b9d4ff] backdrop-blur-sm"
                 >
                   <svg
                     viewBox="0 0 24 24"
@@ -777,7 +777,7 @@ export function SearchResults({ query, onResearch }: SearchResultsProps) {
                   <button
                     type="button"
                     onClick={() => onResearch(query.keyword, query.scope)}
-                    className="btn-accent rounded-full px-2.5 py-1 text-[11px] font-medium"
+                    className="btn-accent rounded-full px-2.5 py-1 text-caption font-medium"
                   >
                     重新搜索
                   </button>
@@ -792,7 +792,7 @@ export function SearchResults({ query, onResearch }: SearchResultsProps) {
           </div>
         </div>
         {phase === "done" && siteProgress.length === 0 && !snapshotAt && (
-          <p className="text-on-image mt-2 text-[12px] text-[rgba(243,245,249,0.7)]">
+          <p className="text-on-image mt-2 text-sub text-[rgba(243,245,249,0.7)]">
             当前没有「已启用且验证通过」的站点，请先在设置里配置站点。
           </p>
         )}
@@ -893,7 +893,7 @@ function FacetChip({
       type="button"
       onClick={onToggle}
       aria-pressed={active}
-      className={`h-7 rounded-full border px-2.5 text-[11px] transition-all ${active ? CHIP_ACTIVE_CLS : CHIP_IDLE_CLS}`}
+      className={`h-7 rounded-full border px-2.5 text-caption transition-all ${active ? CHIP_ACTIVE_CLS : CHIP_IDLE_CLS}`}
     >
       {label}
       <span className="tnum ml-1 opacity-60">{count}</span>
@@ -981,7 +981,7 @@ function GroupedResults({
                   <button
                     type="button"
                     onClick={() => setUncapped((prev) => toggleIn(prev, key))}
-                    className="ml-4 mt-2 px-1 py-0.5 text-[12px] text-[var(--accent-2)] transition-colors hover:text-[var(--text)]"
+                    className="ml-4 mt-2 px-1 py-0.5 text-sub text-[var(--accent-2)] transition-colors hover:text-[var(--text)]"
                   >
                     展开其余 {rows.length - GROUP_ROW_CAP} 个版本 ▾
                   </button>
@@ -1030,33 +1030,33 @@ function GroupHeader({
       className="flex w-full items-center gap-3 rounded-2xl border border-white/[0.09] bg-white/[0.045] px-4 py-2.5 text-left backdrop-blur-xl transition-colors hover:border-white/[0.16] hover:bg-white/[0.07]"
     >
       <span
-        className={`shrink-0 text-[10px] text-[var(--text-faint)] transition-transform ${open ? "rotate-90" : ""}`}
+        className={`shrink-0 text-micro text-[var(--text-faint)] transition-transform ${open ? "rotate-90" : ""}`}
       >
         ▶
       </span>
       <span className="min-w-0 flex-1 truncate">
-        <span className="text-[14.5px] font-semibold text-[var(--text)]">
+        <span className="text-body font-semibold text-[var(--text)]">
           {unparsed ? "未识别" : (meta.nameZh ?? meta.nameEn)}
         </span>
         {!unparsed && meta.nameZh && meta.nameEn && (
-          <span className="ml-2 text-[12px] text-[var(--text-muted)]">{meta.nameEn}</span>
+          <span className="ml-2 text-sub text-[var(--text-muted)]">{meta.nameEn}</span>
         )}
         {info && (
-          <span className="tnum ml-2 text-[12px] text-[var(--text-faint)]">{info}</span>
+          <span className="tnum ml-2 text-sub text-[var(--text-faint)]">{info}</span>
         )}
       </span>
       <span className="flex shrink-0 items-center gap-1.5">
-        <span className="tnum rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+        <span className="tnum rounded-md bg-white/[0.05] px-1.5 py-0.5 text-micro text-[var(--text-muted)]">
           {rows.length} 个版本
         </span>
         {topRes && (
-          <span className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10px] text-[var(--accent-2)]">
+          <span className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-micro text-[var(--accent-2)]">
             最高 {topRes}
           </span>
         )}
         {hasCompletePack && <span className={COMPLETE_BADGE_CLS}>全集包</span>}
         {freeCount > 0 && (
-          <span className="tnum rounded-md bg-[#4ade80]/15 px-1.5 py-0.5 text-[10px] font-semibold text-[#79d193]">
+          <span className="tnum rounded-md bg-[#4ade80]/15 px-1.5 py-0.5 text-micro font-semibold text-[#79d193]">
             {freeCount} 个免费
           </span>
         )}
@@ -1231,17 +1231,17 @@ function FilterToolbar({
             type="button"
             onClick={() => setSheetOpen((v) => !v)}
             aria-expanded={sheetOpen}
-            className={`flex h-7 items-center gap-1.5 rounded-full border px-3 text-[11px] transition-all ${
+            className={`flex h-7 items-center gap-1.5 rounded-full border px-3 text-caption transition-all ${
               badge > 0 ? CHIP_ACTIVE_CLS : CHIP_IDLE_CLS
             }`}
           >
             筛选
             {badge > 0 && (
-              <span className="tnum rounded-full bg-[var(--accent)]/25 px-1.5 text-[10px]">
+              <span className="tnum rounded-full bg-[var(--accent)]/25 px-1.5 text-micro">
                 {badge}
               </span>
             )}
-            <span className={`text-[9px] opacity-70 transition-transform ${sheetOpen ? "rotate-180" : ""}`}>▾</span>
+            <span className={`text-micro opacity-70 transition-transform ${sheetOpen ? "rotate-180" : ""}`}>▾</span>
           </button>
 
           {sheetOpen && (
@@ -1316,17 +1316,17 @@ function FacetDropdown<T extends string | number>({
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        className={`flex h-7 items-center gap-1.5 rounded-full border px-3 text-[11px] transition-all ${
+        className={`flex h-7 items-center gap-1.5 rounded-full border px-3 text-caption transition-all ${
           active.size > 0 ? CHIP_ACTIVE_CLS : CHIP_IDLE_CLS
         }`}
       >
         {label}
         {active.size > 0 && (
-          <span className="tnum rounded-full bg-[var(--accent)]/25 px-1.5 text-[10px]">
+          <span className="tnum rounded-full bg-[var(--accent)]/25 px-1.5 text-micro">
             {active.size}
           </span>
         )}
-        <span className={`text-[9px] opacity-70 transition-transform ${open ? "rotate-180" : ""}`}>
+        <span className={`text-micro opacity-70 transition-transform ${open ? "rotate-180" : ""}`}>
           ▾
         </span>
       </button>
@@ -1383,14 +1383,14 @@ function SortDropdown({
       key={o.key}
       type="button"
       onClick={() => pick(o.key)}
-      className={`flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-[11px] transition-colors ${
+      className={`flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-caption transition-colors ${
         o.key === sort.key
           ? "bg-white/[0.09] text-[var(--text)]"
           : "text-[var(--text-muted)] hover:bg-white/[0.06] hover:text-[var(--text)]"
       }`}
     >
       {o.label}
-      {o.key === sort.key && <span className="text-[12px]">{arrow}</span>}
+      {o.key === sort.key && <span className="text-sub">{arrow}</span>}
     </button>
   );
   return (
@@ -1400,25 +1400,25 @@ function SortDropdown({
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-label={`排序：${label}${sort.dir === "desc" ? "降序" : "升序"}`}
-        className={`flex h-7 items-center gap-1.5 rounded-full border px-3 text-[11px] transition-all ${CHIP_IDLE_CLS}`}
+        className={`flex h-7 items-center gap-1.5 rounded-full border px-3 text-caption transition-all ${CHIP_IDLE_CLS}`}
       >
         {label}
-        <span className="text-[12px]">{arrow}</span>
-        <span className={`text-[9px] opacity-70 transition-transform ${open ? "rotate-180" : ""}`}>
+        <span className="text-sub">{arrow}</span>
+        <span className={`text-micro opacity-70 transition-transform ${open ? "rotate-180" : ""}`}>
           ▾
         </span>
       </button>
       {open && (
         <div className="absolute left-0 top-full z-30 mt-2 w-44 rounded-2xl border border-white/[0.12] bg-[rgba(14,16,22,0.96)] p-1.5 shadow-2xl backdrop-blur-2xl">
-          <p className="px-2.5 pb-1 pt-1.5 text-[10px] text-[var(--text-faint)]">常规</p>
+          <p className="px-2.5 pb-1 pt-1.5 text-micro text-[var(--text-faint)]">常规</p>
           {SORT_OPTIONS.map(item)}
           {smartOptions.length > 0 && (
             <>
-              <p className="px-2.5 pb-1 pt-2 text-[10px] text-[var(--text-faint)]">智能</p>
+              <p className="px-2.5 pb-1 pt-2 text-micro text-[var(--text-faint)]">智能</p>
               {smartOptions.map(item)}
             </>
           )}
-          <p className="border-t border-white/[0.08] px-2.5 pb-1 pt-2 text-[10px] text-[var(--text-faint)]">
+          <p className="border-t border-white/[0.08] px-2.5 pb-1 pt-2 text-micro text-[var(--text-faint)]">
             点击当前项可切换升降序
           </p>
         </div>
@@ -1430,7 +1430,7 @@ function SortDropdown({
 function SheetGroup({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <p className="mb-1.5 text-[11px] font-medium text-[var(--text-faint)]">{title}</p>
+      <p className="mb-1.5 text-caption font-medium text-[var(--text-faint)]">{title}</p>
       <div className="flex flex-wrap gap-1.5">{children}</div>
     </div>
   );
@@ -1463,10 +1463,10 @@ function FilterSheet({
       <div className="absolute right-0 top-full z-30 mt-2 max-h-[60vh] w-[480px] max-w-[82vw] overflow-y-auto rounded-2xl border border-white/[0.12] bg-[rgba(14,16,22,0.96)] p-4 shadow-2xl backdrop-blur-2xl">
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <p className="text-[13px] font-medium text-[var(--text)]">筛选结果</p>
-            <p className="mt-0.5 text-[11px] text-[var(--text-faint)]">可多选，分类之间组合生效</p>
+            <p className="text-ui font-medium text-[var(--text)]">筛选结果</p>
+            <p className="mt-0.5 text-caption text-[var(--text-faint)]">可多选，分类之间组合生效</p>
           </div>
-          <button type="button" onClick={onClose} className={`grid size-7 place-items-center rounded-full border text-sm ${CHIP_IDLE_CLS}`} aria-label="关闭筛选">
+          <button type="button" onClick={onClose} className={`grid size-7 place-items-center rounded-full border text-body ${CHIP_IDLE_CLS}`} aria-label="关闭筛选">
             ×
           </button>
         </div>
@@ -1595,14 +1595,14 @@ function FilterSheet({
           <button
             type="button"
             onClick={() => onChange(emptyFilters())}
-            className="btn-glass h-8 px-3 text-[11px] text-[var(--text-muted)]"
+            className="btn-glass h-8 px-3 text-caption text-[var(--text-muted)]"
           >
             清除全部
           </button>
           <button
             type="button"
             onClick={onClose}
-            className="btn-accent h-8 rounded-full px-4 text-[11px] font-medium"
+            className="btn-accent h-8 rounded-full px-4 text-caption font-medium"
           >
             查看 {resultCount} 条结果
           </button>
@@ -1640,7 +1640,7 @@ function AppliedChips({
 
   return (
     <div className="mt-2 flex flex-wrap items-center gap-1.5 px-1">
-      <span className="text-[11px] text-[var(--text-faint)]">生效条件</span>
+      <span className="text-caption text-[var(--text-faint)]">生效条件</span>
       {chips.map(({ key, value }) => (
         <button
           key={`${key}:${value}`}
@@ -1648,7 +1648,7 @@ function AppliedChips({
           onClick={() =>
             onChange({ ...filters, [key]: toggleIn(filters[key] as Set<string | number>, value) })
           }
-          className={`group flex h-6 items-center gap-1 rounded-full border px-2 text-[11px] transition-all hover:bg-white/[0.2] ${CHIP_ACTIVE_CLS}`}
+          className={`group flex h-6 items-center gap-1 rounded-full border px-2 text-caption transition-all hover:bg-white/[0.2] ${CHIP_ACTIVE_CLS}`}
         >
           {labelOf(key, value)}
           <span className="opacity-60 transition-opacity group-hover:opacity-100">×</span>
@@ -1657,7 +1657,7 @@ function AppliedChips({
       <button
         type="button"
         onClick={() => onChange(emptyFilters())}
-        className="ml-1 text-[11px] text-[var(--text-faint)] transition-colors hover:text-[var(--text)]"
+        className="ml-1 text-caption text-[var(--text-faint)] transition-colors hover:text-[var(--text)]"
       >
         清除全部
       </button>
@@ -1704,7 +1704,7 @@ function SiteStatusSummary({
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         title="查看各站点的搜索详情"
-        className="flex items-center gap-1.5 rounded-full border border-white/[0.12] bg-white/[0.05] px-2.5 py-1 text-[11px] text-[var(--text-muted)] backdrop-blur-sm transition-colors hover:border-white/[0.22] hover:text-[var(--text)]"
+        className="flex items-center gap-1.5 rounded-full border border-white/[0.12] bg-white/[0.05] px-2.5 py-1 text-caption text-[var(--text-muted)] backdrop-blur-sm transition-colors hover:border-white/[0.22] hover:text-[var(--text)]"
       >
         <span className={`size-1.5 rounded-full ${dotCls}`} />
         {streaming ? (
@@ -1717,7 +1717,7 @@ function SiteStatusSummary({
             )}
           </>
         )}
-        <span className="text-[9px] opacity-70">▾</span>
+        <span className="text-micro opacity-70">▾</span>
       </button>
 
       {open && (
@@ -1738,17 +1738,17 @@ function SiteStatusSummary({
                             : "bg-[#4ade80]"
                       }`}
                     />
-                    <span className="min-w-0 flex-1 truncate text-[12px] text-[var(--text)]">
+                    <span className="min-w-0 flex-1 truncate text-sub text-[var(--text)]">
                       {s.site_name}
                     </span>
                     {/* 右侧固定：状态 + 条数/耗时。失败也带耗时——超时一眼可辨 */}
                     {s.phase === "searching" && (
-                      <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+                      <span className="shrink-0 text-caption text-[var(--text-faint)]">
                         搜索中…
                       </span>
                     )}
                     {s.phase === "ok" && (
-                      <span className="tnum shrink-0 text-[11px] text-[var(--text-muted)]">
+                      <span className="tnum shrink-0 text-caption text-[var(--text-muted)]">
                         {s.count} 条
                         {s.elapsed_ms !== null && (
                           <span className="text-[var(--text-faint)]">
@@ -1758,7 +1758,7 @@ function SiteStatusSummary({
                       </span>
                     )}
                     {s.phase === "error" && (
-                      <span className="tnum shrink-0 text-[11px] text-[#ff9a9a]">
+                      <span className="tnum shrink-0 text-caption text-[#ff9a9a]">
                         失败
                         {s.elapsed_ms !== null && (
                           <span className="opacity-75"> · {formatElapsed(s.elapsed_ms)}</span>
@@ -1770,7 +1770,7 @@ function SiteStatusSummary({
                   {s.phase === "error" && s.error && (
                     <p
                       title={s.error}
-                      className="mt-0.5 line-clamp-2 pl-3.5 text-[11px] leading-4 text-[#ff9a9a]/80"
+                      className="mt-0.5 line-clamp-2 pl-3.5 text-caption leading-4 text-[#ff9a9a]/80"
                     >
                       {s.error}
                     </p>
@@ -1780,7 +1780,7 @@ function SiteStatusSummary({
             </ul>
             {/* 汇总行：整次搜索的总耗时（≈ 最慢站点耗时）；快照回放同样有值 */}
             {totalElapsedMs !== null && (
-              <div className="mt-1 border-t border-white/[0.08] px-2 pb-0.5 pt-1.5 text-[11px] text-[var(--text-faint)]">
+              <div className="mt-1 border-t border-white/[0.08] px-2 pb-0.5 pt-1.5 text-caption text-[var(--text-faint)]">
                 总耗时 {formatElapsed(totalElapsedMs)}
                 <span className="opacity-70">（以最慢的站点为准）</span>
               </div>
@@ -1819,7 +1819,7 @@ function PosterResults({ hits }: { hits: TorrentHit[] }) {
       {withoutPoster.length > 0 && (
         <div>
           {withPoster.length > 0 && (
-            <p className="text-on-image mb-2 text-[11px] text-[rgba(243,245,249,0.7)]">
+            <p className="text-on-image mb-2 text-caption text-[rgba(243,245,249,0.7)]">
               以下 {withoutPoster.length} 条结果没有海报，按列表展示
             </p>
           )}
@@ -1911,7 +1911,7 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
           fallback={
             // 占位：海报缺失/加载失败时的深色底 + 居中站点名
             <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-white/[0.05] to-black/40">
-              <span className="px-3 text-center text-[11px] text-[var(--text-faint)]">
+              <span className="px-3 text-center text-caption text-[var(--text-faint)]">
                 {hit.site_name}
               </span>
             </div>
@@ -1924,7 +1924,7 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
             {posterPromoBadges(hit).map((b) => (
               <span
                 key={b.text}
-                className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold ${b.cls}`}
+                className={`rounded-md px-1.5 py-0.5 text-micro font-semibold ${b.cls}`}
               >
                 {b.text}
               </span>
@@ -1933,7 +1933,7 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
           {/* 张数常显（含 1 张）：点开前就知道里面有几张图，只有一张时不必特意点开 */}
           <span
             title={`共 ${gallery.length} 张图片，点击卡片浏览`}
-            className="tnum flex shrink-0 items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-[10px] font-medium text-white/85"
+            className="tnum flex shrink-0 items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-micro font-medium text-white/85"
           >
             <PhotoIcon className="size-3" />
             {gallery.length}
@@ -1941,20 +1941,20 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
         </div>
         {/* 底部渐变 + 标题/元信息 */}
         <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/45 to-transparent px-2.5 pb-2 pt-8">
-          <p className="line-clamp-2 text-[12px] font-medium leading-4 text-white">
+          <p className="line-clamp-2 text-sub font-medium leading-4 text-white">
             {name ? name.primary : hit.title}
             {name && hit.attrs?.year != null && (
               <span className="tnum ml-1.5 font-normal text-white/60">{hit.attrs.year}</span>
             )}
           </p>
-          <p className="tnum mt-1 text-[10px] text-white/70">
+          <p className="tnum mt-1 text-micro text-white/70">
             {size && <span className="mr-2">{size}</span>}
             <span className="text-[#a7d9b6]">↑{hit.seeders}</span>
             <span className="ml-1.5 text-[#e0c19f]">↓{hit.leechers}</span>
           </p>
           {/* 来源站点 + 发布时间：都是次要信息，同一行弱化展示。时间相对展示，
               与列表模式统一（父级 pointer-events-none 让精确时刻的 title 失效）。 */}
-          <p className="mt-0.5 flex items-center gap-1.5 text-[10px] text-white/50">
+          <p className="mt-0.5 flex items-center gap-1.5 text-micro text-white/50">
             <span className="min-w-0 truncate">{hit.site_name}</span>
             {hit.upload_time && (
               <>
@@ -1976,14 +1976,14 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}
-                className="rounded-lg border border-white/40 bg-black/40 px-2.5 py-1 text-[11px] text-white backdrop-blur-sm transition-colors hover:bg-black/60"
+                className="rounded-lg border border-white/40 bg-black/40 px-2.5 py-1 text-caption text-white backdrop-blur-sm transition-colors hover:bg-black/60"
               >
                 详情
               </a>
             )}
             <DownloadButton
               hit={hit}
-              className="btn-accent rounded-lg px-2.5 py-1 text-[11px] font-medium"
+              className="btn-accent rounded-lg px-2.5 py-1 text-caption font-medium"
             />
           </div>
         )}
@@ -2153,7 +2153,7 @@ const TorrentRow = memo(function TorrentRow({
           {asSpecRow ? (
             <p
               title={rawTitleTooltip(hit)}
-              className="truncate text-[13px] font-medium leading-5 text-[var(--text)]"
+              className="truncate text-ui font-medium leading-5 text-[var(--text)]"
             >
               {spec ?? hit.title}
             </p>
@@ -2161,39 +2161,39 @@ const TorrentRow = memo(function TorrentRow({
             // 解析出片名：标题行 = 主名 + 外文名 + 年份，原始种子名/副标题收进悬停提示
             <p
               title={rawTitleTooltip(hit)}
-              className="truncate text-[13.5px] font-medium leading-5 text-[var(--text)]"
+              className="truncate text-ui font-medium leading-5 text-[var(--text)]"
             >
               {name.primary}
               {name.secondary && (
-                <span className="ml-2 text-[12px] font-normal text-[var(--text-muted)]">
+                <span className="ml-2 text-sub font-normal text-[var(--text-muted)]">
                   {name.secondary}
                 </span>
               )}
               {hit.attrs?.year != null && (
-                <span className="tnum ml-2 text-[12px] font-normal text-[var(--text-faint)]">
+                <span className="tnum ml-2 text-sub font-normal text-[var(--text-faint)]">
                   {hit.attrs.year}
                 </span>
               )}
             </p>
           ) : (
-            <p className="truncate text-[13.5px] font-medium leading-5 text-[var(--text)]">
+            <p className="truncate text-ui font-medium leading-5 text-[var(--text)]">
               {hit.title}
             </p>
           )}
           {((!name && hit.subtitle) || hit.site_category_name) && (
-            <p className="mt-0.5 flex items-baseline gap-2 text-[12px] text-[var(--text-muted)]">
+            <p className="mt-0.5 flex items-baseline gap-2 text-sub text-[var(--text-muted)]">
               {!name && hit.subtitle && (
                 <span className="min-w-0 truncate">{hit.subtitle}</span>
               )}
               {hit.site_category_name && (
-                <span className="shrink-0 text-[11px] text-[var(--text-faint)]">
+                <span className="shrink-0 text-caption text-[var(--text-faint)]">
                   {hit.site_category_name}
                 </span>
               )}
             </p>
           )}
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            <span className="shrink-0 rounded-md bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-[var(--accent-2)]">
+            <span className="shrink-0 rounded-md bg-white/[0.06] px-1.5 py-0.5 text-micro font-medium text-[var(--accent-2)]">
               {hit.site_name}
             </span>
             {/* 全集徽标紧跟站点：属于资源身份而非促销，任何行模式都展示 */}
@@ -2205,7 +2205,7 @@ const TorrentRow = memo(function TorrentRow({
         </div>
 
         {/* 固定指标列带短标签，数值的含义无需靠图标猜测，跨行仍可垂直比较。 */}
-        <div className="tnum hidden shrink-0 grid-cols-[70px_78px_78px] gap-x-3 text-right text-[11px] lg:grid">
+        <div className="tnum hidden shrink-0 grid-cols-[70px_78px_78px] gap-x-3 text-right text-caption lg:grid">
           <Metric label="大小" value={size || "—"} />
           <Metric label="做种 / 下载" value={<><span className={seederTone(hit.seeders)}>{hit.seeders}</span><span className="text-[var(--text-faint)]"> / {hit.leechers}</span></>} />
           <Metric
@@ -2225,14 +2225,14 @@ const TorrentRow = memo(function TorrentRow({
                 href={hit.detail_url}
                 target="_blank"
                 rel="noreferrer"
-                className="btn-glass h-7 px-3 text-[11px] text-[var(--text-muted)]"
+                className="btn-glass h-7 px-3 text-caption text-[var(--text-muted)]"
               >
                 详情
               </a>
             )}
             <DownloadButton
               hit={hit}
-              className="btn-accent flex h-7 items-center rounded-full px-3 text-[11px] font-medium"
+              className="btn-accent flex h-7 items-center rounded-full px-3 text-caption font-medium"
             />
           </div>
         )}
@@ -2253,7 +2253,7 @@ function Metric({
 }) {
   return (
     <span title={title} className="flex min-w-0 flex-col gap-0.5">
-      <span className="truncate text-[9px] text-[var(--text-faint)]">{label}</span>
+      <span className="truncate text-micro text-[var(--text-faint)]">{label}</span>
       <span className="truncate text-[var(--text-muted)]">{value}</span>
     </span>
   );
@@ -2284,7 +2284,7 @@ function PromoBadges({ hit }: { hit: TorrentHit }) {
       {badges.map((b) => (
         <span
           key={b.text}
-          className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold ${b.cls}`}
+          className={`rounded-md px-1.5 py-0.5 text-micro font-semibold ${b.cls}`}
         >
           {b.text}
         </span>
@@ -2336,7 +2336,7 @@ function AttrBadges({ attrs }: { attrs: TorrentAttrs }) {
       {shown.map((c) => (
         <span
           key={c.text}
-          className={`rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10px] ${c.cls ?? "text-[var(--text-muted)]"}`}
+          className={`rounded-md bg-white/[0.05] px-1.5 py-0.5 text-micro ${c.cls ?? "text-[var(--text-muted)]"}`}
         >
           {c.text}
         </span>
@@ -2344,7 +2344,7 @@ function AttrBadges({ attrs }: { attrs: TorrentAttrs }) {
       {folded.length > 0 && (
         <span
           title={folded.map((c) => c.text).join(" · ")}
-          className="tnum cursor-default rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10px] text-[var(--text-faint)]"
+          className="tnum cursor-default rounded-md bg-white/[0.05] px-1.5 py-0.5 text-micro text-[var(--text-faint)]"
         >
           +{folded.length}
         </span>
@@ -2388,7 +2388,7 @@ function completeLabel(attrs: TorrentAttrs | null): string | null {
 
 /** 全集徽标的统一样式（列表/分组/组头）；海报卡用实底变体叠图可读。 */
 const COMPLETE_BADGE_CLS =
-  "rounded-md bg-gradient-to-r from-[#4f8cff]/25 to-[#9d6bff]/25 px-1.5 py-0.5 text-[10px] font-semibold text-[#b9d4ff] ring-1 ring-inset ring-[#6aa7ff]/35";
+  "rounded-md bg-gradient-to-r from-[#4f8cff]/25 to-[#9d6bff]/25 px-1.5 py-0.5 text-micro font-semibold text-[#b9d4ff] ring-1 ring-inset ring-[#6aa7ff]/35";
 
 /* —— 占位 / 空态 —— */
 
@@ -2423,7 +2423,7 @@ const SKELETON_TITLE_WIDTHS = ["72%", "58%", "80%", "64%", "70%", "52%"];
 function SkeletonList({ siteCount }: { siteCount: number }) {
   return (
     <div>
-      <div className="text-on-image flex items-center gap-2 px-1 pb-3 text-[12.5px] text-[rgba(243,245,249,0.8)]">
+      <div className="text-on-image flex items-center gap-2 px-1 pb-3 text-sub text-[rgba(243,245,249,0.8)]">
         <svg
           viewBox="0 0 24 24"
           className="size-3.5 animate-spin text-[var(--accent)]"
@@ -2471,8 +2471,8 @@ function SkeletonList({ siteCount }: { siteCount: number }) {
 function EmptyHint({ title, hint }: { title: string; hint: string }) {
   return (
     <div className="flex min-h-[240px] flex-col items-center justify-center text-center">
-      <p className="text-on-image text-[15px] font-medium text-white">{title}</p>
-      <p className="text-on-image mt-1.5 max-w-sm text-[13px] leading-6 text-[rgba(243,245,249,0.82)]">
+      <p className="text-on-image text-body-lg font-medium text-white">{title}</p>
+      <p className="text-on-image mt-1.5 max-w-sm text-ui leading-6 text-[rgba(243,245,249,0.82)]">
         {hint}
       </p>
     </div>

--- a/apps/web/components/search-settings.tsx
+++ b/apps/web/components/search-settings.tsx
@@ -298,11 +298,11 @@ export function SearchSection() {
 
               {tab.type === "category" ? (
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium text-[var(--text)]">
+                  <p className="text-body font-medium text-[var(--text)]">
                     {CATEGORY_LABEL[tab.id]}
                   </p>
                   {CATEGORY_HINT[tab.id] && (
-                    <p className="mt-0.5 text-[11px] text-[var(--text-faint)]">
+                    <p className="mt-0.5 text-caption text-[var(--text-faint)]">
                       {CATEGORY_HINT[tab.id]}
                     </p>
                   )}
@@ -310,12 +310,12 @@ export function SearchSection() {
               ) : (
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <p className="truncate text-sm font-medium text-[var(--text)]">{tab.name}</p>
-                    <span className="shrink-0 rounded-full bg-[var(--accent-soft)] px-2 py-0.5 text-[10px] font-semibold text-[var(--accent)]">
+                    <p className="truncate text-body font-medium text-[var(--text)]">{tab.name}</p>
+                    <span className="shrink-0 rounded-full bg-[var(--accent-soft)] px-2 py-0.5 text-micro font-semibold text-[var(--accent)]">
                       自定义
                     </span>
                   </div>
-                  <p className="mt-0.5 truncate text-[11px] text-[var(--text-faint)]">
+                  <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]">
                     {presetSummary(tab)}
                   </p>
                 </div>
@@ -327,7 +327,7 @@ export function SearchSection() {
                     type="button"
                     onClick={() => openEditor(tab)}
                     disabled={busy || loading}
-                    className="btn-glass px-2.5 py-1 text-[11px] font-medium disabled:opacity-40"
+                    className="btn-glass px-2.5 py-1 text-caption font-medium disabled:opacity-40"
                   >
                     编辑
                   </button>
@@ -335,7 +335,7 @@ export function SearchSection() {
                     type="button"
                     onClick={() => deletePreset(tab)}
                     disabled={busy || loading}
-                    className="rounded-full px-2.5 py-1 text-[11px] font-medium text-[var(--text-faint)] transition-colors hover:bg-[var(--danger)]/15 hover:text-[var(--danger)] disabled:opacity-40"
+                    className="rounded-full px-2.5 py-1 text-caption font-medium text-[var(--text-faint)] transition-colors hover:bg-[var(--danger)]/15 hover:text-[var(--danger)] disabled:opacity-40"
                   >
                     删除
                   </button>
@@ -364,7 +364,7 @@ export function SearchSection() {
             type="button"
             onClick={() => openEditor(null)}
             disabled={busy || loading}
-            className="btn-glass mt-3 px-3.5 py-2 text-xs font-medium disabled:opacity-40"
+            className="btn-glass mt-3 px-3.5 py-2 text-sub font-medium disabled:opacity-40"
           >
             <PlusIcon className="size-4" />
             <span>新建自定义分类</span>
@@ -386,12 +386,12 @@ export function SearchSection() {
       )}
 
       {error && (
-        <p className="rounded-xl border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-4 py-2.5 text-xs text-[var(--danger)]">
+        <p className="rounded-xl border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-4 py-2.5 text-sub text-[var(--danger)]">
           {error}
         </p>
       )}
 
-      <p className="text-xs leading-6 text-[var(--text-faint)]">
+      <p className="text-sub leading-6 text-[var(--text-faint)]">
         按住左侧手柄拖动即可调整顺序——列表顺序即搜索面板中分类标签的排列顺序，「全部」固定在首位。
         自定义分类可组合多个资源分类与指定站点，一次搜索只打勾选的站点。
         改动即时保存到服务端，所有设备与浏览器保持一致。
@@ -475,7 +475,7 @@ function PresetEditor({
     });
 
   const chipCls = (active: boolean) =>
-    `rounded-full border px-3 py-1 text-[12px] transition-colors ${
+    `rounded-full border px-3 py-1 text-sub transition-colors ${
       active
         ? "border-[var(--accent)]/60 bg-[var(--accent)]/15 text-[var(--accent)]"
         : "border-white/[0.09] bg-white/[0.04] text-[var(--text-muted)] hover:border-white/[0.18] hover:text-[var(--text)]"
@@ -488,7 +488,7 @@ function PresetEditor({
       </h3>
       <div className="css-glass space-y-5 !rounded-2xl p-5">
         <div>
-          <label className="mb-1.5 block text-xs font-medium text-[var(--text-muted)]">
+          <label className="mb-1.5 block text-sub font-medium text-[var(--text-muted)]">
             名称（1~16 字）
           </label>
           <input
@@ -498,12 +498,12 @@ function PresetEditor({
             maxLength={16}
             placeholder="如：4K 影剧、MT 专搜"
             autoFocus
-            className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+            className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
           />
         </div>
 
         <div>
-          <p className="mb-1.5 text-xs font-medium text-[var(--text-muted)]">
+          <p className="mb-1.5 text-sub font-medium text-[var(--text-muted)]">
             资源分类 <span className="text-[var(--text-faint)]">（不勾选 = 不限分类）</span>
           </p>
           <div className="flex flex-wrap gap-1.5">
@@ -521,13 +521,13 @@ function PresetEditor({
         </div>
 
         <div>
-          <p className="mb-1.5 text-xs font-medium text-[var(--text-muted)]">
+          <p className="mb-1.5 text-sub font-medium text-[var(--text-muted)]">
             搜索站点 <span className="text-[var(--text-faint)]">（不勾选 = 全部可用站点）</span>
           </p>
           {siteOptions === null ? (
-            <p className="text-[12px] text-[var(--text-faint)]">正在加载站点列表…</p>
+            <p className="text-sub text-[var(--text-faint)]">正在加载站点列表…</p>
           ) : siteOptions.length === 0 ? (
-            <p className="text-[12px] text-[var(--text-faint)]">
+            <p className="text-sub text-[var(--text-faint)]">
               还没有接入任何站点；先切到「站点接入」标签页添加，或直接保存（默认搜全部可用站点）。
             </p>
           ) : (
@@ -543,7 +543,7 @@ function PresetEditor({
                   }`}
                 >
                   {site.displayName}
-                  {!site.usable && <span className="ml-1 text-[10px]">·不可用</span>}
+                  {!site.usable && <span className="ml-1 text-micro">·不可用</span>}
                 </button>
               ))}
             </div>
@@ -552,8 +552,8 @@ function PresetEditor({
 
         <div className="flex items-center gap-3">
           <div className="min-w-0 flex-1">
-            <p className="text-xs font-medium text-[var(--text-muted)]">图览模式</p>
-            <p className="mt-0.5 text-[11px] leading-4 text-[var(--text-faint)]">
+            <p className="text-sub font-medium text-[var(--text-muted)]">图览模式</p>
+            <p className="mt-0.5 text-caption leading-4 text-[var(--text-faint)]">
               用该分类搜索时，带海报的结果默认以图墙展示（仅部分站点返回海报，
               如 M-Team）；结果页右上角可随时临时切换。
             </p>
@@ -572,8 +572,8 @@ function PresetEditor({
 
         <div className="flex items-center gap-3">
           <div className="min-w-0 flex-1">
-            <p className="text-xs font-medium text-[var(--text-muted)]">无痕搜索</p>
-            <p className="mt-0.5 text-[11px] leading-4 text-[var(--text-faint)]">
+            <p className="text-sub font-medium text-[var(--text-muted)]">无痕搜索</p>
+            <p className="mt-0.5 text-caption leading-4 text-[var(--text-faint)]">
               用该分类搜索时不写入搜索历史，搜索面板的「最近搜索」不会出现相关记录，
               适合隐私敏感的分类。
             </p>
@@ -595,7 +595,7 @@ function PresetEditor({
             type="button"
             onClick={onCancel}
             disabled={busy}
-            className="btn-glass px-3.5 py-1.5 text-xs font-medium disabled:opacity-40"
+            className="btn-glass px-3.5 py-1.5 text-sub font-medium disabled:opacity-40"
           >
             取消
           </button>
@@ -603,7 +603,7 @@ function PresetEditor({
             type="button"
             onClick={onSave}
             disabled={busy || !draft.name.trim()}
-            className="btn-accent rounded-full px-4 py-1.5 text-xs font-semibold disabled:opacity-40"
+            className="btn-accent rounded-full px-4 py-1.5 text-sub font-semibold disabled:opacity-40"
           >
             {busy ? "保存中…" : "保存"}
           </button>

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -55,7 +55,7 @@ export function SettingsSidebar({ active, onSelect, onBack }: SettingsSidebarPro
         <button
           type="button"
           onClick={onBack}
-          className="btn-glass px-3.5 py-1.5 text-xs font-medium text-[var(--text-muted)] hover:text-[var(--text)]"
+          className="btn-glass px-3.5 py-1.5 text-sub font-medium text-[var(--text-muted)] hover:text-[var(--text)]"
         >
           <ArrowLeftIcon className="size-4" />
           <span>返回工作台</span>
@@ -63,8 +63,8 @@ export function SettingsSidebar({ active, onSelect, onBack }: SettingsSidebarPro
       </div>
 
       <div className="px-4 pb-4 pt-4">
-        <h2 className="text-sheen text-[19px] font-semibold tracking-tight">设置</h2>
-        <p className="mt-1 text-xs text-[var(--text-muted)]">管理账号与工作台偏好</p>
+        <h2 className="text-sheen text-title-lg font-semibold tracking-tight">设置</h2>
+        <p className="mt-1 text-sub text-[var(--text-muted)]">管理账号与工作台偏好</p>
       </div>
 
       {/* 分区列表：标准 SaaS 设置菜单——紧凑单行（小图标内联 + 标签），
@@ -85,7 +85,7 @@ export function SettingsSidebar({ active, onSelect, onBack }: SettingsSidebarPro
                     className="glass-row nav-item gap-2.5 px-2.5 py-[7px]"
                   >
                     <Icon className="size-4 shrink-0" />
-                    <span className="truncate text-[13px] font-medium">
+                    <span className="truncate text-ui font-medium">
                       {section.label}
                     </span>
                   </button>
@@ -129,10 +129,10 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
           <div className="min-w-0">
             {/* 实色 + 暗投影（不用 text-sheen 渐变裁切——全站蒙版默认轻档、
                 背景大图透上来时，半透明渐变字压在亮背景上会发灰，实色白字最稳） */}
-            <h1 className="text-on-image text-[22px] font-semibold tracking-tight text-[var(--text)] max-md:text-[19px]">
+            <h1 className="text-on-image text-[22px] font-semibold tracking-tight text-[var(--text)] max-md:text-title-lg">
               {section.label}
             </h1>
-            <p className="text-on-image mt-0.5 text-[13px] text-[var(--text-muted)]">
+            <p className="text-on-image mt-0.5 text-ui text-[var(--text-muted)]">
               {section.description}
             </p>
           </div>
@@ -225,7 +225,7 @@ function ProfileSection() {
           />
           {/* hover / 上传中：圆形遮罩浮出提示，暗示头像可点击更换 */}
           <span
-            className={`absolute inset-0 flex items-center justify-center rounded-full bg-black/55 text-[11px] font-semibold text-white transition-opacity ${
+            className={`absolute inset-0 flex items-center justify-center rounded-full bg-black/55 text-caption font-semibold text-white transition-opacity ${
               avatarBusy ? "opacity-100" : "touch-reveal opacity-0 group-hover:opacity-100"
             }`}
           >
@@ -242,13 +242,13 @@ function ProfileSection() {
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
             <p className="text-xl font-semibold tracking-tight">{session.nickname}</p>
-            <span className="rounded-full border border-white/[0.12] bg-[var(--accent-soft)] px-2.5 py-0.5 text-[11px] font-semibold text-[var(--accent)]">
+            <span className="rounded-full border border-white/[0.12] bg-[var(--accent-soft)] px-2.5 py-0.5 text-caption font-semibold text-[var(--accent)]">
               超级管理员
             </span>
           </div>
-          <p className="mt-1 text-sm text-[var(--text-muted)]">@{session.username}</p>
+          <p className="mt-1 text-body text-[var(--text-muted)]">@{session.username}</p>
           {avatarError && (
-            <p className="mt-1.5 text-[12px] text-[var(--danger)]">{avatarError}</p>
+            <p className="mt-1.5 text-sub text-[var(--danger)]">{avatarError}</p>
           )}
         </div>
       </div>
@@ -273,10 +273,10 @@ function FieldRow({ label, value, hint }: { label: string; value: string; hint?:
   return (
     <div className="flex items-center justify-between gap-4 px-5 py-4 first:rounded-t-2xl last:rounded-b-2xl">
       <div>
-        <p className="text-sm font-medium text-[var(--text)]">{label}</p>
-        {hint && <p className="mt-0.5 text-[11px] text-[var(--text-faint)]">{hint}</p>}
+        <p className="text-body font-medium text-[var(--text)]">{label}</p>
+        {hint && <p className="mt-0.5 text-caption text-[var(--text-faint)]">{hint}</p>}
       </div>
-      <span className="text-sm text-[var(--text-muted)]">{value}</span>
+      <span className="text-body text-[var(--text-muted)]">{value}</span>
     </div>
   );
 }
@@ -316,7 +316,7 @@ function NicknameRow() {
   return (
     <div className="px-5 py-4 first:rounded-t-2xl last:rounded-b-2xl">
       <div className="flex items-center justify-between gap-4">
-        <p className="text-sm font-medium text-[var(--text)]">昵称</p>
+        <p className="text-body font-medium text-[var(--text)]">昵称</p>
         {editing ? (
           <div className="flex items-center gap-2">
             <input
@@ -326,13 +326,13 @@ function NicknameRow() {
               onKeyDown={(e) => e.key === "Enter" && save()}
               maxLength={32}
               autoFocus
-              className="w-44 rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+              className="w-44 rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-1.5 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
             />
             <button
               type="button"
               onClick={save}
               disabled={busy}
-              className="btn-accent rounded-full px-3.5 py-1.5 text-xs font-semibold disabled:opacity-40"
+              className="btn-accent rounded-full px-3.5 py-1.5 text-sub font-semibold disabled:opacity-40"
             >
               {busy ? "保存中…" : "保存"}
             </button>
@@ -340,21 +340,21 @@ function NicknameRow() {
               type="button"
               onClick={() => setEditing(false)}
               disabled={busy}
-              className="btn-glass px-3 py-1.5 text-xs font-medium"
+              className="btn-glass px-3 py-1.5 text-sub font-medium"
             >
               取消
             </button>
           </div>
         ) : (
           <div className="flex items-center gap-3">
-            <span className="text-sm text-[var(--text-muted)]">{session.nickname}</span>
-            <button type="button" onClick={startEdit} className="btn-glass px-3 py-1 text-xs font-medium">
+            <span className="text-body text-[var(--text-muted)]">{session.nickname}</span>
+            <button type="button" onClick={startEdit} className="btn-glass px-3 py-1 text-sub font-medium">
               编辑
             </button>
           </div>
         )}
       </div>
-      {error && <p className="mt-2 text-right text-[12px] text-[var(--danger)]">{error}</p>}
+      {error && <p className="mt-2 text-right text-sub text-[var(--danger)]">{error}</p>}
     </div>
   );
 }
@@ -400,13 +400,13 @@ function ChangePasswordCard() {
     autoComplete: string,
   ) => (
     <div>
-      <label className="mb-1.5 block text-xs font-medium text-[var(--text-muted)]">{label}</label>
+      <label className="mb-1.5 block text-sub font-medium text-[var(--text-muted)]">{label}</label>
       <input
         type="password"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         autoComplete={autoComplete}
-        className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+        className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
       />
     </div>
   );
@@ -416,9 +416,9 @@ function ChangePasswordCard() {
       {field("当前密码", oldPassword, setOldPassword, "current-password")}
       {field("新密码（至少 8 位）", newPassword, setNewPassword, "new-password")}
       {field("确认新密码", confirm, setConfirm, "new-password")}
-      {error && <p className="text-[12px] text-[var(--danger)]">{error}</p>}
+      {error && <p className="text-sub text-[var(--danger)]">{error}</p>}
       {done && (
-        <p className="text-[12px] text-[var(--text-muted)]">
+        <p className="text-sub text-[var(--text-muted)]">
           密码已修改，其他设备的登录已全部失效；当前会话保持有效。
         </p>
       )}
@@ -427,7 +427,7 @@ function ChangePasswordCard() {
           type="button"
           onClick={submit}
           disabled={busy || !oldPassword || !newPassword || !confirm}
-          className="btn-accent rounded-full px-4.5 py-2 text-[13px] font-semibold disabled:opacity-40"
+          className="btn-accent rounded-full px-4.5 py-2 text-ui font-semibold disabled:opacity-40"
         >
           {busy ? "提交中…" : "修改密码"}
         </button>
@@ -464,7 +464,7 @@ function AppearanceSection() {
             type="button"
             aria-pressed={t.id === tab}
             onClick={() => setTab(t.id)}
-            className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-medium transition-colors ${
+            className={`rounded-full px-3.5 py-1.5 text-sub font-medium transition-colors ${
               t.id === tab
                 ? "bg-white/[0.14] text-white"
                 : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
@@ -573,23 +573,23 @@ function BackdropGroup() {
             {/* 底部信息渐变 + 当前背景名 */}
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-black/65 to-transparent" />
             <div className="pointer-events-none absolute bottom-4 left-5 text-white">
-              <p className="text-on-image text-sm font-semibold">
+              <p className="text-on-image text-body font-semibold">
                 {isCustom ? "自定义背景" : "默认背景 · 深色调"}
               </p>
-              <p className="text-on-image mt-0.5 text-[11px] text-white/75">
+              <p className="text-on-image mt-0.5 text-caption text-white/75">
                 点击或拖入图片即可更换
               </p>
             </div>
             {/* hover：轻压暗 + 中央浮出更换按钮 */}
             <div className="touch-reveal pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition duration-300 group-hover:bg-black/25 group-hover:opacity-100">
-              <span className="btn-accent rounded-full px-4.5 py-2 text-xs font-semibold">
+              <span className="btn-accent rounded-full px-4.5 py-2 text-sub font-semibold">
                 更换图片
               </span>
             </div>
             {/* 拖拽投放态 */}
             {dragging && (
               <div className="absolute inset-2 z-10 flex items-center justify-center rounded-xl border-2 border-dashed border-[var(--accent)] bg-black/50 backdrop-blur-sm">
-                <p className="text-sm font-semibold text-[var(--accent-strong)]">
+                <p className="text-body font-semibold text-[var(--accent-strong)]">
                   松开，设为首页背景
                 </p>
               </div>
@@ -597,7 +597,7 @@ function BackdropGroup() {
             {/* 上传 / 加载中的遮罩 */}
             {(busy || loading) && (
               <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-                <p className="text-sm font-medium text-white/90">
+                <p className="text-body font-medium text-white/90">
                   {busy ? "正在应用…" : "加载中…"}
                 </p>
               </div>
@@ -635,7 +635,7 @@ function BackdropGroup() {
               <span className="flex h-[68px] w-[120px] items-center justify-center rounded-lg border border-dashed border-white/[0.22] bg-black/25 backdrop-blur-md transition-colors group-hover/tile:border-white/[0.4] group-hover/tile:bg-white/[0.06]">
                 <PlusIcon className="size-5 text-[var(--text-muted)] transition-colors group-hover/tile:text-[var(--text)]" />
               </span>
-              <span className="text-on-image mt-1.5 block text-center text-[11px] text-[var(--text-muted)]">
+              <span className="text-on-image mt-1.5 block text-center text-caption text-[var(--text-muted)]">
                 上传
               </span>
             </button>
@@ -644,12 +644,12 @@ function BackdropGroup() {
           <input ref={inputRef} type="file" accept="image/*" hidden onChange={handlePick} />
 
           {error && (
-            <p className="rounded-xl border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-4 py-2.5 text-xs text-[var(--danger)]">
+            <p className="rounded-xl border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-4 py-2.5 text-sub text-[var(--danger)]">
               {error}
             </p>
           )}
 
-          <p className="text-on-image text-xs leading-5 text-[var(--text-faint)]">
+          <p className="text-on-image text-sub leading-5 text-[var(--text-faint)]">
             建议使用 16:9、分辨率较高的横图。上传的图全部保留在服务端图库（最多 20
             张），点选即切换、hover 缩略图可删除；玻璃面板的折射随生效图一并更新，跨设备访问同一实例保持一致。
           </p>
@@ -781,10 +781,10 @@ function InterfaceTextureGroup() {
           onChange={(v) => update({ scrim: { dark: v / 100 } })}
         />
 
-        {error && <p className="text-[12px] text-[var(--danger)]">{error}</p>}
+        {error && <p className="text-sub text-[var(--danger)]">{error}</p>}
 
         <div className="flex items-center justify-between gap-3">
-          <p className="text-[11px] text-[var(--text-faint)]">
+          <p className="text-caption text-[var(--text-faint)]">
             {dirty ? "调节实时预览中，保存后对所有设备生效" : "设置已保存，跨设备一致"}
           </p>
           <div className="flex items-center gap-2">
@@ -792,7 +792,7 @@ function InterfaceTextureGroup() {
               type="button"
               onClick={reset}
               disabled={loading || busy || isDefault}
-              className="btn-glass px-3.5 py-1.5 text-xs font-medium disabled:opacity-40"
+              className="btn-glass px-3.5 py-1.5 text-sub font-medium disabled:opacity-40"
             >
               恢复默认
             </button>
@@ -800,7 +800,7 @@ function InterfaceTextureGroup() {
               type="button"
               onClick={() => void save(draft)}
               disabled={loading || busy || !dirty}
-              className="btn-accent rounded-full px-4 py-1.5 text-xs font-semibold disabled:opacity-40"
+              className="btn-accent rounded-full px-4 py-1.5 text-sub font-semibold disabled:opacity-40"
             >
               {busy ? "保存中…" : "保存"}
             </button>
@@ -839,15 +839,15 @@ function SliderRow({
   return (
     <div>
       <div className="flex items-baseline justify-between">
-        <p className="text-sm font-medium text-[var(--text)]">{label}</p>
-        <span className="tnum text-xs text-[var(--text-muted)]">
+        <p className="text-body font-medium text-[var(--text)]">{label}</p>
+        <span className="tnum text-sub text-[var(--text-muted)]">
           {value}
           {unit}
         </span>
       </div>
-      <p className="mt-0.5 text-[11px] text-[var(--text-faint)]">{hint}</p>
+      <p className="mt-0.5 text-caption text-[var(--text-faint)]">{hint}</p>
       <div className="mt-2.5 flex items-center gap-3">
-        <span className="w-10 shrink-0 text-right text-[11px] text-[var(--text-faint)]">
+        <span className="w-10 shrink-0 text-right text-caption text-[var(--text-faint)]">
           {minLabel}
         </span>
         <input
@@ -861,7 +861,7 @@ function SliderRow({
           onChange={(e) => onChange(Number(e.target.value))}
           className="range-glass flex-1"
         />
-        <span className="w-10 shrink-0 text-[11px] text-[var(--text-faint)]">{maxLabel}</span>
+        <span className="w-10 shrink-0 text-caption text-[var(--text-faint)]">{maxLabel}</span>
       </div>
     </div>
   );
@@ -939,7 +939,7 @@ function BackdropTile({
         )}
       </div>
       <span
-        className={`text-on-image mt-1.5 block truncate text-center text-[11px] ${
+        className={`text-on-image mt-1.5 block truncate text-center text-caption ${
           active ? "font-semibold text-[var(--text)]" : "text-[var(--text-muted)]"
         }`}
       >
@@ -966,7 +966,7 @@ function GenericSection({ sectionId }: { sectionId: string }) {
               key={label}
               className="flex items-center justify-between gap-4 px-5 py-3.5"
             >
-              <span className="text-sm font-medium text-[var(--text)]">{label}</span>
+              <span className="text-body font-medium text-[var(--text)]">{label}</span>
               {/* LiquidGlassButton 本质是一个真实 WebGL 的开关控件 */}
               <LiquidGlassButton
                 backgroundImage={backdrop}
@@ -982,7 +982,7 @@ function GenericSection({ sectionId }: { sectionId: string }) {
         </div>
       </SettingsGroup>
 
-      <p className="text-xs leading-6 text-[var(--text-faint)]">
+      <p className="text-sub leading-6 text-[var(--text-faint)]">
         这是「{sectionId}」分区的占位内容。后续会接入真实配置项与后端接口。
       </p>
     </div>

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -155,14 +155,15 @@ export function Sidebar({
                 data-active={activeNav === item.id}
                 onClick={() => onSelect(item.id)}
                 title={collapsed ? item.label : undefined}
-                className={`glass-row nav-item py-2 ${collapsed ? "justify-center px-0" : "px-3"}`}
+                className={`glass-row nav-item py-2 max-md:py-2.5 ${collapsed ? "justify-center px-0" : "px-3"}`}
               >
-                <Icon className="size-[18px] shrink-0" />
+                {/* 图标移动端提到 22px：与顶栏图标键同标准（iOS 列表行图标的惯用比例） */}
+                <Icon className="size-[18px] shrink-0 max-md:size-[22px]" />
                 {/* 字号写在 span 上而非 button 上：globals.css 的 `button { font: inherit }`
                     是无 @layer 的普通规则，会压过 Tailwind 的 @layer utilities——写在
-                    button 上的 text-[13px] 不生效，会退回 body 的 14px。 */}
+                    button 上的 text-ui 不生效，会退回 body 的 14px。 */}
                 {!collapsed && (
-                  <span className="flex-1 text-[13px] font-medium">{item.label}</span>
+                  <span className="flex-1 text-ui font-medium">{item.label}</span>
                 )}
               </button>
             );
@@ -175,7 +176,7 @@ export function Sidebar({
             <Section label="最近会话" icon={<ClockIcon className="size-3.5" />}>
               <div className="space-y-0.5">
                 {conversations.length === 0 ? (
-                  <p className="px-2.5 py-1 text-[11px] leading-5 text-[var(--text-faint)]">
+                  <p className="px-2.5 py-1 text-caption leading-5 text-[var(--text-faint)]">
                     还没有会话，从「新任务」开始。
                   </p>
                 ) : (
@@ -350,7 +351,7 @@ function RunRow({
         data-active={active}
         onClick={onClick}
         title={`更新于 ${time}`}
-        className="glass-row nav-item items-center gap-2.5 px-2.5 py-1"
+        className="glass-row nav-item items-center gap-2.5 px-2.5 py-1 max-md:py-2"
       >
         {/* 状态点：仿 ChatGPT 的极简指示。容器始终占位（size-[7px]）以保证所有标题左对齐，
             但只有「运行中」才在其中画出小圆点 + 向外扩散的 ping 光晕；历史会话留空占位。 */}
@@ -366,7 +367,7 @@ function RunRow({
             加宽，行尾按钮直接浮在淡出区上——文字看起来「渐隐进」按钮下方。
             用 mask 而非渐变色遮罩：侧栏底是 WebGL 玻璃，没有可匹配的实色。 */}
         <span
-          className={`flex-1 overflow-hidden whitespace-nowrap text-[13px] font-medium text-[var(--text)] ${
+          className={`flex-1 overflow-hidden whitespace-nowrap text-ui font-medium text-[var(--text)] ${
             open
               ? "[mask-image:linear-gradient(to_right,#000_calc(100%_-_44px),transparent_calc(100%_-_12px))]"
               : "[mask-image:linear-gradient(to_right,#000_calc(100%_-_16px),transparent)] group-hover/run:[mask-image:linear-gradient(to_right,#000_calc(100%_-_44px),transparent_calc(100%_-_12px))]"
@@ -389,11 +390,12 @@ function RunRow({
           const rect = e.currentTarget.getBoundingClientRect();
           setMenuPos({ left: rect.right - 144, top: rect.bottom + 6 });
         }}
-        className={`glass-row !absolute right-1.5 top-1/2 !size-6 -translate-y-1/2 justify-center !rounded-md !p-0 transition-opacity duration-200 ${
+        // 移动端：视觉放大一档（32px）+ .touch-target 把命中区撑到 44px（iOS HIG）
+        className={`glass-row touch-target !absolute right-1.5 top-1/2 !size-6 -translate-y-1/2 justify-center !rounded-md !p-0 transition-opacity duration-200 max-md:!size-8 ${
           open ? "opacity-100" : "touch-reveal opacity-0 group-hover/run:opacity-100"
         }`}
       >
-        <MoreIcon className="size-4" />
+        <MoreIcon className="size-4 max-md:size-5" />
       </button>
 
       {open &&
@@ -406,17 +408,17 @@ function RunRow({
             <button
               type="button"
               onClick={() => pick(onRename)}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium"
+              className="glass-row px-2.5 py-2 text-ui font-medium max-md:py-2.5"
             >
-              <PencilIcon className="size-4 shrink-0 opacity-80" />
+              <PencilIcon className="size-4 shrink-0 opacity-80 max-md:size-5" />
               <span className="flex-1">重命名</span>
             </button>
             <button
               type="button"
               onClick={() => pick(onDelete)}
-              className="glass-row px-2.5 py-2 text-[13px] font-medium !text-[var(--danger)] hover:!bg-[rgba(255,107,107,0.12)]"
+              className="glass-row px-2.5 py-2 text-ui font-medium !text-[var(--danger)] hover:!bg-[rgba(255,107,107,0.12)] max-md:py-2.5"
             >
-              <TrashIcon className="size-4 shrink-0 opacity-80" />
+              <TrashIcon className="size-4 shrink-0 opacity-80 max-md:size-5" />
               <span className="flex-1">删除会话</span>
             </button>
           </div>,

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -174,7 +174,7 @@ export function SiteConfigSection() {
             type="button"
             aria-pressed={t.id === tab}
             onClick={() => setTab(t.id)}
-            className={`rounded-full px-3.5 py-1.5 text-[12.5px] font-medium transition-colors ${
+            className={`rounded-full px-3.5 py-1.5 text-sub font-medium transition-colors ${
               t.id === tab
                 ? "bg-white/[0.14] text-white"
                 : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
@@ -190,13 +190,13 @@ export function SiteConfigSection() {
       ) : (
         <>
           {error && (
-            <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-sm text-[#ff6b6b]">
+            <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
               {error}
             </div>
           )}
 
           <div className="flex items-center justify-between gap-4">
-            <p className="text-xs text-[var(--text-muted)]">
+            <p className="text-sub text-[var(--text-muted)]">
               {loading
                 ? "加载中…"
                 : `已接入 ${configured.length} 个站点 · 本地累计缓存 ${totalCached.toLocaleString("zh-CN")} 条种子，保存后系统会自动验证有效性。`}
@@ -206,7 +206,7 @@ export function SiteConfigSection() {
                 type="button"
                 onClick={() => void load()}
                 disabled={loading}
-                className="btn-glass px-3.5 py-1.5 text-xs font-medium"
+                className="btn-glass px-3.5 py-1.5 text-sub font-medium"
               >
                 刷新
               </button>
@@ -215,7 +215,7 @@ export function SiteConfigSection() {
                 type="button"
                 onClick={() => setAdding((v) => !v)}
                 disabled={loading}
-                className="btn-accent flex items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-xs font-semibold disabled:opacity-60"
+                className="btn-accent flex items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-sub font-semibold disabled:opacity-60"
               >
                 <PlusIcon className="size-4" />
                 添加站点
@@ -249,8 +249,8 @@ export function SiteConfigSection() {
                   <ServerIcon className="size-6" />
                 </span>
                 <div>
-                  <p className="text-sm font-medium text-[var(--text)]">还没有配置任何站点</p>
-                  <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  <p className="text-body font-medium text-[var(--text)]">还没有配置任何站点</p>
+                  <p className="mt-1 text-sub text-[var(--text-muted)]">
                     点击右上角「添加站点」开始接入。
                   </p>
                 </div>
@@ -315,16 +315,16 @@ function AddSitePanel({ available, onCreated, onCancel, onError }: AddSitePanelP
       <div className="css-glass !rounded-xl p-4">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-[var(--text)]">
+            <p className="truncate text-body font-semibold text-[var(--text)]">
               {selected.display_name}
             </p>
-            <p className="truncate text-[11px] text-[var(--text-faint)]">{selected.base_url}</p>
+            <p className="truncate text-caption text-[var(--text-faint)]">{selected.base_url}</p>
           </div>
           <button
             type="button"
             onClick={() => setSelected(null)}
             disabled={busy}
-            className="btn-glass shrink-0 px-3 py-1.5 text-xs font-medium"
+            className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium"
           >
             重新选择
           </button>
@@ -364,7 +364,7 @@ function AddSitePanel({ available, onCreated, onCancel, onError }: AddSitePanelP
         <button
           type="button"
           onClick={onCancel}
-          className="btn-glass shrink-0 px-3 py-1.5 text-xs font-medium"
+          className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium"
         >
           取消
         </button>
@@ -372,11 +372,11 @@ function AddSitePanel({ available, onCreated, onCancel, onError }: AddSitePanelP
 
       <div className="scroll-thin max-h-64 space-y-1 overflow-y-auto">
         {available.length === 0 ? (
-          <p className="px-2 py-6 text-center text-sm text-[var(--text-muted)]">
+          <p className="px-2 py-6 text-center text-body text-[var(--text-muted)]">
             所有支持的站点都已配置。
           </p>
         ) : filtered.length === 0 ? (
-          <p className="px-2 py-6 text-center text-sm text-[var(--text-muted)]">
+          <p className="px-2 py-6 text-center text-body text-[var(--text-muted)]">
             没有匹配「{query}」的站点。
           </p>
         ) : (
@@ -388,14 +388,14 @@ function AddSitePanel({ available, onCreated, onCancel, onError }: AddSitePanelP
               className="glass-row nav-item w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
             >
               <span className="min-w-0">
-                <span className="block truncate text-[13px] font-medium text-[var(--text)]">
+                <span className="block truncate text-ui font-medium text-[var(--text)]">
                   {item.display_name}
                 </span>
-                <span className="block truncate text-[11px] text-[var(--text-faint)]">
+                <span className="block truncate text-caption text-[var(--text-faint)]">
                   {item.base_url}
                 </span>
               </span>
-              <span className="shrink-0 text-[11px] text-[var(--text-muted)]">
+              <span className="shrink-0 text-caption text-[var(--text-muted)]">
                 {item.supported_auth_types.map((a) => AUTH_TYPE_LABEL[a.auth_type]).join(" / ")}
               </span>
             </button>
@@ -449,21 +449,21 @@ function SiteCard({
     <div className="css-glass !rounded-xl">
       {/* 顶部行：首字母徽标 + 站点信息 + 状态 + 操作 */}
       <div className="flex items-center gap-3.5 p-4">
-        <span className="icon-chip size-10 !rounded-xl text-sm font-semibold">
+        <span className="icon-chip size-10 !rounded-xl text-body font-semibold">
           {item.display_name.charAt(0).toUpperCase()}
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <p className="truncate text-sm font-semibold text-[var(--text)]">{item.display_name}</p>
+            <p className="truncate text-body font-semibold text-[var(--text)]">{item.display_name}</p>
             <span
-              className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium"
+              className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
               style={{ background: `${meta.color}1f`, color: meta.color }}
             >
               <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
               {meta.label}
             </span>
           </div>
-          <p className="mt-0.5 truncate text-[11px] text-[var(--text-faint)]">
+          <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]">
             {site.status === "failed" && site.last_error
               ? site.last_error
               : `${AUTH_TYPE_LABEL[site.auth_type]} · 上次检查 ${formatRelativeTime(site.last_checked_at)}`}
@@ -544,7 +544,7 @@ function SiteCard({
         </div>
       )}
       {stats?.last_error && (
-        <p className="border-t border-white/[0.06] px-4 py-2.5 text-[11px] text-[#ff6b6b]">
+        <p className="border-t border-white/[0.06] px-4 py-2.5 text-caption text-[#ff6b6b]">
           上次同步失败：{stats.last_error}
         </p>
       )}
@@ -581,8 +581,8 @@ function nextSyncLabel(iso: string | null): string {
 function ProfileStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <p className="text-[10px] text-[var(--text-faint)]">{label}</p>
-      <p className="mt-0.5 truncate text-[13px] font-semibold text-[var(--text)]">{value}</p>
+      <p className="text-micro text-[var(--text-faint)]">{label}</p>
+      <p className="mt-0.5 truncate text-ui font-semibold text-[var(--text)]">{value}</p>
     </div>
   );
 }
@@ -611,7 +611,7 @@ function SiteActionsMenu({
   // 靠近视口边缘时自动翻转/收边，绝不会像绝对定位那样把父容器/页面撑开。
   // 开合状态、点击外部关闭、键盘导航与焦点管理都由 Radix 托管。
   const itemClass =
-    "glass-row nav-item cursor-pointer px-3 py-2 text-xs font-medium outline-none " +
+    "glass-row nav-item cursor-pointer px-3 py-2 text-sub font-medium outline-none " +
     "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)] " +
     "data-[disabled]:pointer-events-none data-[disabled]:opacity-40";
 
@@ -692,7 +692,7 @@ function SiteForm({ item, site, busy, onSubmit }: SiteFormProps) {
       {/* 授权类型选择（多于一种时才展示） */}
       {options.length > 1 && (
         <div>
-          <label className="mb-1.5 block text-xs font-medium text-[var(--text-muted)]">
+          <label className="mb-1.5 block text-sub font-medium text-[var(--text-muted)]">
             授权方式
           </label>
           <div className="flex flex-wrap gap-2">
@@ -702,7 +702,7 @@ function SiteForm({ item, site, busy, onSubmit }: SiteFormProps) {
                 type="button"
                 onClick={() => setAuthType(opt.auth_type)}
                 data-active={authType === opt.auth_type}
-                className="glass-row nav-item !w-auto px-3 py-1.5 text-xs font-medium"
+                className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
               >
                 {AUTH_TYPE_LABEL[opt.auth_type]}
               </button>
@@ -716,12 +716,12 @@ function SiteForm({ item, site, busy, onSubmit }: SiteFormProps) {
         const fm = FIELD_META[field] ?? { label: field, kind: "text" as const };
         return (
           <div key={field}>
-            <label className="mb-1.5 block text-xs font-medium text-[var(--text-muted)]">
+            <label className="mb-1.5 block text-sub font-medium text-[var(--text-muted)]">
               {fm.label}
             </label>
             {/* Cookie 恰是插件的用武之地：就地提一句，不打断手动粘贴的用户 */}
             {field === "cookie" && (
-              <p className="mb-1.5 text-[11px] text-[var(--text-faint)]">
+              <p className="mb-1.5 text-caption text-[var(--text-faint)]">
                 手动粘贴的 Cookie 过期后需重填；推荐用本页下方的 MovieClaw 浏览器插件自动同步。
               </p>
             )}
@@ -732,7 +732,7 @@ function SiteForm({ item, site, busy, onSubmit }: SiteFormProps) {
                 rows={3}
                 autoComplete="off"
                 placeholder={site ? "出于安全，请重新填写" : ""}
-                className="scroll-thin w-full resize-none rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+                className="scroll-thin w-full resize-none rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
               />
             ) : (
               <input
@@ -742,7 +742,7 @@ function SiteForm({ item, site, busy, onSubmit }: SiteFormProps) {
                 placeholder={site ? "出于安全，请重新填写" : ""}
                 // Chrome 对 password 字段会无视 "off" 仍弹出已存密码，须用 "new-password" 抑制
                 autoComplete={fm.kind === "password" ? "new-password" : "off"}
-                className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+                className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
               />
             )}
           </div>
@@ -754,7 +754,7 @@ function SiteForm({ item, site, busy, onSubmit }: SiteFormProps) {
           type="button"
           onClick={submit}
           disabled={busy || !canSubmit}
-          className="btn-accent rounded-full px-4.5 py-2 text-[13px] font-semibold disabled:opacity-40"
+          className="btn-accent rounded-full px-4.5 py-2 text-ui font-semibold disabled:opacity-40"
         >
           {busy ? "保存中…" : site ? "保存并重新验证" : "保存并验证"}
         </button>

--- a/apps/web/components/subscribe-dialog.tsx
+++ b/apps/web/components/subscribe-dialog.tsx
@@ -209,9 +209,9 @@ export function SubscribeDialog({
   return (
     <Modal open onClose={onClose} label={`订阅《${target.title}》`} width="lg">
       <div className="scroll-thin max-h-[76dvh] overflow-y-auto p-6 max-md:p-5">
-          <h2 className="text-[17px] font-bold text-white">
+          <h2 className="text-title font-bold text-white">
             订阅追踪
-            <span className="ml-2 text-[13px] font-normal text-[var(--text-muted)]">
+            <span className="ml-2 text-ui font-normal text-[var(--text-muted)]">
               {target.title}
               {target.year ? ` (${target.year})` : ""}
             </span>
@@ -219,20 +219,20 @@ export function SubscribeDialog({
 
           {/* —— 加载 / 错误 —— */}
           {!prepared && !error && (
-            <div className="mt-8 flex items-center justify-center gap-2.5 pb-4 text-[13px] text-[var(--text-muted)]">
+            <div className="mt-8 flex items-center justify-center gap-2.5 pb-4 text-ui text-[var(--text-muted)]">
               <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
               正在获取条目信息…
             </div>
           )}
           {error && (
-            <p className="mt-4 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-[13px] leading-6 text-red-200">
+            <p className="mt-4 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
               {error}
             </p>
           )}
 
           {/* —— 豆瓣收敛：未收录 —— */}
           {prepared?.status === "not_found" && (
-            <p className="mt-4 text-[13.5px] leading-6 text-[var(--text-muted)]">
+            <p className="mt-4 text-ui leading-6 text-[var(--text-muted)]">
               TMDB 未收录该条目，暂时无法订阅。订阅依赖 TMDB
               的别名与季集数据来匹配站点资源，可尝试在 TMDB 搜索入口确认条目后再订阅。
             </p>
@@ -241,7 +241,7 @@ export function SubscribeDialog({
           {/* —— 豆瓣收敛：多候选确认 —— */}
           {prepared?.status === "ambiguous" && (
             <div className="mt-4">
-              <p className="text-[13px] text-[var(--text-muted)]">
+              <p className="text-ui text-[var(--text-muted)]">
                 找到多个可能的条目，请确认你订阅的是哪一部：
               </p>
               <div className="mt-3 grid grid-cols-4 gap-3 max-md:grid-cols-3 max-md:gap-2">
@@ -259,8 +259,8 @@ export function SubscribeDialog({
                         className="size-full"
                       />
                     </div>
-                    <p className="mt-1.5 truncate text-[12px] text-white/90">{c.title}</p>
-                    <p className="truncate text-[11px] text-[var(--text-faint)]">
+                    <p className="mt-1.5 truncate text-sub text-white/90">{c.title}</p>
+                    <p className="truncate text-caption text-[var(--text-faint)]">
                       {c.year ?? "年份未知"}
                     </p>
                   </button>
@@ -272,7 +272,7 @@ export function SubscribeDialog({
           {/* —— 已订阅：管理态 —— */}
           {prepared?.status === "ready" && prepared.existing_subscription_id && (
             <div className="mt-4">
-              <p className="flex items-center gap-2 text-[13.5px] text-white/85">
+              <p className="flex items-center gap-2 text-ui text-white/85">
                 <CheckIcon className="size-4 text-[#4ade80]" />
                 该{target.kind === "movie" ? "电影" : "剧集"}已在订阅中，movieclaw
                 正在持续追踪资源。
@@ -281,7 +281,7 @@ export function SubscribeDialog({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="btn-glass h-9 px-4 text-[13px] font-medium"
+                  className="btn-glass h-9 px-4 text-ui font-medium"
                 >
                   好的
                 </button>
@@ -289,7 +289,7 @@ export function SubscribeDialog({
                   type="button"
                   disabled={busy}
                   onClick={unsubscribe}
-                  className="h-9 rounded-full border border-red-400/30 bg-red-500/10 px-4 text-[13px] font-medium text-red-200 transition hover:bg-red-500/20 disabled:opacity-50"
+                  className="h-9 rounded-full border border-red-400/30 bg-red-500/10 px-4 text-ui font-medium text-red-200 transition hover:bg-red-500/20 disabled:opacity-50"
                 >
                   取消订阅
                 </button>
@@ -301,14 +301,14 @@ export function SubscribeDialog({
           {prepared?.status === "ready" && !prepared.existing_subscription_id && (
             <div className="mt-4 space-y-5">
               {prepared.movie_owned && (
-                <p className="flex items-center gap-2 rounded-xl border border-[#4ade80]/25 bg-[#4ade80]/10 px-3.5 py-2.5 text-[12.5px] text-[#4ade80]">
+                <p className="flex items-center gap-2 rounded-xl border border-[#4ade80]/25 bg-[#4ade80]/10 px-3.5 py-2.5 text-sub text-[#4ade80]">
                   <CheckIcon className="size-4 shrink-0" />
                   媒体库里已有这部电影，订阅后不会重复下载
                 </p>
               )}
               {prepared.media?.kind === "tv" && (
                 <section>
-                  <h3 className="mb-2 text-[13px] font-semibold text-white/85">
+                  <h3 className="mb-2 text-ui font-semibold text-white/85">
                     选择要收录的季
                     <span className="ml-2 font-normal text-[var(--text-faint)]">
                       勾选即要整季（含未播集）
@@ -327,10 +327,10 @@ export function SubscribeDialog({
 
                   <label className="mt-4 flex cursor-pointer items-center justify-between rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-3">
                     <span>
-                      <span className="block text-[13px] font-medium text-white/90">
+                      <span className="block text-ui font-medium text-white/90">
                         持续追新
                       </span>
-                      <span className="mt-0.5 block text-[11.5px] text-[var(--text-faint)]">
+                      <span className="mt-0.5 block text-caption text-[var(--text-faint)]">
                         之后播出的新集、新一季自动加入追踪
                       </span>
                     </span>
@@ -346,11 +346,11 @@ export function SubscribeDialog({
 
               {ruleSets.length > 0 && (
                 <section>
-                  <h3 className="mb-2 text-[13px] font-semibold text-white/85">资源规则</h3>
+                  <h3 className="mb-2 text-ui font-semibold text-white/85">资源规则</h3>
                   <select
                     value={ruleSetId ?? undefined}
                     onChange={(e) => setRuleSetId(Number(e.target.value))}
-                    className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2.5 text-[13px] text-white/90 outline-none focus:border-white/25 [&>option]:bg-[#181c28]"
+                    className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2.5 text-ui text-white/90 outline-none focus:border-white/25 [&>option]:bg-[#181c28]"
                   >
                     {ruleSets.map((r) => (
                       <option key={r.id} value={r.id}>
@@ -364,11 +364,11 @@ export function SubscribeDialog({
 
               {libraries.length > 0 && (
                 <section>
-                  <h3 className="mb-2 text-[13px] font-semibold text-white/85">入库到</h3>
+                  <h3 className="mb-2 text-ui font-semibold text-white/85">入库到</h3>
                   <select
                     value={libraryId ?? undefined}
                     onChange={(e) => setLibraryId(Number(e.target.value))}
-                    className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2.5 text-[13px] text-white/90 outline-none focus:border-white/25 [&>option]:bg-[#181c28]"
+                    className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2.5 text-ui text-white/90 outline-none focus:border-white/25 [&>option]:bg-[#181c28]"
                   >
                     {libraries.map((l) => (
                       <option key={l.id} value={l.id}>
@@ -379,14 +379,14 @@ export function SubscribeDialog({
                   </select>
                   {/* 收藏范围路由徽标：说明"为什么默认选了这个库"；用户改库即消失 */}
                   {routed && routed.reason && libraryId === routed.libraryId && (
-                    <p className="mt-1.5 text-[11.5px] leading-relaxed text-[var(--accent)]/90">
+                    <p className="mt-1.5 text-caption leading-relaxed text-[var(--accent)]/90">
                       自动选库：{routed.reason}
                     </p>
                   )}
                   {/* 投递路由预检：与后端真实投递同源判定，配置问题当场亮出 */}
                   {dispatchPreview &&
                     (dispatchPreview.ok ? (
-                      <p className="mt-1.5 text-[11.5px] leading-relaxed text-[var(--text-faint)]">
+                      <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
                         {dispatchPreview.mode === "watch" ? (
                           <>
                             将投递到监听导入目录{" "}
@@ -414,7 +414,7 @@ export function SubscribeDialog({
                         )}
                       </p>
                     ) : (
-                      <p className="mt-1.5 rounded-lg border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-[11.5px] leading-relaxed text-amber-200">
+                      <p className="mt-1.5 rounded-lg border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-caption leading-relaxed text-amber-200">
                         {dispatchPreview.warning}
                       </p>
                     ))}
@@ -425,7 +425,7 @@ export function SubscribeDialog({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="btn-glass h-9 px-4 text-[13px] font-medium"
+                  className="btn-glass h-9 px-4 text-ui font-medium"
                 >
                   取消
                 </button>
@@ -433,7 +433,7 @@ export function SubscribeDialog({
                   type="button"
                   disabled={!canSubmit}
                   onClick={submit}
-                  className="btn-accent h-9 rounded-full px-5 text-[13px] font-semibold disabled:opacity-50"
+                  className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-50"
                 >
                   {busy ? "正在订阅…" : "确认订阅"}
                 </button>
@@ -480,12 +480,12 @@ function SeasonRow({
       }`}
     >
       <span className="flex items-baseline gap-2.5">
-        <span className="text-[13px] font-medium text-white/90">
+        <span className="text-ui font-medium text-white/90">
           {season.season_number === 0 ? "特别篇" : `第 ${season.season_number} 季`}
         </span>
-        <span className="tnum text-[11.5px] text-[var(--text-faint)]">{progress}</span>
+        <span className="tnum text-caption text-[var(--text-faint)]">{progress}</span>
         {owned && (
-          <span className="tnum text-[11.5px] font-medium text-[#4ade80]/90">{owned}</span>
+          <span className="tnum text-caption font-medium text-[#4ade80]/90">{owned}</span>
         )}
       </span>
       <input

--- a/apps/web/components/subscription-inspector-view.tsx
+++ b/apps/web/components/subscription-inspector-view.tsx
@@ -86,8 +86,8 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
       <div className="flex h-full flex-col">
         <PageNav items={fallbackTrail} />
         <div className="flex flex-1 flex-col items-center justify-center gap-4">
-          <p className="text-[14px] text-[var(--text-muted)]">未能加载该订阅，可能已被删除。</p>
-          <Link href="/subscriptions" className="btn-glass px-4 py-2 text-[13px] font-medium">
+          <p className="text-body text-[var(--text-muted)]">未能加载该订阅，可能已被删除。</p>
+          <Link href="/subscriptions" className="btn-glass px-4 py-2 text-ui font-medium">
             <ArrowLeftIcon className="size-4" />
             返回订阅列表
           </Link>
@@ -100,7 +100,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
     return (
       <div className="flex h-full flex-col">
         <PageNav items={fallbackTrail} />
-        <div className="flex flex-1 items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+        <div className="flex flex-1 items-center justify-center gap-2.5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在加载订阅详情…
         </div>
@@ -169,7 +169,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
           )}
 
           <div className="min-w-0 flex-1">
-            <p className="text-[11px] font-semibold tracking-[0.22em] text-[var(--accent-2)]">
+            <p className="text-caption font-semibold tracking-[0.22em] text-[var(--accent-2)]">
               {isMovie ? "电影订阅" : "剧集订阅"}
             </p>
             <h1 className="mt-1.5 flex flex-wrap items-baseline gap-2.5 text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[20px]">
@@ -179,12 +179,12 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
               >
                 {detail.media.title}
               </Link>
-              <span className="tnum shrink-0 text-[14px] font-normal text-white/50">
+              <span className="tnum shrink-0 text-body font-normal text-white/50">
                 {detail.media.year ?? ""}
               </span>
             </h1>
 
-            <p className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12.5px] text-white/70">
+            <p className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sub text-white/70">
               <span className="flex items-center gap-1.5">
                 <span className="size-1.5 rounded-full" style={{ backgroundColor: meta.color }} />
                 {meta.label} · {subscriptionProgressNote(detail)}
@@ -213,7 +213,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
               type="button"
               disabled={busy || detail.status === "completed"}
               onClick={togglePause}
-              className="btn-glass h-9 bg-white/10 px-4 text-[12.5px] font-medium backdrop-blur-md disabled:opacity-40"
+              className="btn-glass h-9 bg-white/10 px-4 text-sub font-medium backdrop-blur-md disabled:opacity-40"
             >
               {detail.status === "paused" ? "恢复追踪" : "暂停"}
             </button>
@@ -221,7 +221,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
               type="button"
               disabled={busy}
               onClick={remove}
-              className="h-9 rounded-full border border-red-400/30 bg-red-500/10 px-4 text-[12.5px] font-medium text-red-200 transition hover:bg-red-500/20 disabled:opacity-40"
+              className="h-9 rounded-full border border-red-400/30 bg-red-500/10 px-4 text-sub font-medium text-red-200 transition hover:bg-red-500/20 disabled:opacity-40"
             >
               取消订阅
             </button>
@@ -243,7 +243,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
           label="活动记录"
           count={activities.length}
         />
-        <span className="ml-2 text-[12px] text-[var(--text-faint)]">
+        <span className="ml-2 text-sub text-[var(--text-faint)]">
           {tab === "wanted" ? "每个追踪单元此刻到哪一步了" : "系统对该订阅的每个动作"}
         </span>
       </div>
@@ -262,7 +262,7 @@ export function SubscriptionInspectorView({ id }: { id: number }) {
 /** Hero 里的参数徽片：无边框纯填充胶囊（全站「无线框」原则）。 */
 function ParamChip({ children }: { children: React.ReactNode }) {
   return (
-    <span className="rounded-full bg-white/[0.09] px-2.5 py-1 text-[11.5px] text-white/75 backdrop-blur-sm">
+    <span className="rounded-full bg-white/[0.09] px-2.5 py-1 text-caption text-white/75 backdrop-blur-sm">
       {children}
     </span>
   );
@@ -289,7 +289,7 @@ function ProgressStrip({
           style={{ width: `${(inPipeline / denom) * 100}%` }}
         />
       </div>
-      <p className="tnum mt-2 text-[12px] text-white/55">
+      <p className="tnum mt-2 text-sub text-white/55">
         共 {total} 项 · 缺 {wanted}
         {inPipeline > 0 && ` · 下载中 ${inPipeline}`}
         {imported > 0 && ` · 已入库 ${imported}`}
@@ -315,14 +315,14 @@ function InspectorTab({
       type="button"
       aria-pressed={active}
       onClick={onClick}
-      className={`flex items-center gap-2 rounded-full px-4 py-1.5 text-[13px] font-medium transition-colors ${
+      className={`flex items-center gap-2 rounded-full px-4 py-1.5 text-ui font-medium transition-colors ${
         active
           ? "bg-white/[0.14] text-white"
           : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
       }`}
     >
       {label}
-      <span className="tnum text-[11.5px] opacity-70">{count}</span>
+      <span className="tnum text-caption opacity-70">{count}</span>
     </button>
   );
 }
@@ -354,7 +354,7 @@ function activityColor(type: SubscriptionActivity["type"]): string {
 function ActivityTimeline({ activities }: { activities: SubscriptionActivity[] }) {
   if (activities.length === 0) {
     return (
-      <p className="rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] p-5 text-[12.5px] leading-6 text-[var(--text-muted)] backdrop-blur-xl">
+      <p className="rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] p-5 text-sub leading-6 text-[var(--text-muted)] backdrop-blur-xl">
         暂无活动记录。系统开始搜索、匹配或投递后，每个动作都会记录在这里。
       </p>
     );
@@ -378,9 +378,9 @@ function ActivityTimeline({ activities }: { activities: SubscriptionActivity[] }
               <div
                 className={`flex min-w-0 flex-1 items-baseline gap-5 ${last ? "" : "pb-5"}`}
               >
-                <p className="min-w-0 flex-1 text-[13px] leading-6 text-white/85">{a.message}</p>
+                <p className="min-w-0 flex-1 text-ui leading-6 text-white/85">{a.message}</p>
                 <span
-                  className="tnum shrink-0 text-[11.5px] text-[var(--text-faint)]"
+                  className="tnum shrink-0 text-caption text-[var(--text-faint)]"
                   title={formatDateTime(a.created_at)}
                 >
                   {formatRelativeTime(a.created_at)}
@@ -398,7 +398,7 @@ function ActivityTimeline({ activities }: { activities: SubscriptionActivity[] }
 function WantedBreakdown({ wanted, isMovie }: { wanted: WantedItem[]; isMovie: boolean }) {
   if (wanted.length === 0) {
     return (
-      <p className="rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] p-5 text-[12.5px] leading-6 text-[var(--text-muted)] backdrop-blur-xl">
+      <p className="rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] p-5 text-sub leading-6 text-[var(--text-muted)] backdrop-blur-xl">
         当前没有追踪项。开启「持续追新」后，新集播出会自动加入。
       </p>
     );
@@ -421,7 +421,7 @@ function WantedBreakdown({ wanted, isMovie }: { wanted: WantedItem[]; isMovie: b
             className="overflow-hidden rounded-2xl border border-white/[0.07] bg-[rgba(14,16,22,0.45)] backdrop-blur-xl"
           >
             {!isMovie && (
-              <p className="border-b border-white/[0.06] px-5 py-2.5 text-[12.5px] font-semibold text-white/80">
+              <p className="border-b border-white/[0.06] px-5 py-2.5 text-sub font-semibold text-white/80">
                 {season === 0 ? "特别篇" : `第 ${season} 季`}
                 <span className="ml-2 font-normal text-[var(--text-faint)]">
                   {items.filter((w) => w.status !== "wanted").length}/{items.length} 已安排
@@ -447,20 +447,20 @@ function WantedRow({ wanted: w, isMovie }: { wanted: WantedItem; isMovie: boolea
   const { label, color, note } = wantedPresentation(w);
   return (
     <li className="flex items-center gap-4 px-5 py-2.5">
-      <span className="tnum w-14 shrink-0 text-[12.5px] font-medium text-white/90">
+      <span className="tnum w-14 shrink-0 text-sub font-medium text-white/90">
         {isMovie ? "正片" : `E${String(w.episode_number).padStart(2, "0")}`}
       </span>
       <span
-        className="shrink-0 rounded-full px-2 py-0.5 text-[10.5px] font-semibold"
+        className="shrink-0 rounded-full px-2 py-0.5 text-micro font-semibold"
         style={{ backgroundColor: `${color}22`, color }}
       >
         {label}
       </span>
-      <span className="tnum min-w-0 flex-1 truncate text-[12px] text-[var(--text-muted)]">
+      <span className="tnum min-w-0 flex-1 truncate text-sub text-[var(--text-muted)]">
         {note}
       </span>
       {w.search_attempts > 0 && (
-        <span className="tnum shrink-0 text-[11px] text-[var(--text-faint)]">
+        <span className="tnum shrink-0 text-caption text-[var(--text-faint)]">
           已搜索 {w.search_attempts} 次
         </span>
       )}

--- a/apps/web/components/subscription-settings-section.tsx
+++ b/apps/web/components/subscription-settings-section.tsx
@@ -121,12 +121,12 @@ function PipelineHealthPanel() {
   return (
     <section>
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="text-[14px] font-semibold text-white/90">订阅链路体检</h3>
+        <h3 className="text-body font-semibold text-white/90">订阅链路体检</h3>
         <button
           type="button"
           onClick={reload}
           disabled={busy}
-          className="btn-glass flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium disabled:opacity-60"
+          className="btn-glass flex items-center gap-1.5 px-3 py-1.5 text-sub font-medium disabled:opacity-60"
         >
           {busy && (
             <span className="size-3 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
@@ -134,19 +134,19 @@ function PipelineHealthPanel() {
           重新体检
         </button>
       </div>
-      <p className="mb-4 text-[12.5px] leading-6 text-[var(--text-muted)]">
+      <p className="mb-4 text-sub leading-6 text-[var(--text-muted)]">
         逐库预演「资源搜索 → 下载 → 投递 → 入库」的完整链路，与真实投递同一套判定。
         红点表示订阅会卡在那一步（工单不会丢，修好后自动重试）；黄点能转但有降级。
         修改配置后回到本页会自动重检。
       </p>
 
       {failed && (
-        <p className="rounded-xl bg-white/[0.03] px-4 py-5 text-center text-[13px] text-[var(--text-muted)]">
+        <p className="rounded-xl bg-white/[0.03] px-4 py-5 text-center text-ui text-[var(--text-muted)]">
           体检加载失败，请重试
         </p>
       )}
       {health === null && !failed && (
-        <p className="flex items-center gap-2.5 rounded-xl bg-white/[0.03] px-4 py-5 text-[13px] text-[var(--text-muted)]">
+        <p className="flex items-center gap-2.5 rounded-xl bg-white/[0.03] px-4 py-5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在体检…
         </p>
@@ -204,14 +204,14 @@ function SetupChecklist({ health }: { health: PipelineHealth }) {
   ];
   return (
     <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] p-4">
-      <p className="mb-3 text-[13px] font-medium text-white/90">
+      <p className="mb-3 text-ui font-medium text-white/90">
         把订阅跑起来需要三步（完成后这里会变成链路体检）：
       </p>
       <div className="space-y-2">
         {steps.map((step, i) => (
           <div key={step.label} className="flex items-center gap-3">
             <span
-              className={`flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold ${
+              className={`flex size-5 shrink-0 items-center justify-center rounded-full text-caption font-semibold ${
                 step.done ? "bg-[#4ade80]/20 text-[#4ade80]" : "bg-white/10 text-white/70"
               }`}
             >
@@ -219,16 +219,16 @@ function SetupChecklist({ health }: { health: PipelineHealth }) {
             </span>
             <span className="min-w-0 flex-1">
               <span
-                className={`text-[13px] font-medium ${step.done ? "text-white/50 line-through" : "text-white/90"}`}
+                className={`text-ui font-medium ${step.done ? "text-white/50 line-through" : "text-white/90"}`}
               >
                 {step.label}
               </span>
-              <span className="ml-2 text-[11.5px] text-[var(--text-faint)]">{step.hint}</span>
+              <span className="ml-2 text-caption text-[var(--text-faint)]">{step.hint}</span>
             </span>
             {!step.done && (
               <Link
                 href={step.href as never}
-                className="btn-glass shrink-0 px-3 py-1.5 text-[12px] font-medium"
+                className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium"
               >
                 {step.action}
               </Link>
@@ -236,7 +236,7 @@ function SetupChecklist({ health }: { health: PipelineHealth }) {
           </div>
         ))}
       </div>
-      <p className="mt-3 text-[11.5px] leading-relaxed text-[var(--text-faint)]">
+      <p className="mt-3 text-caption leading-relaxed text-[var(--text-faint)]">
         可选第四步：「监听导入」让下载区与媒体库分离（PT 保种推荐）——下载器落盘的
         内容自动硬链接进库，源文件继续做种。不配置则直接下载进库根，同样能自动入账。
       </p>
@@ -252,7 +252,7 @@ function SetupChecklist({ health }: { health: PipelineHealth }) {
 function IssueCardList({ issues }: { issues: PipelineIssue[] }) {
   return (
     <div className="space-y-2.5">
-      <p className="text-[13px] font-medium text-white/90">
+      <p className="text-ui font-medium text-white/90">
         需要处理 {issues.length} 件事（下方库卡片的红黄点都来自这里）：
       </p>
       {issues.map((issue) => (
@@ -273,13 +273,13 @@ function IssueCard({ issue }: { issue: PipelineIssue }) {
       <div className="flex items-start gap-2.5">
         <span className={`mt-[5px] size-2 shrink-0 rounded-full ${STATUS_META[issue.status].dot}`} />
         <div className="min-w-0 flex-1">
-          <p className="text-[13.5px] font-semibold text-white/95">{issue.title}</p>
+          <p className="text-ui font-semibold text-white/95">{issue.title}</p>
           {issue.affected_libraries.length > 0 && (
-            <p className="mt-1 text-[11.5px] text-[var(--text-faint)]">
+            <p className="mt-1 text-caption text-[var(--text-faint)]">
               影响 {issue.affected_libraries.length} 个库：{issue.affected_libraries.join("、")}
             </p>
           )}
-          <p className="mt-1.5 text-[12.5px] leading-relaxed text-[var(--text-muted)]">
+          <p className="mt-1.5 text-sub leading-relaxed text-[var(--text-muted)]">
             {issue.detail}
           </p>
         </div>
@@ -306,24 +306,24 @@ function FixOptionBlock({ option, ordinal }: { option: FixOption; ordinal: numbe
   const href = fixOptionHref(option);
   return (
     <div className="flex flex-col rounded-lg bg-white/[0.04] p-3">
-      <p className="text-[12.5px] font-semibold text-white/90">
+      <p className="text-sub font-semibold text-white/90">
         {ordinal !== null && (
-          <span className="mr-1.5 inline-flex size-4.5 items-center justify-center rounded-full bg-white/10 text-[10.5px] text-white/70">
+          <span className="mr-1.5 inline-flex size-4.5 items-center justify-center rounded-full bg-white/10 text-micro text-white/70">
             {ordinal}
           </span>
         )}
         {option.title}
       </p>
       {option.why && (
-        <p className="mt-1.5 text-[11.5px] leading-relaxed text-[var(--text-faint)]">{option.why}</p>
+        <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">{option.why}</p>
       )}
-      <p className="mt-1.5 flex-1 text-[12px] leading-relaxed text-[var(--text-muted)]">
+      <p className="mt-1.5 flex-1 text-sub leading-relaxed text-[var(--text-muted)]">
         {option.steps}
       </p>
       {href && (
         <Link
           href={href as never}
-          className="btn-glass mt-2.5 self-start px-3 py-1.5 text-[12px] font-medium"
+          className="btn-glass mt-2.5 self-start px-3 py-1.5 text-sub font-medium"
         >
           {option.fix_label} →
         </Link>
@@ -358,11 +358,11 @@ function FlowStepper({ nodes }: { nodes: FlowNode[] }) {
             }`}
           >
             <span className={`size-1.5 shrink-0 rounded-full ${STATUS_META[node.status].dot}`} />
-            <span className="text-[12px] font-medium text-white/90">{node.label}</span>
+            <span className="text-sub font-medium text-white/90">{node.label}</span>
             {node.sub && (
               <span
                 dir="rtl"
-                className="max-w-[180px] truncate font-mono text-[11px] text-[var(--text-faint)]"
+                className="max-w-[180px] truncate font-mono text-caption text-[var(--text-faint)]"
                 title={node.sub}
               >
                 {"‎" + node.sub + "‎"}
@@ -407,7 +407,7 @@ function SharedSegmentsRow({
   return (
     <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-3">
       <div className="flex items-center gap-3">
-        <span className="w-24 shrink-0 text-[12px] text-[var(--text-faint)] max-md:hidden">
+        <span className="w-24 shrink-0 text-sub text-[var(--text-faint)] max-md:hidden">
           公共链路
         </span>
         <FlowStepper nodes={nodes} />
@@ -470,32 +470,32 @@ function LibraryPipelineCard({
     <div className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-3">
       <div className="flex items-center gap-3">
         <span className="w-24 shrink-0 max-md:hidden">
-          <span className="block truncate text-[13px] font-medium text-white/90">
+          <span className="block truncate text-ui font-medium text-white/90">
             {pipeline.library_name}
           </span>
-          <span className="block text-[11px] text-[var(--text-faint)]">
+          <span className="block text-caption text-[var(--text-faint)]">
             {pipeline.kind === "movie" ? "电影" : "剧集"}
             {pipeline.is_default ? " · 默认" : ""}
           </span>
         </span>
         <div className="min-w-0 flex-1">
-          <p className="mb-1.5 text-[12.5px] font-medium text-white/90 md:hidden">
+          <p className="mb-1.5 text-sub font-medium text-white/90 md:hidden">
             {pipeline.library_name}
           </p>
           <FlowStepper nodes={nodes} />
           {/* 正向叙事：订阅命中本库会发生什么——全绿时的可预期，不用去玩模拟一单 */}
           {pipeline.narrative && (
-            <p className="mt-1.5 text-[11.5px] leading-relaxed text-[var(--text-faint)]">
+            <p className="mt-1.5 text-caption leading-relaxed text-[var(--text-faint)]">
               {pipeline.narrative}
             </p>
           )}
         </div>
         <div className="flex shrink-0 flex-col items-end gap-1">
-          <span className={`text-[12px] font-medium ${meta.text}`}>{meta.label}</span>
+          <span className={`text-sub font-medium ${meta.text}`}>{meta.label}</span>
           <button
             type="button"
             onClick={() => setShowAll((v) => !v)}
-            className="text-[11px] text-[var(--text-faint)] hover:text-white"
+            className="text-caption text-[var(--text-faint)] hover:text-white"
           >
             {showAll ? "收起" : "查看全部"}
           </button>
@@ -517,7 +517,7 @@ function ProblemList({ checks }: { checks: PipelineCheck[] }) {
             <span
               className={`mt-[5px] size-1.5 shrink-0 rounded-full ${STATUS_META[check.status].dot}`}
             />
-            <p className="min-w-0 flex-1 text-[12px] leading-relaxed text-[var(--text-muted)]">
+            <p className="min-w-0 flex-1 text-sub leading-relaxed text-[var(--text-muted)]">
               <span className="font-medium text-[var(--text)]">{check.label}</span>
               <span className="ml-2">{check.detail}</span>
               {fix && (
@@ -580,8 +580,8 @@ function SimulatePanel() {
 
   return (
     <section>
-      <h3 className="mb-2 text-[14px] font-semibold text-white/90">模拟一单</h3>
-      <p className="mb-3 text-[12.5px] leading-6 text-[var(--text-muted)]">
+      <h3 className="mb-2 text-body font-semibold text-white/90">模拟一单</h3>
+      <p className="mb-3 text-sub leading-6 text-[var(--text-muted)]">
         搜一部片，看它订阅后会进哪个库、投递到哪、怎么入库——只做预演，不会真的订阅。
         配完收藏范围想确认「某类片会进哪」，在这里试一下就知道。
       </p>
@@ -591,22 +591,22 @@ function SimulatePanel() {
         onChange={(e) => setQuery(e.target.value)}
         placeholder="输入片名，如：葬送的芙莉莲"
         autoComplete="off"
-        className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2.5 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+        className="w-full rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2.5 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
       />
       {searching && (
-        <p className="mt-2 text-[12px] text-[var(--text-faint)]">正在搜索…</p>
+        <p className="mt-2 text-sub text-[var(--text-faint)]">正在搜索…</p>
       )}
       {candidates !== null && !searching && !picked && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {candidates.length === 0 && (
-            <p className="text-[12px] text-[var(--text-faint)]">没有找到条目，换个关键词试试</p>
+            <p className="text-sub text-[var(--text-faint)]">没有找到条目，换个关键词试试</p>
           )}
           {candidates.map((item) => (
             <button
               key={item.id}
               type="button"
               onClick={() => pick(item)}
-              className="glass-row nav-item !w-auto px-3 py-1.5 text-[12px] font-medium"
+              className="glass-row nav-item !w-auto px-3 py-1.5 text-sub font-medium"
             >
               {item.title}
               <span className="ml-1.5 text-[var(--text-faint)]">
@@ -618,11 +618,11 @@ function SimulatePanel() {
       )}
       {picked && (
         <div className="mt-3 rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-3">
-          <p className="text-[13px] font-medium text-white/90">
+          <p className="text-ui font-medium text-white/90">
             《{picked.title}》{picked.year ? ` (${picked.year})` : ""}
           </p>
           {preview === null ? (
-            <p className="mt-2 text-[12px] text-[var(--text-faint)]">正在预演…</p>
+            <p className="mt-2 text-sub text-[var(--text-faint)]">正在预演…</p>
           ) : (
             <div className="mt-2 space-y-1.5">
               <SimStep
@@ -643,11 +643,11 @@ function SimulatePanel() {
                 }
               />
               {preview.ok ? (
-                <p className="flex items-center gap-1.5 pt-1 text-[12.5px] font-medium text-[#4ade80]">
+                <p className="flex items-center gap-1.5 pt-1 text-sub font-medium text-[#4ade80]">
                   ✓ 全链路可行：订阅后即可自动下载并整理入库
                 </p>
               ) : (
-                <p className="rounded-lg border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-[12px] leading-relaxed text-amber-200">
+                <p className="rounded-lg border border-amber-400/25 bg-amber-500/10 px-3 py-2 text-sub leading-relaxed text-amber-200">
                   {preview.warning}
                 </p>
               )}
@@ -661,8 +661,8 @@ function SimulatePanel() {
 
 function SimStep({ n, text }: { n: number; text: string }) {
   return (
-    <p className="flex items-start gap-2.5 text-[12.5px] leading-relaxed text-[var(--text-muted)]">
-      <span className="mt-px flex size-4.5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[10.5px] font-semibold text-white/70">
+    <p className="flex items-start gap-2.5 text-sub leading-relaxed text-[var(--text-muted)]">
+      <span className="mt-px flex size-4.5 shrink-0 items-center justify-center rounded-full bg-white/10 text-micro font-semibold text-white/70">
         {n}
       </span>
       <span className="min-w-0 flex-1">{text}</span>
@@ -685,13 +685,13 @@ function RuleSetsPanel() {
 
   return (
     <section>
-      <h3 className="mb-2 text-[14px] font-semibold text-white/90">规则组</h3>
-      <p className="mb-4 text-[12.5px] leading-6 text-[var(--text-muted)]">
+      <h3 className="mb-2 text-body font-semibold text-white/90">规则组</h3>
+      <p className="mb-4 text-sub leading-6 text-[var(--text-muted)]">
         规则组定义「什么样的资源可接受」（分辨率、来源等硬条件与偏好排序），
         在订阅弹窗中按订阅选用；标「默认」的组是新订阅的初始选择。
       </p>
       {ruleSets === null ? (
-        <p className="rounded-xl bg-white/[0.03] px-4 py-4 text-[13px] text-[var(--text-muted)]">
+        <p className="rounded-xl bg-white/[0.03] px-4 py-4 text-ui text-[var(--text-muted)]">
           正在加载…
         </p>
       ) : (
@@ -701,15 +701,15 @@ function RuleSetsPanel() {
               key={rs.id}
               className="flex items-center gap-3 rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-2.5"
             >
-              <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-white/90">
+              <span className="min-w-0 flex-1 truncate text-ui font-medium text-white/90">
                 {rs.name}
               </span>
               {rs.is_default && (
-                <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.1] px-2 py-0.5 text-[10.5px] font-semibold text-white/80">
+                <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.1] px-2 py-0.5 text-micro font-semibold text-white/80">
                   默认
                 </span>
               )}
-              <span className="shrink-0 text-[11.5px] text-[var(--text-faint)]">
+              <span className="shrink-0 text-caption text-[var(--text-faint)]">
                 {Object.keys(rs.spec ?? {}).length === 0 ? "全不限" : "已配置条件"}
               </span>
             </div>

--- a/apps/web/components/subscriptions-view.tsx
+++ b/apps/web/components/subscriptions-view.tsx
@@ -70,7 +70,7 @@ export function SubscriptionsView() {
           <h2 className="text-on-image text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[21px]">
             我的订阅
           </h2>
-          <p className="text-on-image mt-1.5 text-[13px] text-[var(--text-muted)] max-md:mt-1 max-md:text-[12px]">
+          <p className="text-on-image mt-1.5 text-ui text-[var(--text-muted)] max-md:mt-1 max-md:text-sub">
             共 {visible.length} 部{mediaType === "movie" ? "电影" : "剧集"} ·
             movieclaw 会持续追踪并在新资源放出后自动入库
           </p>
@@ -84,7 +84,7 @@ export function SubscriptionsView() {
       {healthIssue && (
         <Link
           href={"/settings/subscription" as Route}
-          className="mx-6 mt-4 block rounded-xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-[12.5px] leading-relaxed text-amber-200 transition hover:bg-amber-500/15 max-md:mx-4"
+          className="mx-6 mt-4 block rounded-xl border border-amber-400/25 bg-amber-500/10 px-4 py-3 text-sub leading-relaxed text-amber-200 transition hover:bg-amber-500/15 max-md:mx-4"
         >
           {healthIssue.libraryErrors > 0
             ? `${healthIssue.libraryErrors} 个媒体库的入库链路有问题，相关订阅暂时无法自动下载入库（已下达的任务会自动重试）`
@@ -94,7 +94,7 @@ export function SubscriptionsView() {
       )}
 
       {subscriptions === null && !failed && (
-        <div className="mt-16 flex items-center justify-center gap-2.5 text-[13px] text-[var(--text-muted)]">
+        <div className="mt-16 flex items-center justify-center gap-2.5 text-ui text-[var(--text-muted)]">
           <span className="size-4 animate-spin rounded-full border-2 border-white/20 border-t-white/70" />
           正在加载订阅…
         </div>
@@ -102,11 +102,11 @@ export function SubscriptionsView() {
 
       {failed && (
         <div className="mt-16 flex flex-col items-center gap-3 text-center">
-          <p className="text-[13.5px] text-[var(--text-muted)]">订阅列表加载失败</p>
+          <p className="text-ui text-[var(--text-muted)]">订阅列表加载失败</p>
           <button
             type="button"
             onClick={reload}
-            className="btn-glass px-4 py-2 text-[13px] font-medium text-[var(--text)]"
+            className="btn-glass px-4 py-2 text-ui font-medium text-[var(--text)]"
           >
             重试
           </button>
@@ -114,7 +114,7 @@ export function SubscriptionsView() {
       )}
 
       {subscriptions !== null && !failed && visible.length === 0 && (
-        <p className="mt-16 text-center text-[13.5px] leading-7 text-[var(--text-muted)]">
+        <p className="mt-16 text-center text-ui leading-7 text-[var(--text-muted)]">
           还没有订阅任何{mediaType === "movie" ? "电影" : "剧集"}。
           <br />
           在发现页或搜索结果里打开影片详情，点「订阅追踪」即可加入。
@@ -149,7 +149,7 @@ function MediaTypeSwitcher({
           type="button"
           aria-pressed={value === type}
           onClick={() => onChange(type)}
-          className={`rounded-full px-4 py-1.5 text-xs font-semibold transition ${
+          className={`rounded-full px-4 py-1.5 text-sub font-semibold transition ${
             value === type
               ? "bg-white/15 text-white shadow-sm"
               : "text-[var(--text-muted)] hover:text-white"
@@ -184,7 +184,7 @@ function SubscriptionCell({ sub }: { sub: Subscription }) {
         item={toVisualItem(sub)}
         href={`/subscriptions/${sub.id}` as Route}
       />
-      <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-[11px] text-[var(--text-muted)]">
+      <p className="text-on-image mt-1.5 flex items-center gap-1.5 truncate text-caption text-[var(--text-muted)]">
         <span
           className="size-1.5 shrink-0 rounded-full"
           style={{ backgroundColor: meta.color }}

--- a/apps/web/components/system-logs-section.tsx
+++ b/apps/web/components/system-logs-section.tsx
@@ -352,7 +352,7 @@ export function SystemLogsSection() {
           disabled={loading || days.length === 0}
           aria-label="选择日志日期"
           onChange={(e) => switchDay(e.target.value)}
-          className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-[13px] text-[var(--text)] outline-none focus:border-[var(--accent)]/60 [&>option]:bg-[#1a1e28]"
+          className="rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60 [&>option]:bg-[#1a1e28]"
         >
           {days.length === 0 && <option value="">暂无日志</option>}
           {days.map((d) => (
@@ -362,7 +362,7 @@ export function SystemLogsSection() {
           ))}
         </select>
         {activeMeta && (
-          <span className="tnum text-xs text-[var(--text-muted)]">
+          <span className="tnum text-sub text-[var(--text-muted)]">
             {formatBytes(activeMeta.size_bytes)}
             {content && ` · 共 ${content.total_lines} 行`}
           </span>
@@ -371,7 +371,7 @@ export function SystemLogsSection() {
 
         {/* 自动刷新分段：关闭 / 3s / 10s / 30s；生效时点亮呼吸绿点 */}
         <div className="flex items-center gap-2">
-          <span className="flex items-center gap-1.5 text-xs text-[var(--text-muted)]">
+          <span className="flex items-center gap-1.5 text-sub text-[var(--text-muted)]">
             {refreshMs > 0 && isLatestDay && (
               <span className="relative flex size-1.5">
                 <span className="absolute inline-flex size-full animate-ping rounded-full bg-emerald-400/60" />
@@ -394,7 +394,7 @@ export function SystemLogsSection() {
                   role="radio"
                   aria-checked={active}
                   onClick={() => changeRefresh(opt.value)}
-                  className={`rounded-md px-2 py-1 text-[12px] font-medium transition-colors ${
+                  className={`rounded-md px-2 py-1 text-sub font-medium transition-colors ${
                     active
                       ? "bg-white/[0.13] text-[var(--text)]"
                       : "text-[var(--text-muted)] hover:text-[var(--text)]"
@@ -411,7 +411,7 @@ export function SystemLogsSection() {
           type="button"
           onClick={() => void refresh(activeDay)}
           disabled={loading}
-          className="btn-glass px-3.5 py-1.5 text-xs font-medium disabled:opacity-40"
+          className="btn-glass px-3.5 py-1.5 text-sub font-medium disabled:opacity-40"
         >
           {loading ? "加载中…" : "刷新"}
         </button>
@@ -419,7 +419,7 @@ export function SystemLogsSection() {
   );
 
   const errorBanner = error ? (
-    <p className="rounded-xl border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-4 py-2.5 text-xs text-[var(--danger)]">
+    <p className="rounded-xl border border-[var(--danger)]/30 bg-[var(--danger)]/10 px-4 py-2.5 text-sub text-[var(--danger)]">
       {error}
     </p>
   ) : null;
@@ -444,7 +444,7 @@ export function SystemLogsSection() {
                   role="radio"
                   aria-checked={active}
                   onClick={() => setLevelFilter(f.id)}
-                  className={`rounded-full px-2.5 py-[3px] text-[12px] transition-colors ${
+                  className={`rounded-full px-2.5 py-[3px] text-sub transition-colors ${
                     active
                       ? "bg-white/[0.14] font-medium text-[var(--text)]"
                       : "text-[var(--text-muted)] hover:bg-white/[0.06] hover:text-[var(--text)]"
@@ -463,7 +463,7 @@ export function SystemLogsSection() {
             onChange={(e) => setQuery(e.target.value)}
             placeholder="搜索日志…"
             aria-label="搜索日志"
-            className="w-40 rounded-lg border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 text-[12px] text-[var(--text)] outline-none placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/60 sm:w-52"
+            className="w-40 rounded-lg border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 text-sub text-[var(--text)] outline-none placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/60 sm:w-52"
           />
           <button
             type="button"
@@ -479,14 +479,14 @@ export function SystemLogsSection() {
         {/* 截断提示：默认只取末尾片段，超大日志按需再全量加载 */}
         {content?.truncated && (
           <div className="flex items-center justify-between gap-3 border-b border-white/[0.06] bg-white/[0.02] px-4 py-1.5">
-            <p className="text-[11px] text-[var(--text-faint)]">
+            <p className="text-caption text-[var(--text-faint)]">
               日志较长，仅加载末尾 {content.lines.length} 行（全天共 {content.total_lines} 行）
             </p>
             <button
               type="button"
               onClick={() => activeDay && void loadDay(activeDay, { tail: 0 })}
               disabled={loading}
-              className="shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-white/[0.08] hover:text-[var(--text)] disabled:opacity-40"
+              className="shrink-0 rounded-full px-2.5 py-0.5 text-caption font-medium text-[var(--text-muted)] transition-colors hover:bg-white/[0.08] hover:text-[var(--text)] disabled:opacity-40"
             >
               加载全部
             </button>
@@ -498,7 +498,7 @@ export function SystemLogsSection() {
           <div
             ref={scrollRef}
             onScroll={handleScroll}
-            className={`scroll-thin overflow-auto bg-black/45 font-mono text-[11.5px] leading-[1.65] ${
+            className={`scroll-thin overflow-auto bg-black/45 font-mono text-caption leading-[1.65] ${
               fullscreen ? "h-full" : "h-[62vh] min-h-[18rem]"
             }`}
           >
@@ -523,7 +523,7 @@ export function SystemLogsSection() {
                 })}
               </div>
             ) : (
-              <p className="px-6 py-12 text-center font-sans text-xs text-[var(--text-faint)]">
+              <p className="px-6 py-12 text-center font-sans text-sub text-[var(--text-faint)]">
                 {loading
                   ? "日志加载中…"
                   : days.length === 0
@@ -540,7 +540,7 @@ export function SystemLogsSection() {
             <button
               type="button"
               onClick={scrollToBottom}
-              className="btn-glass absolute bottom-4 right-4 flex items-center gap-1.5 !rounded-full px-3.5 py-1.5 text-xs font-medium shadow-lg"
+              className="btn-glass absolute bottom-4 right-4 flex items-center gap-1.5 !rounded-full px-3.5 py-1.5 text-sub font-medium shadow-lg"
             >
               <span aria-hidden>↓</span>
               {pendingNew} 条新日志
@@ -577,13 +577,13 @@ export function SystemLogsSection() {
       {logWindow}
 
       <div className="flex items-start justify-between gap-4">
-        <p className="text-on-image text-xs leading-5 text-[var(--text-faint)]">
+        <p className="text-on-image text-sub leading-5 text-[var(--text-faint)]">
           日志按天存档在服务端 data/logs 目录（Docker 部署挂载 data 卷即可持久化），
           超过保留天数的旧日志会自动清理；保留天数与目录位置可通过 LOG_RETENTION_DAYS、LOG_DIR
           环境变量调整。
         </p>
         {!isLatestDay && activeDay && refreshMs > 0 && (
-          <p className="shrink-0 text-xs text-[var(--text-faint)]">正在查看历史日志，自动刷新已暂停</p>
+          <p className="shrink-0 text-sub text-[var(--text-faint)]">正在查看历史日志，自动刷新已暂停</p>
         )}
       </div>
     </div>
@@ -601,7 +601,7 @@ function LogRow({ entry, query }: { entry: LogEntry; query: string }) {
     <div className={`flex items-start gap-2.5 px-4 py-[3px] transition-colors hover:bg-white/[0.04] ${style.row}`}>
       <span className="tnum shrink-0 select-none text-[var(--text-faint)]">{entry.time || "​"}</span>
       <span
-        className={`mt-[2px] w-[46px] shrink-0 select-none rounded px-1 py-px text-center text-[9.5px] font-semibold tracking-wide ${style.badge}`}
+        className={`mt-[2px] w-[46px] shrink-0 select-none rounded px-1 py-px text-center text-micro font-semibold tracking-wide ${style.badge}`}
       >
         {LEVEL_BADGE_LABEL[entry.level]}
       </span>

--- a/apps/web/components/tooltip.tsx
+++ b/apps/web/components/tooltip.tsx
@@ -80,7 +80,7 @@ export function Tooltip({
           >
             <div
               style={transitionStyles}
-              className="select-text rounded-xl border border-white/[0.12] bg-[rgba(16,18,26,0.97)] px-3.5 py-2.5 text-[12px] leading-relaxed text-[var(--text)] shadow-2xl backdrop-blur-2xl"
+              className="select-text rounded-xl border border-white/[0.12] bg-[rgba(16,18,26,0.97)] px-3.5 py-2.5 text-sub leading-relaxed text-[var(--text)] shadow-2xl backdrop-blur-2xl"
             >
               <FloatingArrow
                 ref={arrowRef}

--- a/apps/web/components/top250-view.tsx
+++ b/apps/web/components/top250-view.tsx
@@ -125,13 +125,13 @@ export function Top250View() {
       <header className="mx-auto max-w-[1500px]">
         <div className="mt-1 flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
           <div>
-            <p className="text-xs font-semibold tracking-[0.18em] text-[var(--accent-2)]">
+            <p className="text-sub font-semibold tracking-[0.18em] text-[var(--accent-2)]">
               DOUBAN RANKING
             </p>
             <h1 className="mt-1 text-3xl font-bold tracking-[-0.03em] text-[var(--text)]">
               豆瓣电影 Top 250
             </h1>
-            <p className="mt-2 text-sm text-[var(--text-muted)]">
+            <p className="mt-2 text-body text-[var(--text-muted)]">
               {items ? `完整收录 ${items.length} 部影片` : "正在读取完整榜单…"}
             </p>
           </div>
@@ -142,18 +142,18 @@ export function Top250View() {
               onChange={(event) => updateQuery(event.target.value)}
               placeholder="搜索片名"
               aria-label="搜索 Top 250 片名"
-              className="min-w-0 flex-1 bg-transparent text-sm text-[var(--text)] outline-none placeholder:text-[var(--text-muted)]"
+              className="min-w-0 flex-1 bg-transparent text-body text-[var(--text)] outline-none placeholder:text-[var(--text-muted)]"
             />
           </label>
         </div>
         {genres.length > 0 && (
           <div className="mt-6 flex flex-wrap items-center gap-2 max-md:mt-4">
-            <span className="mr-1 text-xs font-semibold text-[var(--text-muted)]">类型</span>
+            <span className="mr-1 text-sub font-semibold text-[var(--text-muted)]">类型</span>
             <button
               type="button"
               aria-pressed={selectedGenres.length === 0}
               onClick={clearGenres}
-              className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+              className={`rounded-full border px-3 py-1.5 text-sub font-semibold transition ${
                 selectedGenres.length === 0
                   ? "border-white/20 bg-white/15 text-white"
                   : "border-white/[0.07] bg-black/20 text-[var(--text-muted)] hover:border-white/15 hover:text-white"
@@ -167,21 +167,21 @@ export function Top250View() {
                 type="button"
                 aria-pressed={selectedGenres.includes(name)}
                 onClick={() => toggleGenre(name)}
-                className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                className={`rounded-full border px-3 py-1.5 text-sub font-semibold transition ${
                   selectedGenres.includes(name)
                     ? "border-white/20 bg-white/15 text-white"
                     : "border-white/[0.07] bg-black/20 text-[var(--text-muted)] hover:border-white/15 hover:text-white"
                 }`}
               >
                 {name}
-                <span className="tnum ml-1 text-[10px] opacity-55">{count}</span>
+                <span className="tnum ml-1 text-micro opacity-55">{count}</span>
               </button>
             ))}
             {selectedGenres.length > 0 && (
               <button
                 type="button"
                 onClick={clearGenres}
-                className="ml-1 rounded-full px-2 py-1.5 text-xs font-semibold text-[var(--accent-2)] transition hover:text-white"
+                className="ml-1 rounded-full px-2 py-1.5 text-sub font-semibold text-[var(--accent-2)] transition hover:text-white"
               >
                 清除筛选（{selectedGenres.length}）
               </button>
@@ -191,7 +191,7 @@ export function Top250View() {
       </header>
 
       {error && (
-        <div className="mx-auto mt-16 max-w-md rounded-2xl border border-white/10 bg-black/25 p-8 text-center text-sm text-[var(--text-muted)]">
+        <div className="mx-auto mt-16 max-w-md rounded-2xl border border-white/10 bg-black/25 p-8 text-center text-body text-[var(--text-muted)]">
           {error}
         </div>
       )}
@@ -201,7 +201,7 @@ export function Top250View() {
       {items && (
         <main className="mx-auto mt-8 max-w-[1500px]">
           {filtered.length === 0 ? (
-            <div className="py-20 text-center text-sm text-[var(--text-muted)]">
+            <div className="py-20 text-center text-body text-[var(--text-muted)]">
               没有找到匹配的影片
             </div>
           ) : (
@@ -220,7 +220,7 @@ export function Top250View() {
 
           <div
             ref={loadMoreRef}
-            className="mt-8 flex h-10 items-center justify-center text-xs text-[var(--text-muted)]"
+            className="mt-8 flex h-10 items-center justify-center text-sub text-[var(--text-muted)]"
             aria-live="polite"
           >
             {hasMore
@@ -246,7 +246,7 @@ function RankBadge({ rank }: { rank: number }) {
           : "bg-black/70 text-white";
   return (
     <span
-      className={`tnum absolute -left-1.5 -top-1.5 z-10 min-w-8 rounded-lg px-2 py-1 text-center text-xs font-black shadow-lg ring-1 ring-white/15 ${tone}`}
+      className={`tnum absolute -left-1.5 -top-1.5 z-10 min-w-8 rounded-lg px-2 py-1 text-center text-sub font-black shadow-lg ring-1 ring-white/15 ${tone}`}
     >
       {rank}
     </span>

--- a/apps/web/components/user-menu.tsx
+++ b/apps/web/components/user-menu.tsx
@@ -90,18 +90,22 @@ export function UserMenu({ onOpenSettings, collapsed = false }: UserMenuProps) {
         <AvatarBadge
           nickname={session.nickname}
           avatarUrl={session.avatar_url}
-          className="size-9 text-[13px]"
+          className="size-9 text-ui"
         />
         <div className="min-w-0">
-          <p className="truncate text-[13px] font-semibold text-[var(--text)]">{session.nickname}</p>
-          <p className="truncate text-[11px] text-[var(--text-muted)]">@{session.username}</p>
+          <p className="truncate text-ui font-semibold text-[var(--text)]">{session.nickname}</p>
+          <p className="truncate text-caption text-[var(--text-muted)]">@{session.username}</p>
         </div>
       </div>
       <div className="my-1" />
-      <MenuItem icon={<GearIcon className="size-[18px]" />} label="设置" onClick={() => go()} />
+      <MenuItem
+        icon={<GearIcon className="size-[18px] max-md:size-[22px]" />}
+        label="设置"
+        onClick={() => go()}
+      />
       <div className="my-1" />
       <MenuItem
-        icon={<LogoutIcon className="size-[18px]" />}
+        icon={<LogoutIcon className="size-[18px] max-md:size-[22px]" />}
         label="退出登录"
         danger
         onClick={handleLogout}
@@ -125,15 +129,15 @@ export function UserMenu({ onOpenSettings, collapsed = false }: UserMenuProps) {
         <AvatarBadge
           nickname={session.nickname}
           avatarUrl={session.avatar_url}
-          className="size-9 text-[13px]"
+          className="size-9 text-ui"
         />
         {!collapsed && (
           <>
             <span className="min-w-0 flex-1">
-              <span className="block truncate text-[13px] font-semibold text-[var(--text)]">
+              <span className="block truncate text-ui font-semibold text-[var(--text)]">
                 {session.nickname}
               </span>
-              <span className="block truncate text-[11px] text-[var(--text-muted)]">超级管理员</span>
+              <span className="block truncate text-caption text-[var(--text-muted)]">超级管理员</span>
             </span>
             <svg
               viewBox="0 0 20 20"
@@ -169,7 +173,7 @@ function MenuItem({
     <button
       type="button"
       onClick={onClick}
-      className={`glass-row px-2.5 py-2 text-[13px] font-medium ${
+      className={`glass-row px-2.5 py-2 text-ui font-medium max-md:py-2.5 ${
         danger ? "!text-[var(--danger)] hover:!bg-[rgba(255,107,107,0.12)]" : ""
       }`}
     >


### PR DESCRIPTION
## 背景

移动端字体普遍偏小、不符合 iOS 人机界面规范（HIG）：全站硬编码了 180+ 处 9~13px 的桌面紧凑字号，除输入框外没有任何移动端放大；触控目标也只有顶栏达到 44pt 标准。

## 改动

**语义字号 token 体系（globals.css `@theme`）**

全站字号收口为九档语义 token（`text-micro` ~ `text-title-lg`），Tailwind v4 将其编译为 `font-size: var(--text-*)` 变量引用，移动端只需在媒体查询里覆盖 `:root` 变量即可整体换档：

- 桌面档延续原紧凑排版（10~19px，半像素档就近归并，观感变化 ≤1px）；
- 移动档对齐 iOS HIG：正文 16~17px（iOS Body 17pt）、UI 控件文字 16px、辅助 13~14px、最小 11px（消灭 9~10px 不可读小字）；
- `text-[Npx]` 任意值、`text-xs`/`text-sm` 全量迁移（46 个文件）；≥20px 的展示性大标题不在此列（本就达标且自带断点）。

**触控目标与图标（移动端）**

- 新增 `.touch-target` 工具类：视觉不便放大的小按钮（会话行 ⋯、WebGL 发送键）用伪元素把命中区撑到 44×44（iOS HIG 最小可点目标）；
- composer 附件/发送键提到 44px，会话行、菜单项加大内边距；
- 侧栏导航与菜单行内图标移动端 18→22px，与顶栏图标键既有的 44/22 两档标准统一。

## 验证

- `pnpm build`、`pnpm lint` 通过；
- 产物 CSS 确认：token 定义、`var(--text-*)` 引用、767px 移动覆盖三者齐备；
- Playwright + Chromium 实测（390×844 与 1280×800）：移动端 `body=16px`、桌面 `body=14px`，各档 token 均按预期解析；
- 静态扫描零残留（vendor 中实际被引用的 4 个组件字号均达标，未动 vendor）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY6MZCWuqp5iKCeWizeue1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY6MZCWuqp5iKCeWizeue1)_