### PR TITLE
feat(settings): 外部访问地址未设置时给引导小字与「使用当前地址」一键保存

### DIFF
--- a/apps/web/components/app-config-section.tsx
+++ b/apps/web/components/app-config-section.tsx
@@ -199,6 +199,9 @@ export function AppConfigSection() {
                 }
               />
               <input
+                // key 随已保存值变化：一键填入/规范化（去尾斜杠）保存后，
+                // 非受控输入框靠重挂载同步显示最新落库值
+                key={view.external_url}
                 type="text"
                 defaultValue={view.external_url}
                 onBlur={(e) => handleUrlBlur(e.target.value)}
@@ -208,6 +211,22 @@ export function AppConfigSection() {
               />
             </div>
             {urlError && <p className="mt-1.5 text-right text-caption text-red-300">{urlError}</p>}
+            {/* 未设置时的引导：说清设置的收益 + 一键把当前浏览器地址落库 */}
+            {!view.external_url && !urlError && (
+              <div className="mt-2 flex items-center justify-end gap-2.5 max-md:flex-col max-md:items-stretch">
+                <p className="text-caption leading-5 text-[var(--text-faint)]">
+                  尚未设置：设置后 AI 助手的回复和通知才能带上指向本应用的可点击页面链接
+                </p>
+                <button
+                  type="button"
+                  onClick={() => commit({ external_url: currentOrigin })}
+                  disabled={saveState === "saving"}
+                  className="btn-glass shrink-0 px-3 py-1 text-caption font-semibold disabled:opacity-40"
+                >
+                  使用当前地址
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## 概述

外部访问地址字段的两处体验优化：未设置时给出引导与一键保存入口。

## 改动内容

- **一键保存**：占位符已动态取浏览器当前 origin，新增「使用当前地址」按钮，点一下直接落库，免去手抄地址；输入框 `key` 随落库值变化重挂载，保证非受控输入同步回显规范化后的保存值
- **引导小字**：未设置且无校验错误时，在字段下方以小字说明设置的收益——设置后 AI 助手的回复和通知才能带上指向本应用的可点击页面链接（Agent 系统提示词环境段消费该地址）；设置后引导自动消失

## 测试

- 纯前端改动；eslint 0 errors、tsc 全绿、Next 生产构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg)_