### PR TITLE
移动端会话页体验优化 + Kimi K3 模型预设

### DIFF
--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -349,6 +349,8 @@ function processSummary(items: AgentProcessItem[]): string {
 /**
  * 处理过程折叠块（仿 Claude）：头部进行中显示实时状态、完成后显示一句话
  * 总结；点击展开思考与工具调用的混合列表（按实际发生顺序）。
+ * 展开后是第二级折叠：工具调用只呈现单行摘要清单，点击某一行才展开
+ * 该次调用的参数与输出——一轮动辄十几次调用，全量平铺等于没有排版。
  */
 const ProcessBlock = memo(function ProcessBlock({ segment, active }: { segment: AgentTurnSegment & { kind: "process" }; active: boolean }) {
   const [open, setOpen] = useState(false);
@@ -405,47 +407,87 @@ function toolInput(tool: AgentTurnToolCall): { lang: CodeLang; code: string } | 
   }
 }
 
-/** 单次工具调用卡片：参数完整展示（shiki 高亮）+ 生成/执行中/回执三种状态。
- *  memo：store 对工具条目也是不可变更新，未被触碰的卡片整卡跳过；
- *  参数明细的 JSON.parse/stringify（大参数可达几 KB）按 tool 缓存，
+/**
+ * 单行参数摘要（清单态用）：bash 把命令压成一行，其余工具压成
+ * 「键: 值」串。只求一眼认出这次调用在干什么，超出部分由 CSS 截断。
+ */
+function toolSummary(tool: AgentTurnToolCall): string {
+  const raw = tool.label.slice(tool.name.length + 1, -1);
+  if (!raw || raw === "{}") return "";
+  try {
+    const args = JSON.parse(raw) as Record<string, unknown>;
+    if (tool.name === "bash" && typeof args.command === "string") {
+      return args.command.replace(/\s+/g, " ").trim();
+    }
+    return Object.entries(args)
+      .map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)
+      .join(", ");
+  } catch {
+    return raw;
+  }
+}
+
+/** 单次工具调用（对齐 Claude/Codex 的两级呈现）：默认只占一行——
+ *  工具名 + 参数摘要 + 状态尾标（✓/✗/进度环），点击行内任意处才展开
+ *  参数（shiki 高亮）与输出详情。
+ *  memo：store 对工具条目也是不可变更新，未被触碰的行整行跳过；
+ *  摘要与参数明细的 JSON.parse/stringify（大参数可达几 KB）按 tool 缓存，
  *  不再在每次渲染中内联执行。 */
 const ToolCallCard = memo(function ToolCallCard({ tool }: { tool: AgentTurnToolCall }) {
-  const input = useMemo(
-    () => (tool.argsDone === false ? null : toolInput(tool)),
-    [tool],
-  );
+  const [open, setOpen] = useState(false);
+  const streaming = tool.argsDone === false;
+  const input = useMemo(() => (streaming ? null : toolInput(tool)), [tool, streaming]);
+  const summary = useMemo(() => (streaming ? "" : toolSummary(tool)), [tool, streaming]);
+
   return (
-    <div className="rounded-lg border border-white/[0.05] bg-white/[0.02] px-2.5 py-1.5">
-      {tool.argsDone === false ? (
-        // 参数生成中：工具名固定，参数区右锚定滚动显示最新生成的尾部——
-        // 长参数溢出时新字符持续从右侧推入，肉眼可见任务仍在进行
-        <p className="flex font-mono text-caption text-[var(--accent-2)]">
-          <span className="shrink-0">⚙ {tool.name}(</span>
+    <div className="min-w-0">
+      <button
+        type="button"
+        // 参数生成中没有可展开的定稿详情，此时行只作进度展示、不可点击
+        disabled={streaming}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full min-w-0 items-center gap-1.5 py-0.5 text-left font-mono text-caption disabled:cursor-default"
+      >
+        <ChevronRightIcon
+          className={`size-3 shrink-0 text-[var(--text-faint)] transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="shrink-0 text-[var(--accent-2)]">{tool.name}</span>
+        {streaming ? (
+          // 参数生成中：右锚定滚动显示最新生成的尾部——长参数溢出时新字符
+          // 持续从右侧推入，肉眼可见任务仍在进行
           <span className="flex min-w-0 flex-1 justify-end overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_24px)]">
-            <span className="whitespace-nowrap">
+            <span className="whitespace-nowrap text-[var(--text-faint)]">
               {tool.label.slice(tool.name.length + 1).slice(-300)}
             </span>
           </span>
-        </p>
-      ) : (
-        <>
-          <p className="font-mono text-caption text-[var(--accent-2)]">⚙ {tool.name}</p>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-[var(--text-faint)]">{summary}</span>
+        )}
+        {streaming || tool.output === undefined ? (
+          <span className="shrink-0">
+            <ProgressRing />
+          </span>
+        ) : (
+          <span className={`shrink-0 ${tool.isError ? "text-[#ff6b6b]" : "text-[var(--text-faint)]"}`}>
+            {tool.isError ? "✗" : "✓"}
+          </span>
+        )}
+      </button>
+      {open && !streaming && (
+        <div className="mt-1 min-w-0 rounded-lg border border-white/[0.05] bg-white/[0.02] px-2.5 py-1.5">
           {input && <HighlightedCode code={input.code} lang={input.lang} />}
-        </>
-      )}
-      {tool.argsDone === false ? (
-        <p className="mt-0.5 animate-pulse text-caption text-[var(--text-faint)]">生成参数中…</p>
-      ) : tool.output === undefined ? (
-        <p className="mt-0.5 text-caption text-[var(--text-faint)]">执行中…</p>
-      ) : (
-        <div
-          // 行高用相对值：字号随语义 token 在移动端换档（11→13px），固定 16px 行高会挤死多行日志
-          className={`scroll-thin mt-1 max-h-44 overflow-y-auto whitespace-pre-wrap break-words font-mono text-caption leading-[1.45] ${
-            tool.isError ? "text-[#ff6b6b]" : "text-[var(--text-muted)]"
-          }`}
-        >
-          {tool.isError ? "✗ " : "✓ "}
-          {tool.output}
+          {tool.output === undefined ? (
+            <p className="mt-0.5 text-caption text-[var(--text-faint)]">执行中…</p>
+          ) : (
+            <div
+              // 行高用相对值：字号随语义 token 在移动端换档（11→13px），固定 16px 行高会挤死多行日志
+              className={`scroll-thin mt-1 max-h-44 overflow-y-auto whitespace-pre-wrap break-words font-mono text-caption leading-[1.45] ${
+                tool.isError ? "text-[#ff6b6b]" : "text-[var(--text-muted)]"
+              }`}
+            >
+              {tool.output}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -108,7 +108,9 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
             // 只在跨越阈值时落 state，滚动过程中不做无谓的重渲染
             setAtBottom((previous) => (previous === near ? previous : near));
           }}
-          className="scroll-thin min-h-0 flex-1 overflow-y-auto px-6 py-6 max-md:px-4 max-md:py-4"
+          // overflow-x-hidden 兜底：任何子元素意外超宽（如未换行的长 token）都不许
+          // 把消息列撑出横向滚动——移动端一旦横滚，整列内容会被推出屏幕左侧
+          className="scroll-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-6 py-6 max-md:px-4 max-md:py-4"
         >
           <div className="mx-auto max-w-3xl space-y-8">
             {conversation.turns.map((turn) => (
@@ -164,7 +166,7 @@ const TurnView = memo(function TurnView({ turn }: { turn: AgentTurn }) {
     <div className="group/turn space-y-3">
       {/* 用户消息：右侧玻璃气泡 */}
       <div className="flex justify-end">
-        <div className="max-w-[80%] whitespace-pre-wrap rounded-2xl bg-[var(--glass-fill-active)] px-4 py-3 text-body leading-6 text-[var(--text)]">
+        <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl bg-[var(--glass-fill-active)] px-4 py-3 text-body leading-6 text-[var(--text)]">
           {turn.input}
         </div>
       </div>
@@ -190,7 +192,7 @@ const TurnView = memo(function TurnView({ turn }: { turn: AgentTurn }) {
         })}
 
         {turn.status === "error" && (
-          <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-3.5 py-2.5 text-ui leading-5 text-[#ff6b6b]">
+          <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-3.5 py-2.5 text-ui leading-5 break-words text-[#ff6b6b]">
             {turn.error}
           </div>
         )}
@@ -366,9 +368,11 @@ const ProcessBlock = memo(function ProcessBlock({ segment, active }: { segment: 
         <div className="mt-1.5 space-y-2 border-l-2 border-white/[0.08] pl-3">
           {segment.items.map((item, index) =>
             item.kind === "thinking" ? (
+              // break-words 必须有：思考文本常出现资源名这种几十字符无空格的长
+              // token（点号不是换行机会点），不断词会把整个消息列撑出横向溢出
               <p
                 key={index}
-                className="whitespace-pre-wrap text-sub leading-5 text-[var(--text-faint)]"
+                className="whitespace-pre-wrap break-words text-sub leading-5 text-[var(--text-faint)]"
               >
                 {item.text}
               </p>
@@ -476,7 +480,7 @@ const CompactionCard = memo(function CompactionCard({
       </button>
       {open && (
         <div className="mt-1.5 space-y-1.5 border-l-2 border-white/[0.08] pl-3">
-          <p className="whitespace-pre-wrap text-sub leading-5 text-[var(--text-faint)]">
+          <p className="whitespace-pre-wrap break-words text-sub leading-5 text-[var(--text-faint)]">
             {segment.summary}
           </p>
           <p className="text-caption text-[var(--text-faint)]">

--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -15,6 +15,7 @@ import {
   type AgentTurnToolCall,
   useAgentConversations,
 } from "@/lib/agent-conversations";
+import { usePageChrome } from "@/lib/page-chrome";
 import { usePageTitle } from "@/lib/use-page-title";
 
 /**
@@ -34,6 +35,15 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
   const { get, open, send, stop } = useAgentConversations();
   const conversation = get(conversationId);
   usePageTitle(conversation?.title);
+  // 移动端全局顶栏：把会话标题挂上去顶替品牌字标（见 lib/page-chrome.tsx），
+  // 页面自己的标题行随之只在桌面端保留——窄屏上不再吃「顶栏 + 标题」两行高度。
+  // 标题可能先于详情就绪（侧栏最近会话已带），也会随自动命名更新，跟着值重挂即可。
+  const chrome = usePageChrome();
+  const title = conversation?.title;
+  useEffect(() => {
+    if (!chrome || !title) return;
+    return chrome.setTopBarTitle(title);
+  }, [chrome, title]);
   const [input, setInput] = useState("");
   // 服务端详情加载失败的提示（404 = 会话不存在；其余为网络/服务错误）
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -89,9 +99,11 @@ export function AgentConversationView({ conversationId }: { conversationId: stri
     // 沉浸页：内容直接铺在页面纯色底（.page-solid）上，不再包阅读面板卡片；
     // immersive-theme 在容器内切换为中性灰阶 + 系统字体的阅读配色
     <div className="immersive-theme flex h-full flex-col">
-      {/* 顶部条：只留会话标题。「生成中 / 就绪」的全局状态点已由每轮页脚的
-          进度环取代——状态属于那一轮，放在正文旁边比钉在标题上更有指向性 */}
-      <header className="flex h-14 shrink-0 items-center px-5 max-md:h-11 max-md:px-4">
+      {/* 顶部条：只留会话标题，且仅桌面端渲染——移动端标题已挂进全局顶栏
+          （见上方 setTopBarTitle），这里再画一行就是重复信息。「生成中 / 就绪」
+          的全局状态点已由每轮页脚的进度环取代——状态属于那一轮，放在正文旁边
+          比钉在标题上更有指向性 */}
+      <header className="flex h-14 shrink-0 items-center px-5 max-md:hidden">
         <h1 className="truncate text-body font-semibold tracking-[-0.01em]">
           {conversation.title}
         </h1>

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -95,6 +95,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     setTopBarActionsState(node);
     return () => setTopBarActionsState((current) => (current === node ? null : current));
   }, []);
+  // 页面标题顶替顶栏字标（如会话页），见 lib/page-chrome.tsx 的 setTopBarTitle。
+  // 存 token 对象而非裸字符串：撤销时按引用比对，新旧页面短暂共存且标题恰好
+  // 相同时，先卸载那个的清理不会误清新页面刚挂上的标题。
+  const [topBarTitle, setTopBarTitleState] = useState<{ text: string } | null>(null);
+  const setTopBarTitle = useCallback((text: string) => {
+    const token = { text };
+    setTopBarTitleState(token);
+    return () => setTopBarTitleState((current) => (current === token ? null : current));
+  }, []);
 
   const isSettings = pathname.startsWith("/settings");
   const activeNav = navIdFromPath(pathname);
@@ -197,8 +206,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const showMobileTopBar = isMobile && pageNavCount === 0;
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
   const pageChrome = useMemo(
-    () => ({ registerPageNav, onSearch: handleSearch, openDrawer, setTopBarActions }),
-    [registerPageNav, handleSearch, openDrawer, setTopBarActions],
+    () => ({ registerPageNav, onSearch: handleSearch, openDrawer, setTopBarActions, setTopBarTitle }),
+    [registerPageNav, handleSearch, openDrawer, setTopBarActions, setTopBarTitle],
   );
 
   // 移动端抽屉：切换路由即自动收起（点导航项跳走后抽屉不该还盖着新页面），
@@ -272,7 +281,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
          页面自己的 PageNav 认领（对应 globals.css 的 .app-shell[data-topbar] 规则）。 */
       <div className="app-shell relative z-10 h-[100dvh] w-full" data-topbar={showMobileTopBar}>
         {showMobileTopBar && (
-          <MobileTopBar onMenu={openDrawer} onSearch={handleSearch} actions={topBarActions} />
+          <MobileTopBar
+            onMenu={openDrawer}
+            onSearch={handleSearch}
+            actions={topBarActions}
+            title={topBarTitle?.text}
+          />
         )}
         {/* 主区铺满外壳（absolute 而非 flex 子项）：全站页面清一色是
             「外层 h-full + 内层 overflow-y-auto」，h-full 要能解析就必须有一个
@@ -351,11 +365,14 @@ function MobileTopBar({
   onMenu,
   onSearch,
   actions,
+  title,
 }: {
   onMenu: () => void;
   onSearch: (keyword: string, scope: SearchScope, options?: SearchSubmitOptions) => void;
   /** 当前页面挂上来的页面级控件（见 lib/page-chrome.tsx 的 setTopBarActions） */
   actions?: React.ReactNode;
+  /** 当前页面挂上来的标题：有则顶替品牌字标（见 setTopBarTitle） */
+  title?: string;
 }) {
   const router = useRouter();
   return (
@@ -375,23 +392,31 @@ function MobileTopBar({
         >
           <MenuIcon className="size-[22px]" />
         </button>
-        {/* 字标可点区拉到 44px 高（与图标键同标准）——图片本身保持 h-7 的视觉
-            大小，命中区靠按钮撑起，否则 28px 高的字标在触屏上很难点中 */}
-        <button
-          type="button"
-          onClick={() => router.push("/")}
-          aria-label="回到首页"
-          className="flex h-11 shrink-0 items-center transition-opacity active:opacity-60"
-        >
-          <Image
-            src="/movieclaw-logo-rotor.png"
-            alt="MovieClaw"
-            width={1920}
-            height={525}
-            priority
-            className="h-7 w-auto max-w-[104px] object-contain"
-          />
-        </button>
+        {title ? (
+          // 页面标题顶替字标：min-w-0 + truncate 让超长标题在汉堡与右侧控件
+          // 之间安全截断成省略号，绝不把搜索键挤出屏幕或撑破顶栏
+          <h1 className="min-w-0 flex-1 truncate text-body font-semibold tracking-[-0.01em] text-[var(--text)]">
+            {title}
+          </h1>
+        ) : (
+          /* 字标可点区拉到 44px 高（与图标键同标准）——图片本身保持 h-7 的视觉
+             大小，命中区靠按钮撑起，否则 28px 高的字标在触屏上很难点中 */
+          <button
+            type="button"
+            onClick={() => router.push("/")}
+            aria-label="回到首页"
+            className="flex h-11 shrink-0 items-center transition-opacity active:opacity-60"
+          >
+            <Image
+              src="/movieclaw-logo-rotor.png"
+              alt="MovieClaw"
+              width={1920}
+              height={525}
+              priority
+              className="h-7 w-auto max-w-[104px] object-contain"
+            />
+          </button>
+        )}
         {/* 页面级控件塞在字标与搜索之间——那段本来就空着，够放一个分段控件；
             min-w-0 让它在窄屏上自己收缩，而不是把搜索挤出屏幕 */}
         <div className="ml-auto flex min-w-0 shrink items-center gap-2">

--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -406,7 +406,9 @@ function RunRow({
           <div
             ref={menuRef}
             className="menu-surface w-36 overflow-hidden rounded-xl p-1.5"
-            style={{ position: "fixed", left: menuPos.left, top: menuPos.top, zIndex: 50 }}
+            // z 必须压过移动端抽屉（.mobile-drawer 是 60）：侧栏在窄屏上装进抽屉，
+            // 菜单虽 Portal 到 body，z 不够会被抽屉盖住——表现为点 ⋯ 毫无反应
+            style={{ position: "fixed", left: menuPos.left, top: menuPos.top, zIndex: 70 }}
           >
             <button
               type="button"

--- a/apps/web/lib/page-chrome.tsx
+++ b/apps/web/lib/page-chrome.tsx
@@ -53,6 +53,14 @@ export interface PageChromeValue {
    * 在 effect 里调用并返回它的清理函数；节点要用稳定依赖构造，别在渲染期直接调。
    */
   setTopBarActions: (node: ReactNode) => () => void;
+  /**
+   * 把页面标题挂进移动端全局顶栏、顶替品牌字标的位置，返回撤销函数。
+   *
+   * 给沉浸类顶层页面（如 Agent 会话）：窄屏上字标传达不了任何新信息（用户
+   * 就在应用里），这一格让给「我在看哪个会话」远比品牌曝光有用。字标只在
+   * 没有页面认领标题时兜底显示。同样在 effect 里调用。
+   */
+  setTopBarTitle: (title: string) => () => void;
 }
 
 const PageChromeContext = createContext<PageChromeValue | null>(null);

--- a/src/movieclaw_llm/providers/presets/kimi.yaml
+++ b/src/movieclaw_llm/providers/presets/kimi.yaml
@@ -1,7 +1,7 @@
 # Kimi 开放平台（月之暗面官方，api.moonshot.cn，OpenAI 兼容）。
-# 模型数据以官方文档为准（platform.moonshot.cn / platform.kimi.com，
-# 抓取于 2026-07-13）。输出与输入共享 256K 窗口、无独立输出上限，
-# max_output_tokens 留空；官方未公布思考预算上限，留空。
+# 模型数据以官方文档为准（platform.kimi.com，抓取于 2026-07-31）。
+# K2 系输出与输入共享 256K 窗口、K3 未单独公布输出上限，
+# max_output_tokens 一律留空；官方未公布思考预算上限，留空。
 # 编程专用的 kimi-k2.7-code 系未收录（仅思考、面向代码场景）。
 id: kimi
 display_name: Kimi 官方（月之暗面）
@@ -11,7 +11,16 @@ compat:
   thinking_field: reasoning_content
   supports_stream_usage: true
 models:
-  # 最新主力：1T 总参 / 32B 激活 MoE，混合思考，原生多模态
+  # 旗舰（2026-07-17 发布）：2.8T 总参 MoE，1M 上下文。思考始终开启、
+  # 不可关闭，强度走请求顶层 reasoning_effort（low/high/max，默认 max）——
+  # 需要调强度时用实例的 extra_body 传入。temperature/top_p 官方固定
+  # （1.0/0.95），实例配置里请勿另设。官方文档未标注多模态，仅收 text。
+  - id: kimi-k3
+    context_window: 1048576
+    supports_tools: true
+    supports_thinking: true
+    modalities: [text]
+  # K2 主力：1T 总参 / 32B 激活 MoE，混合思考，原生多模态
   - id: kimi-k2.6
     context_window: 262144
     supports_tools: true


### PR DESCRIPTION
## 移动端会话页（/runs/[id]）

- **修复整页横向错位**：思考文本/用户气泡/压缩摘要/错误提示补 `break-words`——无空格长资源名（如 `Fantastic.4:.First.Steps...x264.2Audios-CHD`）曾把消息列撑出横向滚动，整列内容被推出屏幕左侧；消息滚动容器加 `overflow-x-hidden` 兜底。
- **执行过程改两级折叠**（对齐 Claude/Codex）：展开后工具调用先呈现单行清单（工具名 + 参数摘要 + ✓/✗/进度环状态），点击某行再展开参数（shiki 高亮）与输出详情；参数流式生成中保留右锚定滚动尾部效果。
- **会话标题挂进全局顶栏**：page-chrome 新增 `setTopBarTitle` 通道，窄屏上标题顶替品牌字标（`min-w-0 + truncate` 截断超长标题），页面自己的标题行只在桌面端保留，正文区多出一行高度。
- **修复侧栏会话操作菜单失灵**：菜单 Portal 层级（z-50）被移动端抽屉（z-60）盖住，点 ⋯ 看似无反应、无法重命名/删除会话；提到 z-70。

## LLM 模型预设

- Kimi 预设收录 `kimi-k3`（2026-07-17 发布，1M 上下文，思考常开、`reasoning_effort` 调强度，temperature/top_p 官方固定），协议层零改动；抓取日期更新至 2026-07-31。

## 验证

- `tsc --noEmit`、ESLint、`next build` 全部通过
- Python 侧 `test_registry` / `test_openai_chat` 单测通过，注册表实际加载确认 k3/k2.6/k2.5 正常
- 换行修复另用 Chromium 393px 视口对照验证（修复前 overflow=true → 修复后 false）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDf5CdhxFGk9aBYcu9Kjr4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDf5CdhxFGk9aBYcu9Kjr4)_