### PR TITLE
chore(release): bump 版本号至 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "movieclaw"
-version = "0.1.0"
+version = "0.2.0"
 description = "Best-practice Python HTTP service template powered by FastAPI."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/movieclaw_api/__init__.py
+++ b/src/movieclaw_api/__init__.py
@@ -2,4 +2,4 @@
 
 # 应用版本（应用内更新的比对基准）。发版时与 pyproject.toml 的 version、
 # Release tag 三者必须一致，scripts/build-release-artifacts.sh 会校验。
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## 概述

首个应用 Release（v0.2.0）的版本号 bump：`pyproject.toml` 与 `src/movieclaw_api/__init__.py` 同步升至 0.2.0，合入后在合并提交上打 tag `v0.2.0` 触发 release.yml。

## 发版检查清单

- [x] 版本号三处一致：pyproject 0.2.0 / `__version__` 0.2.0 / 待打 tag v0.2.0（build-release-artifacts.sh 强校验）
- [x] 运行时依赖自 `docker/runtime-version`=1 以来零变更（runtime-guard CI 全程在位），无需发新镜像
- [x] 选 0.2.0 而非 0.1.0：基线镜像内代码版本为 0.1.0，Release 版本必须大于它，存量部署的应用内更新才会识别到新版本

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg)_