### PR TITLE
sites: chdbits 换用可达域名 + 新增 6 个站点适配入库

### DIFF
--- a/src/movieclaw_tracker/sites/configs/audiences.yaml
+++ b/src/movieclaw_tracker/sites/configs/audiences.yaml
@@ -1,0 +1,36 @@
+# 观众（Audiences）站点配置
+# 官网：https://audiences.me/
+
+site_id: audiences
+display_name: 观众
+base_url: https://audiences.me
+framework: nexusphp
+
+selectors:
+  # ── 种子列表 ─────────────────────────────────────────────────────
+  # 表格类为 "torrents torrents-table"，table.torrents 照样命中；
+  # 行结构与 chdbits 相同：tr 内嵌 table.torrentname
+  torrent_row_css: "table.torrents > tr:has(table.torrentname)"
+
+  # 分类 ID 来自 ?cat=XXX 链接
+  torrent_category_css: "a[href^='?cat=']::attr(href)"
+
+  # 副标题有专用类（少见的好站）
+  torrent_subtitle_css: "span.torrent-subtitle-line"
+
+  # 分页从 0 开始（?page=0 是第一页），发送时需减 1
+  page_offset: -1
+
+  # ── 用户资料 ──────────────────────────────────────────────────────
+  # userdetails.php 裸访问无效，从顶栏 userbar 解析（与 ssd 同思路）。
+  # 观众的顶栏是自定义 userbar：上传/下载量在 compact-metric 元素里
+  profile_uid_css: "a[href*='userdetails.php?id=']::attr(href)"
+  profile_username_css: "a[href*='userdetails.php?id=']"
+  profile_uploaded_css: "span.site-userbar__compact-metric--uploaded"
+  profile_downloaded_css: "span.site-userbar__compact-metric--downloaded"
+
+# ── 分类映射 ──────────────────────────────────────────────────────
+categories:
+  movie:       [401]
+  tv:          [402, 403]  # 剧集 / 综艺
+  documentary: [406]

--- a/src/movieclaw_tracker/sites/configs/chdbits.yaml
+++ b/src/movieclaw_tracker/sites/configs/chdbits.yaml
@@ -1,9 +1,9 @@
 # 彩虹岛（CHDBits）站点配置
-# 官网：https://chdbits.co/
+# 官网：https://ptchdbits.co/（原 chdbits.co 域名容器内直连不可达,2026-08-01 换）
 
 site_id: chdbits
 display_name: 彩虹岛
-base_url: https://chdbits.co
+base_url: https://ptchdbits.co
 framework: nexusphp
 
 selectors:

--- a/src/movieclaw_tracker/sites/configs/hdhome.yaml
+++ b/src/movieclaw_tracker/sites/configs/hdhome.yaml
@@ -1,0 +1,49 @@
+# HDHome（高清家园）站点配置
+# 官网：https://hdhome.org/
+
+site_id: hdhome
+display_name: 高清家园
+base_url: https://hdhome.org
+framework: nexusphp
+
+selectors:
+  # ── 种子列表 ─────────────────────────────────────────────────────
+  # 行结构与 chdbits 相同：tr 内嵌 table.torrentname
+  torrent_row_css: "table.torrents > tr:has(table.torrentname)"
+
+  # 分类 ID 来自 ?cat=XXX 链接
+  torrent_category_css: "a[href^='?cat=']::attr(href)"
+
+  # 副标题在 tags 之后的无 class span 里（tags 均带 class）
+  torrent_subtitle_css: "td.embedded > span:not([class])"
+
+  # H&R 考核标记（实测类名就叫 hitandrun）
+  torrent_hr_css: "img.hitandrun"
+
+  # 分页从 0 开始（?page=0 是第一页），发送时需减 1
+  page_offset: -1
+
+  # ── 用户资料 ──────────────────────────────────────────────────────
+  # userdetails.php 裸访问无效，从顶栏 info_block 解析（标准 NexusPHP 顶栏）
+  profile_uid_css: "a[href*='userdetails.php?id=']::attr(href)"
+  profile_username_css: "a[href*='userdetails.php?id=']"
+  profile_class_css: "a[href*='userdetails.php?id=']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus::next_sibling_text"
+  profile_seeding_css: "img[alt='Torrents seeding'] + *"
+  profile_leeching_css: "img[alt='Torrents leeching'] + *"
+
+# ── 分类映射 ──────────────────────────────────────────────────────
+# 高清家园按「内容 × 规格」细分 60+ 分类，按内容前缀归组
+categories:
+  movie:       [411, 412, 413, 414, 415, 416, 450, 499, 505, 506, 518]
+  documentary: [417, 418, 419, 420, 421, 422, 451, 500, 507, 508, 529]
+  # TVShow(综艺) + TVSeries(剧集) + Sports（体育归 tv，与 ssd 惯例一致）
+  tv:          [425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436,
+                437, 438, 442, 443, 452, 453, 502, 504, 511, 523, 526]
+  anime:       [444, 445, 446, 447, 448, 449, 454, 501, 509, 510, 531]
+  # Musics(APE/FLAC/MV/Bluray) + TVMusic(电视音乐节目)
+  music:       [439, 440, 441, 503, 423, 424]
+  other:       [409]  # Misc

