### PR TITLE
fix(web): 季选择器标出未入库的季，默认落在第一个在库的季

### DIFF
--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -873,6 +873,17 @@ function SourceLink({ href, label }: { href: string; label: string }) {
 }
 
 /**
+ * 季号 → 展示名（0 是特别篇，TMDB 的 specials 惯例）。整季一个文件都没有的
+ * 季标"未入库"：季选择器里元数据的季和实有的季混在一起，不标出来用户会以为
+ * 自己本地存了那么多季。原生 select 收起时显示的就是选中项的文本，所以这个
+ * 后缀在展开和收起两种状态下都看得到。
+ */
+function seasonLabel(season: number, owned: boolean): string {
+  const name = season === 0 ? "特别篇" : `第 ${season} 季`;
+  return owned ? name : `${name} · 未入库`;
+}
+
+/**
  * 剧集分集区（播放器式）：季选择器 + 分集横滚缩略图卡（剧照 + 集名，
  * 缺集置灰），点选一集在下方展开该集的简介、真实规格与物理文件——
  * 剧集的浏览心智是"看这季有哪些集、这集是什么规格"，与电影的版本切换
@@ -886,7 +897,18 @@ function SeasonEpisodesSection({
   detail: LibraryItemDetail;
 }) {
   const seasons = detail.seasons;
-  const [season, setSeason] = useState(seasons[0]);
+  // 季选择器列的是「元数据的季 ∪ 库里实有的季」，本地没有的季也在里面（看得到
+  // 缺口）。所以要单独算出哪些季真在库——口径与后端 owned_seasons 一致：台账
+  // 文件的季号集合。
+  const ownedSeasons = useMemo(
+    () => new Set(detail.files.map((f) => f.season_number)),
+    [detail.files],
+  );
+  // 默认落在第一个在库的季，而不是季号最小的那一季：只存了第 5、6 季的剧，
+  // 打开详情页就停在满屏置灰的第 1 季，第一眼像"我的片子没了"
+  const [season, setSeason] = useState(
+    () => seasons.find((s) => ownedSeasons.has(s)) ?? seasons[0],
+  );
   const [data, setData] = useState<SeasonEpisodes | null>(null);
   const [failed, setFailed] = useState(false);
   const [selected, setSelected] = useState<number | null>(null);
@@ -935,13 +957,13 @@ function SeasonEpisodesSection({
           >
             {seasons.map((s) => (
               <option key={s} value={s}>
-                {s === 0 ? "特别篇" : `第 ${s} 季`}
+                {seasonLabel(s, ownedSeasons.has(s))}
               </option>
             ))}
           </select>
         ) : (
           <span className="text-sub text-[var(--text-muted)]">
-            {season === 0 ? "特别篇" : `第 ${season} 季`}
+            {seasonLabel(season, ownedSeasons.has(season))}
           </span>
         )}
         {data && (


### PR DESCRIPTION
## 背景

媒体库条目详情页的季选择器，列的是「元数据的季 ∪ 库里实有的季」——后端 `api/routes/libraries.py:1183-1197` 刻意做的并集，目的是让用户看得到缺口（分集那层同理，缺集置灰 + 「在库 N / M 集」）。

但前端两处没跟上这个口径：

- 选择器只写「第 N 季」，本地没有的季和有的季长得一模一样。TMDB 上 10 季、本地只存 2 季时，下拉里 10 个选项看起来都像自己的片子。
- 默认选中 `seasons[0]`，即季号最小的那一季。只存了第 5、6 季的剧，打开详情页就停在满屏置灰的第 1 季，第一眼像片子没了。

## 改动

只动 `apps/web/components/library-item-detail-view.tsx`，不涉及接口和后端。

- 新增 `seasonLabel(season, owned)`：整季一个文件都没有的季，标签后缀「· 未入库」。原生 `select` 收起时显示的就是选中项文本，展开挑季和收起看当前季两种状态下都看得到。
- 默认季改为「第一个在库的季」，与分集默认选中第一个 `owned` 集的既有逻辑对齐——季这层之前漏了这一步。
- 在库判定用 `detail.files` 的季号集合，与后端 `owned_seasons` 同一口径，无需扩接口。

## 验证

- `pnpm web:typecheck` 通过
- `pnpm web:lint` 0 error（2 个 warning 来自未改动的 `glass-panel.tsx` / `library-detail-view.tsx`，是既有的无用 eslint-disable 注释）

## 未包含

海报格（`/library` 与 `/library/[id]` 的库存墙）的季数仍是纯在库口径（`services/library/items.py:372`），显示「2 季 · 15 集」说的就是本地实有。要改成「2 / 10 季」这类完整度口径需要列表接口补元数据总季数，改动更大，本 PR 未做。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCPF8JSRDFMpSeYvZhqZED)_