### PR TITLE
库收藏范围：区域/类型全选快捷键 + 重叠提示给出具体修复指引

### DIFF
--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -105,10 +105,18 @@ function regionLabels(regions: string[], options: RoutingOptions): string[] {
   return parts;
 }
 
+/** 规则字段 → 界面维度名（v1 仅两个维度），用于重叠提示里点名该补哪个条件。 */
+const RULE_FIELD_LABELS: Record<string, string> = {
+  genres: "类型",
+  origin_countries: "区域",
+};
+
 /**
  * 同类型两库的收藏范围可能同时命中同一部作品、且特异性（条件条数）相同
  * ——命中顺序只能靠创建先后，给只读提示（不阻断：加一个条件即可消解）。
  * 「可能同时命中」= 两库共同声明的每个字段取值都有交集。
+ * 提示不止陈述事实，还给出具体做法：点名给创建更晚（即将吃亏）的那个库
+ * 补上它缺的维度——条件数多者优先命中，补完歧义即消。
  */
 function routingOverlapWarnings(libraries: MediaLibrary[]): string[] {
   const declared = libraries.filter((l) => l.match_rules.length > 0);
@@ -124,10 +132,19 @@ function routingOverlapWarnings(libraries: MediaLibrary[]): string[] {
         return ra.values.some((v) => rb.values.includes(v));
       });
       if (compatible) {
-        const first = (a.id ?? 0) < (b.id ?? 0) ? a : b;
+        const [first, later] = (a.id ?? 0) < (b.id ?? 0) ? [a, b] : [b, a];
+        const laterFields = new Set(later.match_rules.map((r) => r.field));
+        const missing = Object.entries(RULE_FIELD_LABELS)
+          .filter(([field]) => !laterFields.has(field))
+          .map(([, label]) => label);
+        const fix =
+          missing.length > 0
+            ? `想让「${later.name}」优先收这类作品：编辑它，补上「${missing.join("」或「")}」条件` +
+              `（用「全选」也可以）——条件多的库优先命中；想维持现状则无需改动。`
+            : `两库已声明相同的维度：错开重叠的取值即可消除歧义。`;
         warnings.push(
           `「${a.name}」与「${b.name}」的收藏范围可能同时命中同一部作品且条件数相同，` +
-            `届时优先进创建更早的「${first.name}」；给其中一个加条件可消除歧义`,
+            `届时优先进创建更早的「${first.name}」。${fix}`,
         );
       }
     }

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -1179,6 +1179,24 @@ export function LibraryFormDialog({
                 {/* 预设组保留为快捷键：一键选中/取消整组，避免「欧美」要点十下 */}
                 <div className="mt-2 flex flex-wrap items-center gap-1.5">
                   <span className="text-caption text-[var(--text-faint)]">快捷组合</span>
+                  {/* 全选/清空：如「纪录片库收全部区域」这类声明逐个点太费劲；
+                      全选后条件数 +1，还能顺带压过单条件区域库消除重叠歧义 */}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const all = Object.keys(routingOptions.country_names);
+                      setMatchRegions((prev) =>
+                        all.every((c) => prev.includes(c)) ? [] : [...new Set([...prev, ...all])],
+                      );
+                    }}
+                    className="glass-row nav-item !w-auto px-2.5 py-1 text-caption font-medium"
+                  >
+                    {Object.keys(routingOptions.country_names).every((c) =>
+                      matchRegions.includes(c),
+                    )
+                      ? "清空"
+                      : "全选"}
+                  </button>
                   {routingOptions.region_presets.map((preset) => {
                     const active = preset.countries.every((c) => matchRegions.includes(c));
                     return (
@@ -1206,7 +1224,21 @@ export function LibraryFormDialog({
               </div>
               <div>
                 <label className={labelClass}>类型（勾选任一即匹配）</label>
-                <div className="flex flex-wrap gap-1.5">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {/* 与区域侧同款的全选/清空快捷键（类型没有预设组，只此一个） */}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setMatchGenres((prev) =>
+                        genreOptions.every((g) => prev.includes(g.id))
+                          ? []
+                          : [...new Set([...prev, ...genreOptions.map((g) => g.id)])],
+                      )
+                    }
+                    className="glass-row nav-item !w-auto px-2.5 py-1 text-caption font-medium"
+                  >
+                    {genreOptions.every((g) => matchGenres.includes(g.id)) ? "清空" : "全选"}
+                  </button>
                   {genreOptions.map((g) => (
                     <button
                       key={g.id}


### PR DESCRIPTION
## 背景

用户建了「纪录片」库（只声明类型=纪录）后，与只声明区域的「大陆剧/日韩剧/港台剧/欧美剧」出现四条重叠歧义提示——条件数打平只能按创建先后裁决，且原提示只说"给其中一个加条件"，不知道具体该怎么做。

## 改动

1. **库表单收藏范围：区域与类型 chips 增加全选/清空快捷键**
   - 区域侧加在「快捷组合」行首，类型侧同款（此前类型无任何快捷键）；
   - 全部已选时按钮显示「清空」；全选采用并入语义，保留不在当前选项列表里的已选值；
   - 给纪录片库全选区域后条件数变为 2，特异性压过单条件区域库，歧义随之消除。

2. **重叠提示从陈述问题升级为具体修复指引**
   - 点名创建更晚（打平时吃亏）的那个库，列出它缺的维度（区域/类型），说明补上后条件多者优先命中、维持现状则无需改动；
   - 两库维度已相同时改为提示错开重叠取值。

## 验证

- `tsc --noEmit` 通过（仅预存的 `baseUrl` 弃用提示，与本改动无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqQ2F7mxVtPbLcEqHafGTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqQ2F7mxVtPbLcEqHafGTi)_