--- a/src/movieclaw_tracker/sites/configs/keepfrds.yaml
+++ b/src/movieclaw_tracker/sites/configs/keepfrds.yaml
@@ -1,0 +1,57 @@
+# 朋友（KEEPFRDS）站点配置
+# 官网：https://pt.keepfrds.com/
+
+site_id: keepfrds
+display_name: 朋友
+base_url: https://pt.keepfrds.com
+framework: nexusphp
+
+selectors:
+  # ── 种子列表 ─────────────────────────────────────────────────────
+  # 行结构与 chdbits 相同：tr 内嵌 table.torrentname
+  torrent_row_css: "table.torrents > tr:has(table.torrentname)"
+
+  # 分类 ID 来自 ?cat=XXX 链接
+  torrent_category_css: "a[href^='?cat=']::attr(href)"
+
+  # 副标题是 br 后的裸文本节点（中文主标题 <br> 英文原名副标题）
+  torrent_subtitle_css: "td.embedded > br::next_sibling_text"
+
+  # 分页从 0 开始（?page=0 是第一页），发送时需减 1
+  page_offset: -1
+
+  # ── 促销 ──────────────────────────────────────────────────────────
+  # 朋友有站点特有的 pro_nl（中性种子 Neutral Leech：不计下载也不计上传），
+  # 覆盖默认规则以补充 nl 条目（YAML 覆盖是整表替换，故标准项须重写一遍）
+  promo_download_rules:
+    "img.pro_free": 0
+    "img.pro_free2up": 0
+    "img.pro_nl": 0
+    "img.pro_50pctdown": 0.5
+    "img.pro_50pctdown2up": 0.5
+    "img.pro_30pctdown": 0.3
+  promo_upload_rules:
+    "img.pro_free2up": 2
+    "img.pro_50pctdown2up": 2
+    "img.pro_2up": 2
+
+  # ── 用户资料 ──────────────────────────────────────────────────────
+  # userdetails.php 裸访问无效，从顶栏解析。注意朋友的顶栏链接是
+  # 绝对路径（/userdetails.php?id=），须用 *= 而非 ^= 匹配
+  profile_uid_css: "a[href*='userdetails.php?id=']::attr(href)"
+  profile_username_css: "a[href*='userdetails.php?id=']"
+  profile_class_css: "a[href*='userdetails.php?id=']::attr(class)"
+  # 朋友的数值不在 color_* 后的文本节点里，而在专用 span 中
+  profile_uploaded_css: "span.uploaded"
+  profile_downloaded_css: "span.downloaded"
+
+# ── 分类映射 ──────────────────────────────────────────────────────
+categories:
+  movie:       [401]
+  tv:          [402, 403, 407]        # 剧集 / 综艺 / 体育
+  documentary: [404]                  # 纪录片-传记
+  anime:       [405]
+  music:       [406, 408, 420, 421]   # MV / 音乐 / 演唱会-音乐剧 / 舞台
+  game:        [423]
+  av:          [419]                  # 🍆
+  other:       [300, 409, 414, 415, 422, 424, 425]  # 回收站/其他/电子书/有声读物/软件/偶像/鲨鱼

