### PR TITLE
ci(release): 发版工作流支持手动触发（workflow_dispatch 输入 tag）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,15 @@ name: release
 on:
   push:
     tags: ["v*"]
+  # 手动触发通道：远程会话（Claude Code 等）的 git 凭证通常只能推分支、
+  # 推不了 tag。这里输入目标 tag 后，由「创建 Release」步骤经 gh 一并创建
+  # tag（指向触发时的 main HEAD）。GITHUB_TOKEN 创建的 tag 不会再触发
+  # 本工作流的 push 事件，无递归风险。
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "要发布的 tag（如 v0.2.0），须与 pyproject / __version__ 一致"
+        required: true
 
 permissions:
   contents: write
@@ -19,6 +28,9 @@ permissions:
 jobs:
   release-artifacts:
     runs-on: ubuntu-latest
+    env:
+      # tag 推送事件取 ref 名；手动触发取输入的 tag。后续步骤统一用它。
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +62,7 @@ jobs:
           # manifest.json.sig；未配置则跳过签名（部署侧不设公钥即不校验）
           RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}" ./scripts/build-release-artifacts.sh dist/release
+          VERSION="${RELEASE_TAG#v}" ./scripts/build-release-artifacts.sh dist/release
 
       - name: 上传 Release assets（Release 不存在则创建）
         env:
@@ -59,13 +71,16 @@ jobs:
           # 带预发布段的 tag（v0.2.0-beta 等）自动标记 GitHub prerelease：
           # 应用内更新的检查逻辑会跳过 prerelease，避免 beta 被推给全量用户
           PRERELEASE_FLAG=""
-          case "$GITHUB_REF_NAME" in
+          case "$RELEASE_TAG" in
             *-*) PRERELEASE_FLAG="--prerelease" ;;
           esac
-          if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
-              --title "$GITHUB_REF_NAME" --generate-notes $PRERELEASE_FLAG
+          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            # --target：tag 不存在时（手动触发通道）在该提交上创建 tag；
+            # tag 推送事件里 tag 已存在，此参数被忽略
+            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "$RELEASE_TAG" --generate-notes $PRERELEASE_FLAG
           fi
           assets=(dist/release/app-web.tar.gz dist/release/app-backend.tar.gz dist/release/manifest.json)
           [ -f dist/release/manifest.json.sig ] && assets+=(dist/release/manifest.json.sig)
-          gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"


### PR DESCRIPTION
## 概述

远程会话（Claude Code 等）的 git 凭证只能推分支、推不了 tag（实测 403），导致按规范发版的「打 tag」一步无法在远程会话完成。给 release.yml 增加手动触发通道。

## 改动内容

- `on.workflow_dispatch.inputs.tag`：输入目标 tag（如 `v0.2.0`）手动触发
- 手动触发时 tag 尚不存在，由创建 Release 的 `gh release create --target "$GITHUB_SHA"` 在触发时的 main HEAD 上一并创建 tag；tag 推送事件里 tag 已存在，`--target` 被忽略，原路径行为不变
- 步骤内统一改用 job 级环境变量 `RELEASE_TAG`（tag 推送取 `github.ref_name`，手动触发取输入）
- 无递归风险：GITHUB_TOKEN 创建的 tag 不会触发本工作流的 push 事件
- 版本三方校验不变：build-release-artifacts.sh 仍强校验 tag / pyproject / `__version__` 一致，输错 tag 会直接构建失败

## 测试

- 工作流 YAML 语法与变量引用逐处核对；tag 推送路径仅做等价替换（`GITHUB_REF_NAME` → `RELEASE_TAG`，两者在 tag 事件下同值）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg)_