### PR TITLE
fix(移动端): 全屏浮层适配收口——弹窗/灯箱/工单面板统一铺到物理底边

### DIFF
--- a/apps/web/components/image-lightbox.tsx
+++ b/apps/web/components/image-lightbox.tsx
@@ -131,13 +131,15 @@ export function ImageLightbox({
   if (images.length === 0) return null;
 
   return createPortal(
-    // 点击空白处关闭；内容区各元素自行 stopPropagation
+    // 点击空白处关闭；内容区各元素自行 stopPropagation。
+    // bottom 越出视口 --vp-overshoot：黑底铺到屏幕物理底边（iOS 独立 App
+    // 的视口矮一截，见 globals.css）；底部缩略图条用加大的 pb 留在视口内
     <div
       role="dialog"
       aria-modal="true"
       aria-label={title ? `图片浏览：${title}` : "图片浏览"}
       onClick={onClose}
-      className="fixed inset-0 z-[70] flex flex-col bg-black/85 backdrop-blur-md"
+      className="fixed inset-0 z-[70] flex flex-col bg-black/85 backdrop-blur-md [bottom:calc(-1*var(--vp-overshoot))]"
     >
       {/* 顶栏：计数 + 标题 + 关闭 */}
       <div className="flex shrink-0 flex-wrap items-center gap-3 px-4 py-3 text-white/85 [padding-top:calc(0.75rem+var(--safe-top))] max-md:gap-2 max-md:px-3">
@@ -262,7 +264,7 @@ export function ImageLightbox({
       {images.length > 1 && (
         <div
           onClick={(e) => e.stopPropagation()}
-          className="scroll-none shrink-0 overflow-x-auto px-4 py-3 [padding-bottom:calc(0.75rem+var(--safe-bottom))] max-md:px-3"
+          className="scroll-none shrink-0 overflow-x-auto px-4 py-3 [padding-bottom:calc(0.75rem+var(--safe-bottom)+var(--vp-overshoot))] max-md:px-3"
         >
           <div className="mx-auto flex w-max gap-2">
             {images.map((url, i) => (

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -1228,7 +1228,14 @@ function IssueDrawer({
     }`;
 
   return createPortal(
-    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label="库工单">
+    // bottom 越出视口 --vp-overshoot：遮罩与右侧全高面板铺到屏幕物理底边
+    // （iOS 独立 App 的视口矮一截，见 globals.css）；列表内容用加大的 pb 留在视口内
+    <div
+      className="fixed inset-0 z-50 [bottom:calc(-1*var(--vp-overshoot))]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="库工单"
+    >
       <button
         type="button"
         aria-label="关闭"
@@ -1357,8 +1364,9 @@ function IssueDrawer({
           </p>
         )}
 
-        {/* 列表区：独立滚动 */}
-        <div className="scroll-thin min-h-0 flex-1 space-y-2 overflow-y-auto px-5 py-4">
+        {/* 列表区：独立滚动。面板底边已铺到物理底边，滚动到底时最后一行
+            要停在安全区与视口截差之上，不被 Home 指示条压住 */}
+        <div className="scroll-thin min-h-0 flex-1 space-y-2 overflow-y-auto px-5 pt-4 pb-[calc(1rem+var(--safe-bottom)+var(--vp-overshoot))]">
           {open === "missing" &&
             missingShown.map((item) => (
               <MissingRow

--- a/apps/web/components/modal.tsx
+++ b/apps/web/components/modal.tsx
@@ -69,8 +69,11 @@ export function Modal({
     // 只有上方两角圆。这是手机上模态的既定语言——出现位置靠近拇指、
     // 内容宽度不被 max-w 白白挤掉，长表单也不会被吊在屏幕正中上下都留空。
     // 底部内边距吃安全区，最后一颗按钮不会压在 Home 指示条上。
+    // bottom 越出视口 --vp-overshoot：iOS 独立 App 的视口比屏幕矮一截（见
+    // globals.css），不越出的话遮罩在屏幕底部留一条没压暗的缝、移动端 bottom
+    // sheet 也会悬在物理底边上方。面板内容用加大的 pb 留在视口内（见下方）。
     <div
-      className={`fixed inset-0 ${raised ? "z-[60]" : "z-50"} flex items-center justify-center p-6 max-md:items-end max-md:p-0`}
+      className={`fixed inset-0 [bottom:calc(-1*var(--vp-overshoot))] ${raised ? "z-[60]" : "z-50"} flex items-center justify-center p-6 max-md:items-end max-md:p-0`}
       role="dialog"
       aria-modal="true"
       aria-label={label}
@@ -85,7 +88,7 @@ export function Modal({
         className="absolute inset-0 cursor-default bg-black/60 backdrop-blur-sm"
       />
       <div
-        className={`relative w-full ${WIDTH_CLS[width]} overflow-hidden rounded-2xl border border-white/10 bg-[rgba(16,18,26,0.92)] shadow-[0_32px_90px_rgba(0,0,0,0.7)] backdrop-blur-2xl max-md:!max-w-none max-md:rounded-b-none max-md:border-x-0 max-md:border-b-0 max-md:pb-[var(--safe-bottom)] ${panelClassName}`}
+        className={`relative w-full ${WIDTH_CLS[width]} overflow-hidden rounded-2xl border border-white/10 bg-[rgba(16,18,26,0.92)] shadow-[0_32px_90px_rgba(0,0,0,0.7)] backdrop-blur-2xl max-md:!max-w-none max-md:rounded-b-none max-md:border-x-0 max-md:border-b-0 max-md:pb-[calc(var(--safe-bottom)+var(--vp-overshoot))] ${panelClassName}`}
       >
         {children}
       </div>

--- a/apps/web/components/notice-center.tsx
+++ b/apps/web/components/notice-center.tsx
@@ -103,7 +103,9 @@ export function NoticeCenter({ collapsed }: { collapsed: boolean }) {
         onClose={() => setOpen(false)}
         label="待处理事项"
         width="lg"
-        panelClassName="flex max-h-[76vh] flex-col"
+        // dvh 而非 vh：iOS 浏览器里 vh 按「地址栏收起后」的大视口算，76vh 的
+        // 弹层会超出实际可视高度（subscribe-dialog 同款约定）
+        panelClassName="flex max-h-[76dvh] flex-col"
       >
         <div className="flex items-center gap-2 px-5 pb-3 pt-5">
           <BellIcon className="size-[18px] text-[var(--danger)]" />

--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -1331,7 +1331,7 @@ function FacetDropdown<T extends string | number>({
         </span>
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-30 mt-2 max-h-[46vh] w-max max-w-[420px] overflow-y-auto rounded-2xl border border-white/[0.12] bg-[rgba(14,16,22,0.96)] p-3 shadow-2xl backdrop-blur-2xl max-md:max-w-[calc(100vw-2rem)]">
+        <div className="absolute left-0 top-full z-30 mt-2 max-h-[46dvh] w-max max-w-[420px] overflow-y-auto rounded-2xl border border-white/[0.12] bg-[rgba(14,16,22,0.96)] p-3 shadow-2xl backdrop-blur-2xl max-md:max-w-[calc(100vw-2rem)]">
           <div className="flex flex-wrap gap-1.5">
             {options.map((o) => (
               <FacetChip
@@ -1460,7 +1460,7 @@ function FilterSheet({
     <>
       {/* 点外/Esc 关闭由 FilterToolbar 的 useDismiss 承担（触发器与弹层同容器） */}
       {/* 宽度收着点：右侧浮层少遮结果列表，让「选择即生效」的变化被看见 */}
-      <div className="absolute right-0 top-full z-30 mt-2 max-h-[60vh] w-[480px] max-w-[82vw] overflow-y-auto rounded-2xl border border-white/[0.12] bg-[rgba(14,16,22,0.96)] p-4 shadow-2xl backdrop-blur-2xl">
+      <div className="absolute right-0 top-full z-30 mt-2 max-h-[60dvh] w-[480px] max-w-[82vw] overflow-y-auto rounded-2xl border border-white/[0.12] bg-[rgba(14,16,22,0.96)] p-4 shadow-2xl backdrop-blur-2xl">
         <div className="mb-4 flex items-center justify-between">
           <div>
             <p className="text-ui font-medium text-[var(--text)]">筛选结果</p>


### PR DESCRIPTION
## 背景

对移动端 / iOS PWA 适配做了一次整体核查（此前黑条问题反复了三轮，根因是各处修复没有统一规则）。本 PR 把全站所有全屏固定层收口到同一条已验证的规则（抽屉、搜索面板已在用）：

> **视觉铺到屏幕物理底边**（`bottom` 越出视口 `--vp-overshoot`），**交互内容用加大的底部内边距留在视口内**。

这条规则在两种视口几何下都安全：

- 视口正常时：越出的部分在屏幕外不可见，加大的内边距恰好把内容顶回物理底边之上；
- 视口矮一截时（iOS PWA 实测状态）：越出的部分补上底部缝隙，内容仍在可触达区域内。

## 本次补齐的浮层

此前遗漏，遮罩会在屏幕底部留一条没压暗的缝、移动端 bottom sheet 会悬在物理底边上方：

| 浮层 | 改动 |
| --- | --- |
| `Modal`（全站弹窗基座，覆盖订阅 / 整理 / 选图 / 目录 / 通知中心等十余个弹窗） | 容器越出 + 移动端面板 `pb` 计入 `--vp-overshoot` |
| 图片灯箱 `image-lightbox` | 黑底越出 + 底部缩略图条 `pb` 计入 `--vp-overshoot` |
| 库工单右侧全高面板 | 遮罩与面板越出 + 列表区 `pb` 计入安全区与越出量 |

## 视口单位统一

`vh` 在 iOS 浏览器按「地址栏收起后」的大视口算，弹层会超出实际可视高度：

- 通知中心弹层 `max-h-[76vh]` → `76dvh`（对齐 `subscribe-dialog` 既有约定）；
- 搜索页两个下拉面板 `46vh` / `60vh` → `dvh`。

## 核查过、确认无需改动的项

- **`.scroll-safe` 覆盖**：13 个页面级滚动容器全有；新任务页（内容居中）、会话页（底部是输入行）、通知中心（走 Modal）按设计不需要；
- **贴顶让位**：全局顶栏、PageNav、灯箱顶栏、搜索面板、抽屉、登录页的 `safe-top` 均已处理；
- **锚定小菜单**（会话行 / 库卡片 ⋯ 菜单、用户菜单）：都在视口内定位，无需越出；
- **搜索结果页透明点击拦截层**：无视觉，无需越出；
- **键盘归位**（`viewport-scroll-reset`）：挂在根布局，覆盖含登录页在内的所有页面。

## 验证

- `pnpm --filter web build` 通过；`pnpm --filter web lint` 0 error（2 条 warning 为既有）。
- iOS 实机验证清单：① 弹任意弹窗（订阅、通知中心），遮罩应压到屏幕最底、bottom sheet 贴底；② 打开图片灯箱，黑底到底、缩略图条不被 Home 指示条压住；③ 库详情页打开「工单」，面板到底、列表滚到底最后一行完整可见。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbwnXN2AJgFoSaEPnAXMTg)_