### PR TITLE
fix(移动端): 修掉 iOS PWA 底部黑条——铺底层向下超出视口至屏幕物理底边

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -120,6 +120,33 @@
 
   /* 移动端顶栏高度：抽屉、页面吸顶元素都以它为基准让位 */
   --mobile-topbar-h: 52px;
+
+  /* —— iOS 独立 App 的「视口比屏幕矮一截」补偿量 ——
+     iOS 在 apple-mobile-web-app-status-bar-style=black-translucent 下，
+     把整个文档**整体上移**到状态栏底下（这正是顶部沉浸的实现方式），但视口
+     高度并不随之增加：视口顶边贴住屏幕物理顶边，底边却比屏幕物理底边高出
+     整整一个 safe-top。那一截不属于视口，页面里任何 position: fixed; inset: 0
+     的铺底层都够不着，于是露出 <body> 背景色（--bg），看上去就是屏幕底部
+     一条与状态栏等高的黑条——iPhone 全面屏 PWA 实测：黑条高度 == safe-top。
+
+     解决办法不是「让内容避开它」（上一版按底部安全区处理，方向就错了：
+     这一截在视口之外，safe-area-inset-bottom 在此模式下恒为 0，怎么让位都没用），
+     而是让铺底层**向下超出视口** var(--vp-overshoot)，一直铺到屏幕物理底边。
+     UI 本身仍留在视口内，天然就在 Home 指示条上方，无需再额外让位。
+
+     只在 iOS 的独立 App 形态下补偿，见下方媒体查询；其余场景恒为 0。 */
+  --vp-overshoot: 0px;
+}
+
+/* display-mode: standalone 限定「加到主屏后独立打开」（浏览器内访问不受影响）；
+   -webkit-touch-callout 是 iOS WebKit 独有特性（macOS Safari 不支持），
+   两者相与即「iOS PWA」。Android PWA、桌面端与浏览器标签页一律不补偿。 */
+@media (display-mode: standalone) {
+  @supports (-webkit-touch-callout: none) {
+    :root {
+      --vp-overshoot: var(--safe-top);
+    }
+  }
 }
 
 * {
@@ -129,6 +156,10 @@
 html,
 body {
   height: 100%;
+  /* 文档整体撑到屏幕物理高度（视口 + --vp-overshoot），铺底层向下超出视口的
+     那一截才在文档的绘制范围内。页面本身不会因此变得可滚动：body 的
+     overflow: hidden 会传导给视口（HTML 规范的背景/溢出传播规则）。 */
+  min-height: calc(100% + var(--vp-overshoot));
 }
 
 html {
@@ -234,7 +265,8 @@ body {
 body::before {
   content: "";
   position: fixed;
-  inset: 0;
+  /* 底边向下超出视口 --vp-overshoot，铺到屏幕物理底边（见变量处的说明） */
+  inset: 0 0 calc(-1 * var(--vp-overshoot)) 0;
   z-index: 0;
   pointer-events: none;
   background:
@@ -277,7 +309,8 @@ body::before {
 }
 .page-scrim {
   position: fixed;
-  inset: 0;
+  /* 与背景大图同样铺到屏幕物理底边，否则底部会漏出一条未压暗的原图 */
+  inset: 0 0 calc(-1 * var(--vp-overshoot)) 0;
   z-index: 5;
   pointer-events: none;
   animation: page-scrim-in 240ms ease both;
@@ -302,7 +335,7 @@ body::before {
  */
 .page-solid {
   position: fixed;
-  inset: 0;
+  inset: 0 0 calc(-1 * var(--vp-overshoot)) 0;
   z-index: 5;
   pointer-events: none;
   background: #0f0f10;
@@ -992,11 +1025,15 @@ body.cmdk-open .app-shell {
   position: fixed;
   z-index: 60;
   top: 0;
-  bottom: 0;
+  /* 抽屉是通栏浮层，底边同样铺到屏幕物理底边 */
+  bottom: calc(-1 * var(--vp-overshoot));
   left: 0;
   width: 86vw;
   max-width: 320px;
-  padding: calc(var(--safe-top) + 10px) 0 calc(var(--safe-bottom) + 10px) calc(var(--safe-left) + 10px);
+  /* 底部内边距把 --vp-overshoot 一并算进去：抽屉的面板铺到了屏幕物理底边，
+     但内容仍要停在视口内，否则最后一项会被 Home 指示条压住 */
+  padding: calc(var(--safe-top) + 10px) 0
+    calc(var(--safe-bottom) + var(--vp-overshoot) + 10px) calc(var(--safe-left) + 10px);
   transition: transform 280ms cubic-bezier(0.2, 0.8, 0.2, 1);
   will-change: transform;
 }
@@ -1010,7 +1047,7 @@ body.cmdk-open .app-shell {
 }
 .mobile-drawer-scrim {
   position: fixed;
-  inset: 0;
+  inset: 0 0 calc(-1 * var(--vp-overshoot)) 0;
   z-index: 55;
   background: rgba(4, 6, 10, 0.55);
   backdrop-filter: blur(2px);

--- a/apps/web/components/search-command.tsx
+++ b/apps/web/components/search-command.tsx
@@ -374,7 +374,9 @@ function SearchPalette({
   return (
     // 遮罩：mousedown 落在遮罩本身（而非面板内）即关闭
     <div
-      className="search-palette-overlay fixed inset-0 z-[80] flex items-start justify-center px-4 pt-[13vh] max-md:px-2 max-md:pt-[calc(var(--safe-top)+10px)]"
+      // bottom 超出视口 --vp-overshoot：遮罩铺到屏幕物理底边（见 globals.css 的说明）。
+      // 面板 items-start 顶部对齐，加高遮罩不会挪动它。
+      className="search-palette-overlay fixed inset-0 z-[80] flex items-start justify-center px-4 pt-[13vh] [bottom:calc(-1*var(--vp-overshoot))] max-md:px-2 max-md:pt-[calc(var(--safe-top)+10px)]"
       onMouseDown={(event) => event.target === event.currentTarget && onClose()}
     >
       <div

--- a/apps/web/lib/backdrop.tsx
+++ b/apps/web/lib/backdrop.tsx
@@ -199,7 +199,9 @@ export function BackdropProvider({ children }: { children: React.ReactNode }) {
           （opacity 由 state 驱动，不是 CSS 变量驱动，可以安全做 transition） */}
       <div
         aria-hidden="true"
-        className="pointer-events-none fixed inset-0 z-[1] transition-opacity duration-700 ease-out"
+        /* bottom 向下超出视口 --vp-overshoot：与 body::before 同样铺到屏幕物理
+           底边，否则 iOS 独立 App 下底部会漏出一条底色（见 globals.css 的说明） */
+        className="pointer-events-none fixed inset-0 z-[1] [bottom:calc(-1*var(--vp-overshoot))] transition-opacity duration-700 ease-out"
         style={{
           opacity: overrideVisible ? 1 : 0,
           backgroundImage: overrideReady ? `url("${overrideReady}")` : undefined,


### PR DESCRIPTION
## 问题

iOS「添加到主屏幕」后打开，屏幕底部有一条与状态栏等高的深色横条，背景大图铺不到物理底边。上一版（234f150）按「底部安全区」来修，方向错了，问题依旧。

## 成因

对用户截图（iPhone 16 Pro Max）逐像素测量：

- 底部色块从 y=2532 到底，颜色恒为 `#0a0b10`（即 `--bg`，不是纯黑），边界是硬边 —— 说明背景图那一层根本够不到那里；
- 色块高度 ≈ 70pt；由顶栏图标位置反推的 `safe-area-inset-top` 也 ≈ 70pt，**两者相等**。

这是 `apple-mobile-web-app-status-bar-style: black-translucent` 的行为：iOS 靠把整个文档**整体上移**到状态栏底下来实现顶部沉浸，但视口高度不跟着增加 —— 视口顶边贴住屏幕物理顶边，底边却比屏幕物理底边高出整整一个 `safe-top`。那一截在视口之外，页面里所有 `position: fixed; inset: 0` 的铺底层都够不着，露出的是 `<body>` 底色。

因此上一版的方向不成立：这一截不在视口内，此模式下 `safe-area-inset-bottom` 恒为 0，内容再怎么让位也补不上。

## 改动

新增 `--vp-overshoot`，仅在 iOS 独立 App 形态下取 `safe-top`（`display-mode: standalone` 与 `-webkit-touch-callout` 相与限定 iOS PWA；Android PWA、桌面端与浏览器标签页恒为 `0px`，无副作用），再让全屏铺底层的底边向下超出视口这一截，铺到屏幕物理底边：

- `body::before`（背景大图）、`lib/backdrop.tsx` 的换图淡入层；
- `.page-scrim` / `.page-solid`（页面蒙版与沉浸实底）；
- `.mobile-drawer` 与其遮罩、搜索命令面板遮罩；
- `html/body` 撑到屏幕物理高度，保证超出视口的那一截在绘制范围内（`body` 的 `overflow: hidden` 传导给视口，页面不会因此变得可滚动）；
- 抽屉底部内边距把这一截算进去：面板铺到底，内容仍停在视口内，不被 Home 指示条压住。

UI 本身继续留在视口内，天然就在 Home 指示条上方，无需额外让位。上一版的 `.scroll-safe` 未改动 —— 它在 Android / 非全面屏路径上仍然正确。

## 验证

- `pnpm --filter web build` 通过；
- `pnpm --filter web lint` 0 error（2 条 warning 为既有、位于本次未改动的文件）；
- 产物 CSS 已核对：`--vp-overshoot` 各条规则均正确编译，`[bottom:...]` 工具类排在 `.inset-0` 之后（覆盖生效）。

注：iOS 实机行为无法在 CI 环境验证，需部署后从主屏图标重新打开确认。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbwnXN2AJgFoSaEPnAXMTg)_