### PR TITLE
feat(network): 应用内更新流量纳入统一网络出口，新增「GitHub 更新」代理开关

### DIFF
--- a/src/movieclaw_api/services/app_update.py
+++ b/src/movieclaw_api/services/app_update.py
@@ -58,6 +58,7 @@ from movieclaw_api.services.system_notice import resolve_notices, upsert_notice
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import NoticeSeverity, NoticeStatus, SystemNotice
 from movieclaw_db.models.scheduled_task import TriggerType
+from movieclaw_net import egress_transport, resolve_proxy_url
 from movieclaw_scheduler import register_task
 
 logger = logging.getLogger("movieclaw_api.app_update")
@@ -382,7 +383,11 @@ async def _fetch_releases(what: str) -> list[dict]:
     if _releases_etag and _releases_cached is not None:
         headers["If-None-Match"] = _releases_etag
     async with httpx.AsyncClient(
-        timeout=_HTTP_TIMEOUT, follow_redirects=True, headers=headers
+        # 走统一网络出口（服务标签 github）：设置页可为更新流量单独开关代理
+        transport=egress_transport("github"),
+        timeout=_HTTP_TIMEOUT,
+        follow_redirects=True,
+        headers=headers,
     ) as client:
         try:
             resp = await client.get(api_url)
@@ -428,7 +433,11 @@ async def _fetch_latest_release() -> tuple[dict, dict]:
         raise BadRequestException("未找到任何应用发布（vX.Y.Z 的 Release），暂无可用更新")
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "movieclaw-updater"}
     async with httpx.AsyncClient(
-        timeout=_HTTP_TIMEOUT, follow_redirects=True, headers=headers
+        # 走统一网络出口（服务标签 github）：设置页可为更新流量单独开关代理
+        transport=egress_transport("github"),
+        timeout=_HTTP_TIMEOUT,
+        follow_redirects=True,
+        headers=headers,
     ) as client:
         raw = await _download_manifest_bytes(client, release)
     manifest = _parse_manifest(raw)