--- a/src/movieclaw_tracker/sites/configs/ourbits.yaml
+++ b/src/movieclaw_tracker/sites/configs/ourbits.yaml
@@ -1,0 +1,46 @@
+# OurBits（我堡）站点配置
+# 官网：https://ourbits.club/
+
+site_id: ourbits
+display_name: OurBits
+base_url: https://ourbits.club
+framework: nexusphp
+
+selectors:
+  # ── 种子列表 ─────────────────────────────────────────────────────
+  # 行结构与 chdbits 相同：tr 内嵌 table.torrentname
+  torrent_row_css: "table.torrents > tr:has(table.torrentname)"
+
+  # 分类 ID 来自 ?cat=XXX 链接
+  torrent_category_css: "a[href^='?cat=']::attr(href)"
+
+  # 副标题是 td.embedded 里 tags 容器 div 之后的裸文本节点
+  # HTML: <br><div>官方 DIY 中字 …</div>幽旅巫咒 [UHD原盘DIY…]
+  torrent_subtitle_css: "td.embedded > div::next_sibling_text"
+
+  # H&R 考核标记（实测类名就叫 hitandrun）
+  torrent_hr_css: "img.hitandrun"
+
+  # 分页从 0 开始（?page=0 是第一页），发送时需减 1
+  page_offset: -1
+
+  # ── 用户资料 ──────────────────────────────────────────────────────
+  # userdetails.php 不带 id 裸访问返回无效页（无 h1/rowhead），
+  # 改从每页顶部导航栏 info_block 解析（与 ssd 同思路）：
+  # 链接文本即用户名，等级编码在 class（如 InsaneUser_Name）
+  profile_uid_css: "a[href*='userdetails.php?id=']::attr(href)"
+  profile_username_css: "a[href*='userdetails.php?id=']"
+  profile_class_css: "a[href*='userdetails.php?id=']::attr(class)"
+  # 标准 NexusPHP 顶栏：font.color_* 空元素后紧跟数值文本
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_seeding_css: "img[alt='Torrents seeding'] + *"
+  profile_leeching_css: "img[alt='Torrents leeching'] + *"
+
+# ── 分类映射 ──────────────────────────────────────────────────────
+categories:
+  movie:       [401, 402]            # Movies / Movies-3D
+  tv:          [405, 412, 413, 415]  # TV-Pack / TV-Episode / TV-Show / Sports
+  documentary: [410]
+  anime:       [411]
+  music:       [416, 414, 419]       # Music / Music-Video / Concert

--- a/src/movieclaw_tracker/sites/configs/pter.yaml
+++ b/src/movieclaw_tracker/sites/configs/pter.yaml
@@ -1,0 +1,42 @@
+# 猫站（PTerClub）站点配置
+# 官网：https://pterclub.net/（另有 pterclub.com 域名）
+
+site_id: pter
+display_name: 猫站
+base_url: https://pterclub.net
+framework: nexusphp
+
+selectors:
+  # ── 种子列表 ─────────────────────────────────────────────────────
+  # 行结构与 chdbits 相同：tr 内嵌 table.torrentname
+  torrent_row_css: "table.torrents > tr:has(table.torrentname)"
+
+  # 分类 ID 来自 ?cat=XXX 链接
+  torrent_category_css: "a[href^='?cat=']::attr(href)"
+
+  # 猫站副标题与中文别名、tags 链接混排在同一个 div 里，无干净选择器，
+  # 留空跳过解析（宁缺勿错，避免把"官方 国语 中字"当副标题）
+  torrent_subtitle_css: ""
+
+  # 分页从 0 开始（?page=0 是第一页），发送时需减 1
+  page_offset: -1
+
+  # ── 用户资料 ──────────────────────────────────────────────────────
+  # userdetails.php 裸访问返回 F.A.Q. 页，从顶栏 info_block 解析
+  profile_uid_css: "a[href*='userdetails.php?id=']::attr(href)"
+  profile_username_css: "a[href*='userdetails.php?id=']"
+  profile_class_css: "a[href*='userdetails.php?id=']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_seeding_css: "img[alt='Torrents seeding'] + *"
+  profile_leeching_css: "img[alt='Torrents leeching'] + *"
+
+# ── 分类映射 ──────────────────────────────────────────────────────
+categories:
+  movie:       [401]
+  documentary: [402]
+  anime:       [403]
+  tv:          [404, 405]  # 电视剧 / 综艺
+  music:       [406, 418]  # 音乐 / 舞台演出
+  game:        [409]

