### PR TITLE
系统提示词注入外部访问地址与前端页面路由表，Agent 可给用户拼准确页面链接

### DIFF
--- a/src/movieclaw_api/api/routes/agent.py
+++ b/src/movieclaw_api/api/routes/agent.py
@@ -34,6 +34,7 @@ from movieclaw_api.services.agent_sessions import (
 )
 from movieclaw_api.services.llm_config import acquire_llm_router
 from movieclaw_api.services.mclaw_tool import render_service_map
+from movieclaw_api.settings import AppServerSetting, get_setting_store
 from movieclaw_db.engine import get_session
 from movieclaw_db.repositories.agent_session_repo import (
     AgentSessionRepository,
@@ -59,19 +60,29 @@ def get_agent_tools(cli_env: dict[str, str]) -> list[AgentTool]:
     ]
 
 
-def _agent_system_prompt() -> str:
+async def _agent_system_prompt() -> str:
     """组装本次运行的系统提示词：通用正文 + 部署环境事实。
 
     日志目录是 API 层的配置（LOG_DIR），按 prompts.build_system_prompt 的
     设计走 extra_environment 传入——mclaw 已对 Agent 隐藏 logs 域（见
     services/mclaw_tool 的 _EXCLUDED_DOMAINS），排查问题靠这里给出的
     路径用 bash 直接检索。
+
+    外部访问地址来自「设置 → 应用设置」（保存即生效），因此每次运行时
+    现读设置存储，不做缓存；未配置时不输出该行，避免模型拼出无效链接。
     """
     log_dir = Path(get_settings().log_dir).resolve()
-    return build_system_prompt(
+    lines = [
         f"- 运行日志目录：{log_dir}，按天一个文件（movieclaw-YYYY-MM-DD.log）。"
         "排查问题时用 bash 的 grep/tail 直接检索日志。"
-    )
+    ]
+    external_url = (await get_setting_store().get(AppServerSetting)).external_url
+    if external_url:
+        lines.append(
+            f"- 本应用的外部访问地址：{external_url}。需要给用户可点击的页面链接时"
+            "以它为前缀（例如订阅详情、媒体库条目页）；不要用容器内地址拼链接。"
+        )
+    return build_system_prompt("\n".join(lines))
 
 
 async def _cli_env(session_id: str) -> dict[str, str]:
@@ -159,7 +170,7 @@ async def start_agent(
         input=payload.input,
         history=history,
         model=payload.model,
-        system_prompt=_agent_system_prompt(),
+        system_prompt=await _agent_system_prompt(),
     )
     run_id = get_agent_run_registry().start(runner, params, on_terminal=recorder.on_terminal)
     await recorder.begin(run_id)
@@ -278,7 +289,7 @@ async def compact_agent_session(
         "",
     )
 
-    messages = [ChatMessage(role="system", content=_agent_system_prompt()), *history]
+    messages = [ChatMessage(role="system", content=await _agent_system_prompt()), *history]
     result = await compact(llm_router, model, messages, ModelSettings())
     if result is None:
         raise UpstreamServiceException("压缩失败：模型未能生成摘要，请稍后重试")

--- a/src/movieclaw_api/api/routes/agent.py
+++ b/src/movieclaw_api/api/routes/agent.py
@@ -60,6 +60,27 @@ def get_agent_tools(cli_env: dict[str, str]) -> list[AgentTool]:
     ]
 
 
+# 前端页面路由表：模型拼可点击链接的唯一依据（(路径模式, 一行说明)）。
+# 与 apps/web/app/(app) 的真实页面结构由守护测试保持同步（见
+# tests/api/test_agent.py 的 test_page_routes_match_web_app_pages）——
+# 前端加页面、改路径时测试会拦下，这张表不会悄悄过期。
+_PAGE_ROUTES: list[tuple[str, str]] = [
+    ("/", "首页"),
+    ("/search", "站点资源搜索页"),
+    ("/discover/{movie|tv}", "发现页（电影/剧集的榜单与分类浏览）"),
+    ("/discover/movie/top250", "豆瓣电影 Top250 榜单"),
+    ("/media/{movie|tv}/{TMDB ID}", "影片/剧集详情页"),
+    ("/media/douban/{豆瓣ID}", "豆瓣词条详情页"),
+    ("/subscriptions", "订阅列表"),
+    ("/subscriptions/{订阅ID}", "订阅详情（ID 来自 sub list/show）"),
+    ("/library", "媒体库总览"),
+    ("/library/{库ID}", "某个媒体库的内容（库 ID 来自 lib list）"),
+    ("/library/{库ID}/item/{条目ID}", "库内条目详情（条目 ID 即 lib items 的 media_item_id）"),
+    ("/people/{影人ID}", "影人档案（ID 来自 people 域）"),
+    ("/settings", "设置页"),
+]
+
+
 async def _agent_system_prompt() -> str:
     """组装本次运行的系统提示词：通用正文 + 部署环境事实。
 
@@ -69,7 +90,8 @@ async def _agent_system_prompt() -> str:
     路径用 bash 直接检索。
 
     外部访问地址来自「设置 → 应用设置」（保存即生效），因此每次运行时
-    现读设置存储，不做缓存；未配置时不输出该行，避免模型拼出无效链接。
+    现读设置存储，不做缓存；未配置时整块不输出——没有前缀，路由表也
+    拼不出有效链接，避免模型给用户无效地址。
     """
     log_dir = Path(get_settings().log_dir).resolve()
     lines = [
@@ -78,9 +100,11 @@ async def _agent_system_prompt() -> str:
     ]
     external_url = (await get_setting_store().get(AppServerSetting)).external_url
     if external_url:
