### PR TITLE
fix(移动端): 修掉 iOS PWA 弹出键盘再收起后整页上移错位

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -156,10 +156,18 @@
 html,
 body {
   height: 100%;
-  /* 文档整体撑到屏幕物理高度（视口 + --vp-overshoot），铺底层向下超出视口的
-     那一截才在文档的绘制范围内。页面本身不会因此变得可滚动：body 的
-     overflow: hidden 会传导给视口（HTML 规范的背景/溢出传播规则）。 */
-  min-height: calc(100% + var(--vp-overshoot));
+  /*
+   * 注意：这里**不要**为了补偿 --vp-overshoot 去加 min-height。
+   *
+   * 曾经写过 min-height: calc(100% + var(--vp-overshoot)) 想把文档撑到屏幕物理
+   * 高度，结果是文档凭空多出这一截可滚动区域。overflow: hidden 只挡得住用户
+   * 主动滚动，挡不住 iOS 自己滚：软键盘弹出时系统会滚动页面去露出聚焦的输入框，
+   * 键盘收起后这段滚动偏移**不会还原**——整页就此上移一个 --vp-overshoot，
+   * 顶栏叠进状态栏里（实测：点输入框弹出键盘再收起，页面即错位）。
+   *
+   * 铺底层用的是 position: fixed + 负 bottom，fixed 元素不参与文档的滚动溢出，
+   * 因此不会制造这段偏移，也无需文档配合撑高。
+   */
 }
 
 html {


### PR DESCRIPTION
## 问题

#24 合并后，底部黑条确实没了（用户实机截图逐像素核对：画面已铺到屏幕物理底边），但引入了新问题：**点输入框弹出软键盘、再收起，整页向上错位**，顶栏叠进状态栏里。

## 成因

是 #24 里那行「保险」写法引起的：

```css
html, body { min-height: calc(100% + var(--vp-overshoot)); }
```

它把文档撑到屏幕物理高度，副作用是文档凭空多出 `--vp-overshoot` 这一截**可滚动区域**。`overflow: hidden` 只挡得住用户主动滚动，挡不住 iOS 自己滚：软键盘弹出时系统会滚动页面去露出聚焦的输入框，键盘收起后这段滚动偏移**不会还原**。

实机截图测量佐证：错位量 204px，与 `--vp-overshoot`（== `safe-top`）、与修复前黑条的高度完全一致 —— 三者是同一个量。

## 改动

删掉这一行。铺底层用的是 `position: fixed` + 负 `bottom`，而 fixed 元素不参与文档的滚动溢出，本来就不需要文档配合撑高 —— #24 的黑条修复靠的是 fixed 层本身，删掉这行不影响。原地留注释记录这条坑，避免后来者再补一次。

## 验证

- `pnpm --filter web build` 通过；
- 产物 CSS 已核对：`min-height` 相关规则确认移除，`--vp-overshoot` 的其余各条规则不受影响。

注：iOS 实机行为无法在 CI 环境验证，需部署后实测。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbwnXN2AJgFoSaEPnAXMTg)_