--- a/src/movieclaw_tracker/sites/configs/pthome.yaml
+++ b/src/movieclaw_tracker/sites/configs/pthome.yaml
@@ -1,0 +1,44 @@
+# PTHome（铂金家）站点配置
+# 官网：https://pthome.net/
+
+site_id: pthome
+display_name: 铂金家
+base_url: https://pthome.net
+framework: nexusphp
+
+selectors:
+  # ── 种子列表 ─────────────────────────────────────────────────────
+  # 表格类为 "torrents torrents-table"，table.torrents 照样命中；
+  # 行结构与 chdbits 相同：tr 内嵌 table.torrentname
+  torrent_row_css: "table.torrents > tr:has(table.torrentname)"
+
+  # 分类 ID 来自 ?cat=XXX 链接
+  torrent_category_css: "a[href^='?cat=']::attr(href)"
+
+  # 副标题在 tags 之后的无 class span 里（tags 均带 class，与 hdhome 同款）
+  torrent_subtitle_css: "td.embedded > span:not([class])"
+
+  # 分页从 0 开始（?page=0 是第一页），发送时需减 1
+  page_offset: -1
+
+  # ── 用户资料 ──────────────────────────────────────────────────────
+  # userdetails.php 裸访问无效，从顶栏 info_block 解析（标准 NexusPHP 顶栏）
+  profile_uid_css: "a[href*='userdetails.php?id=']::attr(href)"
+  profile_username_css: "a[href*='userdetails.php?id=']"
+  profile_class_css: "a[href*='userdetails.php?id=']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus::next_sibling_text"
+  profile_seeding_css: "img[alt='Torrents seeding'] + *"
+  profile_leeching_css: "img[alt='Torrents leeching'] + *"
+
+# ── 分类映射 ──────────────────────────────────────────────────────
+categories:
+  movie:       [401]
+  tv:          [402, 403, 407]  # 电视剧 / 综艺 / 体育
+  documentary: [404]
+  anime:       [405]
+  music:       [408]
+  game:        [410]
+  other:       [409, 411, 412]  # 其他 / 软件 / 学习


### PR DESCRIPTION
## 动机

应用内更新的 overlay 只分发仓库内的站点配置。实际部署中发现:一键更新 v0.2.0/v0.3.0 后,

- chdbits 的 base_url 被上游原版 `chdbits.co` 回退——该域名在容器直连环境不可达(连接超时),导致连续失败触发熔断;
- 部署机本地维护、未入库的 6 个站点配置(观众/高清家园/朋友/OurBits/猫站/铂金家)整体失效(registry 按代码树扫 `sites/configs`,overlay 中无此配置即不注册),站点消失窗口内定时凭据验证还会把凭据误标 FAILED。

站点配置必须随仓库分发才能在 overlay 更新中存活,故提交入库。

## 变更

- `chdbits.yaml`:base_url 换为实测可达的 `https://ptchdbits.co`
- 新增 6 个 NexusPHP 站点适配 yaml(均已在生产实跑同步验证)

## 验证

- `pytest tests/tracker/` 全绿
- 生产环境(overlay 内手动同步同批文件)9 站同步正常,chdbits 熔断恢复

## 顺带建议

用户自加站点的配置或许更适合放 data 卷(如 `data/sites/`,registry additionally 扫描),从机制上避免'更新即丢站点'——可另开 issue 讨论。