+        routes = "\n".join(f"  {pattern}  {desc}" for pattern, desc in _PAGE_ROUTES)
         lines.append(
-            f"- 本应用的外部访问地址：{external_url}。需要给用户可点击的页面链接时"
-            "以它为前缀（例如订阅详情、媒体库条目页）；不要用容器内地址拼链接。"
+            f"- 本应用的外部访问地址：{external_url}。提到订阅、影片、库内条目等页面时，"
+            "尽量附上可点击的 Markdown 链接：以外部访问地址为前缀，路径按下表拼接。"
+            f"只拼表内路径，不要用容器内地址拼链接。\n{routes}"
         )
     return build_system_prompt("\n".join(lines))
 

--- a/tests/api/test_agent.py
+++ b/tests/api/test_agent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -340,3 +341,45 @@ def test_system_prompt_external_url_injection(client) -> None:
     prompt = asyncio.run(_agent_system_prompt())
     # 保存时规范化掉了尾部斜杠
     assert "外部访问地址：http://192.168.1.10:3000。" in prompt
+
+
+def test_page_routes_match_web_app_pages() -> None:
+    """路由表守护：声明的页面必须真实存在，前端新增页面必须显式处理（进表或豁免）。
+
+    归一化规则：路由表的 {参数} 与 Next.js 的 [参数] 目录都归一为 *，
+    只比较路径形状，参数叫什么名字不影响同步判断。
+    """
+    from movieclaw_api.api.routes.agent import _PAGE_ROUTES
+
+    web_app = Path(__file__).resolve().parents[2] / "apps" / "web" / "app" / "(app)"
+    assert web_app.is_dir(), f"前端页面目录不存在：{web_app}"
+
+    fs_routes = set()
+    for page in web_app.rglob("page.tsx"):
+        rel = page.parent.relative_to(web_app).as_posix()
+        if rel == ".":
+            fs_routes.add("/")
+        else:
+            fs_routes.add(
+                "/" + "/".join("*" if seg.startswith("[") else seg for seg in rel.split("/"))
+            )
+
+    def normalize(pattern: str) -> str:
+        if pattern == "/":
+            return "/"
+        return "/" + "/".join(
+            "*" if seg.startswith("{") else seg for seg in pattern.strip("/").split("/")
+        )
+
+    declared = {normalize(pattern) for pattern, _ in _PAGE_ROUTES}
+
+    # 不进路由表的页面：/runs 是 Agent 会话页自身，/settings 子分区给 /settings 兜底
+    exempt = {"/runs/*", "/settings/*"}
+
+    ghosts = declared - fs_routes
+    assert not ghosts, f"路由表声明了前端不存在的页面：{sorted(ghosts)}"
+    unhandled = fs_routes - declared - exempt
+    assert not unhandled, (
+        f"前端新增了路由表未覆盖的页面：{sorted(unhandled)}——"
+        "要么补进 _PAGE_ROUTES 告知模型，要么加入本测试的豁免清单"
+    )

--- a/tests/api/test_agent.py
+++ b/tests/api/test_agent.py
@@ -323,3 +323,20 @@ def test_cancel_run_ends_with_cancelled_event(client, monkeypatch) -> None:
 
     events = parse_sse(client.get(f"/api/v1/agent/runs/{run_id}/stream").text)
     assert events[-1][1] == "agent_cancelled"
+
+
+def test_system_prompt_external_url_injection(client) -> None:
+    """外部访问地址注入系统提示词环境段：未配置不出现，配置后原文出现。"""
+    from movieclaw_api.api.routes.agent import _agent_system_prompt
+
+    prompt = asyncio.run(_agent_system_prompt())
+    assert "外部访问地址" not in prompt
+
+    saved = client.put(
+        "/api/v1/app/config",
+        json={"port": 0, "external_url": "http://192.168.1.10:3000/"},
+    )
+    assert saved.status_code == 200
+    prompt = asyncio.run(_agent_system_prompt())
+    # 保存时规范化掉了尾部斜杠
+    assert "外部访问地址：http://192.168.1.10:3000。" in prompt


### PR DESCRIPTION
## 改动内容

### 外部访问地址注入（`_agent_system_prompt` 改为异步）
- 「设置 → 应用设置」的外部访问地址（`external_url`）保存即生效，故每次 Agent 运行/上下文压缩时现读设置存储，不做缓存
- 未配置时整块不输出，避免模型给用户拼无效链接

### 前端页面路由表
- 只给地址前缀模型无从知道产品的页面路径；随外部地址一起注入路由表：路径模式 + 一行说明 + ID 来源提示（订阅 ID 来自 `sub list`、条目 ID 即 `lib items` 的 `media_item_id` 等）
- 提示模型以 Markdown 链接形式附上页面地址，只拼表内路径、不用容器内地址

### 守护测试
- 新增 `test_page_routes_match_web_app_pages`：路由表与 `apps/web/app/(app)` 的真实页面结构双向同步——声明了不存在的页面、或前端新增页面未登记（进表或豁免），测试都会拦下
- 新增 `test_system_prompt_external_url_injection`：未配置不出现、配置后原文出现（含尾斜杠规范化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wguYKjUZZojbUCx1BB9XB

---
_Generated by [Claude Code](https://claude.ai/code/session_012wguYKjUZZojbUCx1BB9XB)_