### PR TITLE
feat(settings): 「应用设置」与「关于与更新」合并为「应用」分区

### DIFF
--- a/apps/web/app/(app)/settings/[section]/page.tsx
+++ b/apps/web/app/(app)/settings/[section]/page.tsx
@@ -24,6 +24,8 @@ export default async function SettingsSectionPage({
   const { section } = await params;
   // 旧「搜索」分区已并入「资源站点」，老书签/历史链接重定向过去，不要 404
   if (section === "search") redirect("/settings/sites" as Route);
+  // 旧「关于与更新」分区已并入「应用」，同样重定向兜底
+  if (section === "about") redirect("/settings/app" as Route);
   if (!settingsSections.some((s) => s.id === section)) notFound();
   return <SettingsPanel active={section} />;
 }

--- a/apps/web/components/app-config-section.tsx
+++ b/apps/web/components/app-config-section.tsx
@@ -40,6 +40,10 @@ export function AppConfigSection() {
   const [urlError, setUrlError] = useState<string | null>(null);
   const [restartPhase, setRestartPhase] = useState<RestartPhase>("idle");
   const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 外部访问地址的最佳示例就是用户此刻浏览器正在使用的地址（SSR 阶段无 window，
+  // 但表单要等客户端拉到配置才渲染，这里只是兜底给个通用示例）
+  const currentOrigin =
+    typeof window === "undefined" ? "https://movie.example.com" : window.location.origin;
 
   const reload = useCallback(() => {
     setFailed(false);
@@ -180,13 +184,16 @@ export function AppConfigSection() {
                 label="外部访问地址"
                 help={
                   <>
-                    <p>从网络上能访问到本应用的完整地址，保存即生效。</p>
+                    <p>
+                      从网络上能访问到本应用的完整地址，保存即生效。通常就是你浏览器
+                      地址栏正在使用的地址（输入框的提示即当前地址，照填即可）。
+                    </p>
                     <p className="mt-1.5">
-                      例：<code>http://192.168.1.10:3000</code>，或经反向代理后的{" "}
+                      若经反向代理 / 域名访问，请填代理后的对外地址，如{" "}
                       <code>https://movie.example.com</code>。
                     </p>
                     <p className="mt-1.5 text-[var(--text-muted)]">
-                      用于后续生成通知里的跳转链接、对外回调地址等需要绝对 URL 的场景。
+                      用于生成通知里的跳转链接、对外回调地址等需要绝对 URL 的场景。
                     </p>
                   </>
                 }
@@ -196,7 +203,7 @@ export function AppConfigSection() {
                 defaultValue={view.external_url}
                 onBlur={(e) => handleUrlBlur(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
-                placeholder="http://192.168.1.10:3000"
+                placeholder={currentOrigin}
                 className="w-[300px] max-w-[55%] rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-2 font-mono text-sub text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-faint)] focus:border-[var(--accent)]/50 max-md:w-full max-md:max-w-none"
               />
             </div>

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -161,13 +161,17 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
         ) : section.id === "weixin" ? (
           <WeixinBindingSection />
         ) : section.id === "app" ? (
-          <AppConfigSection />
+          // 「应用」一个分区收拢应用自身的一切：版本与更新（AppUpdateSection：
+          // 版本/更新/模型/回退）在前，网络与维护（AppConfigSection：外部访问
+          // 地址/重启）在后——重启这类危险操作按惯例垫底
+          <div className="space-y-7">
+            <AppUpdateSection />
+            <AppConfigSection />
+          </div>
         ) : section.id === "network" ? (
           <NetworkConfigSection />
         ) : section.id === "logs" ? (
           <SystemLogsSection />
-        ) : section.id === "about" ? (
-          <AppUpdateSection />
         ) : (
           <GenericSection sectionId={section.id} />
         )}

--- a/apps/web/lib/mock-data.ts
+++ b/apps/web/lib/mock-data.ts
@@ -12,7 +12,6 @@ import {
   FolderIcon,
   GearIcon,
   GlobeIcon,
-  InfoIcon,
   PaletteIcon,
   ServerIcon,
   SparkIcon,
@@ -140,10 +139,9 @@ export const settingsSectionGroups: SettingsSectionGroup[] = [
   {
     label: "系统",
     items: [
-      { id: "app", label: "应用设置", description: "外部访问地址与重启应用", icon: GearIcon },
+      { id: "app", label: "应用", description: "版本与更新、外部访问地址与重启", icon: GearIcon },
       { id: "network", label: "网络与代理", description: "外部服务的代理与镜像地址，解决 TMDB 等不可达", icon: GlobeIcon },
       { id: "logs", label: "系统日志", description: "后端运行日志，按天存档", icon: TerminalIcon },
-      { id: "about", label: "关于与更新", description: "当前版本、检查更新与版本回退", icon: InfoIcon },
     ],
   },
 ];


### PR DESCRIPTION
## 概述

「应用设置」（外部访问地址 + 重启）与「关于与更新」（版本/更新/回退）都是"应用自身"的事务，两个分区功能相近、分开徒增理解负担，合并为一个「应用」分区。

## 改动内容

- 设置侧栏「系统」组：合并为 `应用`（版本与更新、外部访问地址与重启），移除 `关于与更新` 入口
- 分区内容按组排列：版本 / 更新 / NER 识别模型 / 回退 / 网络 / 维护——复用现有两个组件原样堆叠，重启等危险操作按惯例垫底
- 旧链接 `/settings/about` 重定向到 `/settings/app`（沿用 search → sites 的兜底先例，不 404）
- 修复外部访问地址输入提示：占位符由硬编码示例 IP（`http://192.168.1.10:3000`）改为动态取 `window.location.origin`——用户此刻浏览器正在使用的地址就是该字段的最佳示例；帮助文案同步说明"照提示填即可，反代场景填代理后地址"

## 测试

- 纯前端改动（后端接口无变化，spec 不变）；eslint 0 errors、tsc 全绿、Next 生产构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg)_