@@ -633,6 +642,11 @@ def _download_and_apply(manifest: dict) -> None:
         total = sum(int(manifest["files"][n].get("size") or 0) for n in _ARTIFACT_NAMES)
         done = 0
         with httpx.Client(
+            # 出口层的 transport 只有 async 版，同步下载客户端按同一服务
+            # 标签解析代理地址；trust_env=False 与出口层语义对齐——是否
+            # 走代理只由「设置 → 网络与代理」决定，不再隐式吃环境变量
+            proxy=resolve_proxy_url("github"),
+            trust_env=False,
             timeout=_HTTP_TIMEOUT,
             follow_redirects=True,
             headers={"User-Agent": "movieclaw-updater"},
@@ -831,6 +845,11 @@ def _download_and_apply_model(release: dict, manifest: dict) -> None:
         total = sum(int(manifest["files"][n].get("size") or 0) for n in _MODEL_FILES)
         done = 0
         with httpx.Client(
+            # 出口层的 transport 只有 async 版，同步下载客户端按同一服务
+            # 标签解析代理地址；trust_env=False 与出口层语义对齐——是否
+            # 走代理只由「设置 → 网络与代理」决定，不再隐式吃环境变量
+            proxy=resolve_proxy_url("github"),
+            trust_env=False,
             timeout=_HTTP_TIMEOUT,
             follow_redirects=True,
             headers={"User-Agent": "movieclaw-updater"},
@@ -905,7 +924,10 @@ async def start_model_update() -> UpdateProgressView:
             )
         headers = {"User-Agent": "movieclaw-updater"}
         async with httpx.AsyncClient(
-            timeout=_HTTP_TIMEOUT, follow_redirects=True, headers=headers
+            transport=egress_transport("github"),
+            timeout=_HTTP_TIMEOUT,
+            follow_redirects=True,
+            headers=headers,
         ) as client:
             raw = await _download_manifest_bytes(client, release)
         manifest = _parse_model_manifest(raw)

--- a/src/movieclaw_api/services/network_config.py
+++ b/src/movieclaw_api/services/network_config.py
@@ -179,6 +179,17 @@ async def _probe_target(service: str, session: AsyncSession) -> tuple[str, dict[
 
         base, api_key = await resolve_provider_endpoint(session)
         return f"{base.rstrip('/')}/models", {"Authorization": f"Bearer {api_key}"}
+    if service == "github":
+        # 与应用内更新的检查请求同源（api.github.com 或 UPDATE_API_BASE_URL 反代）
+        settings = get_settings()
+        url = (
+            f"{settings.update_api_base_url.rstrip('/')}"
+            f"/repos/{settings.update_repo}/releases?per_page=1"
+        )
+        return url, {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "movieclaw-updater",
+        }
     if service.startswith("site:"):
         site_id = service.removeprefix("site:")
         try:
@@ -203,6 +214,14 @@ def _classify_probe(service: str, status_code: int) -> NetworkTestResult:
             message = "网络连通，API Key 有效"
         elif status_code in (401, 403):
             message = "网络连通，但 API Key 无效"
+        else:
+            message = f"网络连通（HTTP {status_code}）"
+        return NetworkTestResult(ok=True, message=message)
+    if service == "github":
+        if status_code == 200:
+            message = "网络连通，可正常检查更新"
+        elif status_code in (403, 429):
+            message = "网络连通，但 GitHub 接口限流中（稍后自动恢复，不影响每日自动检查）"
         else:
             message = f"网络连通（HTTP {status_code}）"
         return NetworkTestResult(ok=True, message=message)

--- a/src/movieclaw_api/settings/network.py
+++ b/src/movieclaw_api/settings/network.py
@@ -32,6 +32,12 @@ BUILTIN_EGRESS_SERVICES: list[dict[str, str]] = [
     },
     {"id": "douban", "label": "豆瓣", "description": "豆瓣榜单与搜索（国内网络通常可直连）"},
     {"id": "llm", "label": "AI 模型", "description": "大语言模型供应商接口"},
+    {
+        "id": "github",
+        "label": "GitHub 更新",
+        "description": "应用内更新的检查与产物下载（api.github.com / github.com），"
+        "国内网络常需代理；也可配 UPDATE_DOWNLOAD_MIRROR 加速镜像替代",
+    },
 ]
 
 
@@ -42,11 +48,12 @@ BUILTIN_EGRESS_SERVICES: list[dict[str, str]] = [
     secret_fields=["proxy_url"],
 )
 class NetworkEgressSetting(SettingSchema):
-    """统一网络出口配置。默认值 = 跟随环境变量，仅 TMDB 与图片回源走代理。
+    """统一网络出口配置。默认值 = 跟随环境变量，TMDB、图片回源与 GitHub
+    更新走代理。
 
     这样 Docker 部署者只要 ``-e HTTPS_PROXY=...`` 就能解决最常见的
-    「TMDB 被墙」问题，而 PT 站/豆瓣保持直连（国内直连通常更快，且部分
-    PT 站风控在意出口 IP）。
+    「TMDB / GitHub 被墙」问题，而 PT 站/豆瓣保持直连（国内直连通常更快，
+    且部分 PT 站风控在意出口 IP）。
     """
 
     proxy_mode: Literal["off", "env", "manual"] = Field(
@@ -58,7 +65,7 @@ class NetworkEgressSetting(SettingSchema):
         description="手动模式的代理地址，支持 http:// 与 socks5://（如 socks5://192.168.1.2:7891）",
     )
     proxy_services: list[str] = Field(
-        default_factory=lambda: ["tmdb", "image"],
+        default_factory=lambda: ["tmdb", "image", "github"],
         description="走代理的服务标签列表；PT 站用 site:<站点id> 形式按站独立控制",
     )
     tmdb_api_base_url: str = Field(

--- a/src/movieclaw_net/egress.py
+++ b/src/movieclaw_net/egress.py
@@ -77,14 +77,15 @@ class ProxyMode(StrEnum):
 class EgressConfig:
     """出口层的生效配置（由 movieclaw_api 从配置域加载后灌入）。
 
-    默认值即「未配置过」的行为：跟随环境变量，且只有 TMDB 与图片回源走代理
-    ——这是国内部署最常见的诉求（TMDB 被墙），同时不影响 PT 站直连更快的现实。
+    默认值即「未配置过」的行为：跟随环境变量，TMDB、图片回源与 GitHub 更新
+    走代理——这是国内部署最常见的诉求（TMDB / GitHub 被墙），同时不影响
+    PT 站直连更快的现实。
     """
 
     proxy_mode: ProxyMode = ProxyMode.ENV
     proxy_url: str = ""
     proxy_services: frozenset[str] = field(
-        default_factory=lambda: frozenset({"tmdb", "image"})
+        default_factory=lambda: frozenset({"tmdb", "image", "github"})
     )
 
 

--- a/tests/api/test_network.py
+++ b/tests/api/test_network.py
@@ -54,11 +54,11 @@ def test_get_config_returns_defaults_and_catalog(client):
     resp = client.get("/api/v1/network/config")
     assert resp.status_code == 200
     data = resp.json()["data"]
-    # 默认：跟随环境变量，TMDB 与图片回源走代理
+    # 默认：跟随环境变量，TMDB、图片回源与 GitHub 更新走代理
     assert data["proxy_mode"] == "env"
-    assert sorted(data["proxy_services"]) == ["image", "tmdb"]
+    assert sorted(data["proxy_services"]) == ["github", "image", "tmdb"]
     service_ids = [item["id"] for item in data["services"]]
-    assert {"tmdb", "image", "douban", "llm"} <= set(service_ids)
+    assert {"tmdb", "image", "douban", "llm", "github"} <= set(service_ids)
     # 镜像默认值供前端 placeholder 展示
     assert data["mirror_defaults"]["tmdb_api_base_url"].startswith("http")
 
@@ -81,6 +81,28 @@ def test_save_manual_proxy_takes_effect_immediately(client):
     data = client.get("/api/v1/network/config").json()["data"]
     assert data["proxy_mode"] == "manual"
     assert data["proxy_url"] == "socks5://192.168.1.2:7891"
+
+
+def test_github_service_routes_through_proxy(client):
+    """GitHub 更新流量按服务标签独立控制：开则走代理，关则直连。"""
+    client.put(
+        "/api/v1/network/config",
+        json={
+            "proxy_mode": "manual",
+            "proxy_url": "http://192.168.1.2:7890",
+            "proxy_services": ["github"],
+        },
+    )
+    assert resolve_proxy_url("github") == "http://192.168.1.2:7890"
+    client.put(
+        "/api/v1/network/config",
+        json={
+            "proxy_mode": "manual",
+            "proxy_url": "http://192.168.1.2:7890",
+            "proxy_services": ["tmdb"],
+        },
+    )
+    assert resolve_proxy_url("github") is None
 
 
 def test_save_rejects_bad_proxy_scheme(client):


### PR DESCRIPTION
## 概述

「设置 → 网络与代理」新增「GitHub 更新」服务开关，让应用内更新的检查与下载可走代理——国内网络下 GitHub 直连常慢或不通，走代理能显著提速检查更新。

此前存在架构缺口：更新服务（`app_update.py`）的全部 HTTP 请求都是裸 httpx 客户端，网络设置页的代理配置对更新流量零作用（只能隐式吃环境变量代理，或配 `UPDATE_DOWNLOAD_MIRROR` 镜像）。

## 改动内容

- **出口层接线**：检查更新、清单下载、产物下载、模型更新的 5 个 httpx 客户端全部纳入统一网络出口（服务标签 `github`）；异步客户端走 `egress_transport`（含熔断、配置热切换），同步下载客户端按同一标签 `resolve_proxy_url` + `trust_env=False`（与出口层语义对齐：是否走代理只由设置页决定）
- **服务目录**：`BUILTIN_EGRESS_SERVICES` 新增「GitHub 更新」项，设置页开关列表动态渲染、前端零改动；连通性测试探测与更新检查同源的 Release 接口（`{UPDATE_API_BASE_URL}/repos/{repo}/releases?per_page=1`），403/429 给出限流提示
- **默认值**：`proxy_services` 默认加入 `github`（与 TMDB/图片回源同理：国内被墙是常态），设置域与出口层两处默认同步

## 行为变化说明（升级注意）

- 已保存过网络配置的存量用户：`proxy_services` 里没有 `github`，更新流量将按设置页语义**直连**（此前隐式吃 `HTTPS_PROXY` 环境变量）。依赖该隐式行为的部署，升级后需在「设置 → 网络与代理」开启「GitHub 更新」开关
- `UPDATE_DOWNLOAD_MIRROR` 加速镜像机制不变，与代理开关可独立使用

## 测试

- 新增 `test_github_service_routes_through_proxy`（按标签独立路由：开则走代理、关则直连）
- `tests/api/test_network.py` + `tests/api/test_app_update.py` + `tests/net` + `tests/api/test_app_config.py`：56 passed（1 个失败为沙箱注入代理环境变量导致的既有环境性用例，干净主干同样失败）
- 接口 schema 无变化，spec 基线不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMKdEVkDUtsD21D9YBxbrg)_