### PR TITLE
fix(ci): pnpm/action-setup 显式指定版本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+        with:
+          # package.json 未声明 packageManager，须显式给版本（与 release.yml 一致）
+          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
ci.yml 首跑 web 作业失败：package.json 未声明 `packageManager`，`pnpm/action-setup@v4` 无从推断版本、启动即失败。与 release.yml 保持一致，显式传 `version: 10`。python 作业（NER 模型下载 + ruff + pytest）首跑已绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh3pZibwVXRak1AfHvfcJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh3pZibwVXRak1AfHvfcJj)_