### PR TITLE
test(cli): 命令树快照补充 app show/set/restart

### DIFF
--- a/tests/cli/command_tree_snapshot.txt
+++ b/tests/cli/command_tree_snapshot.txt
@@ -5,6 +5,9 @@ agent sessions list
 agent sessions rename
 agent sessions show
 agent start
+app restart
+app set
+app show
 appearance active set
 appearance backdrops delete
 appearance backdrops download


### PR DESCRIPTION
## 概述

修复 #46 合并后主干的快照守护测试失败。

## 改动内容

- `tests/cli/command_tree_snapshot.txt` 补充新增的三条 CLI 命令：`app show` / `app set` / `app restart`——#46 新增 `/app` 接口时重导出了 spec 基线，但遗漏了命令树快照的重新生成，`test_command_tree_matches_snapshot` 在主干失败

## 测试

- `tests/cli` 全组 60 passed（含快照守护）；`tests/api` 全组此前已验证通过，本次改动不涉及

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg)_