### PR TITLE
feat(channels): Telegram/Discord 通道接入与统一消息推送

### DIFF
--- a/apps/web/components/im-push-section.tsx
+++ b/apps/web/components/im-push-section.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import Link from "next/link";
+
+import { ChatIcon } from "@/components/icons";
+import { useLlmConfigured } from "@/components/llm-gate";
+import { WeixinBindingSection } from "@/components/weixin-binding-section";
+import {
+  type ChannelPushConfig,
+  type ImAccount,
+  type ImBinding,
+  type ImChannelId,
+  getChannelPushConfig,
+  getImBindingStatus,
+  listImAccounts,
+  sendChannelPushTest,
+  startImBinding,
+  unbindImAccount,
+  updateChannelPushConfig,
+} from "@/lib/api/channels";
+import { useBackdrop } from "@/lib/backdrop";
+import { formatRelativeTime } from "@/lib/time";
+import { useVisiblePolling } from "@/lib/use-visible-polling";
+import { LiquidGlassButton } from "@/vendor/liquid-glass";
+
+/** 平台文案（组件唯一的平台差异落点）。 */
+const CHANNEL_META: Record<
+  ImChannelId,
+  { label: string; tokenHint: string; howTo: string }
+> = {
+  telegram: {
+    label: "Telegram",
+    tokenHint: "从 @BotFather 创建 bot 后获得的 token",
+    howTo: "在 Telegram 搜索 @BotFather 创建 bot 并复制 token；国内网络请先在「设置 → 网络」为 Telegram 开启代理。",
+  },
+  discord: {
+    label: "Discord",
+    tokenHint: "Discord 开发者后台 Bot 页面的 token",
+    howTo: "在 discord.com/developers 创建应用 → Bot → Reset Token 复制；国内网络请先在「设置 → 网络」为 Discord 开启代理。",
+  },
+};
+
+/**
+ * 「消息推送」设置分区：Telegram 与 Discord 的配对码绑定 + 测试推送。
+ *
+ * 交互（与微信绑定同节奏，但无二维码）：
+ * 1. 填 bot token → 发起绑定 → 面板显示 6 位配对码；
+ * 2. 用户去平台私聊 bot 发配对码，前端每 2 秒轮询状态；
+ * 3. confirmed → 刷新列表（发码人即白名单与推送目标）。
+ */
+export function ImPushSection() {
+  const llmConfigured = useLlmConfigured();
+  const [pushMsg, setPushMsg] = useState<string | null>(null);
+  const [pushBusy, setPushBusy] = useState(false);
+
+  async function handleTestPush() {
+    setPushBusy(true);
+    setPushMsg(null);
+    try {
+      const { sent } = await sendChannelPushTest();
+      setPushMsg(`✅ 已推送到 ${sent} 个账号，去客户端看看吧`);
+    } catch (e) {
+      setPushMsg(`⚠️ ${(e as Error).message}`);
+    } finally {
+      setPushBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <p className="text-sub text-[var(--text-muted)]">
+        绑定 Telegram / Discord bot 后：订阅投递、入库完成等事件会自动推送；直接给 bot
+        发消息即可让 AI 助手理解并执行（搜片、订阅、查进度……）。发送
+        <span className="mx-1 rounded bg-white/[0.08] px-1.5 py-0.5 text-caption">/reset</span>
+        重置会话，
+        <span className="mx-1 rounded bg-white/[0.08] px-1.5 py-0.5 text-caption">/stop</span>
+        取消正在进行的处理。
+      </p>
+
+      {llmConfigured === false && (
+        <div className="rounded-xl border border-[#f5c451]/30 bg-[#f5c451]/10 px-4 py-3 text-body text-[#f5c451]">
+          绑定需要先完成 AI 模型配置——对话完全由模型驱动。请先前往
+          <Link
+            href="/settings/llm"
+            className="mx-1 font-medium underline underline-offset-2 hover:opacity-80"
+          >
+            设置 → AI 模型
+          </Link>
+          接入模型供应商。
+        </div>
+      )}
+
+      {/* 微信绑定（扫码流程自成一体，整块复用原组件） */}
+      <div className="space-y-3">
+        <h3 className="text-body font-semibold text-[var(--text)]">微信</h3>
+        <WeixinBindingSection hideIntro />
+      </div>
+
+      <ChannelBindingBlock channel="telegram" disabled={llmConfigured === false} />
+      <ChannelBindingBlock channel="discord" disabled={llmConfigured === false} />
+
+      <PushContentBlock />
+
+      {/* 测试推送：验证已绑定通道能收到系统事件 */}
+      <div className="css-glass !rounded-xl p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-body font-medium text-[var(--text)]">测试推送</p>
+            <p className="mt-0.5 text-caption text-[var(--text-faint)]">
+              向所有已绑定通道（含微信）发送一条测试消息
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={pushBusy}
+            onClick={() => void handleTestPush()}
+            className="btn-glass shrink-0 rounded-full px-4 py-1.5 text-sub font-medium disabled:opacity-40"
+          >
+            发送测试
+          </button>
+        </div>
+        {pushMsg && <p className="mt-2 text-caption text-[var(--text-muted)]">{pushMsg}</p>}
+      </div>
+    </div>
+  );
+}
+
+/** 推送内容开关：控制哪些系统事件会推送（保存即生效，对所有通道含微信生效）。 */
+function PushContentBlock() {
+  const { backdrop } = useBackdrop();
+  const [config, setConfig] = useState<ChannelPushConfig | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getChannelPushConfig()
+      .then(setConfig)
+      .catch((e) => setError((e as Error).message));
+  }, []);
+
+  async function handleToggle(key: keyof ChannelPushConfig, value: boolean) {
+    if (config == null) return;
+    const next = { ...config, [key]: value };
+    setConfig(next); // 乐观更新，失败回滚
+    setError(null);
+    try {
+      await updateChannelPushConfig(next);
+    } catch (e) {
+      setConfig(config);
+      setError((e as Error).message);
+    }
+  }
+
+  const rows: { key: keyof ChannelPushConfig; label: string; desc: string }[] = [
+    { key: "push_dispatch", label: "开始下载", desc: "订阅命中资源并提交下载器时" },
+    { key: "push_imported", label: "入库完成", desc: "下载完成整理进媒体库时" },
+  ];
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-body font-semibold text-[var(--text)]">推送内容</h3>
+      {error && (
+        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
+          {error}
+        </div>
+      )}
+      {config == null ? (
+        <div className="h-[104px] animate-pulse rounded-xl bg-white/[0.04]" />
+      ) : (
+        <div className="css-glass !rounded-xl">
+          {rows.map((row, i) => (
+            <div
+              key={row.key}
+              className={`flex items-center gap-3.5 p-4 ${i > 0 ? "border-t border-white/[0.06]" : ""}`}
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-body font-medium text-[var(--text)]">{row.label}</p>
+                <p className="mt-0.5 text-caption text-[var(--text-faint)]">{row.desc}</p>
+              </div>
+              {/* 与网络设置同款的受控液态玻璃开关 */}
+              <LiquidGlassButton
+                backgroundImage={backdrop}
+                variant="dark"
+                checked={config[row.key]}
+                aria-label={`${row.label}推送`}
+                onCheckedChange={(v: boolean) => void handleToggle(row.key, v)}
+                className="!min-h-0 !w-auto !gap-0 !bg-transparent !p-0"
+              >
+                <span className="sr-only">{config[row.key] ? "已开启" : "已关闭"}</span>
+              </LiquidGlassButton>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 单平台的绑定块：账号列表 + token 输入 + 配对码流程。 */
+function ChannelBindingBlock({
+  channel,
+  disabled,
+}: {
+  channel: ImChannelId;
+  disabled: boolean;
+}) {
+  const meta = CHANNEL_META[channel];
+  const [accounts, setAccounts] = useState<ImAccount[] | null>(null);
+  const [binding, setBinding] = useState<ImBinding | null>(null);
+  const [token, setToken] = useState("");
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [justConfirmed, setJustConfirmed] = useState(false);
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      setAccounts(await listImAccounts(channel));
+    } catch (e) {
+      setError((e as Error).message);
+      setAccounts([]);
+    }
+  }, [channel]);
+
+  useEffect(() => {
+    void loadAccounts();
+  }, [loadAccounts]);
+
+  async function handleStart() {
+    if (!token.trim()) return;
+    setBusy(true);
+    setError(null);
+    setJustConfirmed(false);
+    try {
+      setBinding(await startImBinding(channel, token.trim()));
+      setToken("");
+      setShowForm(false);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // 配对进行中每 2s 轮询；confirmed/终态停止
+  useVisiblePolling(
+    () => {
+      if (binding == null) return;
+      void getImBindingStatus(channel, binding.challenge_id)
+        .then((snap) => {
+          setBinding(snap.status === "confirmed" ? null : snap);
+          if (snap.status === "confirmed") {
+            setJustConfirmed(true);
+            void loadAccounts();
+          }
+        })
+        .catch(() => {
+          /* 轮询失败静默重试（过期由状态自己表达） */
+        });
+    },
+    binding?.status === "pending" ? 2000 : null,
+  );
+
+  async function handleUnbind(accountId: string) {
+    if (!window.confirm(`确定解绑该 ${meta.label} bot？解绑后需重新配对才能使用。`)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await unbindImAccount(channel, accountId);
+      await loadAccounts();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const hasAccounts = (accounts?.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-body font-semibold text-[var(--text)]">{meta.label}</h3>
+        {!disabled && binding == null && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setShowForm((v) => !v)}
+            className="btn-glass rounded-full px-3.5 py-1 text-sub font-medium disabled:opacity-40"
+          >
+            {showForm ? "收起" : hasAccounts ? "新增绑定" : "绑定 bot"}
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
+          {error}
+        </div>
+      )}
+      {justConfirmed && (
+        <div className="rounded-xl border border-[#4ade80]/30 bg-[#4ade80]/10 px-4 py-3 text-body text-[#4ade80]">
+          绑定完成，{meta.label} 通道已启动。现在就可以给 bot 发消息试试。
+        </div>
+      )}
+
+      {/* 已绑定账号列表 */}
+      {accounts == null ? (
+        <div className="h-[72px] animate-pulse rounded-xl bg-white/[0.04]" />
+      ) : hasAccounts ? (
+        <div className="css-glass !rounded-xl">
+          {accounts.map((account, i) => (
+            <div
+              key={account.account_id}
+              className={`flex items-center gap-3.5 p-4 ${i > 0 ? "border-t border-white/[0.06]" : ""}`}
+            >
+              <span className="icon-chip size-10 !rounded-xl">
+                <ChatIcon className="size-5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="truncate text-body font-semibold text-[var(--text)]">
+                    {account.bound_user_id ?? account.account_id}
+                  </p>
+                  <ImAccountStatusPill account={account} />
+                </div>
+                <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]">
+                  {account.status === "stale"
+                    ? (account.last_error ?? "凭据已失效，请重新绑定")
+                    : `机器人 ${account.account_id} · 绑定于 ${formatRelativeTime(account.bound_at)}`}
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void handleUnbind(account.account_id)}
+                className="btn-glass shrink-0 px-3 py-1.5 text-sub font-medium !text-[#ff6b6b] disabled:opacity-40"
+              >
+                解绑
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : binding == null && !showForm ? (
+        <p className="text-caption text-[var(--text-faint)]">{meta.howTo}</p>
+      ) : null}
+
+      {/* token 输入表单 */}
+      {showForm && binding == null && (
+        <div className="css-glass !rounded-xl p-4">
+          <p className="text-caption text-[var(--text-faint)]">{meta.howTo}</p>
+          <div className="mt-3 flex gap-2">
+            <input
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && void handleStart()}
+              autoFocus
+              placeholder={meta.tokenHint}
+              className="flex-1 rounded-xl border border-white/[0.08] bg-white/[0.04] px-3.5 py-2 text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
+            />
+            <button
+              type="button"
+              disabled={busy || !token.trim()}
+              onClick={() => void handleStart()}
+              className="btn-accent rounded-xl px-4 py-2 text-sub font-semibold disabled:opacity-40"
+            >
+              绑定
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 配对码卡片 */}
+      {binding != null && (
+        <div className="css-glass flex flex-col items-center gap-3 !rounded-2xl px-6 py-8 text-center">
+          {binding.status === "pending" ? (
+            <>
+              <p className="text-body font-medium text-[var(--text)]">
+                私聊 @{binding.bot_name} 发送配对码
+              </p>
+              <p className="select-all font-mono text-[32px] font-bold tracking-[0.3em] text-[var(--accent)]">
+                {binding.pair_code}
+              </p>
+              <p className="text-caption text-[var(--text-faint)]">
+                10 分钟内有效 · 发码人将成为唯一可对话的用户与推送目标
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-body font-medium text-[var(--text)]">绑定未完成</p>
+              <p className="text-sub text-[var(--text-muted)]">{binding.message}</p>
+              <button
+                type="button"
+                onClick={() => {
+                  setBinding(null);
+                  setShowForm(true);
+                }}
+                className="btn-accent rounded-full px-4 py-1.5 text-sub font-semibold"
+              >
+                重新发起
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ImAccountStatusPill({ account }: { account: ImAccount }) {
+  const meta =
+    account.status === "stale"
+      ? { label: "需重新绑定", color: "#ff6b6b" }
+      : account.running
+        ? { label: "运行中", color: "#4ade80" }
+        : { label: "未运行", color: "#c0c4cc" };
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
+      style={{ background: `${meta.color}1f`, color: meta.color }}
+    >
+      <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
+      {meta.label}
+    </span>
+  );
+}

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -11,7 +11,7 @@ import { AvatarBadge } from "@/components/avatar-badge";
 import { DownloaderConfigSection } from "@/components/downloader-config-section";
 import { ImportWatchSection } from "@/components/import-watch-section";
 import { LlmConfigSection } from "@/components/llm-config-section";
-import { WeixinBindingSection } from "@/components/weixin-binding-section";
+import { ImPushSection } from "@/components/im-push-section";
 import { NetworkConfigSection } from "@/components/network-config-section";
 import { SiteConfigSection } from "@/components/site-config-section";
 import { SubscriptionSettingsSection } from "@/components/subscription-settings-section";
@@ -163,8 +163,8 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
           <ImportWatchSection />
         ) : section.id === "llm" ? (
           <LlmConfigSection />
-        ) : section.id === "weixin" ? (
-          <WeixinBindingSection />
+        ) : section.id === "im-push" ? (
+          <ImPushSection />
         ) : section.id === "app" ? (
           <AppSection />
         ) : section.id === "network" ? (

--- a/apps/web/components/weixin-binding-section.tsx
+++ b/apps/web/components/weixin-binding-section.tsx
@@ -33,7 +33,7 @@ import { useVisiblePolling } from "@/lib/use-visible-polling";
  * 前置门禁:微信侧对话完全由 AI 模型驱动,未接入模型供应商时不自动出码、
  * 隐藏绑定入口,并展示引导提醒(判定与 useLlmConfigured / 后端同口径)。
  */
-export function WeixinBindingSection() {
+export function WeixinBindingSection({ hideIntro = false }: { hideIntro?: boolean } = {}) {
   // null = 探测中(不出码也不提醒,避免闪烁);false = 未配置(拦下并引导)
   const llmConfigured = useLlmConfigured();
   const [accounts, setAccounts] = useState<WeixinAccount[] | null>(null);
@@ -161,6 +161,7 @@ export function WeixinBindingSection() {
         </div>
       )}
 
+      {!hideIntro && (
       <p className="text-sub text-[var(--text-muted)]">
         绑定后，用你的微信给 AI 助手发消息即可对话（仅扫码人本人可用）。发送
         <span className="mx-1 rounded bg-white/[0.08] px-1.5 py-0.5 text-caption">/reset</span>
@@ -168,6 +169,7 @@ export function WeixinBindingSection() {
         <span className="mx-1 rounded bg-white/[0.08] px-1.5 py-0.5 text-caption">/stop</span>
         取消正在进行的处理。
       </p>
+      )}
 
       {justConfirmed && (
         <div className="rounded-xl border border-[#4ade80]/30 bg-[#4ade80]/10 px-4 py-3 text-body text-[#4ade80]">
@@ -176,7 +178,7 @@ export function WeixinBindingSection() {
       )}
 
       {/* 前置门禁:未接入 AI 模型时给出引导,并隐藏所有绑定入口 */}
-      {llmConfigured === false && (
+      {!hideIntro && llmConfigured === false && (
         <div className="rounded-xl border border-[#f5c451]/30 bg-[#f5c451]/10 px-4 py-3 text-body text-[#f5c451]">
           微信绑定需要先完成 AI 模型配置——微信里的对话完全由模型驱动。请先前往
           <Link

--- a/apps/web/lib/api/channels.ts
+++ b/apps/web/lib/api/channels.ts
@@ -90,3 +90,95 @@ export function unbindWeixinAccount(accountId: string): Promise<Record<string, n
     ),
   );
 }
+
+// ---------------------------------------------------------------------------
+// Telegram / Discord（配对码绑定，见 api/routes/channels_im.py）
+// ---------------------------------------------------------------------------
+
+export type ImChannelId = "telegram" | "discord";
+
+/** 已绑定的 TG/Discord bot 账号（见 schemas.channels.ImAccountView）。 */
+export interface ImAccount {
+  channel_id: string;
+  account_id: string;
+  /** 完成配对的用户 id（白名单，同时是推送目标） */
+  bound_user_id: string | null;
+  status: "active" | "stale";
+  running: boolean;
+  last_error: string | null;
+  bound_at: string;
+}
+
+/** 配对绑定状态（发起返回与轮询同一结构）。 */
+export interface ImBinding {
+  challenge_id: string;
+  status: "pending" | "confirmed" | "expired" | "failed";
+  /** 面板展示的 6 位配对码：用户私聊 bot 发这串数字完成绑定 */
+  pair_code: string;
+  bot_name: string;
+  message: string;
+  account: ImAccount | null;
+}
+
+export function listImAccounts(channel: ImChannelId): Promise<ImAccount[]> {
+  return unwrap(request<ApiEnvelope<ImAccount[]>>(`/channels/im/${channel}/accounts`));
+}
+
+export function startImBinding(channel: ImChannelId, token: string): Promise<ImBinding> {
+  return unwrap(
+    request<ApiEnvelope<ImBinding>>(`/channels/im/${channel}/bindings`, {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    }),
+  );
+}
+
+export function getImBindingStatus(channel: ImChannelId, challengeId: string): Promise<ImBinding> {
+  return unwrap(
+    request<ApiEnvelope<ImBinding>>(
+      `/channels/im/${channel}/bindings/${encodeURIComponent(challengeId)}`,
+    ),
+  );
+}
+
+export function unbindImAccount(
+  channel: ImChannelId,
+  accountId: string,
+): Promise<Record<string, never>> {
+  return unwrap(
+    request<ApiEnvelope<Record<string, never>>>(
+      `/channels/im/${channel}/accounts/${encodeURIComponent(accountId)}`,
+      { method: "DELETE" },
+    ),
+  );
+}
+
+export function sendChannelPushTest(text?: string): Promise<{ sent: number }> {
+  return unwrap(
+    request<ApiEnvelope<{ sent: number }>>(`/channels/im/push-test`, {
+      method: "POST",
+      body: JSON.stringify({ text: text ?? "" }),
+    }),
+  );
+}
+
+/** 推送内容开关（哪些系统事件会推送到已绑定通道）。 */
+export interface ChannelPushConfig {
+  /** 订阅命中并投递下载时推送 */
+  push_dispatch: boolean;
+  /** 下载完成整理入库时推送 */
+  push_imported: boolean;
+}
+
+export function getChannelPushConfig(): Promise<ChannelPushConfig> {
+  return unwrap(request<ApiEnvelope<ChannelPushConfig>>(`/channels/im/push-config`));
+}
+
+export function updateChannelPushConfig(config: ChannelPushConfig): Promise<ChannelPushConfig> {
+  return unwrap(
+    request<ApiEnvelope<ChannelPushConfig>>(`/channels/im/push-config`, {
+      method: "PUT",
+      body: JSON.stringify(config),
+    }),
+  );
+}

--- a/apps/web/lib/mock-data.ts
+++ b/apps/web/lib/mock-data.ts
@@ -133,7 +133,7 @@ export const settingsSectionGroups: SettingsSectionGroup[] = [
     label: "智能",
     items: [
       { id: "llm", label: "AI 模型", description: "大语言模型供应商接入", icon: SparkIcon },
-      { id: "weixin", label: "微信绑定", description: "把 AI 助手接入你的微信，扫码即用", icon: ChatIcon },
+      { id: "im-push", label: "消息推送", description: "微信 / Telegram / Discord 推送与 AI 对话", icon: ChatIcon },
     ],
   },
   {

--- a/src/movieclaw_api/api/router.py
+++ b/src/movieclaw_api/api/router.py
@@ -20,6 +20,7 @@ from movieclaw_api.api.routes.app_update import router as app_update_router
 from movieclaw_api.api.routes.appearance import router as appearance_router
 from movieclaw_api.api.routes.auth import router as auth_router
 from movieclaw_api.api.routes.channels import router as channels_router
+from movieclaw_api.api.routes.channels_im import router as channels_im_router
 from movieclaw_api.api.routes.discover import router as discover_router
 from movieclaw_api.api.routes.downloaders import router as downloaders_router
 from movieclaw_api.api.routes.extension import router as extension_router
@@ -63,6 +64,7 @@ _PROTECTED_ROUTERS = [
     llm_router,
     agent_router,
     channels_router,
+    channels_im_router,
     subscriptions_router,
     libraries_router,
     import_watch_router,

--- a/src/movieclaw_api/api/routes/channels_im.py
+++ b/src/movieclaw_api/api/routes/channels_im.py
@@ -1,0 +1,190 @@
+"""IM 通道接口(Telegram / Discord 的配对码绑定与账号管理)。
+
+前端(设置 → 消息推送)交互流程:
+1. 进页面 GET accounts 展示两个平台的绑定列表;
+2. 填 bot token POST bindings → 返回 6 位配对码;
+3. 用户去 TG/Discord 私聊 bot 发配对码;前端每 2 秒 GET bindings/{id} 轮询;
+4. confirmed → 刷新列表(通道已在收发,发码人即白名单与推送目标)。
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from movieclaw_api.exceptions import BadRequestException, NotFoundException
+from movieclaw_api.schemas.channels import (
+    ChannelPushConfigView,
+    ImAccountView,
+    ImBindingView,
+    ImBindTokenPayload,
+    PushTestPayload,
+)
+from movieclaw_api.schemas.response import ApiResponse, ok
+from movieclaw_api.services.channel_push import push_to_all_channels
+from movieclaw_api.services.im_channel import (
+    IM_CHANNEL_IDS,
+    ImChannelId,
+    PairChallenge,
+    get_im_channels,
+)
+from movieclaw_api.settings import ChannelPushSetting, get_setting_store
+from movieclaw_db.engine import get_session
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
+from movieclaw_db.repositories.llm_provider_repo import LlmProviderRepository
+
+router = APIRouter(prefix="/channels/im", tags=["channels"])
+
+
+def _require_channel(channel: str) -> ImChannelId:
+    if channel not in IM_CHANNEL_IDS:
+        raise NotFoundException(f"未知通道:{channel}")
+    return channel  # type: ignore[return-value]
+
+
+async def _binding_view(challenge: PairChallenge, session: AsyncSession) -> ImBindingView:
+    account: ImAccountView | None = None
+    if challenge.status == "confirmed":
+        row = await ChannelAccountRepository(session).get(challenge.bot_id)
+        if row is not None:
+            service = get_im_channels()
+            account = ImAccountView.from_model(
+                row, running=service.manager.is_running(challenge.channel_id, row.account_id)
+            )
+    return ImBindingView(
+        challenge_id=challenge.challenge_id,
+        status=challenge.status,
+        pair_code=challenge.pair_code,
+        bot_name=challenge.bot_name,
+        message=challenge.message,
+        account=account,
+    )
+
+
+@router.get(
+    "/{channel}/accounts",
+    response_model=ApiResponse[list[ImAccountView]],
+    summary="已绑定的 TG/Discord 账号列表",
+    operation_id="channels.im.accounts.list",
+)
+async def list_im_accounts(
+    channel: str,
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[list[ImAccountView]]:
+    channel_id = _require_channel(channel)
+    service = get_im_channels()
+    rows = await ChannelAccountRepository(session).list_by_channel(channel_id)
+    return ok(
+        [
+            ImAccountView.from_model(
+                row, running=service.manager.is_running(channel_id, row.account_id)
+            )
+            for row in rows
+        ]
+    )
+
+
+@router.post(
+    "/{channel}/bindings",
+    response_model=ApiResponse[ImBindingView],
+    status_code=201,
+    summary="发起配对绑定(提交 bot token,返回配对码)",
+    operation_id="channels.im.bindings.start",
+)
+async def start_im_binding(
+    channel: str,
+    payload: ImBindTokenPayload,
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[ImBindingView]:
+    """校验 token 并生成配对码;用户私聊 bot 发码即完成绑定。
+
+    前置:必须已配置 AI 模型(与微信绑定同口径)。
+    """
+    channel_id = _require_channel(channel)
+    if await LlmProviderRepository(session).get() is None:
+        raise BadRequestException(
+            "绑定需要先完成 AI 模型配置:请先在「设置 → AI 模型」接入模型供应商,再进行绑定"
+        )
+    try:
+        challenge = await get_im_channels().begin_binding(channel_id, payload.token.strip())
+    except ValueError as exc:
+        raise BadRequestException(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 -- 网络不可达等,转成中文业务错误
+        raise BadRequestException(f"发起绑定失败:{exc}") from exc
+    return ok(await _binding_view(challenge, session), message="绑定已发起")
+
+
+@router.get(
+    "/{channel}/bindings/{challenge_id}",
+    response_model=ApiResponse[ImBindingView],
+    summary="查询配对状态(前端轮询)",
+    operation_id="channels.im.bindings.status",
+)
+async def get_im_binding_status(
+    channel: str,
+    challenge_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[ImBindingView]:
+    _require_channel(channel)
+    challenge = get_im_channels().get_challenge(challenge_id)
+    if challenge is None:
+        raise NotFoundException("绑定流程不存在或已过期,请重新发起")
+    return ok(await _binding_view(challenge, session))
+
+
+@router.delete(
+    "/{channel}/accounts/{account_id}",
+    response_model=ApiResponse[dict],
+    summary="解绑 TG/Discord 账号",
+    operation_id="channels.im.accounts.unbind",
+    # 解绑删除凭据、停止通道,须二次确认(CLI 据此决定 --yes 门槛)
+    openapi_extra={"x-cli-dangerous": "confirm"},
+)
+async def unbind_im_account(channel: str, account_id: str) -> ApiResponse[dict]:
+    channel_id = _require_channel(channel)
+    removed = await get_im_channels().unbind(channel_id, account_id)
+    if not removed:
+        raise NotFoundException("账号不存在或已解绑")
+    return ok({}, message="已解绑")
+
+
+@router.post(
+    "/push-test",
+    response_model=ApiResponse[dict],
+    summary="向所有已绑定通道发送测试推送",
+    operation_id="channels.im.push.test",
+)
+async def send_test_push(payload: PushTestPayload) -> ApiResponse[dict]:
+    text = payload.text.strip() or "📣 这是一条来自 movieclaw 的测试推送。收到说明通道工作正常!"
+    sent = await push_to_all_channels(text)
+    if sent == 0:
+        raise BadRequestException("没有可推送的通道账号:请先完成绑定且确保通道在运行")
+    return ok({"sent": sent}, message=f"已推送到 {sent} 个账号")
+
+
+@router.get(
+    "/push-config",
+    response_model=ApiResponse[ChannelPushConfigView],
+    summary="读取推送内容开关",
+    operation_id="channels.im.push.config.get",
+)
+async def get_push_config() -> ApiResponse[ChannelPushConfigView]:
+    setting = await get_setting_store().get(ChannelPushSetting)
+    return ok(
+        ChannelPushConfigView(
+            push_dispatch=setting.push_dispatch, push_imported=setting.push_imported
+        )
+    )
+
+
+@router.put(
+    "/push-config",
+    response_model=ApiResponse[ChannelPushConfigView],
+    summary="保存推送内容开关",
+    operation_id="channels.im.push.config.update",
+)
+async def update_push_config(payload: ChannelPushConfigView) -> ApiResponse[ChannelPushConfigView]:
+    await get_setting_store().set(
+        ChannelPushSetting(push_dispatch=payload.push_dispatch, push_imported=payload.push_imported)
+    )
+    return ok(payload, message="推送设置已保存")

--- a/src/movieclaw_api/lifespan.py
+++ b/src/movieclaw_api/lifespan.py
@@ -166,6 +166,10 @@ def build_lifespan(settings: Settings):
         from movieclaw_api.services.weixin_channel import init_weixin_channel
 
         await init_weixin_channel()
+        # Telegram / Discord 通道:配对码绑定,同一套 Agent 会话体系
+        from movieclaw_api.services.im_channel import init_im_channels
+
+        await init_im_channels()
         logger.info("应用启动完成，数据库就绪")
         try:
             yield
@@ -180,6 +184,9 @@ def build_lifespan(settings: Settings):
             from movieclaw_api.services.weixin_channel import close_weixin_channel
 
             await close_weixin_channel()
+            from movieclaw_api.services.im_channel import close_im_channels
+
+            await close_im_channels()
             # 先停止 Agent，避免它在下游 HTTP 客户端和数据库开始释放后继续工作。
             await close_agent_run_registry()
             if settings.scheduler_enabled:

--- a/src/movieclaw_api/schemas/channels.py
+++ b/src/movieclaw_api/schemas/channels.py
@@ -66,3 +66,67 @@ class WeixinVerifyCodePayload(BaseModel):
     """提交手机微信上显示的配对数字。"""
 
     code: str = Field(min_length=1, max_length=16, description="配对码")
+
+
+# ---------------------------------------------------------------------------
+# Telegram / Discord(配对码绑定)
+# ---------------------------------------------------------------------------
+
+
+class ImAccountView(BaseModel):
+    """已绑定的 TG/Discord bot 账号(绑定页列表项)。"""
+
+    channel_id: str
+    account_id: str
+    #: 完成配对的用户 id(白名单,同时是推送目标)
+    bound_user_id: str | None
+    status: str
+    running: bool
+    last_error: str | None
+    bound_at: datetime
+
+    @classmethod
+    def from_model(cls, row: ChannelAccount, *, running: bool) -> ImAccountView:
+        return cls(
+            channel_id=row.channel_id,
+            account_id=row.account_id,
+            bound_user_id=row.bound_user_id,
+            status=row.status,
+            running=running,
+            last_error=row.last_error,
+            bound_at=row.created_at,
+        )
+
+
+class ImBindTokenPayload(BaseModel):
+    """发起绑定:提交 bot token。"""
+
+    token: str = Field(min_length=8, max_length=256, description="bot token")
+
+
+class ImBindingView(BaseModel):
+    """配对绑定状态(发起返回 + 前端 poll 同一结构)。
+
+    status 取值:pending / confirmed / expired / failed。
+    """
+
+    challenge_id: str
+    status: str
+    #: 面板展示给用户的 6 位配对码(用户私聊 bot 发这串数字完成绑定)
+    pair_code: str
+    bot_name: str
+    message: str
+    account: ImAccountView | None = None
+
+
+class PushTestPayload(BaseModel):
+    """测试推送文本(缺省用默认文案)。"""
+
+    text: str = Field(default="", max_length=500)
+
+
+class ChannelPushConfigView(BaseModel):
+    """推送内容开关(GET 返回与 PUT 载荷同构)。"""
+
+    push_dispatch: bool = Field(description="订阅开始下载时推送")
+    push_imported: bool = Field(description="入库完成时推送")

--- a/src/movieclaw_api/services/channel_push.py
+++ b/src/movieclaw_api/services/channel_push.py
@@ -1,0 +1,86 @@
+"""跨通道主动推送:把系统事件文本扇出到所有已绑定的 IM 通道。
+
+调用方(订阅投递/入库对账等)只管 fire-and-forget:``notify_channels(text)``
+内部起后台任务,任何通道失败都只记日志,绝不影响业务主链路。
+
+微信通道的绑定用户与 TG/Discord 一样从 channel_account.bound_user_id 取,
+出站统一经各账号 dispatcher 的发送泵(顺序与限流集中一处)。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from movieclaw_channel.types import OutboundEnvelope, ReplyContext
+from movieclaw_db.engine import get_database
+from movieclaw_db.models.channel_account import ChannelAccountStatus
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
+
+logger = logging.getLogger("movieclaw_api.channel_push")
+
+
+async def push_to_all_channels(text: str) -> int:
+    """推送到所有通道(微信 + Telegram + Discord),返回入队的账号数。"""
+    count = 0
+
+    # IM 通道(telegram/discord):服务内存里有现成的推送地址簿
+    try:
+        from movieclaw_api.services.im_channel import get_im_channels
+
+        count += await get_im_channels().push_text(text)
+    except RuntimeError:
+        pass  # 服务未初始化(启动早期/测试)
+
+    # 微信通道:从库里取绑定用户,经运行中的 dispatcher 入队
+    try:
+        from movieclaw_api.services.weixin_channel import get_weixin_channel
+        from movieclaw_channel.weixin.adapter import CHANNEL_ID as WEIXIN_CHANNEL_ID
+
+        service = get_weixin_channel()
+        async with get_database().session() as session:
+            rows = await ChannelAccountRepository(session).list_by_channel(WEIXIN_CHANNEL_ID)
+        for row in rows:
+            bound = (row.bound_user_id or "").strip()
+            if not bound or row.status != ChannelAccountStatus.ACTIVE:
+                continue
+            dispatcher = service.manager.get_dispatcher(WEIXIN_CHANNEL_ID, row.account_id)
+            if dispatcher is None:
+                continue
+            reply = ReplyContext(
+                channel_id=WEIXIN_CHANNEL_ID, account_id=row.account_id, user_id=bound
+            )
+            await dispatcher.push_outbound(OutboundEnvelope(reply=reply, text=text, origin="push"))
+            count += 1
+    except RuntimeError:
+        pass
+
+    return count
+
+
+def notify_channels(text: str, event: str = "") -> None:
+    """业务侧唯一入口:后台推送,失败只记日志,不阻塞、不抛错。
+
+    ``event`` 对应 ChannelPushSetting 的开关字段(``push_<event>``):
+    dispatch=投递下载,imported=入库完成。空 event(测试推送)不受开关限制。
+    """
+
+    async def _run() -> None:
+        try:
+            if event:
+                from movieclaw_api.settings import ChannelPushSetting, get_setting_store
+
+                setting = await get_setting_store().get(ChannelPushSetting)
+                if not getattr(setting, f"push_{event}", True):
+                    logger.debug("推送事件 %s 已被用户关闭,跳过", event)
+                    return
+            sent = await push_to_all_channels(text)
+            if sent:
+                logger.info("已推送到 %d 个通道账号:%s", sent, text[:60])
+        except Exception:  # noqa: BLE001 -- 推送绝不能影响业务主链路
+            logger.exception("通道推送失败(已忽略)")
+
+    try:
+        asyncio.get_running_loop().create_task(_run())
+    except RuntimeError:
+        logger.debug("无运行中的事件循环,推送已跳过")

--- a/src/movieclaw_api/services/im_channel.py
+++ b/src/movieclaw_api/services/im_channel.py
@@ -1,0 +1,464 @@
+"""IM 通道服务编排(Telegram / Discord 共用):配对码绑定 + Agent 装配 + 主动推送。
+
+与微信服务(weixin_channel.py)的分工:微信有扫码/配对码/iLink 网关等
+重量级绑定状态机,自成一体;TG/Discord 的绑定简单得多——面板填 bot token,
+服务端生成 6 位配对码,用户私聊 bot 发码即完成绑定(谁发码谁是白名单)。
+两个平台的差异全部收敛在「通道规格」(_ChannelSpec)里,服务本体只写一份。
+
+Agent 装配与微信同款红线:受限工具集(仅 mclaw 产品操作),不开宿主 shell;
+会话与 Web「最近会话」共用 agent_session 体系,/reset 换新会话。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from movieclaw_agent import AgentRunner, AgentStartParams
+from movieclaw_agent.events import AgentEvent
+from movieclaw_agent.tools import make_mclaw_tool
+from movieclaw_api.core.config import get_settings
+from movieclaw_api.exceptions import NotFoundException
+from movieclaw_api.services import auth as auth_service
+from movieclaw_api.services.agent_session_recorder import AgentSessionRecorder
+from movieclaw_api.services.agent_sessions import get_agent_session_store
+from movieclaw_api.services.llm_config import acquire_llm_router
+from movieclaw_api.services.mclaw_tool import render_service_map
+from movieclaw_channel import ChannelManager, InboundMessage
+from movieclaw_channel.adapter import ChannelAdapter
+from movieclaw_channel.discord import CHANNEL_ID as DISCORD_CHANNEL_ID
+from movieclaw_channel.discord import DiscordAdapter, DiscordClient
+from movieclaw_channel.dispatcher import make_dispatcher
+from movieclaw_channel.telegram import CHANNEL_ID as TELEGRAM_CHANNEL_ID
+from movieclaw_channel.telegram import TelegramAdapter, TelegramClient
+from movieclaw_channel.types import OutboundEnvelope, ReplyContext
+from movieclaw_db.engine import get_database
+from movieclaw_db.models.channel_account import ChannelAccount, ChannelAccountStatus
+from movieclaw_db.repositories.agent_session_repo import AgentSessionRepository
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
+
+logger = logging.getLogger("movieclaw_api.im_channel")
+
+ImChannelId = Literal["telegram", "discord"]
+IM_CHANNEL_IDS: tuple[ImChannelId, ...] = (TELEGRAM_CHANNEL_ID, DISCORD_CHANNEL_ID)
+
+#: IM 侧 Agent 步数上限(与微信同口径)
+_IM_MAX_STEPS = 40
+_ACK_TEXT = "思考中💭"
+#: 配对码有效期
+_PAIR_TTL_S = 10 * 60
+
+
+# ---------------------------------------------------------------------------
+# 通道规格:平台差异的唯一落点
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _ChannelSpec:
+    channel_id: str
+    display_name: str
+    #: token → (客户端, 关闭函数)
+    make_client: Callable[[str], Any]
+    make_adapter: Callable[[Any, str], ChannelAdapter]
+    #: 校验 token 并返回 (bot 账号 id, bot 展示名)
+    validate: Callable[[Any], Awaitable[tuple[str, str]]]
+
+
+async def _tg_validate(client: TelegramClient) -> tuple[str, str]:
+    me = await client.get_me()
+    return str(me["id"]), str(me.get("username") or me.get("first_name") or me["id"])
+
+
+async def _dc_validate(client: DiscordClient) -> tuple[str, str]:
+    me = await client.get_me()
+    return str(me["id"]), str(me.get("username") or me["id"])
+
+
+_SPECS: dict[str, _ChannelSpec] = {
+    TELEGRAM_CHANNEL_ID: _ChannelSpec(
+        channel_id=TELEGRAM_CHANNEL_ID,
+        display_name="Telegram",
+        make_client=TelegramClient,
+        make_adapter=TelegramAdapter,
+        validate=_tg_validate,
+    ),
+    DISCORD_CHANNEL_ID: _ChannelSpec(
+        channel_id=DISCORD_CHANNEL_ID,
+        display_name="Discord",
+        make_client=DiscordClient,
+        make_adapter=DiscordAdapter,
+        validate=_dc_validate,
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# 配对码绑定
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class PairChallenge:
+    """一次进行中的配对绑定。
+
+    生命周期:begin(token 校验通过)→ 临时账号已在收消息,等用户私聊 bot
+    发配对码 → 命中后落库转正、绑定发码人为白名单 → confirmed。
+    过期(10 分钟)自动停临时账号。
+    """
+
+    challenge_id: str
+    channel_id: str
+    pair_code: str
+    bot_id: str
+    bot_name: str
+    status: Literal["pending", "confirmed", "expired", "failed"] = "pending"
+    message: str = ""
+    expires_at: float = field(default_factory=lambda: time.monotonic() + _PAIR_TTL_S)
+
+
+class ImChannelService:
+    """进程级单例:Telegram 与 Discord 两个通道的账号管理。"""
+
+    def __init__(self) -> None:
+        self.manager = ChannelManager()
+        self._clients: dict[str, Any] = {}  # "channel:account_id" → client
+        self._challenges: dict[str, PairChallenge] = {}
+        #: 配对期临时凭据:challenge_id → token(确认后才落库)
+        self._pending_tokens: dict[str, str] = {}
+        #: 主动推送地址簿:"channel:account_id" → ReplyContext(绑定用户)
+        self._push_targets: dict[str, ReplyContext] = {}
+
+    # ------------------------------------------------------------------
+    # 生命周期
+    # ------------------------------------------------------------------
+    async def start(self) -> None:
+        async with get_database().session() as session:
+            repo = ChannelAccountRepository(session)
+            rows: list[tuple[ChannelAccount, str]] = []
+            for channel_id in IM_CHANNEL_IDS:
+                for row in await repo.list_by_channel(channel_id):
+                    if row.status == ChannelAccountStatus.ACTIVE:
+                        rows.append((row, ChannelAccountRepository.decrypted_token(row)))
+        for row, token in rows:
+            try:
+                await self._start_account(row, token)
+            except Exception:
+                logger.exception(
+                    "IM 账号启动失败 channel=%s account=%s", row.channel_id, row.account_id
+                )
+        if rows:
+            logger.info("IM 通道已启动 %d 个账号", len(rows))
+
+    async def stop(self) -> None:
+        await self.manager.close()
+        for client in self._clients.values():
+            await client.aclose()
+        self._clients.clear()
+        self._push_targets.clear()
+
+    # ------------------------------------------------------------------
+    # 账号装配
+    # ------------------------------------------------------------------
+    def _key(self, channel_id: str, account_id: str) -> str:
+        return f"{channel_id}:{account_id}"
+
+    async def _start_account(self, row: ChannelAccount, token: str) -> None:
+        spec = _SPECS[row.channel_id]
+        key = self._key(row.channel_id, row.account_id)
+        old = self._clients.pop(key, None)
+        if old is not None:
+            await self.manager.stop_account(row.channel_id, row.account_id)
+            await old.aclose()
+
+        client = spec.make_client(token)
+        self._clients[key] = client
+        adapter = spec.make_adapter(client, row.account_id)
+
+        bound_user = (row.bound_user_id or "").strip()
+        if bound_user:
+            self._push_targets[key] = ReplyContext(
+                channel_id=row.channel_id,
+                account_id=row.account_id,
+                user_id=bound_user,
+            )
+        dispatcher = make_dispatcher(
+            adapter,
+            # 白名单 = 完成配对的用户本人;缺失(异常数据)时拒绝所有人
+            is_allowed=lambda uid, _bound=bound_user: bool(_bound) and uid == _bound,
+            run_agent=self._run_agent,
+            reset_session=self._reset_session,
+        )
+        await self.manager.start_account(
+            adapter,
+            dispatcher,
+            account_id=row.account_id,
+            initial_cursor=row.cursor or "",
+            save_cursor=self._make_cursor_saver(row.account_id),
+            on_auth_error=self._make_auth_error_handler(row.channel_id),
+        )
+
+    @staticmethod
+    def _make_cursor_saver(account_id: str) -> Callable[[str], Awaitable[None]]:
+        async def save(cursor: str) -> None:
+            async with get_database().session() as session:
+                await ChannelAccountRepository(session).save_cursor(account_id, cursor)
+
+        return save
+
+    def _make_auth_error_handler(self, channel_id: str) -> Callable[[str], Awaitable[None]]:
+        async def on_auth_error(account_id: str) -> None:
+            async with get_database().session() as session:
+                await ChannelAccountRepository(session).mark_stale(
+                    account_id, f"{_SPECS[channel_id].display_name} bot 凭据已失效,请重新绑定"
+                )
+            key = self._key(channel_id, account_id)
+            self._push_targets.pop(key, None)
+            client = self._clients.pop(key, None)
+            if client is not None:
+                await client.aclose()
+
+        return on_auth_error
+
+    # ------------------------------------------------------------------
+    # 配对码绑定流程
+    # ------------------------------------------------------------------
+    async def begin_binding(self, channel_id: ImChannelId, token: str) -> PairChallenge:
+        """校验 token → 生成配对码 → 起临时账号等待用户发码。"""
+        spec = _SPECS[channel_id]
+        client = spec.make_client(token)
+        try:
+            bot_id, bot_name = await spec.validate(client)
+        except Exception as exc:
+            await client.aclose()
+            raise ValueError(f"{spec.display_name} bot token 校验失败:{exc}") from exc
+
+        pair_code = f"{secrets.randbelow(1_000_000):06d}"
+        challenge = PairChallenge(
+            challenge_id=uuid.uuid4().hex[:16],
+            channel_id=channel_id,
+            pair_code=pair_code,
+            bot_id=bot_id,
+            bot_name=bot_name,
+            message=f"请在 {spec.display_name} 上私聊 @{bot_name} 发送配对码 {pair_code}",
+        )
+        self._challenges[challenge.challenge_id] = challenge
+        self._pending_tokens[challenge.challenge_id] = token
+
+        # 配对期临时收发:任何人发来的消息只跟配对码比对,不进 Agent。
+        # 命中即落库转正、以正式白名单重启账号。
+        adapter = spec.make_adapter(client, bot_id)
+        key = self._key(channel_id, bot_id)
+        old = self._clients.pop(key, None)
+        if old is not None:
+            await self.manager.stop_account(channel_id, bot_id)
+            await old.aclose()
+        self._clients[key] = client
+
+        async def pair_agent(
+            msg: InboundMessage, emit: Callable[[str], Awaitable[None]]
+        ) -> None:
+            ch = self._challenges.get(challenge.challenge_id)
+            if ch is None or ch.status != "pending":
+                return
+            if time.monotonic() > ch.expires_at:
+                ch.status = "expired"
+                ch.message = "配对码已过期,请重新发起绑定"
+                return
+            if msg.text.strip() != ch.pair_code:
+                await emit("配对码不正确。请发送面板上显示的 6 位数字完成绑定。")
+                return
+            await self._confirm_binding(ch, msg)
+            await emit("绑定成功!我是 movieclaw 助手,现在可以直接发消息让我干活了。")
+
+        dispatcher = make_dispatcher(adapter, is_allowed=lambda _uid: True, run_agent=pair_agent)
+        await self.manager.start_account(
+            adapter,
+            dispatcher,
+            account_id=bot_id,
+            initial_cursor="",
+            save_cursor=self._make_cursor_saver(bot_id),
+            on_auth_error=self._make_auth_error_handler(channel_id),
+        )
+        return challenge
+
+    async def _confirm_binding(self, challenge: PairChallenge, msg: InboundMessage) -> None:
+        """配对码命中:凭据落库、发码人即白名单,重启为正式账号。"""
+        token = self._pending_tokens.pop(challenge.challenge_id, "")
+        if not token:
+            challenge.status = "failed"
+            challenge.message = "绑定状态已丢失,请重新发起"
+            return
+        async with get_database().session() as session:
+            row = await ChannelAccountRepository(session).upsert(
+                channel_id=challenge.channel_id,
+                account_id=challenge.bot_id,
+                token=token,
+                base_url="",
+                bound_user_id=msg.user_id,
+            )
+        challenge.status = "confirmed"
+        challenge.message = "绑定完成,通道已启动"
+        logger.info(
+            "IM 绑定完成 channel=%s bot=%s user=%s",
+            challenge.channel_id,
+            challenge.bot_id,
+            msg.user_id,
+        )
+        # 从配对模式切到正式模式(热替换;当前正在配对回调里,起后台任务避免自锁)
+        asyncio.get_running_loop().create_task(self._start_account(row, token))
+
+    def get_challenge(self, challenge_id: str) -> PairChallenge | None:
+        ch = self._challenges.get(challenge_id)
+        if ch is not None and ch.status == "pending" and time.monotonic() > ch.expires_at:
+            ch.status = "expired"
+            ch.message = "配对码已过期,请重新发起绑定"
+            self._pending_tokens.pop(challenge_id, None)
+        return ch
+
+    # ------------------------------------------------------------------
+    # 账号管理
+    # ------------------------------------------------------------------
+    async def unbind(self, channel_id: str, account_id: str) -> bool:
+        await self.manager.stop_account(channel_id, account_id)
+        key = self._key(channel_id, account_id)
+        self._push_targets.pop(key, None)
+        client = self._clients.pop(key, None)
+        if client is not None:
+            await client.aclose()
+        async with get_database().session() as session:
+            return await ChannelAccountRepository(session).delete(account_id)
+
+    # ------------------------------------------------------------------
+    # 主动推送
+    # ------------------------------------------------------------------
+    async def push_text(self, text: str) -> int:
+        """把一条文本推给所有已绑定且在运行的账号;返回送达队列的账号数。"""
+        count = 0
+        for key, reply in self._push_targets.items():
+            channel_id, account_id = key.split(":", 1)
+            dispatcher = self.manager.get_dispatcher(channel_id, account_id)
+            if dispatcher is None:
+                continue
+            await dispatcher.push_outbound(OutboundEnvelope(reply=reply, text=text, origin="push"))
+            count += 1
+        return count
+
+    # ------------------------------------------------------------------
+    # 会话持久化与 Agent 执行(与微信同一套体系)
+    # ------------------------------------------------------------------
+    async def _ensure_agent_session(self, msg: InboundMessage) -> str:
+        store = get_agent_session_store()
+        display = _SPECS[msg.channel_id].display_name
+        async with get_database().session() as session:
+            account_repo = ChannelAccountRepository(session)
+            row = await account_repo.get(msg.account_id)
+            existing = (row.agent_session_id or "").strip() if row else ""
+            if existing:
+                session_row = await AgentSessionRepository(session).get(existing)
+                if session_row is not None and store.path(existing).exists():
+                    return existing
+                logger.warning(
+                    "IM 会话已失效,将新建 account=%s session=%s", msg.account_id, existing
+                )
+            header = store.create()
+            await AgentSessionRepository(session).create(
+                header.session_id, title=f"{display} · {msg.user_id}"
+            )
+            await account_repo.set_agent_session(msg.account_id, header.session_id)
+            return header.session_id
+
+    async def _reset_session(self, session_key: str) -> None:
+        account_id = session_key.split(":", 2)[1]
+        async with get_database().session() as session:
+            await ChannelAccountRepository(session).set_agent_session(account_id, None)
+
+    async def _run_agent(self, msg: InboundMessage, emit: Callable[[str], Awaitable[None]]) -> None:
+        from movieclaw_channel.pusher import StepReplyPusher
+
+        await emit(_ACK_TEXT)
+        try:
+            async with get_database().session() as session:
+                llm_router = await acquire_llm_router(session)
+        except NotFoundException as exc:
+            await emit(f"⚠️ {exc.message}")
+            return
+
+        store = get_agent_session_store()
+        session_id = await self._ensure_agent_session(msg)
+        history = store.build_history(session_id)
+        recorder = AgentSessionRecorder(store, session_id, entry_count=len(history))
+        await recorder.record_user_input(msg.text)
+
+        runner = AgentRunner(
+            llm_router,
+            tools=await self._restricted_tools(session_id, msg.channel_id),
+            max_steps=_IM_MAX_STEPS,
+            on_message=recorder.on_message,
+            on_compaction=recorder.on_compaction,
+        )
+        run_id = uuid.uuid4().hex[:12]
+        await recorder.begin(run_id)
+
+        pusher = StepReplyPusher(emit)
+        last_event: AgentEvent | None = None
+        try:
+            async for ev in runner.start(
+                AgentStartParams(input=msg.text, history=history), run_id=run_id
+            ):
+                last_event = ev
+                await pusher.feed(ev)
+        finally:
+            terminal = (
+                last_event
+                if last_event is not None
+                and last_event.type in ("agent_done", "agent_error", "agent_cancelled")
+                else AgentEvent(type="agent_cancelled", run_id=run_id)
+            )
+            await recorder.on_terminal(terminal)
+
+    async def _restricted_tools(self, session_id: str, channel_id: str):
+        """IM 侧受限工具集:仅 mclaw 产品操作工具,与微信同一安全红线。"""
+        settings = get_settings()
+        workdir = Path(settings.agent_workspace_dir).resolve() / channel_id
+        workdir.mkdir(parents=True, exist_ok=True)
+        token = await auth_service.issue_agent_token(session_id)
+        cli_env = {
+            "MOVIECLAW_SERVER": f"http://127.0.0.1:{settings.port}",
+            "MOVIECLAW_TOKEN": token,
+        }
+        return [make_mclaw_tool(workdir, cli_env, render_service_map())]
+
+
+# ---------------------------------------------------------------------------
+# 进程级单例
+# ---------------------------------------------------------------------------
+
+_service: ImChannelService | None = None
+
+
+async def init_im_channels() -> ImChannelService:
+    global _service
+    _service = ImChannelService()
+    await _service.start()
+    return _service
+
+
+def get_im_channels() -> ImChannelService:
+    if _service is None:
+        raise RuntimeError("IM 通道服务尚未初始化")
+    return _service
+
+
+async def close_im_channels() -> None:
+    global _service
+    if _service is not None:
+        await _service.stop()
+        _service = None

--- a/src/movieclaw_api/services/subscription/dispatch.py
+++ b/src/movieclaw_api/services/subscription/dispatch.py
@@ -183,6 +183,16 @@ async def dispatch(
         )
     )
     await recompute_subscription_status(session, subscription, item)
+
+    # IM 通道推送(微信/TG/Discord;fire-and-forget,失败不影响投递链路)
+    if not dry_run:
+        from movieclaw_api.services.channel_push import notify_channels
+
+        notify_channels(
+            f"📥 开始下载:《{item.title}》{units_label}\n"
+            f"来自 {candidate.site_id} 的「{candidate.title[:60]}」",
+            event="dispatch",
+        )
     return True
 
 

--- a/src/movieclaw_api/services/subscription/wanted_fulfillment.py
+++ b/src/movieclaw_api/services/subscription/wanted_fulfillment.py
@@ -82,6 +82,10 @@ async def close_fulfilled_wanted(session: AsyncSession, media_item_id: int) -> i
             )
         )
         await recompute_subscription_status(session, subscription, item)
+        # IM 通道推送(微信/TG/Discord;fire-and-forget,失败不影响对账链路)
+        from movieclaw_api.services.channel_push import notify_channels
+
+        notify_channels(f"🎬 已入库:《{item.title}》{units_text(wanted_rows)}", event="imported")
         # 内容已进库，该订阅在途种子的落点告警（若有）自动熄灭
         from movieclaw_api.services.system_notice import resolve_notices
 

--- a/src/movieclaw_api/settings/__init__.py
+++ b/src/movieclaw_api/settings/__init__.py
@@ -30,6 +30,9 @@ from movieclaw_api.settings.base import (
     list_descriptors,
     register_setting,
 )
+from movieclaw_api.settings.channel_push import (
+    ChannelPushSetting,
+)
 from movieclaw_api.settings.network import (
     BUILTIN_EGRESS_SERVICES,
     NetworkEgressSetting,
@@ -85,6 +88,7 @@ __all__ = [
     "SessionSecretSetting",
     # 网络与代理
     "NetworkEgressSetting",
+    "ChannelPushSetting",
     "BUILTIN_EGRESS_SERVICES",
     # 应用服务（外部访问地址）
     "AppServerSetting",

--- a/src/movieclaw_api/settings/channel_push.py
+++ b/src/movieclaw_api/settings/channel_push.py
@@ -1,0 +1,26 @@
+"""消息推送配置域(「设置 → 消息推送」的推送内容开关)。
+
+控制哪些系统事件会推送到已绑定的 IM 通道(微信/Telegram/Discord)。
+事件键与 ``services.channel_push.notify_channels`` 的 ``event`` 参数一一对应,
+新增推送事件时在这里加开关字段。
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from movieclaw_api.settings.base import SettingSchema, register_setting
+
+CHANNEL_PUSH_NAMESPACE = "channels.push"
+
+
+@register_setting(namespace=CHANNEL_PUSH_NAMESPACE, title="消息推送")
+class ChannelPushSetting(SettingSchema):
+    """推送内容开关(默认全开,与未配置时的行为一致)。"""
+
+    push_dispatch: bool = Field(
+        default=True, description="订阅命中并开始下载时推送(「开始下载」)"
+    )
+    push_imported: bool = Field(
+        default=True, description="下载完成整理入库时推送(「已入库」)"
+    )

--- a/src/movieclaw_api/settings/network.py
+++ b/src/movieclaw_api/settings/network.py
@@ -33,6 +33,16 @@ BUILTIN_EGRESS_SERVICES: list[dict[str, str]] = [
     {"id": "douban", "label": "豆瓣", "description": "豆瓣榜单与搜索（国内网络通常可直连）"},
     {"id": "llm", "label": "AI 模型", "description": "大语言模型供应商接口"},
     {
+        "id": "telegram",
+        "label": "Telegram 推送",
+        "description": "Telegram bot 收发消息(api.telegram.org),国内网络需代理",
+    },
+    {
+        "id": "discord",
+        "label": "Discord 推送",
+        "description": "Discord bot 收发消息(discord.com / gateway),国内网络需代理",
+    },
+    {
         "id": "github",
         "label": "GitHub 更新",
         "description": "应用内更新的检查与产物下载（api.github.com / github.com），"

--- a/src/movieclaw_channel/discord/__init__.py
+++ b/src/movieclaw_channel/discord/__init__.py
@@ -1,0 +1,4 @@
+from movieclaw_channel.discord.adapter import CHANNEL_ID, DiscordAdapter
+from movieclaw_channel.discord.client import DiscordApiError, DiscordClient
+
+__all__ = ["CHANNEL_ID", "DiscordAdapter", "DiscordApiError", "DiscordClient"]

--- a/src/movieclaw_channel/discord/adapter.py
+++ b/src/movieclaw_channel/discord/adapter.py
@@ -1,0 +1,187 @@
+"""DiscordAdapter —— 实现通道协议的 Discord 收发实现。
+
+收消息走 Gateway websocket(Bot API 没有 HTTP 长轮询收消息的口):
+Hello → Identify → 心跳保活 → MESSAGE_CREATE 事件。刻意不做 RESUME——
+断线后直接重新 Identify,本场景消息量极小,丢 RESUME 换实现简单。
+
+只处理私聊(无 guild_id 的消息):私聊内容不需要 MESSAGE CONTENT 特权
+intent,用户在开发者后台建 bot 时零额外配置。发消息走 REST(client.py)。
+
+代理:websocket 连接按 egress 配置解析 "discord" 标签的代理地址,
+与 REST 同一开关(websockets 库原生支持 http/socks 代理)。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import random
+from typing import Any
+
+from websockets.asyncio.client import connect
+from websockets.exceptions import ConnectionClosed, InvalidStatus
+
+from movieclaw_channel.adapter import ChannelContext
+from movieclaw_channel.discord.client import DiscordClient
+from movieclaw_channel.types import ChannelAuthError, InboundMessage, ReplyContext
+from movieclaw_net import resolve_proxy_url
+
+logger = logging.getLogger("movieclaw_channel.discord.adapter")
+
+CHANNEL_ID = "discord"
+
+_GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
+#: DIRECT_MESSAGES;私聊内容不需要 MESSAGE_CONTENT 特权 intent
+_INTENTS = 1 << 12
+#: 凭据级关闭码:4004 鉴权失败;4014 intents 未被允许(理论上不会,兜底)
+_AUTH_CLOSE_CODES = (4004, 4014)
+_RECONNECT_DELAY_S = 5.0
+
+_OP_DISPATCH = 0
+_OP_HEARTBEAT = 1
+_OP_IDENTIFY = 2
+_OP_RECONNECT = 7
+_OP_INVALID_SESSION = 9
+_OP_HELLO = 10
+
+
+class DiscordAdapter:
+    """Discord 通道适配器(单 bot)。"""
+
+    channel_id = CHANNEL_ID
+    #: Discord 单条消息 2000 字符上限,留余量
+    max_text_len = 1900
+
+    def __init__(self, client: DiscordClient, account_id: str) -> None:
+        self._client = client
+        self._account_id = account_id
+
+    async def run(self, ctx: ChannelContext) -> None:
+        stop = ctx.stop or asyncio.Event()
+        logger.info("Discord Gateway 循环启动 account=%s", self._account_id)
+        while not stop.is_set():
+            try:
+                await self._connect_once(ctx, stop)
+            except ChannelAuthError:
+                raise
+            except Exception as exc:  # noqa: BLE001 -- 网络抖动统一退避重连
+                logger.warning("Discord Gateway 断开,%s 秒后重连:%s", _RECONNECT_DELAY_S, exc)
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(stop.wait(), timeout=_RECONNECT_DELAY_S)
+        logger.info("Discord Gateway 循环退出 account=%s", self._account_id)
+
+    async def _connect_once(self, ctx: ChannelContext, stop: asyncio.Event) -> None:
+        """一次完整的 Gateway 会话:连接 → Identify → 收事件直到断开或 stop。"""
+        proxy = resolve_proxy_url("discord")
+        try:
+            ws_ctx = connect(_GATEWAY_URL, proxy=proxy, open_timeout=15, close_timeout=5)
+        except TypeError:
+            # websockets < 14 无 proxy 参数;直连兜底(用户配了代理时会连不上,
+            # 日志已能定位到这里)
+            ws_ctx = connect(_GATEWAY_URL, open_timeout=15, close_timeout=5)
+
+        async with ws_ctx as ws:
+            heartbeat_task: asyncio.Task[None] | None = None
+            #: 最近收到的事件序号(心跳携带);用单元素列表让心跳任务读到最新值
+            seq_holder: list[int | None] = [None]
+            try:
+                while not stop.is_set():
+                    recv = asyncio.ensure_future(ws.recv())
+                    stop_wait = asyncio.ensure_future(stop.wait())
+                    done, _ = await asyncio.wait(
+                        {recv, stop_wait}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    stop_wait.cancel()
+                    if recv not in done:
+                        recv.cancel()
+                        return
+                    payload = json.loads(recv.result())
+
+                    op = payload.get("op")
+                    if payload.get("s") is not None:
+                        seq_holder[0] = payload["s"]
+
+                    if op == _OP_HELLO:
+                        interval = payload["d"]["heartbeat_interval"] / 1000
+                        heartbeat_task = asyncio.create_task(
+                            self._heartbeat(ws, interval, seq_holder),
+                            name=f"discord-heartbeat-{self._account_id}",
+                        )
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "op": _OP_IDENTIFY,
+                                    "d": {
+                                        "token": self._client.token,
+                                        "intents": _INTENTS,
+                                        "properties": {
+                                            "os": "linux",
+                                            "browser": "movieclaw",
+                                            "device": "movieclaw",
+                                        },
+                                    },
+                                }
+                            )
+                        )
+                    elif op == _OP_DISPATCH and payload.get("t") == "MESSAGE_CREATE":
+                        msg = self._normalize(payload.get("d") or {})
+                        if msg is not None:
+                            await ctx.on_inbound(msg)
+                    elif op in (_OP_RECONNECT, _OP_INVALID_SESSION):
+                        logger.info("Discord 要求重连(op=%s)", op)
+                        return
+                    # HEARTBEAT_ACK 及其他事件忽略
+            except ConnectionClosed as exc:
+                if exc.rcvd is not None and exc.rcvd.code in _AUTH_CLOSE_CODES:
+                    raise ChannelAuthError(
+                        f"Discord bot token 无效或权限不足(关闭码 {exc.rcvd.code}),请重新绑定"
+                    ) from exc
+                raise
+            except InvalidStatus as exc:
+                raise ChannelAuthError(f"Discord Gateway 握手被拒:{exc}") from exc
+            finally:
+                if heartbeat_task is not None:
+                    heartbeat_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await heartbeat_task
+
+    @staticmethod
+    async def _heartbeat(ws: Any, interval_s: float, seq_holder: list[int | None]) -> None:
+        """按服务端节奏发心跳;首拍加随机抖动(协议建议)。"""
+        await asyncio.sleep(interval_s * random.random())
+        while True:
+            await ws.send(json.dumps({"op": _OP_HEARTBEAT, "d": seq_holder[0]}))
+            await asyncio.sleep(interval_s)
+
+    def _normalize(self, data: dict[str, Any]) -> InboundMessage | None:
+        if data.get("guild_id"):
+            return None  # 只处理私聊
+        author = data.get("author") or {}
+        if author.get("bot"):
+            return None
+        user_id = str(author.get("id") or "")
+        channel_id = str(data.get("channel_id") or "")
+        if not user_id or not channel_id:
+            return None
+        reply = ReplyContext(
+            channel_id=self.channel_id,
+            account_id=self._account_id,
+            user_id=user_id,
+            token={"dm_channel_id": channel_id},
+        )
+        return InboundMessage(
+            channel_id=self.channel_id,
+            account_id=self._account_id,
+            user_id=user_id,
+            text=str(data.get("content") or ""),
+            reply=reply,
+            provider_message_id=str(data.get("id") or ""),
+        )
+
+    async def send_text(self, reply: ReplyContext, text: str) -> None:
+        channel_id = reply.token.get("dm_channel_id") or await self._client.get_dm_channel(
+            reply.user_id
+        )
+        await self._client.send_message(str(channel_id), text)

--- a/src/movieclaw_channel/discord/client.py
+++ b/src/movieclaw_channel/discord/client.py
@@ -1,0 +1,73 @@
+"""Discord 的最小 REST 客户端(收消息走 Gateway,见 adapter)。
+
+只封装用到的四个接口:校验 token(users/@me)、建私聊频道、发消息、typing。
+不引入 discord.py 这类重依赖。出口走 egress_transport("discord")。
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+import httpx
+
+from movieclaw_net import egress_transport
+
+_API_BASE = "https://discord.com/api/v10"
+
+
+class DiscordApiError(Exception):
+    """REST 调用失败;``auth_failed`` 标记 token 级错误(401)。"""
+
+    def __init__(self, message: str, *, auth_failed: bool = False) -> None:
+        super().__init__(message)
+        self.auth_failed = auth_failed
+
+
+class DiscordClient:
+    """单 bot 的 Discord REST 客户端。"""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self._http = httpx.AsyncClient(
+            transport=egress_transport("discord"),
+            timeout=httpx.Timeout(30.0, connect=10.0),
+            headers={"Authorization": f"Bot {token}"},
+        )
+        #: user_id → 私聊频道 id 缓存(建私聊频道是幂等接口,缓存只省往返)
+        self._dm_channels: dict[str, str] = {}
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    async def _call(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+        resp = await self._http.request(method, f"{_API_BASE}{path}", json=payload)
+        if resp.status_code == 401:
+            raise DiscordApiError("Discord bot token 无效或已吊销(HTTP 401)", auth_failed=True)
+        if resp.status_code >= 400:
+            detail = ""
+            with contextlib.suppress(Exception):  # 非 JSON 响应,状态码足够定位
+                detail = str(resp.json().get("message") or "")
+            raise DiscordApiError(f"Discord API {path} 失败(HTTP {resp.status_code}){detail}")
+        if resp.status_code == 204:
+            return None
+        return resp.json()
+
+    async def get_me(self) -> dict[str, Any]:
+        return await self._call("GET", "/users/@me")
+
+    async def get_dm_channel(self, user_id: str) -> str:
+        """取(或创建)与某用户的私聊频道 id。"""
+        cached = self._dm_channels.get(user_id)
+        if cached:
+            return cached
+        data = await self._call("POST", "/users/@me/channels", {"recipient_id": user_id})
+        channel_id = str(data["id"])
+        self._dm_channels[user_id] = channel_id
+        return channel_id
+
+    async def send_message(self, channel_id: str, text: str) -> None:
+        await self._call("POST", f"/channels/{channel_id}/messages", {"content": text})
+
+    async def trigger_typing(self, channel_id: str) -> None:
+        await self._call("POST", f"/channels/{channel_id}/typing", {})

--- a/src/movieclaw_channel/manager.py
+++ b/src/movieclaw_channel/manager.py
@@ -57,6 +57,13 @@ class ChannelManager:
         rt = self._accounts.get(self._key(channel_id, account_id))
         return rt is not None and rt.task is not None and not rt.task.done()
 
+    def get_dispatcher(self, channel_id: str, account_id: str) -> ChannelDispatcher | None:
+        """取运行中账号的 dispatcher(主动推送用);未运行返回 None。"""
+        rt = self._accounts.get(self._key(channel_id, account_id))
+        if rt is None or rt.task is None or rt.task.done():
+            return None
+        return rt.dispatcher
+
     def is_stale(self, channel_id: str, account_id: str) -> bool:
         rt = self._accounts.get(self._key(channel_id, account_id))
         return rt.stale if rt else False

--- a/src/movieclaw_channel/telegram/__init__.py
+++ b/src/movieclaw_channel/telegram/__init__.py
@@ -1,0 +1,4 @@
+from movieclaw_channel.telegram.adapter import CHANNEL_ID, TelegramAdapter
+from movieclaw_channel.telegram.client import TelegramApiError, TelegramClient
+
+__all__ = ["CHANNEL_ID", "TelegramAdapter", "TelegramApiError", "TelegramClient"]

--- a/src/movieclaw_channel/telegram/adapter.py
+++ b/src/movieclaw_channel/telegram/adapter.py
@@ -1,0 +1,119 @@
+"""TelegramAdapter —— 实现通道协议的 Telegram 收发实现。
+
+收消息循环:getUpdates 长轮询,游标 = 已确认的 update_id + 1(字符串形式
+持久化到 channel_account.cursor,重启续传)。只处理私聊文本消息——群聊
+场景的鉴权与打扰控制是另一回事,P0 不做。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any
+
+import httpx
+
+from movieclaw_channel.adapter import ChannelContext
+from movieclaw_channel.telegram.client import TelegramApiError, TelegramClient
+from movieclaw_channel.types import ChannelAuthError, InboundMessage, ReplyContext
+
+logger = logging.getLogger("movieclaw_channel.telegram.adapter")
+
+CHANNEL_ID = "telegram"
+
+_MAX_CONSECUTIVE_FAILURES = 3
+_RETRY_DELAY_S = 2.0
+_BACKOFF_DELAY_S = 30.0
+
+
+class TelegramAdapter:
+    """Telegram 通道适配器(单 bot)。"""
+
+    channel_id = CHANNEL_ID
+    #: Telegram 单条消息 4096 字符上限,留余量
+    max_text_len = 3900
+
+    def __init__(self, client: TelegramClient, account_id: str) -> None:
+        self._client = client
+        self._account_id = account_id
+
+    async def run(self, ctx: ChannelContext) -> None:
+        stop = ctx.stop or asyncio.Event()
+        logger.info("Telegram 收消息循环启动 account=%s", self._account_id)
+        offset = int(ctx.initial_cursor) if ctx.initial_cursor.isdigit() else None
+        failures = 0
+
+        while not stop.is_set():
+            try:
+                updates = await self._client.get_updates(offset, stop=stop)
+            except TelegramApiError as exc:
+                if exc.auth_failed:
+                    raise ChannelAuthError(str(exc)) from exc
+                failures += 1
+                logger.error("getUpdates 失败 (%d/%d):%s", failures, _MAX_CONSECUTIVE_FAILURES, exc)
+                hit_cap = failures >= _MAX_CONSECUTIVE_FAILURES
+                if hit_cap:
+                    failures = 0
+                await self._sleep(stop, _BACKOFF_DELAY_S if hit_cap else _RETRY_DELAY_S)
+                continue
+            except httpx.HTTPError as exc:
+                failures += 1
+                logger.error(
+                    "getUpdates 网络错误 (%d/%d):%s", failures, _MAX_CONSECUTIVE_FAILURES, exc
+                )
+                hit_cap = failures >= _MAX_CONSECUTIVE_FAILURES
+                if hit_cap:
+                    failures = 0
+                await self._sleep(stop, _BACKOFF_DELAY_S if hit_cap else _RETRY_DELAY_S)
+                continue
+            failures = 0
+
+            for update in updates:
+                update_id = update.get("update_id")
+                if isinstance(update_id, int):
+                    offset = update_id + 1
+                    await ctx.save_cursor(str(offset))
+                msg = self._normalize(update)
+                if msg is not None:
+                    await ctx.on_inbound(msg)
+
+        logger.info("Telegram 收消息循环退出 account=%s", self._account_id)
+
+    def _normalize(self, update: dict[str, Any]) -> InboundMessage | None:
+        message = update.get("message")
+        if not isinstance(message, dict):
+            return None
+        chat = message.get("chat") or {}
+        if chat.get("type") != "private":
+            return None
+        sender = message.get("from") or {}
+        if sender.get("is_bot"):
+            return None
+        user_id = str(sender.get("id") or "")
+        if not user_id:
+            return None
+        reply = ReplyContext(
+            channel_id=self.channel_id,
+            account_id=self._account_id,
+            user_id=user_id,
+            token={"chat_id": chat.get("id")},
+        )
+        return InboundMessage(
+            channel_id=self.channel_id,
+            account_id=self._account_id,
+            user_id=user_id,
+            text=str(message.get("text") or message.get("caption") or ""),
+            reply=reply,
+            provider_message_id=f"{chat.get('id')}:{message.get('message_id')}",
+            timestamp_ms=int(message.get("date") or 0) * 1000,
+        )
+
+    async def send_text(self, reply: ReplyContext, text: str) -> None:
+        # 主动推送时 token 里没有 chat_id,私聊场景 chat_id == user_id
+        await self._client.send_message(reply.token.get("chat_id") or reply.user_id, text)
+
+    @staticmethod
+    async def _sleep(stop: asyncio.Event, seconds: float) -> None:
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop.wait(), timeout=seconds)

--- a/src/movieclaw_channel/telegram/client.py
+++ b/src/movieclaw_channel/telegram/client.py
@@ -1,0 +1,88 @@
+"""Telegram Bot API 的最小 HTTP 客户端。
+
+只封装本项目用到的四个方法(getMe / getUpdates / sendMessage / sendChatAction),
+不引入 python-telegram-bot 这类重依赖。出口走 egress_transport("telegram"):
+国内部署 api.telegram.org 被墙,用户在「设置 → 网络」勾选 telegram 走代理即可。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+
+from movieclaw_net import egress_transport
+
+#: 401/404 = bot token 无效或被吊销,对应通道层的凭据失效语义
+_AUTH_ERROR_STATUS = (401, 404)
+
+
+class TelegramApiError(Exception):
+    """Bot API 返回 ok=false 时抛出;``auth_failed`` 标记凭据级错误。"""
+
+    def __init__(self, message: str, *, auth_failed: bool = False) -> None:
+        super().__init__(message)
+        self.auth_failed = auth_failed
+
+
+class TelegramClient:
+    """单 bot 的 Bot API 客户端(线程不安全,通道层单任务使用)。"""
+
+    def __init__(self, token: str) -> None:
+        self._base = f"https://api.telegram.org/bot{token}"
+        # 长轮询 50s + 余量;连接池与微信客户端同款「每账号一个」
+        self._http = httpx.AsyncClient(
+            transport=egress_transport("telegram"),
+            timeout=httpx.Timeout(65.0, connect=10.0),
+        )
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    async def _call(self, method: str, payload: dict[str, Any] | None = None) -> Any:
+        resp = await self._http.post(f"{self._base}/{method}", json=payload or {})
+        if resp.status_code in _AUTH_ERROR_STATUS:
+            raise TelegramApiError(
+                f"Telegram bot token 无效或已吊销(HTTP {resp.status_code})", auth_failed=True
+            )
+        data = resp.json()
+        if not data.get("ok"):
+            raise TelegramApiError(
+                f"Telegram API {method} 失败:{data.get('description') or resp.status_code}"
+            )
+        return data.get("result")
+
+    async def get_me(self) -> dict[str, Any]:
+        return await self._call("getMe")
+
+    async def get_updates(
+        self, offset: int | None, *, timeout_s: int = 50, stop: asyncio.Event | None = None
+    ) -> list[dict[str, Any]]:
+        """长轮询取增量消息;stop 置位时通过取消在飞请求尽快返回。"""
+        payload: dict[str, Any] = {
+            "timeout": timeout_s,
+            "allowed_updates": ["message"],
+        }
+        if offset is not None:
+            payload["offset"] = offset
+        call = asyncio.ensure_future(self._call("getUpdates", payload))
+        if stop is None:
+            return await call
+        stop_wait = asyncio.ensure_future(stop.wait())
+        try:
+            done, _ = await asyncio.wait({call, stop_wait}, return_when=asyncio.FIRST_COMPLETED)
+            if call in done:
+                return call.result()
+            call.cancel()
+            return []
+        finally:
+            stop_wait.cancel()
+
+    async def send_message(self, chat_id: str | int, text: str) -> None:
+        # 纯文本发送:Agent 输出是 Markdown,但 TG 的 parse_mode 对不配对的
+        # 星号/下划线会整条报错,宁可裸发也不能丢消息
+        await self._call("sendMessage", {"chat_id": chat_id, "text": text})
+
+    async def send_chat_action(self, chat_id: str | int, action: str = "typing") -> None:
+        await self._call("sendChatAction", {"chat_id": chat_id, "action": action})

--- a/tests/channel/test_im_adapters.py
+++ b/tests/channel/test_im_adapters.py
@@ -1,0 +1,116 @@
+"""Telegram / Discord 适配器的消息归一化与配对码生命周期测试。"""
+
+from __future__ import annotations
+
+import time
+
+from movieclaw_channel.discord.adapter import DiscordAdapter
+from movieclaw_channel.discord.client import DiscordClient
+from movieclaw_channel.telegram.adapter import TelegramAdapter
+from movieclaw_channel.telegram.client import TelegramClient
+
+
+def _tg_adapter() -> TelegramAdapter:
+    return TelegramAdapter(TelegramClient("dummy-token"), "bot1")
+
+
+def _dc_adapter() -> DiscordAdapter:
+    return DiscordAdapter(DiscordClient("dummy-token"), "bot1")
+
+
+class TestTelegramNormalize:
+    def test_private_text_message(self) -> None:
+        msg = _tg_adapter()._normalize(
+            {
+                "update_id": 100,
+                "message": {
+                    "message_id": 7,
+                    "date": 1700000000,
+                    "text": "帮我找沙丘2",
+                    "chat": {"id": 123, "type": "private"},
+                    "from": {"id": 123, "is_bot": False},
+                },
+            }
+        )
+        assert msg is not None
+        assert msg.user_id == "123"
+        assert msg.text == "帮我找沙丘2"
+        assert msg.reply.token["chat_id"] == 123
+        assert msg.provider_message_id == "123:7"
+
+    def test_group_message_ignored(self) -> None:
+        msg = _tg_adapter()._normalize(
+            {
+                "message": {
+                    "text": "hi",
+                    "chat": {"id": -100, "type": "supergroup"},
+                    "from": {"id": 123, "is_bot": False},
+                }
+            }
+        )
+        assert msg is None
+
+    def test_bot_message_ignored(self) -> None:
+        msg = _tg_adapter()._normalize(
+            {
+                "message": {
+                    "text": "hi",
+                    "chat": {"id": 123, "type": "private"},
+                    "from": {"id": 9, "is_bot": True},
+                }
+            }
+        )
+        assert msg is None
+
+
+class TestDiscordNormalize:
+    def test_dm_message(self) -> None:
+        msg = _dc_adapter()._normalize(
+            {
+                "id": "555",
+                "channel_id": "888",
+                "content": "订阅怪奇物语",
+                "author": {"id": "42", "bot": False},
+            }
+        )
+        assert msg is not None
+        assert msg.user_id == "42"
+        assert msg.text == "订阅怪奇物语"
+        assert msg.reply.token["dm_channel_id"] == "888"
+
+    def test_guild_message_ignored(self) -> None:
+        msg = _dc_adapter()._normalize(
+            {
+                "id": "555",
+                "channel_id": "888",
+                "guild_id": "1",
+                "content": "hi",
+                "author": {"id": "42"},
+            }
+        )
+        assert msg is None
+
+    def test_bot_author_ignored(self) -> None:
+        msg = _dc_adapter()._normalize(
+            {"id": "5", "channel_id": "8", "content": "x", "author": {"id": "9", "bot": True}}
+        )
+        assert msg is None
+
+
+class TestPairChallengeExpiry:
+    def test_expired_challenge_flips_status(self) -> None:
+        from movieclaw_api.services.im_channel import ImChannelService, PairChallenge
+
+        service = ImChannelService()
+        challenge = PairChallenge(
+            challenge_id="c1",
+            channel_id="telegram",
+            pair_code="123456",
+            bot_id="b1",
+            bot_name="bot",
+            expires_at=time.monotonic() - 1,  # 已过期
+        )
+        service._challenges["c1"] = challenge
+        got = service.get_challenge("c1")
+        assert got is not None
+        assert got.status == "expired"


### PR DESCRIPTION
## 动机

面板此前只有微信一个 IM 通道,也没有系统事件的主动推送。本 PR 把 Telegram 和 Discord 接入现有通道框架,并补上统一的推送能力。

## 内容

**新通道(复用 adapter/manager/dispatcher 框架,微信实现零改动)**
- Telegram:Bot API 长轮询收发,update_id 游标断点续传,仅处理私聊
- Discord:Gateway websocket 收消息 + REST 发消息,只用 DIRECT_MESSAGES intent(私聊内容不需要特权 intent,开发者后台零额外配置);websocket 库复用 uvicorn[standard] 既有依赖,**无新增依赖**

**绑定(比扫码简单)**
- 面板填 bot token → 校验后显示 6 位配对码 → 用户私聊 bot 发码即完成绑定
- 发码人自动成为唯一白名单与推送目标;token 经 SecretBox 加密,复用 channel_account 表,**无数据库迁移**

**互动 AI**
- 与微信同一套受限工具集(仅 mclaw 产品操作,不开宿主 shell)与 agent_session 会话体系,对话在 Web「最近会话」可回放,/reset、/stop 同款支持

**主动推送**
- 开始下载、入库完成两个事件推送到所有已绑定通道(含微信)
- 推送内容开关(channels.push 设置域)+ 面板测试推送按钮
- fire-and-forget:推送任何失败只记日志,不影响业务主链路

**面板与网络**
- 「消息推送」分区:整合微信绑定 + TG/Discord 配对绑定 + 推送内容开关 + 测试推送(原独立「微信绑定」分区并入)
- 「设置 → 网络」新增 telegram/discord 代理标签(国内部署两个平台都需代理)

## 测试

- 新增 tests/channel/test_im_adapters.py:两平台消息归一化(私聊/群聊/bot 消息过滤)与配对码过期,22 个通道测试全绿
- ruff / tsc / eslint 通过;预存的失败用例(enrich NER 等)与本 PR 无关