### PR TITLE
feat(channel): 微信绑定前置 AI 模型配置门禁

### DIFF
--- a/apps/web/components/weixin-binding-section.tsx
+++ b/apps/web/components/weixin-binding-section.tsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import Link from "next/link";
+
 import { ChatIcon } from "@/components/icons";
+import { useLlmConfigured } from "@/components/llm-gate";
 import {
   type WeixinAccount,
   type WeixinBindingSnapshot,
@@ -26,8 +29,13 @@ import { useVisiblePolling } from "@/lib/use-visible-polling";
  *   confirmed → 二维码消失、提示完成、刷新列表(此时通道已在收发);
  *   expired/failed → 展示原因 + 「重新生成」按钮;
  * - 已有绑定后,除非点「新增绑定」,二维码不再出现。
+ *
+ * 前置门禁:微信侧对话完全由 AI 模型驱动,未接入模型供应商时不自动出码、
+ * 隐藏绑定入口,并展示引导提醒(判定与 useLlmConfigured / 后端同口径)。
  */
 export function WeixinBindingSection() {
+  // null = 探测中(不出码也不提醒,避免闪烁);false = 未配置(拦下并引导)
+  const llmConfigured = useLlmConfigured();
   const [accounts, setAccounts] = useState<WeixinAccount[] | null>(null);
   const [binding, setBinding] = useState<WeixinBindingSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -73,15 +81,19 @@ export function WeixinBindingSection() {
     }
   }, []);
 
-  // 进入页面:先拉列表;为空则自动发起绑定(仅首次)
+  // 进入页面:先拉账号列表
   useEffect(() => {
-    void loadAccounts().then((rows) => {
-      if (rows.length === 0 && !autoStartedRef.current) {
-        autoStartedRef.current = true;
-        void beginBinding();
-      }
-    });
-  }, [loadAccounts, beginBinding]);
+    void loadAccounts();
+  }, [loadAccounts]);
+
+  // 列表为空且模型已配置时自动发起绑定(仅首次);未配置模型不出码
+  useEffect(() => {
+    if (llmConfigured !== true || accounts == null) return;
+    if (accounts.length === 0 && !autoStartedRef.current) {
+      autoStartedRef.current = true;
+      void beginBinding();
+    }
+  }, [llmConfigured, accounts, beginBinding]);
 
   // 绑定进行中每 2s poll 状态;终态停止
   const polling =
@@ -163,6 +175,20 @@ export function WeixinBindingSection() {
         </div>
       )}
 
+      {/* 前置门禁:未接入 AI 模型时给出引导,并隐藏所有绑定入口 */}
+      {llmConfigured === false && (
+        <div className="rounded-xl border border-[#f5c451]/30 bg-[#f5c451]/10 px-4 py-3 text-body text-[#f5c451]">
+          微信绑定需要先完成 AI 模型配置——微信里的对话完全由模型驱动。请先前往
+          <Link
+            href="/settings/llm"
+            className="mx-1 font-medium underline underline-offset-2 hover:opacity-80"
+          >
+            设置 → AI 模型
+          </Link>
+          接入模型供应商，再回来扫码绑定。
+        </div>
+      )}
+
       {loading ? (
         <div className="h-[104px] animate-pulse rounded-xl bg-white/[0.04]" />
       ) : (
@@ -233,8 +259,8 @@ export function WeixinBindingSection() {
             </div>
           )}
 
-          {/* 已有绑定且当前没在走绑定流程:提供「新增绑定」入口 */}
-          {hasAccounts && binding == null && (
+          {/* 已有绑定且当前没在走绑定流程:提供「新增绑定」入口(模型未配置时隐藏) */}
+          {hasAccounts && binding == null && llmConfigured !== false && (
             <button
               type="button"
               disabled={busy}
@@ -245,8 +271,8 @@ export function WeixinBindingSection() {
             </button>
           )}
 
-          {/* 空态且绑定发起失败(网关不可达等):手动重试入口 */}
-          {!hasAccounts && binding == null && (
+          {/* 空态且绑定发起失败(网关不可达等):手动重试入口(模型未配置时隐藏,由上方提醒引导) */}
+          {!hasAccounts && binding == null && llmConfigured !== false && (
             <div className="css-glass flex flex-col items-center gap-3 !rounded-2xl px-6 py-12 text-center">
               <span className="icon-chip size-12 !rounded-2xl">
                 <ChatIcon className="size-6" />

--- a/src/movieclaw_api/api/routes/channels.py
+++ b/src/movieclaw_api/api/routes/channels.py
@@ -29,6 +29,7 @@ from movieclaw_api.services.weixin_channel import get_weixin_channel
 from movieclaw_channel.weixin.adapter import CHANNEL_ID
 from movieclaw_db.engine import get_session
 from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
+from movieclaw_db.repositories.llm_provider_repo import LlmProviderRepository
 
 router = APIRouter(prefix="/channels/weixin", tags=["channels"])
 
@@ -74,8 +75,19 @@ async def list_weixin_accounts(
     summary="发起微信扫码绑定",
     operation_id="channels.weixin.bindings.start",
 )
-async def start_weixin_binding() -> ApiResponse[WeixinBindingStartView]:
-    """获取二维码并启动后台状态轮询;前端拿 challenge_id 开始 poll。"""
+async def start_weixin_binding(
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[WeixinBindingStartView]:
+    """获取二维码并启动后台状态轮询;前端拿 challenge_id 开始 poll。
+
+    前置:必须已配置 AI 模型——微信侧对话完全由模型驱动,没配置时绑定了
+    也无法使用,不如在入口拦下并引导去设置(与 acquire_llm_router 同口径,
+    只看是否已配置,连通性验证失败仍放行由运行时报错)。
+    """
+    if await LlmProviderRepository(session).get() is None:
+        raise BadRequestException(
+            "微信绑定需要先完成 AI 模型配置:请先在「设置 → AI 模型」接入模型供应商,再进行绑定"
+        )
     try:
         challenge = await get_weixin_channel().binding.begin()
     except Exception as exc:  # noqa: BLE001 -- 网关不可达等,转成中文业务错误


### PR DESCRIPTION
微信侧对话完全由模型驱动,未配置模型时绑定了也无法使用,在入口拦下并引导。

## 内容

- **后端(硬闸)**:`POST /channels/weixin/bindings` 校验模型供应商已配置,未配置返回 400 中文引导错误;绕过前端直调接口也拦得住
- **前端(体验层)**:进入「微信绑定」页先探测模型配置(复用 `useLlmConfigured` 门禁钩子):
  - 未配置 → 顶部黄色引导提醒(内嵌「设置 → AI 模型」跳转链接),不自动出码,隐藏「生成绑定二维码 / 新增绑定」入口;已绑定账号列表照常展示
  - 已配置 → 行为不变;探测中 → 不出码不提醒,避免闪烁
- 判定口径与对话入口 `LlmGate` / 后端 `acquire_llm_router` 一致:只看是否已配置,连通性验证失败仍放行由运行时报错

## 验证

- web typecheck / eslint 干净
- 后端 32 个测试通过(鉴权守护、openapi 契约、channel 全量)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144SCyB4Gh8EbguBDepRPbC

---
_Generated by [Claude Code](https://claude.ai/code/session_0144SCyB4Gh8EbguBDepRPbC)_