### PR TITLE
feat(channel): 微信通道 —— 扫码绑定 + Agent 对话接入

### DIFF
--- a/alembic/versions/20260801_0900_c1d4f7a2b930_add_channel_account.py
+++ b/alembic/versions/20260801_0900_c1d4f7a2b930_add_channel_account.py
@@ -1,0 +1,54 @@
+"""add channel_account table
+
+IM 通道账号表(微信为首个通道):扫码绑定后的凭据(SecretBox 密文)、
+就近接入地址、收消息增量游标与白名单用户。设计背景见
+movieclaw_db.models.channel_account 模块头。
+
+Revision ID: c1d4f7a2b930
+Revises: b9c2e5a0f718
+Create Date: 2026-08-01 09:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d4f7a2b930"
+down_revision: str | None = "b9c2e5a0f718"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "channel_account",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("channel_id", sa.String(), nullable=False),
+        sa.Column("account_id", sa.String(), nullable=False),
+        sa.Column("token", sa.String(), nullable=False),
+        sa.Column("base_url", sa.String(), nullable=False),
+        sa.Column("bound_user_id", sa.String(), nullable=True),
+        sa.Column("cursor", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("last_error", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_channel_account_channel_id"), "channel_account", ["channel_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_channel_account_account_id"), "channel_account", ["account_id"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_channel_account_account_id"), table_name="channel_account")
+    op.drop_index(op.f("ix_channel_account_channel_id"), table_name="channel_account")
+    op.drop_table("channel_account")

--- a/apps/web/components/icons.tsx
+++ b/apps/web/components/icons.tsx
@@ -325,3 +325,10 @@ export const RefreshIcon = (p: IconProps) => (
     <path d="M21 3v6h-6" />
   </Base>
 );
+
+export const ChatIcon = (p: IconProps) => (
+  <Base {...p}>
+    <path d="M21 11.5a7.5 7.5 0 0 1-7.5 7.5c-1.06 0-2.07-.2-3-.57L5 20l1.57-4.5A7.5 7.5 0 1 1 21 11.5Z" />
+    <path d="M9.5 11.5h.01M13.5 11.5h.01" />
+  </Base>
+);

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -8,6 +8,7 @@ import { AvatarBadge } from "@/components/avatar-badge";
 import { DownloaderConfigSection } from "@/components/downloader-config-section";
 import { ImportWatchSection } from "@/components/import-watch-section";
 import { LlmConfigSection } from "@/components/llm-config-section";
+import { WeixinBindingSection } from "@/components/weixin-binding-section";
 import { NetworkConfigSection } from "@/components/network-config-section";
 import { SiteConfigSection } from "@/components/site-config-section";
 import { SubscriptionSettingsSection } from "@/components/subscription-settings-section";
@@ -155,6 +156,8 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
           <ImportWatchSection />
         ) : section.id === "llm" ? (
           <LlmConfigSection />
+        ) : section.id === "weixin" ? (
+          <WeixinBindingSection />
         ) : section.id === "network" ? (
           <NetworkConfigSection />
         ) : section.id === "logs" ? (

--- a/apps/web/components/weixin-binding-section.tsx
+++ b/apps/web/components/weixin-binding-section.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ChatIcon } from "@/components/icons";
+import {
+  type WeixinAccount,
+  type WeixinBindingSnapshot,
+  getWeixinBindingStatus,
+  listWeixinAccounts,
+  startWeixinBinding,
+  submitWeixinVerifyCode,
+  unbindWeixinAccount,
+} from "@/lib/api/channels";
+import { formatRelativeTime } from "@/lib/time";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
+
+/**
+ * 「微信绑定」设置分区。
+ *
+ * 交互状态机(与产品确认的流程):
+ * - 进入页面先拉账号列表:非空 → 只展示列表(不出二维码);为空 → 自动发起
+ *   绑定并展示二维码;
+ * - 出码后每 2 秒 poll 绑定状态(后端只读内存快照,毫秒级返回):
+ *   need_verify_code → 二维码旁弹出配对码输入框;
+ *   confirmed → 二维码消失、提示完成、刷新列表(此时通道已在收发);
+ *   expired/failed → 展示原因 + 「重新生成」按钮;
+ * - 已有绑定后,除非点「新增绑定」,二维码不再出现。
+ */
+export function WeixinBindingSection() {
+  const [accounts, setAccounts] = useState<WeixinAccount[] | null>(null);
+  const [binding, setBinding] = useState<WeixinBindingSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [verifyCode, setVerifyCode] = useState("");
+  const [justConfirmed, setJustConfirmed] = useState(false);
+  // 空列表只自动出码一次:失败/过期后由用户手动点按钮,不无限自动重试
+  const autoStartedRef = useRef(false);
+
+  const loadAccounts = useCallback(async () => {
+    setError(null);
+    try {
+      return await listWeixinAccounts().then((rows) => {
+        setAccounts(rows);
+        return rows;
+      });
+    } catch (e) {
+      setError((e as Error).message);
+      setAccounts([]);
+      return [];
+    }
+  }, []);
+
+  const beginBinding = useCallback(async () => {
+    setError(null);
+    setJustConfirmed(false);
+    setVerifyCode("");
+    setBusy(true);
+    try {
+      const start = await startWeixinBinding();
+      setBinding({
+        challenge_id: start.challenge_id,
+        status: "pending",
+        message: start.message,
+        qrcode_url: start.qrcode_url,
+        qrcode_image: start.qrcode_image,
+        account: null,
+      });
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  // 进入页面:先拉列表;为空则自动发起绑定(仅首次)
+  useEffect(() => {
+    void loadAccounts().then((rows) => {
+      if (rows.length === 0 && !autoStartedRef.current) {
+        autoStartedRef.current = true;
+        void beginBinding();
+      }
+    });
+  }, [loadAccounts, beginBinding]);
+
+  // 绑定进行中每 2s poll 状态;终态停止
+  const polling =
+    binding != null &&
+    (binding.status === "pending" ||
+      binding.status === "scanned" ||
+      binding.status === "need_verify_code");
+  useVisiblePolling(
+    () => {
+      if (binding == null) return;
+      void getWeixinBindingStatus(binding.challenge_id)
+        .then((snap) => {
+          setBinding(snap);
+          if (snap.status === "confirmed" || snap.status === "already_bound") {
+            setJustConfirmed(snap.status === "confirmed");
+            setBinding(null); // 二维码消失
+            void loadAccounts();
+          }
+        })
+        .catch(() => {
+          /* poll 失败静默重试(challenge 过期由状态自己表达) */
+        });
+    },
+    polling ? 2000 : null,
+  );
+
+  async function handleVerifySubmit() {
+    if (binding == null || !verifyCode.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await submitWeixinVerifyCode(binding.challenge_id, verifyCode.trim());
+      setVerifyCode("");
+      // 提交后立即把本地状态推回 scanned,等待下一次 poll 的服务端判定
+      setBinding({ ...binding, status: "scanned", message: "正在校验配对码…" });
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleUnbind(accountId: string) {
+    if (!window.confirm("确定解绑该微信账号？解绑后需重新扫码才能使用。")) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await unbindWeixinAccount(accountId);
+      await loadAccounts();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const loading = accounts == null;
+  const hasAccounts = (accounts?.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-5">
+      {error && (
+        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
+          {error}
+        </div>
+      )}
+
+      <p className="text-sub text-[var(--text-muted)]">
+        绑定后，用你的微信给 AI 助手发消息即可对话（仅扫码人本人可用）。发送
+        <span className="mx-1 rounded bg-white/[0.08] px-1.5 py-0.5 text-caption">/reset</span>
+        重置会话，
+        <span className="mx-1 rounded bg-white/[0.08] px-1.5 py-0.5 text-caption">/stop</span>
+        取消正在进行的处理。
+      </p>
+
+      {justConfirmed && (
+        <div className="rounded-xl border border-[#4ade80]/30 bg-[#4ade80]/10 px-4 py-3 text-body text-[#4ade80]">
+          绑定完成，微信通道已启动。现在就可以在微信里发消息试试。
+        </div>
+      )}
+
+      {loading ? (
+        <div className="h-[104px] animate-pulse rounded-xl bg-white/[0.04]" />
+      ) : (
+        <>
+          {/* 已绑定账号列表 */}
+          {hasAccounts && (
+            <div className="css-glass !rounded-xl">
+              {accounts!.map((account, i) => (
+                <div
+                  key={account.account_id}
+                  className={`flex items-center gap-3.5 p-4 ${i > 0 ? "border-t border-white/[0.06]" : ""}`}
+                >
+                  <span className="icon-chip size-10 !rounded-xl">
+                    <ChatIcon className="size-5" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-body font-semibold text-[var(--text)]">
+                        {account.bound_user_id ?? account.account_id}
+                      </p>
+                      <AccountStatusPill account={account} />
+                    </div>
+                    <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]">
+                      {account.status === "stale"
+                        ? (account.last_error ?? "凭据已失效，请重新扫码绑定")
+                        : `机器人 ${account.account_id} · 绑定于 ${formatRelativeTime(account.bound_at)}`}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void handleUnbind(account.account_id)}
+                    className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium !text-[#ff6b6b] disabled:opacity-40"
+                  >
+                    解绑
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* 绑定进行中:二维码卡片 */}
+          {binding != null && <BindingCard binding={binding} onRetry={() => void beginBinding()} />}
+
+          {/* 配对码输入(need_verify_code) */}
+          {binding?.status === "need_verify_code" && (
+            <div className="css-glass !rounded-xl p-4">
+              <p className="text-body font-medium text-[var(--text)]">{binding.message}</p>
+              <div className="mt-3 flex gap-2">
+                <input
+                  value={verifyCode}
+                  onChange={(e) => setVerifyCode(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && void handleVerifySubmit()}
+                  inputMode="numeric"
+                  autoFocus
+                  placeholder="手机微信上显示的数字"
+                  className="flex-1 rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+                />
+                <button
+                  type="button"
+                  disabled={busy || !verifyCode.trim()}
+                  onClick={() => void handleVerifySubmit()}
+                  className="btn-accent rounded-xl px-4 py-2 text-sub font-semibold disabled:opacity-40"
+                >
+                  确认
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* 已有绑定且当前没在走绑定流程:提供「新增绑定」入口 */}
+          {hasAccounts && binding == null && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void beginBinding()}
+              className="btn-glass rounded-full px-4 py-1.5 text-sub font-medium disabled:opacity-40"
+            >
+              新增绑定
+            </button>
+          )}
+
+          {/* 空态且绑定发起失败(网关不可达等):手动重试入口 */}
+          {!hasAccounts && binding == null && (
+            <div className="css-glass flex flex-col items-center gap-3 !rounded-2xl px-6 py-12 text-center">
+              <span className="icon-chip size-12 !rounded-2xl">
+                <ChatIcon className="size-6" />
+              </span>
+              <div>
+                <p className="text-body font-medium text-[var(--text)]">
+                  {justConfirmed ? "还没有其他绑定" : "还没有绑定微信"}
+                </p>
+                <p className="mt-1 text-sub text-[var(--text-muted)]">
+                  生成二维码后用手机微信扫描，即可把 AI 助手接入微信。
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void beginBinding()}
+                className="btn-accent mt-1 rounded-full px-4 py-1.5 text-sub font-semibold disabled:opacity-40"
+              >
+                生成绑定二维码
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/** 绑定二维码卡片:二维码 + 实时状态;过期/失败给重试按钮。 */
+function BindingCard({
+  binding,
+  onRetry,
+}: {
+  binding: WeixinBindingSnapshot;
+  onRetry: () => void;
+}) {
+  const terminal = binding.status === "expired" || binding.status === "failed";
+  return (
+    <div className="css-glass flex flex-col items-center gap-4 !rounded-2xl px-6 py-8 text-center">
+      {!terminal && (
+        <div className="rounded-2xl bg-white p-3">
+          {/* 服务端渲染的 SVG data URL;用原生 img 展示内联数据,无需 next/image 优化 */}
+          <img src={binding.qrcode_image} alt="微信绑定二维码" className="size-48" />
+        </div>
+      )}
+      <div>
+        <p className="text-body font-medium text-[var(--text)]">
+          {binding.status === "scanned" ? "已扫码" : terminal ? "绑定未完成" : "等待扫码"}
+        </p>
+        <p className="mt-1 text-sub text-[var(--text-muted)]">{binding.message}</p>
+      </div>
+      {terminal ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="btn-accent rounded-full px-4 py-1.5 text-sub font-semibold"
+        >
+          重新生成二维码
+        </button>
+      ) : (
+        <p className="text-caption text-[var(--text-faint)]">
+          打开手机微信，扫一扫上方二维码
+        </p>
+      )}
+    </div>
+  );
+}
+
+function AccountStatusPill({ account }: { account: WeixinAccount }) {
+  const meta =
+    account.status === "stale"
+      ? { label: "需重新绑定", color: "#ff6b6b" }
+      : account.running
+        ? { label: "运行中", color: "#4ade80" }
+        : { label: "未运行", color: "#c0c4cc" };
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
+      style={{ background: `${meta.color}1f`, color: meta.color }}
+    >
+      <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
+      {meta.label}
+    </span>
+  );
+}

--- a/apps/web/lib/api/channels.ts
+++ b/apps/web/lib/api/channels.ts
@@ -1,0 +1,92 @@
+import { request } from "@/lib/http";
+
+/** 后端统一响应信封（见 movieclaw_api.schemas.response.ApiResponse） */
+interface ApiEnvelope<T> {
+  success: boolean;
+  code: string;
+  message: string;
+  data: T;
+}
+
+async function unwrap<T>(promise: Promise<ApiEnvelope<T>>): Promise<T> {
+  return (await promise).data;
+}
+
+/** 已绑定的微信账号（见 schemas.channels.WeixinAccountView）。 */
+export interface WeixinAccount {
+  account_id: string;
+  /** 扫码绑定人的微信用户 id（白名单：只有此人能对话） */
+  bound_user_id: string | null;
+  /** active=正常；stale=凭据失效需重新扫码 */
+  status: "active" | "stale";
+  /** 当前进程内收发循环是否在运行 */
+  running: boolean;
+  last_error: string | null;
+  bound_at: string;
+}
+
+/** 绑定流程状态（见 schemas.channels.WeixinBindingStatusView 的注释）。 */
+export type WeixinBindingStatus =
+  | "pending"
+  | "scanned"
+  | "need_verify_code"
+  | "confirmed"
+  | "already_bound"
+  | "expired"
+  | "failed";
+
+export interface WeixinBindingStart {
+  challenge_id: string;
+  qrcode_url: string;
+  /** 服务端渲染好的二维码 SVG data URL，<img> 直接显示 */
+  qrcode_image: string;
+  message: string;
+}
+
+export interface WeixinBindingSnapshot {
+  challenge_id: string;
+  status: WeixinBindingStatus;
+  message: string;
+  qrcode_url: string;
+  qrcode_image: string;
+  account: WeixinAccount | null;
+}
+
+export function listWeixinAccounts(init?: RequestInit): Promise<WeixinAccount[]> {
+  return unwrap(request<ApiEnvelope<WeixinAccount[]>>("/channels/weixin/accounts", init));
+}
+
+export function startWeixinBinding(): Promise<WeixinBindingStart> {
+  return unwrap(
+    request<ApiEnvelope<WeixinBindingStart>>("/channels/weixin/bindings", { method: "POST" }),
+  );
+}
+
+export function getWeixinBindingStatus(challengeId: string): Promise<WeixinBindingSnapshot> {
+  return unwrap(
+    request<ApiEnvelope<WeixinBindingSnapshot>>(
+      `/channels/weixin/bindings/${encodeURIComponent(challengeId)}`,
+    ),
+  );
+}
+
+export function submitWeixinVerifyCode(
+  challengeId: string,
+  code: string,
+): Promise<Record<string, never>> {
+  return unwrap(
+    request<ApiEnvelope<Record<string, never>>>(
+      `/channels/weixin/bindings/${encodeURIComponent(challengeId)}/verify-code`,
+      { method: "POST", body: JSON.stringify({ code }) },
+    ),
+  );
+}
+
+export function unbindWeixinAccount(accountId: string): Promise<Record<string, never>> {
+  return unwrap(
+    request<ApiEnvelope<Record<string, never>>>(
+      `/channels/weixin/accounts/${encodeURIComponent(accountId)}`,
+      { method: "DELETE" },
+    ),
+  );
+}

--- a/apps/web/lib/mock-data.ts
+++ b/apps/web/lib/mock-data.ts
@@ -6,6 +6,7 @@
 import type { ComponentType, SVGProps } from "react";
 import {
   BookmarkIcon,
+  ChatIcon,
   DownloadIcon,
   FilmIcon,
   FolderIcon,
@@ -131,6 +132,7 @@ export const settingsSectionGroups: SettingsSectionGroup[] = [
     label: "智能",
     items: [
       { id: "llm", label: "AI 模型", description: "大语言模型供应商接入", icon: SparkIcon },
+      { id: "weixin", label: "微信绑定", description: "把 AI 助手接入你的微信，扫码即用", icon: ChatIcon },
     ],
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
   # qbittorrent-api 用日历版本号（YYYY.M.PATCH），按年份上限约束。
   "qbittorrent-api>=2025.1.0,<2027.0.0",
   "transmission-rpc>=7.0.0,<8.0.0",
+  # 微信绑定二维码：纯 Python 生成 SVG（不引 pillow），前端 <img> 直接渲染。
+  "qrcode>=8.0,<9.0",
   # LLM 接入层（movieclaw_llm）：官方 openai SDK 作为唯一协议客户端，
   # 通过自定义 base_url 覆盖所有 OpenAI 兼容端点（含阿里云百炼 compatible-mode）。
   "openai>=2.45.0,<3.0.0",

--- a/src/movieclaw_api/api/router.py
+++ b/src/movieclaw_api/api/router.py
@@ -17,6 +17,7 @@ from movieclaw_api.api.deps import require_login
 from movieclaw_api.api.routes.agent import router as agent_router
 from movieclaw_api.api.routes.appearance import router as appearance_router
 from movieclaw_api.api.routes.auth import router as auth_router
+from movieclaw_api.api.routes.channels import router as channels_router
 from movieclaw_api.api.routes.discover import router as discover_router
 from movieclaw_api.api.routes.downloaders import router as downloaders_router
 from movieclaw_api.api.routes.extension import router as extension_router
@@ -59,6 +60,7 @@ _PROTECTED_ROUTERS = [
     images_router,
     llm_router,
     agent_router,
+    channels_router,
     subscriptions_router,
     libraries_router,
     import_watch_router,

--- a/src/movieclaw_api/api/routes/channels.py
+++ b/src/movieclaw_api/api/routes/channels.py
@@ -145,6 +145,8 @@ async def submit_weixin_verify_code(
     response_model=ApiResponse[dict],
     summary="解绑微信账号",
     operation_id="channels.weixin.accounts.unbind",
+    # 解绑删除凭据、停止通道,须二次确认(CLI 据此决定 --yes 门槛)
+    openapi_extra={"x-cli-dangerous": "confirm"},
 )
 async def unbind_weixin_account(account_id: str) -> ApiResponse[dict]:
     """停止收发循环并删除凭据;之后该 bot 需重新扫码才能使用。"""

--- a/src/movieclaw_api/api/routes/channels.py
+++ b/src/movieclaw_api/api/routes/channels.py
@@ -9,6 +9,11 @@
 
 from __future__ import annotations
 
+import base64
+from functools import lru_cache
+
+import qrcode
+import qrcode.image.svg
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,6 +31,19 @@ from movieclaw_db.engine import get_session
 from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
 
 router = APIRouter(prefix="/channels/weixin", tags=["channels"])
+
+
+@lru_cache(maxsize=8)
+def _qrcode_data_url(content: str) -> str:
+    """把二维码内容渲染成 SVG data URL,前端 <img> 直接显示。
+
+    纯 Python SVG 路径(不依赖 pillow);缓存最近几张——同一 challenge 的
+    poll 每 1-2 秒来一次,内容不变时不必重复编码。
+    """
+    if not content:
+        return ""
+    img = qrcode.make(content, image_factory=qrcode.image.svg.SvgPathImage, box_size=12)
+    return "data:image/svg+xml;base64," + base64.b64encode(img.to_string()).decode()
 
 
 @router.get(
@@ -66,6 +84,7 @@ async def start_weixin_binding() -> ApiResponse[WeixinBindingStartView]:
         WeixinBindingStartView(
             challenge_id=challenge.challenge_id,
             qrcode_url=challenge.qrcode_url,
+            qrcode_image=_qrcode_data_url(challenge.qrcode_url),
             message=challenge.message,
         ),
         message="绑定已发起",
@@ -100,6 +119,7 @@ async def get_weixin_binding_status(
             status=challenge.status,
             message=challenge.message,
             qrcode_url=challenge.qrcode_url,
+            qrcode_image=_qrcode_data_url(challenge.qrcode_url),
             account=account_view,
         )
     )

--- a/src/movieclaw_api/api/routes/channels.py
+++ b/src/movieclaw_api/api/routes/channels.py
@@ -1,0 +1,134 @@
+"""IM 通道接口(微信绑定与账号管理)。
+
+前端(设置 → AI → 微信绑定)交互流程:
+1. 进页面先 GET accounts:非空 → 只展示列表;为空 → 自动 POST bindings 出码;
+2. 拿到 challenge_id 后每 1-2 秒 GET bindings/{id} 轮询状态;
+3. need_verify_code → 页面弹输入框,POST verify-code 后继续轮询;
+4. confirmed → 二维码消失,刷新列表(此时通道已在收发,扫码人可直接对话)。
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from movieclaw_api.exceptions import BadRequestException, NotFoundException
+from movieclaw_api.schemas.channels import (
+    WeixinAccountView,
+    WeixinBindingStartView,
+    WeixinBindingStatusView,
+    WeixinVerifyCodePayload,
+)
+from movieclaw_api.schemas.response import ApiResponse, ok
+from movieclaw_api.services.weixin_channel import get_weixin_channel
+from movieclaw_channel.weixin.adapter import CHANNEL_ID
+from movieclaw_db.engine import get_session
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
+
+router = APIRouter(prefix="/channels/weixin", tags=["channels"])
+
+
+@router.get(
+    "/accounts",
+    response_model=ApiResponse[list[WeixinAccountView]],
+    summary="已绑定的微信账号列表",
+    operation_id="channels.weixin.accounts.list",
+)
+async def list_weixin_accounts(
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[list[WeixinAccountView]]:
+    service = get_weixin_channel()
+    rows = await ChannelAccountRepository(session).list_by_channel(CHANNEL_ID)
+    return ok(
+        [
+            WeixinAccountView.from_model(
+                row, running=service.manager.is_running(CHANNEL_ID, row.account_id)
+            )
+            for row in rows
+        ]
+    )
+
+
+@router.post(
+    "/bindings",
+    response_model=ApiResponse[WeixinBindingStartView],
+    status_code=201,
+    summary="发起微信扫码绑定",
+    operation_id="channels.weixin.bindings.start",
+)
+async def start_weixin_binding() -> ApiResponse[WeixinBindingStartView]:
+    """获取二维码并启动后台状态轮询;前端拿 challenge_id 开始 poll。"""
+    try:
+        challenge = await get_weixin_channel().binding.begin()
+    except Exception as exc:  # noqa: BLE001 -- 网关不可达等,转成中文业务错误
+        raise BadRequestException(f"发起微信绑定失败:{exc}") from exc
+    return ok(
+        WeixinBindingStartView(
+            challenge_id=challenge.challenge_id,
+            qrcode_url=challenge.qrcode_url,
+            message=challenge.message,
+        ),
+        message="绑定已发起",
+    )
+
+
+@router.get(
+    "/bindings/{challenge_id}",
+    response_model=ApiResponse[WeixinBindingStatusView],
+    summary="查询绑定状态(前端轮询)",
+    operation_id="channels.weixin.bindings.status",
+)
+async def get_weixin_binding_status(
+    challenge_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[WeixinBindingStatusView]:
+    service = get_weixin_channel()
+    challenge = service.binding.get(challenge_id)
+    if challenge is None:
+        raise NotFoundException("绑定流程不存在或已过期,请重新发起")
+
+    account_view: WeixinAccountView | None = None
+    if challenge.status == "confirmed" and challenge.result is not None:
+        row = await ChannelAccountRepository(session).get(challenge.result.bot_id)
+        if row is not None:
+            account_view = WeixinAccountView.from_model(
+                row, running=service.manager.is_running(CHANNEL_ID, row.account_id)
+            )
+    return ok(
+        WeixinBindingStatusView(
+            challenge_id=challenge.challenge_id,
+            status=challenge.status,
+            message=challenge.message,
+            qrcode_url=challenge.qrcode_url,
+            account=account_view,
+        )
+    )
+
+
+@router.post(
+    "/bindings/{challenge_id}/verify-code",
+    response_model=ApiResponse[dict],
+    summary="提交扫码配对数字",
+    operation_id="channels.weixin.bindings.verify",
+)
+async def submit_weixin_verify_code(
+    challenge_id: str, payload: WeixinVerifyCodePayload
+) -> ApiResponse[dict]:
+    accepted = get_weixin_channel().binding.submit_verify_code(challenge_id, payload.code)
+    if not accepted:
+        raise NotFoundException("绑定流程不存在或已结束,请重新发起")
+    return ok({}, message="配对码已提交,正在校验")
+
+
+@router.delete(
+    "/accounts/{account_id}",
+    response_model=ApiResponse[dict],
+    summary="解绑微信账号",
+    operation_id="channels.weixin.accounts.unbind",
+)
+async def unbind_weixin_account(account_id: str) -> ApiResponse[dict]:
+    """停止收发循环并删除凭据;之后该 bot 需重新扫码才能使用。"""
+    removed = await get_weixin_channel().unbind(account_id)
+    if not removed:
+        raise NotFoundException("账号不存在或已解绑")
+    return ok({}, message="已解绑")

--- a/src/movieclaw_api/lifespan.py
+++ b/src/movieclaw_api/lifespan.py
@@ -147,6 +147,11 @@ def build_lifespan(settings: Settings):
         from movieclaw_api.services.library.ingest import init_ingest_watcher
 
         await init_ingest_watcher()
+        # 微信通道:拉起所有已绑定账号的收发循环(getUpdates 长轮询)。
+        # 放在 Agent 注册表与 LLM 配置就绪之后——入站消息要驱动 Agent 运行。
+        from movieclaw_api.services.weixin_channel import init_weixin_channel
+
+        await init_weixin_channel()
         logger.info("应用启动完成，数据库就绪")
         try:
             yield
@@ -157,6 +162,10 @@ def build_lifespan(settings: Settings):
 
             await close_ingest_watcher()
             await close_library_watcher()
+            # 先停微信通道(掐断在飞长轮询、停会话 worker),再停 Agent 注册表。
+            from movieclaw_api.services.weixin_channel import close_weixin_channel
+
+            await close_weixin_channel()
             # 先停止 Agent，避免它在下游 HTTP 客户端和数据库开始释放后继续工作。
             await close_agent_run_registry()
             if settings.scheduler_enabled:

--- a/src/movieclaw_api/schemas/channels.py
+++ b/src/movieclaw_api/schemas/channels.py
@@ -1,0 +1,65 @@
+"""IM 通道(微信绑定)相关的请求/响应模型。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from movieclaw_db.models.channel_account import ChannelAccount
+
+
+class WeixinAccountView(BaseModel):
+    """已绑定账号(绑定页列表项)。"""
+
+    account_id: str
+    #: 扫码绑定人的微信用户 id(白名单)
+    bound_user_id: str | None
+    #: active=正常;stale=凭据失效,需重新扫码
+    status: str
+    #: 当前进程内收发循环是否在运行
+    running: bool
+    last_error: str | None
+    bound_at: datetime
+
+    @classmethod
+    def from_model(cls, row: ChannelAccount, *, running: bool) -> WeixinAccountView:
+        return cls(
+            account_id=row.account_id,
+            bound_user_id=row.bound_user_id,
+            status=row.status,
+            running=running,
+            last_error=row.last_error,
+            bound_at=row.created_at,
+        )
+
+
+class WeixinBindingStartView(BaseModel):
+    """发起绑定的返回:前端渲染二维码并开始 poll。"""
+
+    challenge_id: str
+    #: 二维码内容链接(前端用它渲染二维码图)
+    qrcode_url: str
+    message: str
+
+
+class WeixinBindingStatusView(BaseModel):
+    """绑定状态快照(前端每 1-2 秒 poll 一次,后端只读内存,毫秒级返回)。
+
+    status 取值:
+    pending / scanned / need_verify_code / confirmed / already_bound /
+    expired / failed。confirmed 时通道已启动,account 字段附带账号信息。
+    """
+
+    challenge_id: str
+    status: str
+    message: str
+    #: 二维码可能中途刷新(过期自动换新),前端每次 poll 都以此为准重绘
+    qrcode_url: str
+    account: WeixinAccountView | None = None
+
+
+class WeixinVerifyCodePayload(BaseModel):
+    """提交手机微信上显示的配对数字。"""
+
+    code: str = Field(min_length=1, max_length=16, description="配对码")

--- a/src/movieclaw_api/schemas/channels.py
+++ b/src/movieclaw_api/schemas/channels.py
@@ -38,8 +38,10 @@ class WeixinBindingStartView(BaseModel):
     """发起绑定的返回:前端渲染二维码并开始 poll。"""
 
     challenge_id: str
-    #: 二维码内容链接(前端用它渲染二维码图)
+    #: 二维码内容链接(扫码目标;备用展示)
     qrcode_url: str
+    #: 服务端渲染好的二维码图(SVG data URL),前端 <img> 直接显示
+    qrcode_image: str
     message: str
 
 
@@ -56,6 +58,7 @@ class WeixinBindingStatusView(BaseModel):
     message: str
     #: 二维码可能中途刷新(过期自动换新),前端每次 poll 都以此为准重绘
     qrcode_url: str
+    qrcode_image: str
     account: WeixinAccountView | None = None
 
 

--- a/src/movieclaw_api/services/weixin_channel.py
+++ b/src/movieclaw_api/services/weixin_channel.py
@@ -1,0 +1,251 @@
+"""微信通道服务编排:绑定注册表 + 通道管理器 + Agent 装配的粘合层。
+
+职责边界:
+- movieclaw_channel 只管「收发字节与事件调度」,不知道 LLM/工具/历史;
+- 本服务把三者拼起来:绑定确认 → 落库 + 热启动;入站消息 → 装配受限
+  工具集的 AgentRunner → StepReplyPusher → 出站队列。
+
+安全红线(与设计讨论一致):微信侧 Agent 用**受限工具集**——只挂 mclaw
+产品操作工具,不开 bash/read/write/edit 工作区工具。IM 是远程入口,
+即使有白名单,也不该让它拿到宿主机 shell。
+
+会话历史(P0):内存态 deque,进程重启即清空;每会话保留最近 40 条消息。
+持久化转录是后续迭代(复用 agent_sessions 存储)的事,不在本层内实现。
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from movieclaw_agent import AgentRunner, AgentStartParams
+from movieclaw_agent.tools import make_mclaw_tool
+from movieclaw_api.core.config import get_settings
+from movieclaw_api.exceptions import NotFoundException
+from movieclaw_api.services import auth as auth_service
+from movieclaw_api.services.llm_config import acquire_llm_router
+from movieclaw_api.services.mclaw_tool import render_service_map
+from movieclaw_channel import ChannelManager, InboundMessage
+from movieclaw_channel.dispatcher import make_dispatcher
+from movieclaw_channel.weixin import (
+    BindingResult,
+    WeixinAdapter,
+    WeixinBindingRegistry,
+    WeixinClient,
+)
+from movieclaw_channel.weixin.adapter import CHANNEL_ID
+from movieclaw_db.engine import get_database
+from movieclaw_db.models.channel_account import ChannelAccount, ChannelAccountStatus
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
+from movieclaw_llm import ChatMessage
+
+logger = logging.getLogger("movieclaw_api.weixin_channel")
+
+#: 每会话跨轮历史上限(条):IM 场景轻上下文,超出后滚动遗忘
+_HISTORY_MAX_MESSAGES = 40
+#: 微信侧 Agent 的步数上限:IM 对话不该跑出超长循环,收紧防失控
+_WEIXIN_MAX_STEPS = 40
+
+
+class WeixinChannelService:
+    """进程级单例:随 lifespan 启停。"""
+
+    def __init__(self) -> None:
+        self.manager = ChannelManager()
+        self.binding = WeixinBindingRegistry(
+            on_confirmed=self._on_binding_confirmed,
+            get_local_tokens=self._local_tokens,
+        )
+        #: session_key → 跨轮对话历史(内存态)
+        self._histories: dict[str, deque[ChatMessage]] = {}
+        #: 每账号一个持有连接池的 iLink 客户端,停账号时关闭
+        self._clients: dict[str, WeixinClient] = {}
+
+    # ------------------------------------------------------------------
+    # 生命周期
+    # ------------------------------------------------------------------
+    async def start(self) -> None:
+        """启动时拉起所有已绑定且未失效的账号。"""
+        async with get_database().session() as session:
+            rows = await ChannelAccountRepository(session).list_by_channel(CHANNEL_ID)
+            accounts = [
+                (row, ChannelAccountRepository.decrypted_token(row))
+                for row in rows
+                if row.status == ChannelAccountStatus.ACTIVE
+            ]
+        for row, token in accounts:
+            try:
+                await self._start_account(row, token)
+            except Exception:
+                logger.exception("微信账号启动失败 account=%s", row.account_id)
+        if accounts:
+            logger.info("微信通道已启动 %d 个账号", len(accounts))
+
+    async def stop(self) -> None:
+        await self.binding.close()
+        await self.manager.close()
+        for client in self._clients.values():
+            await client.aclose()
+        self._clients.clear()
+
+    # ------------------------------------------------------------------
+    # 账号装配
+    # ------------------------------------------------------------------
+    async def _start_account(self, row: ChannelAccount, token: str) -> None:
+        account_id = row.account_id
+        # 重新绑定热替换时,先关旧客户端
+        old = self._clients.pop(account_id, None)
+        if old is not None:
+            await self.manager.stop_account(CHANNEL_ID, account_id)
+            await old.aclose()
+
+        client = WeixinClient(row.base_url, token)
+        self._clients[account_id] = client
+        adapter = WeixinAdapter(client, account_id)
+
+        bound_user = (row.bound_user_id or "").strip()
+        dispatcher = make_dispatcher(
+            adapter,
+            # P0 白名单 = 扫码人本人;bound_user 缺失(异常数据)时拒绝所有人
+            is_allowed=lambda uid, _bound=bound_user: bool(_bound) and uid == _bound,
+            run_agent=self._run_agent,
+            reset_session=lambda key: self._histories.pop(key, None) and None,
+        )
+
+        await self.manager.start_account(
+            adapter,
+            dispatcher,
+            account_id=account_id,
+            initial_cursor=row.cursor or "",
+            save_cursor=self._make_cursor_saver(account_id),
+            on_auth_error=self._on_auth_error,
+        )
+
+    @staticmethod
+    def _make_cursor_saver(account_id: str) -> Callable[[str], Awaitable[None]]:
+        async def save(cursor: str) -> None:
+            async with get_database().session() as session:
+                await ChannelAccountRepository(session).save_cursor(account_id, cursor)
+
+        return save
+
+    async def _on_auth_error(self, account_id: str) -> None:
+        """凭据失效回调:落库标记 stale,绑定页据此引导重新扫码。"""
+        async with get_database().session() as session:
+            await ChannelAccountRepository(session).mark_stale(
+                account_id, "微信 bot 凭据已失效,请重新扫码绑定"
+            )
+
+    # ------------------------------------------------------------------
+    # 绑定流程回调
+    # ------------------------------------------------------------------
+    async def _local_tokens(self) -> list[str]:
+        """已绑定账号的 token 列表(服务端判断「是否已绑定过本实例」用)。"""
+        async with get_database().session() as session:
+            rows = await ChannelAccountRepository(session).list_by_channel(CHANNEL_ID)
+            return [ChannelAccountRepository.decrypted_token(r) for r in rows]
+
+    async def _on_binding_confirmed(self, result: BindingResult) -> None:
+        """扫码确认:凭据落库 → 热启动收发循环(成功后前端才看到 confirmed)。"""
+        async with get_database().session() as session:
+            row = await ChannelAccountRepository(session).upsert(
+                channel_id=CHANNEL_ID,
+                account_id=result.bot_id,
+                token=result.bot_token,
+                base_url=result.base_url,
+                bound_user_id=result.user_id or None,
+            )
+        await self._start_account(row, result.bot_token)
+
+    # ------------------------------------------------------------------
+    # 账号管理(API 层调用)
+    # ------------------------------------------------------------------
+    async def unbind(self, account_id: str) -> bool:
+        """解绑:停收发循环、关客户端、删凭据行。"""
+        await self.manager.stop_account(CHANNEL_ID, account_id)
+        client = self._clients.pop(account_id, None)
+        if client is not None:
+            await client.aclose()
+        # 清掉该账号的全部会话历史
+        prefix = f"{CHANNEL_ID}:{account_id}:"
+        for key in [k for k in self._histories if k.startswith(prefix)]:
+            del self._histories[key]
+        async with get_database().session() as session:
+            return await ChannelAccountRepository(session).delete(account_id)
+
+    # ------------------------------------------------------------------
+    # Agent 装配与执行(dispatcher 的 run_agent 回调)
+    # ------------------------------------------------------------------
+    async def _run_agent(
+        self, msg: InboundMessage, emit: Callable[[str], Awaitable[None]]
+    ) -> None:
+        from movieclaw_channel.pusher import StepReplyPusher
+
+        try:
+            async with get_database().session() as session:
+                llm_router = await acquire_llm_router(session)
+        except NotFoundException as exc:
+            await emit(f"⚠️ {exc.message}")
+            return
+
+        history = self._histories.setdefault(
+            msg.session_key, deque(maxlen=_HISTORY_MAX_MESSAGES)
+        )
+        runner = AgentRunner(
+            llm_router,
+            tools=await self._restricted_tools(msg.session_key),
+            max_steps=_WEIXIN_MAX_STEPS,
+        )
+        params = AgentStartParams(input=msg.text, history=list(history))
+        pusher = StepReplyPusher(emit)
+
+        async for ev in runner.start(params):
+            await pusher.feed(ev)
+
+        # 跨轮记忆:只记「用户输入 + 终答」;工具轨迹不进历史(每轮重跑更可靠)
+        if not pusher.errored:
+            history.append(ChatMessage(role="user", content=msg.text))
+            if pusher.final_text:
+                history.append(ChatMessage(role="assistant", content=pusher.final_text))
+
+    async def _restricted_tools(self, session_key: str):
+        """微信侧的受限工具集:仅 mclaw 产品操作工具,不开工作区 shell。"""
+        settings = get_settings()
+        workdir = Path(settings.agent_workspace_dir).resolve() / "weixin"
+        workdir.mkdir(parents=True, exist_ok=True)
+        token = await auth_service.issue_agent_token(session_key)
+        cli_env = {
+            "MOVIECLAW_SERVER": f"http://127.0.0.1:{settings.port}",
+            "MOVIECLAW_TOKEN": token,
+        }
+        return [make_mclaw_tool(workdir, cli_env, render_service_map())]
+
+
+# ---------------------------------------------------------------------------
+# 进程级单例(与 agent_runs 同款 init/get/close 约定)
+# ---------------------------------------------------------------------------
+
+_service: WeixinChannelService | None = None
+
+
+async def init_weixin_channel() -> WeixinChannelService:
+    """lifespan 启动时调用:创建单例并拉起已绑定账号。"""
+    global _service
+    _service = WeixinChannelService()
+    await _service.start()
+    return _service
+
+
+def get_weixin_channel() -> WeixinChannelService:
+    if _service is None:
+        raise RuntimeError("微信通道服务尚未初始化")
+    return _service
+
+
+async def close_weixin_channel() -> None:
+    global _service
+    if _service is not None:
+        await _service.stop()
+        _service = None

--- a/src/movieclaw_api/services/weixin_channel.py
+++ b/src/movieclaw_api/services/weixin_channel.py
@@ -132,11 +132,17 @@ class WeixinChannelService:
         return save
 
     async def _on_auth_error(self, account_id: str) -> None:
-        """凭据失效回调:落库标记 stale,绑定页据此引导重新扫码。"""
+        """凭据失效回调:落库标记 stale,并关闭该账号的连接池。
+
+        绑定页据 stale 状态引导用户重新扫码;重新绑定成功后会构造新客户端。
+        """
         async with get_database().session() as session:
             await ChannelAccountRepository(session).mark_stale(
                 account_id, "微信 bot 凭据已失效,请重新扫码绑定"
             )
+        client = self._clients.pop(account_id, None)
+        if client is not None:
+            await client.aclose()
 
     # ------------------------------------------------------------------
     # 绑定流程回调
@@ -178,9 +184,7 @@ class WeixinChannelService:
     # ------------------------------------------------------------------
     # Agent 装配与执行(dispatcher 的 run_agent 回调)
     # ------------------------------------------------------------------
-    async def _run_agent(
-        self, msg: InboundMessage, emit: Callable[[str], Awaitable[None]]
-    ) -> None:
+    async def _run_agent(self, msg: InboundMessage, emit: Callable[[str], Awaitable[None]]) -> None:
         from movieclaw_channel.pusher import StepReplyPusher
 
         try:
@@ -190,9 +194,7 @@ class WeixinChannelService:
             await emit(f"⚠️ {exc.message}")
             return
 
-        history = self._histories.setdefault(
-            msg.session_key, deque(maxlen=_HISTORY_MAX_MESSAGES)
-        )
+        history = self._histories.setdefault(msg.session_key, deque(maxlen=_HISTORY_MAX_MESSAGES))
         runner = AgentRunner(
             llm_router,
             tools=await self._restricted_tools(msg.session_key),

--- a/src/movieclaw_channel/__init__.py
+++ b/src/movieclaw_channel/__init__.py
@@ -1,0 +1,39 @@
+"""movieclaw_channel —— IM 通道模块(微信为首个实现)。
+
+把外部 IM 平台(微信 iLink Bot 网关等)接入 movieclaw 的 Agent 能力。
+分层设计(docs 讨论定稿):
+
+- ``types``      平台无关的消息 DTO(入站消息 / 回复上下文 / 出站信封);
+- ``adapter``    通道适配器协议:一个平台只需实现「收消息循环 + 发文本」;
+- ``pusher``     StepReplyPusher:把 AgentRunner 事件流按「步」收敛成离散 IM 消息;
+- ``dispatcher`` 事件驱动的收发解耦:会话串行队列(入站) + 出站发送泵;
+- ``manager``    每账号一个后台任务的生命周期管理(启动/停止/崩溃重启);
+- ``weixin``     微信 iLink 适配器(扫码绑定 / getUpdates 长轮询 / sendMessage)。
+
+依赖方向:本包只依赖 movieclaw_agent 的事件类型,不反向依赖 API 层;
+Agent 的装配(LLM 路由、工具集、会话历史)由 API 服务层以回调注入。
+"""
+
+from movieclaw_channel.adapter import ChannelAdapter, ChannelContext
+from movieclaw_channel.dispatcher import ChannelDispatcher, split_message
+from movieclaw_channel.manager import ChannelManager
+from movieclaw_channel.pusher import StepReplyPusher
+from movieclaw_channel.types import (
+    ChannelAuthError,
+    InboundMessage,
+    OutboundEnvelope,
+    ReplyContext,
+)
+
+__all__ = [
+    "ChannelAdapter",
+    "ChannelAuthError",
+    "ChannelContext",
+    "ChannelDispatcher",
+    "ChannelManager",
+    "InboundMessage",
+    "OutboundEnvelope",
+    "ReplyContext",
+    "StepReplyPusher",
+    "split_message",
+]

--- a/src/movieclaw_channel/adapter.py
+++ b/src/movieclaw_channel/adapter.py
@@ -1,0 +1,51 @@
+"""通道适配器协议:一个 IM 平台接入 movieclaw 需要实现的最小面。
+
+刻意保持极小(收消息循环 + 发文本):
+- 绑定流程各平台差异太大(微信是扫码+配对码状态机),不进通用协议,
+  由各自的 binding 模块实现、API 服务层直接调用;
+- 媒体收发是 P2 能力,届时再扩展协议,避免为未来做空设计。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from movieclaw_channel.types import InboundMessage, ReplyContext
+
+
+@dataclass(slots=True)
+class ChannelContext:
+    """manager 注入给 adapter 收消息循环的运行时上下文。"""
+
+    account_id: str
+    #: 入站回调:adapter 归一化一条消息后调用(必须快速返回,内部只入队)
+    on_inbound: Callable[[InboundMessage], Awaitable[None]]
+    #: 游标持久化回调(微信的 get_updates_buf;重启后从上次位置续传)
+    save_cursor: Callable[[str], Awaitable[None]]
+    #: 上次持久化的游标,空串表示从头开始
+    initial_cursor: str = ""
+    #: 停止信号:置位后 adapter 应尽快中断在飞的长轮询并退出循环
+    stop: asyncio.Event | None = None
+
+
+class ChannelAdapter(Protocol):
+    """通道适配器:平台只需知道「怎么收字节、怎么发文本」。"""
+
+    channel_id: str
+    #: 单条文本消息的长度上限(超长由发送泵分片)
+    max_text_len: int
+
+    async def run(self, ctx: ChannelContext) -> None:
+        """收消息主循环:阻塞运行直到 ``ctx.stop`` 置位。
+
+        凭据失效时抛 ``ChannelAuthError``(manager 停账号、标记 stale);
+        其余异常向上抛,由 manager 做退避重启。
+        """
+        ...
+
+    async def send_text(self, reply: ReplyContext, text: str) -> None:
+        """发送一条文本消息(调用方已完成分片,text 不超过 max_text_len)。"""
+        ...

--- a/src/movieclaw_channel/dispatcher.py
+++ b/src/movieclaw_channel/dispatcher.py
@@ -1,0 +1,306 @@
+"""ChannelDispatcher —— 收发与 Agent 运行的事件驱动解耦层(每账号一个实例)。
+
+三段式结构(与用户确认的架构):
+
+    收泵(adapter.run)          会话 worker(每会话一个)         发送泵(本类)
+    归一化→submit_inbound ──▶ 串行取件→run_agent→emit ──▶ 出站队列→分片→send_text
+
+关键语义:
+- **同会话串行**:每个 session_key 一条队列一个 worker,同一用户的消息
+  按序处理,Agent 不会并发跑同一会话;
+- **跨会话并发**:不同用户并行,全局信号量封顶,防止把 LLM 配额打爆;
+- **出站统一走队列**:Agent 回复、命令回执、未来的主动推送都经发送泵,
+  同账号出站顺序有保证,重试/分片集中一处;
+- **收泵永不阻塞在 Agent 上**:submit_inbound 只做去重/鉴权/入队即返回,
+  长任务运行期间新消息照常接收。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from movieclaw_channel.adapter import ChannelAdapter
+from movieclaw_channel.types import InboundMessage, OutboundEnvelope, ReplyContext
+
+logger = logging.getLogger("movieclaw_channel.dispatcher")
+
+#: Agent 执行回调:由 API 服务层注入(装配 LLM 路由/工具/历史后驱动 pusher)。
+#: 第二个参数是 emit——每产出一条完整消息调用一次。
+RunAgentFn = Callable[[InboundMessage, Callable[[str], Awaitable[None]]], Awaitable[None]]
+
+#: 幂等去重窗口(最近 N 条 provider_message_id)
+_DEDUP_WINDOW = 512
+#: 单会话入站队列上限:满了直接拒收新消息并提示,而不是无限排队跑 N 轮 Agent
+_SESSION_QUEUE_SIZE = 8
+#: 出站队列上限(仅作背压兜底,正常远达不到)
+_OUTBOUND_QUEUE_SIZE = 256
+#: 全局 Agent 并发上限(跨会话)
+_MAX_CONCURRENT_RUNS = 2
+#: 出站发送失败的重试次数与间隔
+_SEND_RETRIES = 1
+_SEND_RETRY_DELAY_S = 2.0
+
+
+def split_message(text: str, limit: int) -> list[str]:
+    """把超长文本按段落边界切成若干条,每条不超过 limit 字符。
+
+    优先在空行(段落)处断开;单段仍超限时按行断,再不行硬切。
+    """
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    current = ""
+
+    def push_current() -> None:
+        nonlocal current
+        if current.strip():
+            chunks.append(current.strip())
+        current = ""
+
+    for para in text.split("\n\n"):
+        candidate = f"{current}\n\n{para}" if current else para
+        if len(candidate) <= limit:
+            current = candidate
+            continue
+        push_current()
+        if len(para) <= limit:
+            current = para
+            continue
+        # 单段超限:硬切(按 limit 步进,保证终止)
+        for i in range(0, len(para), limit):
+            chunks.append(para[i : i + limit])
+    push_current()
+    return chunks
+
+
+@dataclass(slots=True)
+class _Session:
+    """一条会话的运行时状态(队列 + worker + 当前运行)。"""
+
+    queue: asyncio.Queue[InboundMessage]
+    worker: asyncio.Task[None] | None = None
+    #: 正在执行的 Agent 运行任务(/stop 的取消目标)
+    current_run: asyncio.Task[None] | None = None
+
+
+@dataclass(slots=True)
+class _DispatcherDeps:
+    """服务层注入的回调集合。"""
+
+    #: 鉴权:该 user_id 是否允许使用本账号(白名单/配对)
+    is_allowed: Callable[[str], bool]
+    #: Agent 执行(见 RunAgentFn)
+    run_agent: RunAgentFn
+    #: /reset 命令:清空该会话的跨轮历史
+    reset_session: Callable[[str], None] = field(default=lambda _key: None)
+
+
+class ChannelDispatcher:
+    """单账号的入站分发 + 出站发送泵。"""
+
+    def __init__(self, adapter: ChannelAdapter, deps: _DispatcherDeps) -> None:
+        self._adapter = adapter
+        self._deps = deps
+        self._sessions: dict[str, _Session] = {}
+        self._seen: OrderedDict[str, None] = OrderedDict()
+        self._outbound: asyncio.Queue[OutboundEnvelope] = asyncio.Queue(
+            maxsize=_OUTBOUND_QUEUE_SIZE
+        )
+        self._run_sema = asyncio.Semaphore(_MAX_CONCURRENT_RUNS)
+        self._pump_task: asyncio.Task[None] | None = None
+        self._closing = False
+
+    # ------------------------------------------------------------------
+    # 生命周期
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        self._pump_task = asyncio.create_task(
+            self._outbound_pump(), name=f"channel-pump-{self._adapter.channel_id}"
+        )
+
+    async def close(self) -> None:
+        """停止全部 worker 与发送泵(不排空队列:进程要退了,快停优先)。"""
+        self._closing = True
+        tasks: list[asyncio.Task[None]] = []
+        for session in self._sessions.values():
+            if session.current_run and not session.current_run.done():
+                session.current_run.cancel()
+            if session.worker and not session.worker.done():
+                session.worker.cancel()
+                tasks.append(session.worker)
+        if self._pump_task and not self._pump_task.done():
+            self._pump_task.cancel()
+            tasks.append(self._pump_task)
+        for t in tasks:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await t
+
+    # ------------------------------------------------------------------
+    # 入站
+    # ------------------------------------------------------------------
+    async def submit_inbound(self, msg: InboundMessage) -> None:
+        """收泵入口:去重 → 鉴权 → 命令 → 入会话队列。必须快速返回。"""
+        if self._closing:
+            return
+        if msg.provider_message_id:
+            if msg.provider_message_id in self._seen:
+                logger.debug("重复消息已忽略 id=%s", msg.provider_message_id)
+                return
+            self._seen[msg.provider_message_id] = None
+            while len(self._seen) > _DEDUP_WINDOW:
+                self._seen.popitem(last=False)
+
+        if not self._deps.is_allowed(msg.user_id):
+            # 与 openclaw 同款策略:未授权静默丢弃,不给探测者任何反馈
+            logger.info("未授权用户消息已丢弃 user=%s", msg.user_id)
+            return
+
+        if await self._handle_command(msg):
+            return
+
+        if not msg.text.strip():
+            await self.push_outbound(
+                OutboundEnvelope(reply=msg.reply, text="暂时只支持文字消息哦。", origin="system")
+            )
+            return
+
+        session = self._sessions.get(msg.session_key)
+        if session is None:
+            session = _Session(queue=asyncio.Queue(maxsize=_SESSION_QUEUE_SIZE))
+            session.worker = asyncio.create_task(
+                self._session_worker(msg.session_key, session),
+                name=f"channel-worker-{msg.session_key}",
+            )
+            self._sessions[msg.session_key] = session
+        try:
+            session.queue.put_nowait(msg)
+        except asyncio.QueueFull:
+            await self.push_outbound(
+                OutboundEnvelope(
+                    reply=msg.reply,
+                    text="排队的消息太多啦,请等我处理完手头的再发。",
+                    origin="system",
+                )
+            )
+
+    async def _handle_command(self, msg: InboundMessage) -> bool:
+        """处理斜杠命令,返回是否已消费该消息。
+
+        /stop 是唯一的「插队」路径:绕过会话队列直接取消当前运行。
+        """
+        cmd = msg.text.strip().lower()
+        if cmd == "/stop":
+            session = self._sessions.get(msg.session_key)
+            run = session.current_run if session else None
+            if run and not run.done():
+                run.cancel()
+                text = "已取消当前处理。"
+            else:
+                text = "当前没有正在进行的处理。"
+            await self.push_outbound(OutboundEnvelope(reply=msg.reply, text=text, origin="system"))
+            return True
+        if cmd == "/reset":
+            self._deps.reset_session(msg.session_key)
+            await self.push_outbound(
+                OutboundEnvelope(
+                    reply=msg.reply, text="会话已重置,我们重新开始吧。", origin="system"
+                )
+            )
+            return True
+        return False
+
+    async def _session_worker(self, session_key: str, session: _Session) -> None:
+        """会话 worker:串行消费本会话队列,每条消息驱动一次 Agent 运行。"""
+        while not self._closing:
+            msg = await session.queue.get()
+
+            async def emit(text: str, *, _reply: ReplyContext = msg.reply) -> None:
+                await self.push_outbound(OutboundEnvelope(reply=_reply, text=text))
+
+            async with self._run_sema:
+                run_task = asyncio.create_task(
+                    self._deps.run_agent(msg, emit),
+                    name=f"channel-run-{session_key}",
+                )
+                session.current_run = run_task
+                try:
+                    await run_task
+                except asyncio.CancelledError:
+                    if run_task.cancelled() and not self._closing:
+                        # /stop 取消的是运行而非 worker:回执后继续下一条
+                        await self.push_outbound(
+                            OutboundEnvelope(reply=msg.reply, text="已取消。", origin="system")
+                        )
+                        continue
+                    raise
+                except Exception:
+                    logger.exception("Agent 运行异常 session=%s", session_key)
+                    await self.push_outbound(
+                        OutboundEnvelope(
+                            reply=msg.reply,
+                            text="⚠️ 处理出错了,请稍后再试。",
+                            origin="system",
+                        )
+                    )
+                finally:
+                    session.current_run = None
+
+    # ------------------------------------------------------------------
+    # 出站
+    # ------------------------------------------------------------------
+    async def push_outbound(self, env: OutboundEnvelope) -> None:
+        """出站统一入口(Agent 回复 / 命令回执 / 未来的主动推送)。"""
+        await self._outbound.put(env)
+
+    async def _outbound_pump(self) -> None:
+        """发送泵:串行取信封 → 分片 → 调 adapter 发送(带一次重试)。"""
+        while True:
+            env = await self._outbound.get()
+            for chunk in split_message(env.text, self._adapter.max_text_len):
+                await self._send_with_retry(env.reply, chunk, env.origin)
+
+    async def _send_with_retry(self, reply: ReplyContext, text: str, origin: str) -> None:
+        for attempt in range(_SEND_RETRIES + 1):
+            try:
+                await self._adapter.send_text(reply, text)
+                return
+            except Exception as exc:  # noqa: BLE001
+                if attempt < _SEND_RETRIES:
+                    logger.warning(
+                        "消息发送失败,%s 秒后重试 user=%s origin=%s err=%s",
+                        _SEND_RETRY_DELAY_S,
+                        reply.user_id,
+                        origin,
+                        exc,
+                    )
+                    await asyncio.sleep(_SEND_RETRY_DELAY_S)
+                else:
+                    logger.error(
+                        "消息发送最终失败,该条已丢弃 user=%s origin=%s err=%s",
+                        reply.user_id,
+                        origin,
+                        exc,
+                    )
+
+
+def make_dispatcher(
+    adapter: ChannelAdapter,
+    *,
+    is_allowed: Callable[[str], bool],
+    run_agent: RunAgentFn,
+    reset_session: Callable[[str], None],
+) -> ChannelDispatcher:
+    """组装一个 dispatcher(隐藏 _DispatcherDeps 这个内部结构)。"""
+    return ChannelDispatcher(
+        adapter,
+        _DispatcherDeps(is_allowed=is_allowed, run_agent=run_agent, reset_session=reset_session),
+    )

--- a/src/movieclaw_channel/dispatcher.py
+++ b/src/movieclaw_channel/dispatcher.py
@@ -176,11 +176,16 @@ class ChannelDispatcher:
         session = self._sessions.get(msg.session_key)
         if session is None:
             session = _Session(queue=asyncio.Queue(maxsize=_SESSION_QUEUE_SIZE))
+            self._sessions[msg.session_key] = session
+        if session.worker is None or session.worker.done():
+            # 首次创建,或 worker 因未预期异常死亡后自动复活——否则该会话的
+            # 队列将无人消费,用户消息从此石沉大海
+            if session.worker is not None:
+                logger.warning("会话 worker 已退出,自动重建 session=%s", msg.session_key)
             session.worker = asyncio.create_task(
                 self._session_worker(msg.session_key, session),
                 name=f"channel-worker-{msg.session_key}",
             )
-            self._sessions[msg.session_key] = session
         try:
             session.queue.put_nowait(msg)
         except asyncio.QueueFull:
@@ -236,10 +241,8 @@ class ChannelDispatcher:
                     await run_task
                 except asyncio.CancelledError:
                     if run_task.cancelled() and not self._closing:
-                        # /stop 取消的是运行而非 worker:回执后继续下一条
-                        await self.push_outbound(
-                            OutboundEnvelope(reply=msg.reply, text="已取消。", origin="system")
-                        )
+                        # /stop 取消的是运行而非 worker(命令处理已回执过,
+                        # 这里不再重复发消息),继续消费下一条
                         continue
                     raise
                 except Exception:

--- a/src/movieclaw_channel/manager.py
+++ b/src/movieclaw_channel/manager.py
@@ -25,6 +25,9 @@ logger = logging.getLogger("movieclaw_channel.manager")
 
 #: 收消息循环异常退出后的重启退避(秒)
 _RESTART_BACKOFF_S = 30.0
+#: 停止账号时的优雅退出窗口:先置 stop 让长轮询中断、notifystop 送达,
+#: 超时仍未退出才强制取消
+_GRACEFUL_STOP_TIMEOUT_S = 5.0
 
 
 @dataclass(slots=True)
@@ -116,6 +119,9 @@ class ChannelManager:
                         await on_auth_error(ctx.account_id)
                     except Exception:  # noqa: BLE001
                         logger.exception("stale 状态回调失败 account=%s", ctx.account_id)
+                # 收消息循环已终止,发送泵/会话 worker 也一并关掉,避免任务泄漏
+                # (账号句柄保留在 _accounts 里,状态接口据此展示 stale)
+                await rt.dispatcher.close()
                 return
             except Exception as exc:  # noqa: BLE001
                 rt.last_error = str(exc)
@@ -135,9 +141,10 @@ class ChannelManager:
             return
         rt.stop.set()
         if rt.task is not None and not rt.task.done():
-            rt.task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await rt.task
+            # 优雅窗口:stop 信号会掐断在飞长轮询,循环自然退出并发 notifystop;
+            # 超时兜底强制取消(wait_for 超时时已自动 cancel 并等待任务结束)
+            with contextlib.suppress(TimeoutError, asyncio.CancelledError, Exception):
+                await asyncio.wait_for(rt.task, timeout=_GRACEFUL_STOP_TIMEOUT_S)
         await rt.dispatcher.close()
         logger.info("通道账号已停止 %s", key)
 

--- a/src/movieclaw_channel/manager.py
+++ b/src/movieclaw_channel/manager.py
@@ -1,0 +1,148 @@
+"""ChannelManager —— 通道账号的生命周期管理。
+
+每个已绑定账号对应一个后台任务组:adapter 收消息循环 + dispatcher(会话
+worker 与发送泵)。manager 负责:
+
+- 启动/停止单个账号(绑定完成后热启动,无需重启进程);
+- 收消息循环崩溃后的退避重启(网络抖动自愈);
+- 凭据失效(ChannelAuthError)时停账号并回调服务层标记 stale;
+- 进程关闭时统一停止全部账号。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from movieclaw_channel.adapter import ChannelAdapter, ChannelContext
+from movieclaw_channel.dispatcher import ChannelDispatcher
+from movieclaw_channel.types import ChannelAuthError
+
+logger = logging.getLogger("movieclaw_channel.manager")
+
+#: 收消息循环异常退出后的重启退避(秒)
+_RESTART_BACKOFF_S = 30.0
+
+
+@dataclass(slots=True)
+class _AccountRuntime:
+    """单账号的运行时句柄。"""
+
+    adapter: ChannelAdapter
+    dispatcher: ChannelDispatcher
+    stop: asyncio.Event
+    task: asyncio.Task[None] | None = None
+    #: 最近一次收消息循环错误(中文,供状态接口展示)
+    last_error: str | None = None
+    stale: bool = field(default=False)
+
+
+class ChannelManager:
+    """进程级单例:管理所有通道账号的后台任务。"""
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, _AccountRuntime] = {}
+
+    @staticmethod
+    def _key(channel_id: str, account_id: str) -> str:
+        return f"{channel_id}:{account_id}"
+
+    def is_running(self, channel_id: str, account_id: str) -> bool:
+        rt = self._accounts.get(self._key(channel_id, account_id))
+        return rt is not None and rt.task is not None and not rt.task.done()
+
+    def is_stale(self, channel_id: str, account_id: str) -> bool:
+        rt = self._accounts.get(self._key(channel_id, account_id))
+        return rt.stale if rt else False
+
+    async def start_account(
+        self,
+        adapter: ChannelAdapter,
+        dispatcher: ChannelDispatcher,
+        *,
+        account_id: str,
+        initial_cursor: str,
+        save_cursor: Callable[[str], Awaitable[None]],
+        on_auth_error: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
+        """启动一个账号(已在运行则先停旧的再起新的,支持重新绑定热替换)。"""
+        key = self._key(adapter.channel_id, account_id)
+        if key in self._accounts:
+            await self.stop_account(adapter.channel_id, account_id)
+
+        stop = asyncio.Event()
+        rt = _AccountRuntime(adapter=adapter, dispatcher=dispatcher, stop=stop)
+        ctx = ChannelContext(
+            account_id=account_id,
+            on_inbound=dispatcher.submit_inbound,
+            save_cursor=save_cursor,
+            initial_cursor=initial_cursor,
+            stop=stop,
+        )
+        dispatcher.start()
+        rt.task = asyncio.create_task(
+            self._supervise(rt, ctx, on_auth_error),
+            name=f"channel-account-{key}",
+        )
+        self._accounts[key] = rt
+        logger.info("通道账号已启动 %s", key)
+
+    async def _supervise(
+        self,
+        rt: _AccountRuntime,
+        ctx: ChannelContext,
+        on_auth_error: Callable[[str], Awaitable[None]] | None,
+    ) -> None:
+        """收消息循环的守护壳:异常退避重启,凭据失效则终止并上报。"""
+        while not ctx.stop.is_set():  # type: ignore[union-attr]
+            try:
+                await rt.adapter.run(ctx)
+                return  # 正常退出 = stop 置位
+            except asyncio.CancelledError:
+                raise
+            except ChannelAuthError as exc:
+                rt.stale = True
+                rt.last_error = str(exc)
+                logger.error(
+                    "通道凭据已失效,账号停止收发,请重新扫码绑定 account=%s err=%s",
+                    ctx.account_id,
+                    exc,
+                )
+                if on_auth_error is not None:
+                    try:
+                        await on_auth_error(ctx.account_id)
+                    except Exception:  # noqa: BLE001
+                        logger.exception("stale 状态回调失败 account=%s", ctx.account_id)
+                return
+            except Exception as exc:  # noqa: BLE001
+                rt.last_error = str(exc)
+                logger.exception(
+                    "收消息循环异常,%s 秒后重启 account=%s", _RESTART_BACKOFF_S, ctx.account_id
+                )
+                try:
+                    await asyncio.wait_for(ctx.stop.wait(), timeout=_RESTART_BACKOFF_S)  # type: ignore[union-attr]
+                    return  # 退避期间被要求停止
+                except TimeoutError:
+                    continue
+
+    async def stop_account(self, channel_id: str, account_id: str) -> None:
+        key = self._key(channel_id, account_id)
+        rt = self._accounts.pop(key, None)
+        if rt is None:
+            return
+        rt.stop.set()
+        if rt.task is not None and not rt.task.done():
+            rt.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await rt.task
+        await rt.dispatcher.close()
+        logger.info("通道账号已停止 %s", key)
+
+    async def close(self) -> None:
+        """进程关闭:停止全部账号。"""
+        for key in list(self._accounts):
+            channel_id, account_id = key.split(":", 1)
+            await self.stop_account(channel_id, account_id)

--- a/src/movieclaw_channel/pusher.py
+++ b/src/movieclaw_channel/pusher.py
@@ -1,0 +1,59 @@
+"""StepReplyPusher —— 把 AgentRunner 事件流按「步」收敛成离散 IM 消息。
+
+收敛规则(与用户逐条确认的设计):
+- Agent loop 的一步 = 一次模型调用;一步产出的完整正文 = 一条 IM 消息;
+- ``text_delta`` 只累积不推送(IM 没有打字机语义);
+- 步边界信号:本步出现第一个 ``tool_call``(正文先于工具调用产生),
+  或 ``agent_done``(终答);
+- ``thinking_delta`` / ``tool_call_delta`` / ``tool_result`` 等中间过程全部丢弃;
+- Markdown 原样透传,不做净化(微信端可渲染)。
+
+一步可能连发多个 tool_call:第一个触发 flush 后缓冲已空,后续天然幂等。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from movieclaw_agent.events import AgentEvent
+
+#: 发射回调:每条完整消息调用一次(dispatcher 把它接到出站队列)
+EmitFn = Callable[[str], Awaitable[None]]
+
+
+class StepReplyPusher:
+    """消费一次 Agent 运行的事件流,产出离散消息文本。"""
+
+    def __init__(self, emit: EmitFn) -> None:
+        self._emit = emit
+        self._buf: list[str] = []
+        #: 终答文本(agent_done 携带),供调用方写入会话历史
+        self.final_text: str = ""
+        #: 是否以错误收尾
+        self.errored: bool = False
+
+    async def feed(self, ev: AgentEvent) -> None:
+        if ev.type == "text_delta":
+            if ev.delta:
+                self._buf.append(ev.delta)
+        elif ev.type == "tool_call":
+            await self._flush()
+        elif ev.type == "agent_done":
+            await self._flush()
+            if ev.result and ev.result.text:
+                self.final_text = ev.result.text
+        elif ev.type == "agent_error":
+            self.errored = True
+            await self._flush()
+            await self._emit(f"⚠️ 处理失败:{ev.error or '未知错误'}")
+        elif ev.type == "agent_cancelled":
+            await self._flush()
+            await self._emit("已取消本次处理。")
+        # thinking_delta / tool_call_start / tool_call_delta / tool_result /
+        # context_compacted / agent_start:中间过程,全部丢弃
+
+    async def _flush(self) -> None:
+        text = "".join(self._buf).strip()
+        self._buf.clear()
+        if text:
+            await self._emit(text)

--- a/src/movieclaw_channel/types.py
+++ b/src/movieclaw_channel/types.py
@@ -1,0 +1,66 @@
+"""通道层的平台无关 DTO。
+
+设计要点:``ReplyContext.token`` 是**通道私有的不透明字典**——微信往里放
+context_token,未来别的通道放别的;通用层(dispatcher/pusher/服务编排)
+永远不解读它,只原样带回给同一个 adapter。这是把 iLink 私有协议细节封死
+在微信适配器内部的关键约定。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+class ChannelAuthError(Exception):
+    """通道凭据失效(如微信 errcode -14 token 过期)。
+
+    adapter 在收发循环里抛出本异常时,manager 会停止该账号并回调服务层
+    把账号标记为 stale——用户须重新扫码绑定,而不是无脑重试。
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ReplyContext:
+    """定位「往哪里回消息」所需的全部信息。"""
+
+    channel_id: str
+    account_id: str
+    #: 平台内用户标识,如微信的 xxx@im.wechat
+    user_id: str
+    #: 通道私有回带数据(微信: {"context_token": "..."}),通用层不解读
+    token: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class InboundMessage:
+    """归一化后的入站消息(adapter 产出,dispatcher 消费)。"""
+
+    channel_id: str
+    account_id: str
+    user_id: str
+    #: 文本正文(语音消息取平台转写文字;P0 不含媒体)
+    text: str
+    reply: ReplyContext
+    #: 平台侧消息标识,用于幂等去重(getUpdates 游标是至少一次投递)
+    provider_message_id: str
+    timestamp_ms: int = 0
+
+    @property
+    def session_key(self) -> str:
+        """会话键:同一账号同一用户 = 一条串行处理的会话。"""
+        return f"{self.channel_id}:{self.account_id}:{self.user_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class OutboundEnvelope:
+    """出站信封:发送泵唯一认识的载荷。
+
+    Agent 回复、命令回执、未来的主动推送(下载完成通知等)都走这一个口,
+    保证同账号出站顺序与限流集中在发送泵一处。
+    """
+
+    reply: ReplyContext
+    text: str
+    #: 来源标记,仅用于日志排障
+    origin: Literal["agent", "system", "push"] = "agent"

--- a/src/movieclaw_channel/weixin/__init__.py
+++ b/src/movieclaw_channel/weixin/__init__.py
@@ -1,0 +1,27 @@
+"""微信 iLink Bot 网关适配器。
+
+对接腾讯官方 iLink 机器人开放网关(HTTPS + JSON),不逆向微信客户端协议:
+
+- ``client``   iLink CGI 客户端(getupdates 长轮询 / sendmessage / 二维码接口);
+- ``adapter``  实现通道协议的 WeixinAdapter(收消息循环 + 发文本);
+- ``binding``  扫码绑定状态机(Web 化:challenge 注册表 + 后台轮询任务)。
+
+协议参考:Tencent/openclaw-weixin 开源实现(MIT)。
+"""
+
+from movieclaw_channel.weixin.adapter import WeixinAdapter
+from movieclaw_channel.weixin.binding import (
+    BindingChallenge,
+    BindingResult,
+    WeixinBindingRegistry,
+)
+from movieclaw_channel.weixin.client import DEFAULT_BASE_URL, WeixinClient
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "BindingChallenge",
+    "BindingResult",
+    "WeixinAdapter",
+    "WeixinBindingRegistry",
+    "WeixinClient",
+]

--- a/src/movieclaw_channel/weixin/adapter.py
+++ b/src/movieclaw_channel/weixin/adapter.py
@@ -15,9 +15,15 @@ import contextlib
 import logging
 from typing import Any
 
+import httpx
+
 from movieclaw_channel.adapter import ChannelContext
 from movieclaw_channel.types import ChannelAuthError, InboundMessage, ReplyContext
-from movieclaw_channel.weixin.client import STALE_TOKEN_ERRCODE, WeixinClient
+from movieclaw_channel.weixin.client import (
+    STALE_TOKEN_ERRCODE,
+    WeixinApiError,
+    WeixinClient,
+)
 
 logger = logging.getLogger("movieclaw_channel.weixin.adapter")
 
@@ -71,7 +77,23 @@ class WeixinAdapter:
 
         try:
             while not stop.is_set():
-                resp = await self._client.get_updates(cursor, stop=stop, timeout_s=timeout_s)
+                try:
+                    resp = await self._client.get_updates(cursor, stop=stop, timeout_s=timeout_s)
+                except (httpx.HTTPError, WeixinApiError) as exc:
+                    # 传输层/网关错误在循环内退避重试(与业务错误同节奏),
+                    # 不抛给 supervisor 整层重启——那会重发 notifystart 且粒度太粗
+                    failures += 1
+                    logger.error(
+                        "getupdates 请求失败 (%d/%d):%s",
+                        failures,
+                        _MAX_CONSECUTIVE_FAILURES,
+                        exc,
+                    )
+                    hit_cap = failures >= _MAX_CONSECUTIVE_FAILURES
+                    if hit_cap:
+                        failures = 0
+                    await self._sleep(stop, _BACKOFF_DELAY_S if hit_cap else _RETRY_DELAY_S)
+                    continue
 
                 ret = resp.get("ret") or 0
                 errcode = resp.get("errcode") or 0

--- a/src/movieclaw_channel/weixin/adapter.py
+++ b/src/movieclaw_channel/weixin/adapter.py
@@ -1,0 +1,155 @@
+"""WeixinAdapter —— 实现通道协议的微信收发实现。
+
+收消息循环(镜像 openclaw-weixin 的 monitor 语义):
+- getupdates 长轮询,服务端可通过 longpolling_timeout_ms 动态调整下轮超时;
+- ``get_updates_buf`` 是增量游标:每轮返回新值就持久化,重启续传(至少一次
+  投递,幂等去重由 dispatcher 负责);
+- errcode -14(token 失效)→ 抛 ChannelAuthError,由 manager 停账号标 stale;
+- 其余错误:连续失败 <3 次退避 2s,达到 3 次退避 30s,自愈后清零。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any
+
+from movieclaw_channel.adapter import ChannelContext
+from movieclaw_channel.types import ChannelAuthError, InboundMessage, ReplyContext
+from movieclaw_channel.weixin.client import STALE_TOKEN_ERRCODE, WeixinClient
+
+logger = logging.getLogger("movieclaw_channel.weixin.adapter")
+
+CHANNEL_ID = "weixin"
+
+_MAX_CONSECUTIVE_FAILURES = 3
+_RETRY_DELAY_S = 2.0
+_BACKOFF_DELAY_S = 30.0
+_DEFAULT_LONG_POLL_S = 35.0
+
+#: 消息 item 类型(iLink 协议):1=文本 3=语音
+_ITEM_TEXT = 1
+_ITEM_VOICE = 3
+#: message_type:2=BOT(自己发出的,收侧跳过)
+_MSG_TYPE_BOT = 2
+
+
+def _extract_text(item_list: list[dict[str, Any]] | None) -> str:
+    """从 item_list 提取文本正文:文本 item 优先,语音 item 取平台转写文字。"""
+    for item in item_list or []:
+        if item.get("type") == _ITEM_TEXT:
+            text = (item.get("text_item") or {}).get("text")
+            if text:
+                return str(text)
+        if item.get("type") == _ITEM_VOICE:
+            text = (item.get("voice_item") or {}).get("text")
+            if text:
+                return str(text)
+    return ""
+
+
+class WeixinAdapter:
+    """微信通道适配器(单账号)。"""
+
+    channel_id = CHANNEL_ID
+    #: 微信单条文本约 4000 字上限,留余量
+    max_text_len = 3800
+
+    def __init__(self, client: WeixinClient, account_id: str) -> None:
+        self._client = client
+        self._account_id = account_id
+
+    async def run(self, ctx: ChannelContext) -> None:
+        stop = ctx.stop or asyncio.Event()
+        await self._client.notify_start()
+        logger.info("微信收消息循环启动 account=%s", self._account_id)
+
+        cursor = ctx.initial_cursor
+        timeout_s = _DEFAULT_LONG_POLL_S
+        failures = 0
+
+        try:
+            while not stop.is_set():
+                resp = await self._client.get_updates(cursor, stop=stop, timeout_s=timeout_s)
+
+                ret = resp.get("ret") or 0
+                errcode = resp.get("errcode") or 0
+                if ret == STALE_TOKEN_ERRCODE or errcode == STALE_TOKEN_ERRCODE:
+                    raise ChannelAuthError(
+                        f"微信 bot 凭据已失效(errcode {STALE_TOKEN_ERRCODE}),请重新扫码绑定"
+                    )
+                if ret != 0 or errcode != 0:
+                    failures += 1
+                    logger.error(
+                        "getupdates 返回错误 ret=%s errcode=%s errmsg=%s (%d/%d)",
+                        ret,
+                        errcode,
+                        resp.get("errmsg"),
+                        failures,
+                        _MAX_CONSECUTIVE_FAILURES,
+                    )
+                    hit_cap = failures >= _MAX_CONSECUTIVE_FAILURES
+                    delay = _BACKOFF_DELAY_S if hit_cap else _RETRY_DELAY_S
+                    if failures >= _MAX_CONSECUTIVE_FAILURES:
+                        failures = 0
+                    await self._sleep(stop, delay)
+                    continue
+                failures = 0
+
+                # 服务端建议的下轮长轮询超时
+                suggested = resp.get("longpolling_timeout_ms")
+                if isinstance(suggested, int) and suggested > 0:
+                    timeout_s = suggested / 1000
+
+                new_cursor = resp.get("get_updates_buf")
+                if new_cursor:
+                    cursor = new_cursor
+                    await ctx.save_cursor(new_cursor)
+
+                for raw in resp.get("msgs") or []:
+                    msg = self._normalize(raw)
+                    if msg is not None:
+                        await ctx.on_inbound(msg)
+        finally:
+            await self._client.notify_stop()
+            logger.info("微信收消息循环退出 account=%s", self._account_id)
+
+    def _normalize(self, raw: dict[str, Any]) -> InboundMessage | None:
+        """iLink WeixinMessage → 归一化入站消息;非用户消息返回 None。"""
+        if raw.get("message_type") == _MSG_TYPE_BOT:
+            return None
+        from_user_id = str(raw.get("from_user_id") or "")
+        if not from_user_id:
+            return None
+
+        token: dict[str, Any] = {}
+        context_token = raw.get("context_token")
+        if context_token:
+            token["context_token"] = context_token
+
+        provider_id = str(raw.get("message_id") or raw.get("client_id") or raw.get("seq") or "")
+        reply = ReplyContext(
+            channel_id=self.channel_id,
+            account_id=self._account_id,
+            user_id=from_user_id,
+            token=token,
+        )
+        return InboundMessage(
+            channel_id=self.channel_id,
+            account_id=self._account_id,
+            user_id=from_user_id,
+            text=_extract_text(raw.get("item_list")),
+            reply=reply,
+            provider_message_id=provider_id,
+            timestamp_ms=int(raw.get("create_time_ms") or 0),
+        )
+
+    async def send_text(self, reply: ReplyContext, text: str) -> None:
+        await self._client.send_text(reply.user_id, text, reply.token.get("context_token"))
+
+    @staticmethod
+    async def _sleep(stop: asyncio.Event, seconds: float) -> None:
+        """可被 stop 打断的退避等待。"""
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop.wait(), timeout=seconds)

--- a/src/movieclaw_channel/weixin/binding.py
+++ b/src/movieclaw_channel/weixin/binding.py
@@ -88,8 +88,18 @@ class WeixinBindingRegistry:
     # 对外操作(API 层调用)
     # ------------------------------------------------------------------
     async def begin(self) -> BindingChallenge:
-        """发起绑定:取二维码、启动后台轮询任务,立即返回。"""
+        """发起绑定:取二维码、启动后台轮询任务,立即返回。
+
+        单飞:同一时刻只保留一个进行中的绑定流程。反复进入绑定页/重复点击
+        「新增绑定」会终止旧流程,避免孤儿轮询任务在后台空转 5 分钟。
+        """
         self._purge_expired()
+        for old in self._challenges.values():
+            if old.status not in _TERMINAL_STATUSES:
+                old.status = "expired"
+                old.message = "已发起新的绑定,本流程终止"
+                if old.task is not None and not old.task.done():
+                    old.task.cancel()
         tokens = await self._get_local_tokens()
         qr = await fetch_qrcode(DEFAULT_BASE_URL, tokens)
         qrcode = str(qr.get("qrcode") or "")

--- a/src/movieclaw_channel/weixin/binding.py
+++ b/src/movieclaw_channel/weixin/binding.py
@@ -1,0 +1,243 @@
+"""微信扫码绑定状态机(Web 化)。
+
+与 CLI 场景(openclaw 从 stdin 读配对码)不同,这里面向 Web 设置页:
+
+- ``begin()`` 拿二维码并启动后台轮询任务,立即返回 challenge;
+- 后台任务对 iLink 做长轮询(单次最长 35s),把最新状态写进 challenge;
+- **前端 poll 的接口只读内存快照,毫秒级返回**——绝不把前端请求穿透到
+  iLink 长轮询上;
+- ``need_verify_code`` 状态时前端弹输入框,``submit_verify_code()`` 置码并
+  唤醒后台任务带码重查;
+- ``confirmed`` 前先执行 ``on_confirmed`` 回调(落库凭据 + 热启动收发循环),
+  回调成功才对外呈现 confirmed——前端看到完成时通道已经活了。
+
+状态机(对外呈现的 status):
+    pending → scanned → confirmed
+            ↘ need_verify_code ↗(码错重入 need_verify_code)
+    pending → already_bound / expired / failed(终态)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from movieclaw_channel.weixin.client import DEFAULT_BASE_URL, fetch_qrcode, poll_qr_status
+
+logger = logging.getLogger("movieclaw_channel.weixin.binding")
+
+#: 一次绑定 challenge 的总时限(超时置 expired)
+_CHALLENGE_TTL_S = 5 * 60
+#: 二维码过期自动刷新的最大次数
+_MAX_QR_REFRESH = 3
+#: 相邻两次状态轮询的间隔(服务端本身长轮询,这里只是节流)
+_POLL_INTERVAL_S = 1.0
+
+_TERMINAL_STATUSES = {"confirmed", "already_bound", "expired", "failed"}
+
+
+@dataclass(frozen=True, slots=True)
+class BindingResult:
+    """扫码确认后服务端签发的凭据。"""
+
+    bot_id: str
+    bot_token: str
+    #: 扫码人的微信用户 id(写入白名单:谁扫码谁才能对话)
+    user_id: str
+    #: 服务端指定的就近接入地址(空则用默认)
+    base_url: str
+
+
+@dataclass(slots=True)
+class BindingChallenge:
+    """一次绑定流程的全部状态(内存态,进程重启即失效)。"""
+
+    challenge_id: str
+    status: str = "pending"
+    qrcode_url: str = ""
+    #: 面向用户的中文提示(配对码错误、失败原因等)
+    message: str = "请用手机微信扫描二维码"
+    result: BindingResult | None = None
+    # ---- 以下为内部字段 ----
+    qrcode: str = ""
+    poll_base_url: str = DEFAULT_BASE_URL
+    verify_code: str | None = None
+    code_event: asyncio.Event = field(default_factory=asyncio.Event)
+    started_at: float = field(default_factory=time.monotonic)
+    task: asyncio.Task[None] | None = None
+
+
+class WeixinBindingRegistry:
+    """绑定 challenge 注册表(进程级单例,由 API 服务层持有)。"""
+
+    def __init__(
+        self,
+        *,
+        on_confirmed: Callable[[BindingResult], Awaitable[None]],
+        get_local_tokens: Callable[[], Awaitable[list[str]]],
+    ) -> None:
+        self._on_confirmed = on_confirmed
+        self._get_local_tokens = get_local_tokens
+        self._challenges: dict[str, BindingChallenge] = {}
+
+    # ------------------------------------------------------------------
+    # 对外操作(API 层调用)
+    # ------------------------------------------------------------------
+    async def begin(self) -> BindingChallenge:
+        """发起绑定:取二维码、启动后台轮询任务,立即返回。"""
+        self._purge_expired()
+        tokens = await self._get_local_tokens()
+        qr = await fetch_qrcode(DEFAULT_BASE_URL, tokens)
+        qrcode = str(qr.get("qrcode") or "")
+        qrcode_url = str(qr.get("qrcode_img_content") or "")
+        if not qrcode or not qrcode_url:
+            raise RuntimeError("获取微信二维码失败:服务端未返回二维码内容")
+
+        challenge = BindingChallenge(
+            challenge_id=uuid.uuid4().hex[:16], qrcode=qrcode, qrcode_url=qrcode_url
+        )
+        challenge.task = asyncio.create_task(
+            self._drive(challenge), name=f"weixin-binding-{challenge.challenge_id}"
+        )
+        self._challenges[challenge.challenge_id] = challenge
+        logger.info("微信绑定已发起 challenge=%s", challenge.challenge_id)
+        return challenge
+
+    def get(self, challenge_id: str) -> BindingChallenge | None:
+        return self._challenges.get(challenge_id)
+
+    def submit_verify_code(self, challenge_id: str, code: str) -> bool:
+        """提交手机上显示的配对数字;challenge 不存在或已终态返回 False。"""
+        challenge = self._challenges.get(challenge_id)
+        if challenge is None or challenge.status in _TERMINAL_STATUSES:
+            return False
+        challenge.verify_code = code.strip()
+        challenge.code_event.set()
+        return True
+
+    async def close(self) -> None:
+        for challenge in self._challenges.values():
+            if challenge.task and not challenge.task.done():
+                challenge.task.cancel()
+
+    # ------------------------------------------------------------------
+    # 后台状态机
+    # ------------------------------------------------------------------
+    async def _drive(self, ch: BindingChallenge) -> None:
+        """轮询 iLink 扫码状态直到终态或超时。"""
+        deadline = ch.started_at + _CHALLENGE_TTL_S
+        qr_refresh_count = 0
+        try:
+            while time.monotonic() < deadline:
+                resp = await poll_qr_status(ch.poll_base_url, ch.qrcode, ch.verify_code)
+                status = str(resp.get("status") or "wait")
+
+                if status == "wait":
+                    pass
+                elif status == "scaned":
+                    # 带码轮询后回到 scaned = 配对码正确,清除暂存
+                    ch.verify_code = None
+                    ch.status = "scanned"
+                    ch.message = "已扫码,请在手机上确认"
+                elif status == "need_verifycode":
+                    rejected = ch.verify_code is not None
+                    ch.verify_code = None
+                    ch.status = "need_verify_code"
+                    ch.message = (
+                        "配对码不正确,请重新输入" if rejected else "请输入手机微信上显示的数字"
+                    )
+                    ch.code_event.clear()
+                    # 等用户在网页上输入配对码(或整体超时)
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    try:
+                        await asyncio.wait_for(ch.code_event.wait(), timeout=remaining)
+                    except TimeoutError:
+                        break
+                    ch.status = "scanned"
+                    ch.message = "正在校验配对码…"
+                    continue  # 立即带码重查
+                elif status == "verify_code_blocked":
+                    ch.status = "failed"
+                    ch.message = "配对码错误次数过多,请稍后重新发起绑定"
+                    return
+                elif status == "expired":
+                    qr_refresh_count += 1
+                    if qr_refresh_count > _MAX_QR_REFRESH:
+                        ch.status = "expired"
+                        ch.message = "二维码多次过期,请重新发起绑定"
+                        return
+                    tokens = await self._get_local_tokens()
+                    qr = await fetch_qrcode(DEFAULT_BASE_URL, tokens)
+                    ch.qrcode = str(qr.get("qrcode") or "")
+                    ch.qrcode_url = str(qr.get("qrcode_img_content") or "")
+                    ch.status = "pending"
+                    ch.message = "二维码已刷新,请重新扫描"
+                    logger.info(
+                        "绑定二维码已刷新(%d/%d) challenge=%s",
+                        qr_refresh_count,
+                        _MAX_QR_REFRESH,
+                        ch.challenge_id,
+                    )
+                elif status == "scaned_but_redirect":
+                    # IDC 就近调度:切换后续轮询主机
+                    host = str(resp.get("redirect_host") or "")
+                    if host:
+                        ch.poll_base_url = f"https://{host}"
+                        logger.info("绑定轮询已重定向到 %s", host)
+                elif status == "binded_redirect":
+                    ch.status = "already_bound"
+                    ch.message = "该微信已绑定过本实例,无需重复绑定"
+                    return
+                elif status == "confirmed":
+                    bot_id = str(resp.get("ilink_bot_id") or "")
+                    bot_token = str(resp.get("bot_token") or "")
+                    if not bot_id or not bot_token:
+                        ch.status = "failed"
+                        ch.message = "绑定失败:服务端未返回完整凭据"
+                        return
+                    result = BindingResult(
+                        bot_id=bot_id,
+                        bot_token=bot_token,
+                        user_id=str(resp.get("ilink_user_id") or ""),
+                        base_url=str(resp.get("baseurl") or "") or DEFAULT_BASE_URL,
+                    )
+                    # 先落库并热启动收发循环,成功后才对外呈现 confirmed
+                    try:
+                        await self._on_confirmed(result)
+                    except Exception:
+                        logger.exception("绑定确认回调失败 challenge=%s", ch.challenge_id)
+                        ch.status = "failed"
+                        ch.message = "绑定成功但保存/启动失败,请查看日志后重试"
+                        return
+                    ch.result = result
+                    ch.status = "confirmed"
+                    ch.message = "绑定完成,微信通道已启动"
+                    logger.info("微信绑定完成 bot=%s", bot_id)
+                    return
+                else:
+                    logger.warning("未知扫码状态 %s,按等待处理", status)
+
+                await asyncio.sleep(_POLL_INTERVAL_S)
+
+            ch.status = "expired"
+            ch.message = "绑定超时,请重新发起"
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("绑定状态机异常 challenge=%s", ch.challenge_id)
+            ch.status = "failed"
+            ch.message = "绑定过程出错,请重试(详情见日志)"
+
+    def _purge_expired(self) -> None:
+        """清掉已终态且超过 TTL 的历史 challenge,防止内存泄漏。"""
+        now = time.monotonic()
+        for cid in list(self._challenges):
+            ch = self._challenges[cid]
+            if now - ch.started_at > _CHALLENGE_TTL_S and ch.status in _TERMINAL_STATUSES:
+                del self._challenges[cid]

--- a/src/movieclaw_channel/weixin/client.py
+++ b/src/movieclaw_channel/weixin/client.py
@@ -1,0 +1,239 @@
+"""iLink Bot 网关的 HTTP 客户端(JSON over HTTPS)。
+
+协议要点(参考 Tencent/openclaw-weixin):
+- 所有接口 POST/GET JSON,bytes 字段(游标、密钥)在 JSON 里是 base64 字符串;
+- 鉴权:``Authorization: Bearer <bot_token>`` + ``AuthorizationType: ilink_bot_token``;
+- 身份头:``iLink-App-Id`` / ``iLink-App-ClientVersion``(版本编码为 0x00MMNNPP);
+- ``getupdates`` 是长轮询:服务端 hold 住请求直到有新消息或超时,客户端超时
+  属正常控制流(返回空结果重试),不算错误;
+- 每个请求体附带 ``base_info``(channel_version + bot_agent,仅观测用)。
+
+网络说明:微信网关是国内直连地址,刻意**不走** movieclaw_net 的代理路由
+(代理通常面向境外站点,套上反而容易断)。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import logging
+import secrets
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("movieclaw_channel.weixin.client")
+
+DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com"
+
+#: 服务端返回该错误码表示 bot_token 已失效,须重新扫码
+STALE_TOKEN_ERRCODE = -14
+
+#: iLink 身份头(与 openclaw-weixin 同款声明)
+_APP_ID = "bot"
+_CHANNEL_VERSION = "0.1.0"
+_BOT_AGENT = f"MovieClaw/{_CHANNEL_VERSION}"
+
+#: 常规接口超时(秒);长轮询单独指定
+_API_TIMEOUT_S = 15.0
+
+
+class WeixinApiError(Exception):
+    """iLink 接口返回业务错误(ret/errcode 非 0)或 HTTP 错误。"""
+
+    def __init__(self, message: str, code: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _encode_client_version(version: str) -> int:
+    """版本号编码为 uint32:major<<16 | minor<<8 | patch(高 8 位固定 0)。"""
+    parts = version.split(".")
+
+    def _num(i: int) -> int:
+        try:
+            return int(parts[i]) & 0xFF
+        except (IndexError, ValueError):
+            return 0
+
+    return (_num(0) << 16) | (_num(1) << 8) | _num(2)
+
+
+def _base_headers() -> dict[str, str]:
+    # X-WECHAT-UIN:随机 uint32 → 十进制字符串 → base64(每请求随机)
+    uin = base64.b64encode(str(secrets.randbits(32)).encode()).decode()
+    return {
+        "Content-Type": "application/json",
+        "iLink-App-Id": _APP_ID,
+        "iLink-App-ClientVersion": str(_encode_client_version(_CHANNEL_VERSION)),
+        "X-WECHAT-UIN": uin,
+    }
+
+
+def _base_info() -> dict[str, str]:
+    return {"channel_version": _CHANNEL_VERSION, "bot_agent": _BOT_AGENT}
+
+
+def _raise_for_business_error(payload: dict[str, Any], label: str) -> None:
+    """检查响应体的 ret/errcode,非 0 则抛业务错误(游标类接口自行处理,不走这里)。"""
+    ret = payload.get("ret")
+    if ret not in (None, 0):
+        raise WeixinApiError(
+            f"{label} 失败:ret={ret} errmsg={payload.get('errmsg') or '(无)'}", code=int(ret)
+        )
+
+
+class WeixinClient:
+    """绑定单个 bot 账号的 iLink CGI 客户端。"""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+        self._token = token
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(_API_TIMEOUT_S))
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    def _headers(self) -> dict[str, str]:
+        headers = _base_headers()
+        headers["AuthorizationType"] = "ilink_bot_token"
+        headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    async def _post(
+        self, endpoint: str, body: dict[str, Any], *, timeout_s: float = _API_TIMEOUT_S
+    ) -> dict[str, Any]:
+        url = f"{self.base_url}/{endpoint}"
+        resp = await self._client.post(
+            url,
+            json={**body, "base_info": _base_info()},
+            headers=self._headers(),
+            timeout=httpx.Timeout(timeout_s),
+        )
+        if resp.status_code != 200:
+            raise WeixinApiError(f"{endpoint} HTTP {resp.status_code}: {resp.text[:200]}")
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # 收消息:getupdates 长轮询
+    # ------------------------------------------------------------------
+    async def get_updates(
+        self,
+        cursor: str,
+        *,
+        stop: asyncio.Event | None = None,
+        timeout_s: float = 35.0,
+    ) -> dict[str, Any]:
+        """长轮询拉取新消息。
+
+        - 客户端超时(服务端 hold 满没消息)→ 返回空结果,调用方直接重试;
+        - ``stop`` 置位 → 立刻掐断在飞请求,返回空结果(收消息循环随即退出);
+        - 业务错误码(含 -14)不在这里抛,原样返回给 adapter 分类处理。
+        """
+        body = {"get_updates_buf": cursor or ""}
+        request = asyncio.ensure_future(
+            self._post("ilink/bot/getupdates", body, timeout_s=timeout_s + 5)
+        )
+        empty = {"ret": 0, "msgs": [], "get_updates_buf": ""}
+
+        if stop is not None:
+            stopper = asyncio.ensure_future(stop.wait())
+            done, _ = await asyncio.wait({request, stopper}, return_when=asyncio.FIRST_COMPLETED)
+            if request not in done:
+                request.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await request
+                return empty
+            stopper.cancel()
+
+        try:
+            return await request
+        except httpx.TimeoutException:
+            logger.debug("getupdates 客户端超时(长轮询正常路径),继续下一轮")
+            return empty
+
+    # ------------------------------------------------------------------
+    # 发消息
+    # ------------------------------------------------------------------
+    async def send_text(self, to_user_id: str, text: str, context_token: str | None) -> None:
+        """发送一条文本消息(context_token 必须原样回带,服务端据此定位会话)。"""
+        msg: dict[str, Any] = {
+            "from_user_id": "",
+            "to_user_id": to_user_id,
+            "client_id": f"movieclaw-{secrets.token_hex(8)}",
+            "message_type": 2,  # BOT
+            "message_state": 2,  # FINISH
+            "item_list": [{"type": 1, "text_item": {"text": text}}],
+        }
+        if context_token:
+            msg["context_token"] = context_token
+        else:
+            logger.warning("发送时缺少 context_token,将无上下文投递 to=%s", to_user_id)
+        payload = await self._post("ilink/bot/sendmessage", {"msg": msg})
+        _raise_for_business_error(payload, "sendmessage")
+
+    # ------------------------------------------------------------------
+    # 生命周期通知(失败只告警,不阻断启停)
+    # ------------------------------------------------------------------
+    async def notify_start(self) -> None:
+        try:
+            await self._post("ilink/bot/msg/notifystart", {}, timeout_s=10)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("notifystart 失败(忽略):%s", exc)
+
+    async def notify_stop(self) -> None:
+        try:
+            await self._post("ilink/bot/msg/notifystop", {}, timeout_s=10)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("notifystop 失败(忽略):%s", exc)
+
+
+# ---------------------------------------------------------------------------
+# 绑定用的无凭据接口(拿二维码 / 轮询扫码状态)
+# 绑定是低频操作,用短生命周期客户端逐次请求,不维护连接池。
+# ---------------------------------------------------------------------------
+
+_QR_BOT_TYPE = "3"
+_QR_POLL_TIMEOUT_S = 35.0
+
+
+async def fetch_qrcode(base_url: str, local_token_list: list[str]) -> dict[str, Any]:
+    """获取登录二维码。返回 {qrcode, qrcode_img_content(二维码链接)}。
+
+    local_token_list:本机已绑定账号的 token(最多 10 个),服务端用它判断
+    「该 bot 是否已绑定过本实例」(binded_redirect)。
+    """
+    url = f"{base_url.rstrip('/')}/ilink/bot/get_bot_qrcode?bot_type={_QR_BOT_TYPE}"
+    async with httpx.AsyncClient(timeout=httpx.Timeout(_API_TIMEOUT_S)) as client:
+        resp = await client.post(
+            url,
+            json={"local_token_list": local_token_list[:10], "base_info": _base_info()},
+            headers=_base_headers(),
+        )
+        if resp.status_code != 200:
+            raise WeixinApiError(f"获取二维码失败 HTTP {resp.status_code}: {resp.text[:200]}")
+        return resp.json()
+
+
+async def poll_qr_status(
+    base_url: str, qrcode: str, verify_code: str | None = None
+) -> dict[str, Any]:
+    """长轮询扫码状态。网络错误/网关超时按「继续等待」处理,返回 {status: wait}。
+
+    返回字段(confirmed 时):bot_token / ilink_bot_id / ilink_user_id / baseurl。
+    """
+    params: dict[str, str] = {"qrcode": qrcode}
+    if verify_code:
+        params["verify_code"] = verify_code
+    url = f"{base_url.rstrip('/')}/ilink/bot/get_qrcode_status"
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(_QR_POLL_TIMEOUT_S + 5)) as client:
+            resp = await client.get(url, params=params, headers=_base_headers())
+            if resp.status_code != 200:
+                logger.warning("扫码状态查询 HTTP %s,按等待处理", resp.status_code)
+                return {"status": "wait"}
+            return resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning("扫码状态查询网络错误,按等待处理:%s", exc)
+        return {"status": "wait"}

--- a/src/movieclaw_channel/weixin/client.py
+++ b/src/movieclaw_channel/weixin/client.py
@@ -205,11 +205,13 @@ async def fetch_qrcode(base_url: str, local_token_list: list[str]) -> dict[str, 
     「该 bot 是否已绑定过本实例」(binded_redirect)。
     """
     url = f"{base_url.rstrip('/')}/ilink/bot/get_bot_qrcode?bot_type={_QR_BOT_TYPE}"
+    # 与 openclaw 一致:即使无 token,POST 也要带 AuthorizationType 声明
+    headers = {**_base_headers(), "AuthorizationType": "ilink_bot_token"}
     async with httpx.AsyncClient(timeout=httpx.Timeout(_API_TIMEOUT_S)) as client:
         resp = await client.post(
             url,
             json={"local_token_list": local_token_list[:10], "base_info": _base_info()},
-            headers=_base_headers(),
+            headers=headers,
         )
         if resp.status_code != 200:
             raise WeixinApiError(f"获取二维码失败 HTTP {resp.status_code}: {resp.text[:200]}")

--- a/src/movieclaw_db/models/__init__.py
+++ b/src/movieclaw_db/models/__init__.py
@@ -12,6 +12,7 @@ from movieclaw_db.models.agent_session import AgentSession
 from movieclaw_db.models.app_setting import AppSetting
 from movieclaw_db.models.base import TimestampMixin, utcnow
 from movieclaw_db.models.cache_entry import CacheEntry
+from movieclaw_db.models.channel_account import ChannelAccount, ChannelAccountStatus
 from movieclaw_db.models.download_hint import DownloadHint
 from movieclaw_db.models.downloader_client import ClientType, DownloaderClient
 from movieclaw_db.models.import_watch import ImportWatch
@@ -52,6 +53,8 @@ __all__ = [
     "utcnow",
     "AgentSession",
     "CacheEntry",
+    "ChannelAccount",
+    "ChannelAccountStatus",
     "SiteCookie",
     "SiteCredential",
     "AuthType",

--- a/src/movieclaw_db/models/channel_account.py
+++ b/src/movieclaw_db/models/channel_account.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from sqlalchemy import Column, Text
+from sqlmodel import Field
+
+from movieclaw_db.models.base import TimestampMixin
+
+
+class ChannelAccountStatus(StrEnum):
+    """通道账号状态。
+
+    - ACTIVE:凭据有效,收发循环正常运行(或待启动);
+    - STALE:凭据已被平台判定失效(如微信 errcode -14),须重新扫码绑定。
+      stale 账号启动时跳过,绑定页展示「需重新绑定」引导。
+    """
+
+    ACTIVE = "active"
+    STALE = "stale"
+
+
+class ChannelAccount(TimestampMixin, table=True):
+    """IM 通道账号表:一行 = 一个已绑定的 bot 账号(微信为首个通道)。
+
+    安全:``token`` 经 SecretBox 加密后落库(``enc::`` 前缀密文),
+    加解密统一在 Repository 层完成,与站点凭据/LLM Key 同款约定。
+
+    ``cursor`` 是收消息增量游标(微信的 get_updates_buf,base64 长文本):
+    每轮长轮询返回新值即覆盖,进程重启后从该位置续传,不丢不重的「不重」
+    部分由 dispatcher 的消息 id 去重兜底(游标语义是至少一次投递)。
+
+    ``bound_user_id`` 是扫码人的平台用户 id,同时充当 P0 的白名单:
+    只有这个用户发来的消息会被处理(谁扫码谁才能用,防陌生人探测)。
+    """
+
+    __tablename__ = "channel_account"
+
+    id: int | None = Field(default=None, primary_key=True)
+    channel_id: str = Field(index=True, description="通道类型:weixin")
+    account_id: str = Field(unique=True, description="平台侧账号 id(微信 ilink_bot_id)")
+    token: str = Field(description="平台凭据(SecretBox 加密密文)")
+    base_url: str = Field(description="平台网关地址(绑定时服务端指定的就近接入)")
+    bound_user_id: str | None = Field(
+        default=None, description="扫码绑定人的平台用户 id(即白名单)"
+    )
+    cursor: str | None = Field(
+        default=None, sa_column=Column(Text), description="收消息增量游标(get_updates_buf)"
+    )
+    status: ChannelAccountStatus = Field(
+        default=ChannelAccountStatus.ACTIVE, description="账号状态(active/stale)"
+    )
+    last_error: str | None = Field(default=None, description="最近一次异常说明(中文)")

--- a/src/movieclaw_db/repositories/channel_account_repo.py
+++ b/src/movieclaw_db/repositories/channel_account_repo.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from movieclaw_db.crypto import get_secret_box
+from movieclaw_db.models.base import utcnow
+from movieclaw_db.models.channel_account import ChannelAccount, ChannelAccountStatus
+
+
+class ChannelAccountRepository:
+    """IM 通道账号表的数据访问层。
+
+    敏感字段加解密收口在本层(与站点凭据/下载器同款约定):
+    - 落库时用 SecretBox 加密 token;
+    - ``decrypted_token`` 仅在装配通道客户端时调用,明文不随 ORM 对象传递。
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(self, account_id: str) -> ChannelAccount | None:
+        result = await self._session.execute(
+            select(ChannelAccount).where(ChannelAccount.account_id == account_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_channel(self, channel_id: str) -> list[ChannelAccount]:
+        result = await self._session.execute(
+            select(ChannelAccount)
+            .where(ChannelAccount.channel_id == channel_id)
+            .order_by(ChannelAccount.created_at)
+        )
+        return list(result.scalars().all())
+
+    async def upsert(
+        self,
+        *,
+        channel_id: str,
+        account_id: str,
+        token: str,
+        base_url: str,
+        bound_user_id: str | None,
+    ) -> ChannelAccount:
+        """绑定成功后落库(重复绑定同一 bot 时覆盖凭据并复位状态/游标)。
+
+        游标一并清空:新凭据对应服务端新会话,旧游标已无意义,从头开始
+        拉取即可(服务端只投递未消费的消息)。
+        """
+        token_enc = get_secret_box().encrypt(token)
+        row = await self.get(account_id)
+        if row is None:
+            row = ChannelAccount(
+                channel_id=channel_id,
+                account_id=account_id,
+                token=token_enc,
+                base_url=base_url,
+                bound_user_id=bound_user_id,
+            )
+        else:
+            row.token = token_enc
+            row.base_url = base_url
+            row.bound_user_id = bound_user_id
+            row.cursor = None
+            row.status = ChannelAccountStatus.ACTIVE
+            row.last_error = None
+            row.updated_at = utcnow()
+        self._session.add(row)
+        await self._session.commit()
+        await self._session.refresh(row)
+        return row
+
+    async def save_cursor(self, account_id: str, cursor: str) -> None:
+        """持久化收消息游标(每轮长轮询有新值就覆盖,高频小写入)。"""
+        row = await self.get(account_id)
+        if row is None:
+            return
+        row.cursor = cursor
+        row.updated_at = utcnow()
+        self._session.add(row)
+        await self._session.commit()
+
+    async def mark_stale(self, account_id: str, reason: str) -> None:
+        """凭据失效:标记 stale,绑定页据此引导用户重新扫码。"""
+        row = await self.get(account_id)
+        if row is None:
+            return
+        row.status = ChannelAccountStatus.STALE
+        row.last_error = reason
+        row.updated_at = utcnow()
+        self._session.add(row)
+        await self._session.commit()
+
+    async def delete(self, account_id: str) -> bool:
+        row = await self.get(account_id)
+        if row is None:
+            return False
+        await self._session.delete(row)
+        await self._session.commit()
+        return True
+
+    @staticmethod
+    def decrypted_token(row: ChannelAccount) -> str:
+        return get_secret_box().decrypt(row.token)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -261,6 +261,8 @@ def test_every_route_denies_anonymous_access(client: TestClient) -> None:
             .replace("{session_id}", "test-session")
             .replace("{day}", "2026-01-01")
             .replace("{path}", "1/poster.jpg")
+            .replace("{challenge_id}", "test-challenge")
+            .replace("{account_id}", "test-bot")
         )
         assert "{" not in url, f"守护测试不认识路径参数，请补充哑值：{path}"
         for method in methods:

--- a/tests/channel/test_dispatcher.py
+++ b/tests/channel/test_dispatcher.py
@@ -1,0 +1,185 @@
+"""ChannelDispatcher:分片、去重、鉴权、同会话串行、/stop 与 /reset。"""
+
+from __future__ import annotations
+
+import asyncio
+
+from movieclaw_channel.dispatcher import make_dispatcher, split_message
+from movieclaw_channel.types import InboundMessage, ReplyContext
+
+# ---------------------------------------------------------------------------
+# split_message(纯函数)
+# ---------------------------------------------------------------------------
+
+
+def test_split_short_text_untouched():
+    assert split_message("你好", 100) == ["你好"]
+
+
+def test_split_empty_text():
+    assert split_message("  \n ", 100) == []
+
+
+def test_split_prefers_paragraph_boundary():
+    text = "第一段。\n\n第二段。\n\n第三段。"
+    chunks = split_message(text, 12)
+    assert all(len(c) <= 12 for c in chunks)
+    assert "".join(chunks).replace("\n\n", "") == text.replace("\n\n", "")
+
+
+def test_split_hard_cuts_oversized_paragraph():
+    text = "字" * 25
+    chunks = split_message(text, 10)
+    assert chunks == ["字" * 10, "字" * 10, "字" * 5]
+
+
+# ---------------------------------------------------------------------------
+# dispatcher 行为(用假 adapter 驱动)
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapter:
+    channel_id = "weixin"
+    max_text_len = 50
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+
+    async def run(self, ctx) -> None:  # pragma: no cover - dispatcher 测试不走收循环
+        raise NotImplementedError
+
+    async def send_text(self, reply: ReplyContext, text: str) -> None:
+        self.sent.append((reply.user_id, text))
+
+
+def _msg(text: str, *, msg_id: str, user: str = "u1@im.wechat") -> InboundMessage:
+    reply = ReplyContext(channel_id="weixin", account_id="bot1", user_id=user)
+    return InboundMessage(
+        channel_id="weixin",
+        account_id="bot1",
+        user_id=user,
+        text=text,
+        reply=reply,
+        provider_message_id=msg_id,
+    )
+
+
+async def _drain(dispatcher, adapter, *, expect: int, timeout: float = 2.0) -> None:
+    """等发送泵把 expect 条消息发完(轮询,避免依赖内部实现)。"""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while len(adapter.sent) < expect:
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError(f"等待发送超时:已发 {len(adapter.sent)}/{expect}")
+        await asyncio.sleep(0.01)
+
+
+async def test_serial_processing_and_reply():
+    """同会话消息按序处理,回复经出站泵送达。"""
+    adapter = FakeAdapter()
+    order: list[str] = []
+
+    async def run_agent(msg, emit):
+        order.append(msg.text)
+        await emit(f"回复:{msg.text}")
+
+    d = make_dispatcher(
+        adapter, is_allowed=lambda _u: True, run_agent=run_agent, reset_session=lambda _k: None
+    )
+    d.start()
+    try:
+        await d.submit_inbound(_msg("一", msg_id="m1"))
+        await d.submit_inbound(_msg("二", msg_id="m2"))
+        await _drain(d, adapter, expect=2)
+        assert order == ["一", "二"]
+        assert [t for _, t in adapter.sent] == ["回复:一", "回复:二"]
+    finally:
+        await d.close()
+
+
+async def test_dedup_and_auth():
+    adapter = FakeAdapter()
+    handled: list[str] = []
+
+    async def run_agent(msg, emit):
+        handled.append(msg.provider_message_id)
+
+    d = make_dispatcher(
+        adapter,
+        is_allowed=lambda u: u == "owner@im.wechat",
+        run_agent=run_agent,
+        reset_session=lambda _k: None,
+    )
+    d.start()
+    try:
+        await d.submit_inbound(_msg("hi", msg_id="dup", user="owner@im.wechat"))
+        await d.submit_inbound(_msg("hi", msg_id="dup", user="owner@im.wechat"))  # 重复:丢
+        await d.submit_inbound(_msg("hi", msg_id="other", user="stranger@im.wechat"))  # 未授权:丢
+        await asyncio.sleep(0.1)
+        assert handled == ["dup"]
+    finally:
+        await d.close()
+
+
+async def test_reset_command():
+    adapter = FakeAdapter()
+    resets: list[str] = []
+
+    async def run_agent(msg, emit):  # pragma: no cover - 命令不进 Agent
+        raise AssertionError("命令消息不应进入 Agent")
+
+    d = make_dispatcher(
+        adapter,
+        is_allowed=lambda _u: True,
+        run_agent=run_agent,
+        reset_session=resets.append,
+    )
+    d.start()
+    try:
+        await d.submit_inbound(_msg("/reset", msg_id="c1"))
+        await _drain(d, adapter, expect=1)
+        assert resets == ["weixin:bot1:u1@im.wechat"]
+        assert "会话已重置" in adapter.sent[0][1]
+    finally:
+        await d.close()
+
+
+async def test_stop_cancels_running_agent():
+    adapter = FakeAdapter()
+    started = asyncio.Event()
+
+    async def run_agent(msg, emit):
+        started.set()
+        await asyncio.sleep(30)  # 模拟长任务,等着被 /stop 取消
+
+    d = make_dispatcher(
+        adapter, is_allowed=lambda _u: True, run_agent=run_agent, reset_session=lambda _k: None
+    )
+    d.start()
+    try:
+        await d.submit_inbound(_msg("跑个长任务", msg_id="m1"))
+        await asyncio.wait_for(started.wait(), timeout=2)
+        await d.submit_inbound(_msg("/stop", msg_id="m2"))
+        # 应收到 /stop 回执与取消回执两条系统消息
+        await _drain(d, adapter, expect=2)
+        texts = [t for _, t in adapter.sent]
+        assert any("已取消当前处理" in t for t in texts)
+    finally:
+        await d.close()
+
+
+async def test_long_reply_is_chunked():
+    adapter = FakeAdapter()
+
+    async def run_agent(msg, emit):
+        await emit("段落甲" * 10 + "\n\n" + "段落乙" * 10)  # 60 字,上限 50
+
+    d = make_dispatcher(
+        adapter, is_allowed=lambda _u: True, run_agent=run_agent, reset_session=lambda _k: None
+    )
+    d.start()
+    try:
+        await d.submit_inbound(_msg("hi", msg_id="m1"))
+        await _drain(d, adapter, expect=2)
+        assert all(len(t) <= 50 for _, t in adapter.sent)
+    finally:
+        await d.close()

--- a/tests/channel/test_dispatcher.py
+++ b/tests/channel/test_dispatcher.py
@@ -159,10 +159,42 @@ async def test_stop_cancels_running_agent():
         await d.submit_inbound(_msg("跑个长任务", msg_id="m1"))
         await asyncio.wait_for(started.wait(), timeout=2)
         await d.submit_inbound(_msg("/stop", msg_id="m2"))
-        # 应收到 /stop 回执与取消回执两条系统消息
-        await _drain(d, adapter, expect=2)
+        # /stop 只回执一条,worker 侧不再重复发「已取消」
+        await _drain(d, adapter, expect=1)
+        await asyncio.sleep(0.05)
         texts = [t for _, t in adapter.sent]
-        assert any("已取消当前处理" in t for t in texts)
+        assert texts == ["已取消当前处理。"]
+    finally:
+        await d.close()
+
+
+async def test_dead_worker_is_revived():
+    """worker 意外死亡后,下一条消息触发自动复活,会话不永久卡死。"""
+    adapter = FakeAdapter()
+    calls: list[str] = []
+
+    async def run_agent(msg, emit):
+        calls.append(msg.text)
+        await emit(f"回复:{msg.text}")
+
+    d = make_dispatcher(
+        adapter, is_allowed=lambda _u: True, run_agent=run_agent, reset_session=lambda _k: None
+    )
+    d.start()
+    try:
+        await d.submit_inbound(_msg("一", msg_id="m1"))
+        await _drain(d, adapter, expect=1)
+        # 模拟 worker 被意外终止(等价于内部未预期崩溃后任务结束)
+        session = d._sessions["weixin:bot1:u1@im.wechat"]  # noqa: SLF001 -- 测试内部状态
+        assert session.worker is not None
+        session.worker.cancel()
+        await asyncio.sleep(0.05)
+        assert session.worker.done()
+
+        await d.submit_inbound(_msg("还活着吗", msg_id="m2"))
+        await _drain(d, adapter, expect=2)
+        assert calls == ["一", "还活着吗"]
+        assert adapter.sent[-1][1] == "回复:还活着吗"
     finally:
         await d.close()
 

--- a/tests/channel/test_pusher.py
+++ b/tests/channel/test_pusher.py
@@ -1,0 +1,65 @@
+"""StepReplyPusher:按「步」收敛 Agent 事件流为离散消息。"""
+
+from __future__ import annotations
+
+from movieclaw_agent.events import AgentDone, AgentEvent
+from movieclaw_channel.pusher import StepReplyPusher
+from movieclaw_llm import ToolCall
+
+
+def _collector() -> tuple[list[str], StepReplyPusher]:
+    emitted: list[str] = []
+
+    async def emit(text: str) -> None:
+        emitted.append(text)
+
+    return emitted, StepReplyPusher(emit)
+
+
+def _ev(type_: str, **kw) -> AgentEvent:
+    return AgentEvent(type=type_, run_id="r1", **kw)
+
+
+async def test_single_step_text_flushed_on_done():
+    emitted, pusher = _collector()
+    await pusher.feed(_ev("agent_start"))
+    await pusher.feed(_ev("text_delta", delta="你好,"))
+    await pusher.feed(_ev("text_delta", delta="我来帮你。"))
+    await pusher.feed(_ev("agent_done", result=AgentDone(text="你好,我来帮你。")))
+    assert emitted == ["你好,我来帮你。"]
+    assert pusher.final_text == "你好,我来帮你。"
+
+
+async def test_step_boundary_at_tool_call():
+    """每一步的正文 = 一条消息:工具调用前的正文先发,终答再发一条。"""
+    emitted, pusher = _collector()
+    await pusher.feed(_ev("text_delta", delta="我先搜一下。"))
+    await pusher.feed(_ev("tool_call", tool_call=ToolCall(id="t1", name="mclaw")))
+    # 同一步连发第二个工具调用:缓冲已空,不产生空消息
+    await pusher.feed(_ev("tool_call", tool_call=ToolCall(id="t2", name="mclaw")))
+    await pusher.feed(_ev("tool_result"))
+    await pusher.feed(_ev("text_delta", delta="找到了这些结果。"))
+    await pusher.feed(_ev("agent_done", result=AgentDone(text="找到了这些结果。")))
+    assert emitted == ["我先搜一下。", "找到了这些结果。"]
+
+
+async def test_thinking_and_deltas_are_dropped():
+    emitted, pusher = _collector()
+    await pusher.feed(_ev("thinking_delta", delta="内心戏"))
+    await pusher.feed(_ev("tool_call_delta", delta='{"a":1}', tool_call_id="t1"))
+    await pusher.feed(_ev("agent_done", result=AgentDone(text=None)))
+    assert emitted == []
+
+
+async def test_error_flushes_then_notifies():
+    emitted, pusher = _collector()
+    await pusher.feed(_ev("text_delta", delta="进行到一半"))
+    await pusher.feed(_ev("agent_error", error="模型超时"))
+    assert emitted == ["进行到一半", "⚠️ 处理失败:模型超时"]
+    assert pusher.errored is True
+
+
+async def test_cancelled_notice():
+    emitted, pusher = _collector()
+    await pusher.feed(_ev("agent_cancelled"))
+    assert emitted == ["已取消本次处理。"]


### PR DESCRIPTION
把 movieclaw 的 Agent 能力接入微信(腾讯官方 iLink Bot 网关,协议参考 Tencent/openclaw-weixin,不逆向微信客户端)。

## 内容

**通道核心层 `src/movieclaw_channel/`(平台无关)**
- `pusher`:StepReplyPusher 把 Agent 事件流按「步」收敛为离散 IM 消息(一步的完整正文 = 一条微信消息,thinking/工具中间过程丢弃,Markdown 原样透传)
- `dispatcher`:事件驱动解耦 —— 收泵只入队即返回、同会话串行 worker、跨会话并发封顶、出站统一发送泵(分片/重试/顺序保证);`/stop` `/reset` 命令;worker 意外死亡自动复活
- `manager`:每账号一个后台任务,网络错误循环内退避,凭据失效停号标 stale,5s 优雅停机窗口

**微信适配器 `weixin/`**
- getupdates 长轮询(stop 可即时中断)、`get_updates_buf` 游标落库续传、消息 ID 去重
- sendmessage 回带 context_token;Web 化扫码绑定状态机(配对码输入、二维码自动刷新、IDC 重定向、绑定单飞)

**数据与接口**
- `channel_account` 表(token 经 SecretBox 加密)+ alembic 迁移
- `/channels/weixin` 五个端点:账号列表 / 发起绑定 / 状态轮询 / 配对码 / 解绑(带 x-cli-dangerous)
- 二维码由后端渲染 SVG data URL(新增纯 Python `qrcode` 依赖,web 侧零新增依赖)

**前端(设置 → 智能 → 微信绑定)**
- 进页拉列表:非空只展示账号列表;为空自动出码并每 2s 轮询;need_verify_code 弹配对码输入;confirmed 后二维码消失、通道即刻可用;此后仅点「新增绑定」再出码

**安全**
- 白名单 = 扫码人本人,未授权消息静默丢弃
- 微信侧 Agent 仅挂 mclaw 受限工具集(不开 bash/文件工具),max_steps 收紧

## 验证

- `tests/channel` 15 个单测全绿(pusher 步边界、dispatcher 串行/去重/鉴权/stop/分片/worker 复活)
- api+agent 全量回归:15 个失败中 14 个经基线(cc8e554)比对确认为历史遗留,唯一新增失败(openapi 契约)已修复
- web typecheck / eslint、ruff lint+format 干净

## 已知边界(后续迭代)

- 会话历史为内存态,进程重启清空;进行中的绑定 challenge 同为内存态
- 媒体收发(CDN AES-128-ECB 加解密)、主动推送(下载完成通知)为 P2/P3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144SCyB4Gh8EbguBDepRPbC

---
_Generated by [Claude Code](https://claude.ai/code/session_0144SCyB4Gh8EbguBDepRPbC)_