### PR TITLE
feat(channels): 订阅推送带配图,文案补齐年份与规格

### DIFF
--- a/src/movieclaw_api/services/channel_push.py
+++ b/src/movieclaw_api/services/channel_push.py
@@ -1,7 +1,16 @@
-"""跨通道主动推送:把系统事件文本扇出到所有已绑定的 IM 通道。
+"""跨通道主动推送:把系统事件文本(可附配图)扇出到所有已绑定的 IM 通道。
 
 调用方(订阅投递/入库对账等)只管 fire-and-forget:``notify_channels(text)``
 内部起后台任务,任何通道失败都只记日志,绝不影响业务主链路。
+
+配图链路:业务方传 ``image_url``(TMDB 图床完整 URL),这里经 ImageCache
+取图(本地缓存命中免回源,回源复用图片代理的 SSRF 防护与代理出口),字节
+随出站信封下发;Telegram/Discord 图文一条发出,微信 adapter 无发图能力,
+发送泵自动退回纯文本。取图失败同样退纯文本——图可以丢,推送不能断。
+
+配图选横版剧照而非竖版海报:IM 客户端的图片气泡宽度随文案长短伸缩,
+竖图会跟着缩放导致不同推送显示大小不一;横图天然顶满气泡最大宽度,
+渲染规格恒定(Telegram 实测结论,2026-08)。
 
 微信通道的绑定用户与 TG/Discord 一样从 channel_account.bound_user_id 取,
 出站统一经各账号 dispatcher 的发送泵(顺序与限流集中一处)。
@@ -24,7 +33,19 @@ logger = logging.getLogger("movieclaw_api.channel_push")
 _push_tasks: set[asyncio.Task[None]] = set()
 
 
-async def push_to_all_channels(text: str) -> int:
+def tmdb_push_image_url(backdrop_path: str | None, poster_path: str | None) -> str | None:
+    """推送配图 URL:优先横版剧照(w780,渲染规格恒定),无剧照回落海报(w500)。"""
+    from movieclaw_api.core.config import get_settings
+
+    base = get_settings().tmdb_image_base_url.rstrip("/")
+    if backdrop_path:
+        return f"{base}/w780{backdrop_path}"
+    if poster_path:
+        return f"{base}/w500{poster_path}"
+    return None
+
+
+async def push_to_all_channels(text: str, photo: bytes | None = None) -> int:
     """推送到所有通道(微信 + Telegram + Discord),返回入队的账号数。"""
     count = 0
 
@@ -32,11 +53,12 @@ async def push_to_all_channels(text: str) -> int:
     try:
         from movieclaw_api.services.im_channel import get_im_channels
 
-        count += await get_im_channels().push_text(text)
+        count += await get_im_channels().push_text(text, photo=photo)
     except RuntimeError:
         pass  # 服务未初始化(启动早期/测试)
 
     # 微信通道:从库里取绑定用户,经运行中的 dispatcher 入队
+    # (photo 照常带上,微信 adapter 无发图能力时发送泵自动退纯文本)
     try:
         from movieclaw_api.services.weixin_channel import get_weixin_channel
         from movieclaw_channel.weixin.adapter import CHANNEL_ID as WEIXIN_CHANNEL_ID
@@ -54,7 +76,9 @@ async def push_to_all_channels(text: str) -> int:
             reply = ReplyContext(
                 channel_id=WEIXIN_CHANNEL_ID, account_id=row.account_id, user_id=bound
             )
-            await dispatcher.push_outbound(OutboundEnvelope(reply=reply, text=text, origin="push"))
+            await dispatcher.push_outbound(
+                OutboundEnvelope(reply=reply, text=text, origin="push", photo=photo)
+            )
             count += 1
     except RuntimeError:
         pass
@@ -62,11 +86,24 @@ async def push_to_all_channels(text: str) -> int:
     return count
 
 
-def notify_channels(text: str, event: str = "") -> None:
+async def _fetch_image(image_url: str) -> bytes | None:
+    """经 ImageCache 取配图字节;任何失败返回 None(推送退纯文本)。"""
+    try:
+        from movieclaw_api.services.image_cache import get_image_cache
+
+        cached = await get_image_cache().get_or_fetch(image_url)
+        return await asyncio.to_thread(cached.path.read_bytes)
+    except Exception:  # noqa: BLE001 -- 配图取不到只降级,不能拦住文本推送
+        logger.info("推送配图获取失败,将发纯文本:%s", image_url)
+        return None
+
+
+def notify_channels(text: str, event: str = "", image_url: str | None = None) -> None:
     """业务侧唯一入口:后台推送,失败只记日志,不阻塞、不抛错。
 
     ``event`` 对应 ChannelPushSetting 的开关字段(``push_<event>``):
     dispatch=投递下载,imported=入库完成。空 event(测试推送)不受开关限制。
+    ``image_url`` 可选,给了就尝试图文推送(取图/发图失败自动退纯文本)。
     """
 
     async def _run() -> None:
@@ -78,7 +115,8 @@ def notify_channels(text: str, event: str = "") -> None:
                 if not getattr(setting, f"push_{event}", True):
                     logger.debug("推送事件 %s 已被用户关闭,跳过", event)
                     return
-            sent = await push_to_all_channels(text)
+            photo = await _fetch_image(image_url) if image_url else None
+            sent = await push_to_all_channels(text, photo=photo)
             if sent:
                 logger.info("已推送到 %d 个通道账号:%s", sent, text[:60])
         except Exception:  # noqa: BLE001 -- 推送绝不能影响业务主链路

--- a/src/movieclaw_api/services/im_channel.py
+++ b/src/movieclaw_api/services/im_channel.py
@@ -476,8 +476,8 @@ class ImChannelService:
     # ------------------------------------------------------------------
     # 主动推送
     # ------------------------------------------------------------------
-    async def push_text(self, text: str) -> int:
-        """把一条文本推给所有已绑定且在运行的账号;返回送达队列的账号数。"""
+    async def push_text(self, text: str, photo: bytes | None = None) -> int:
+        """把一条文本(可附图)推给所有已绑定且在运行的账号;返回送达队列的账号数。"""
         count = 0
         # 快照迭代:推送中途账号凭据失效/解绑会并发修改地址簿,直接迭代会炸
         for key, reply in list(self._push_targets.items()):
@@ -485,7 +485,9 @@ class ImChannelService:
             dispatcher = self.manager.get_dispatcher(channel_id, account_id)
             if dispatcher is None:
                 continue
-            await dispatcher.push_outbound(OutboundEnvelope(reply=reply, text=text, origin="push"))
+            await dispatcher.push_outbound(
+                OutboundEnvelope(reply=reply, text=text, origin="push", photo=photo)
+            )
             count += 1
         return count
 

--- a/src/movieclaw_api/services/subscription/dispatch.py
+++ b/src/movieclaw_api/services/subscription/dispatch.py
@@ -186,12 +186,15 @@ async def dispatch(
 
     # IM 通道推送(微信/TG/Discord;fire-and-forget,失败不影响投递链路)
     if not dry_run:
-        from movieclaw_api.services.channel_push import notify_channels
+        from movieclaw_api.services.channel_push import notify_channels, tmdb_push_image_url
 
+        year_text = f"({item.year}) " if item.year else ""
         notify_channels(
-            f"📥 开始下载:《{item.title}》{units_label}\n"
-            f"来自 {candidate.site_id} 的「{candidate.title[:60]}」",
+            f"📥 开始下载:《{item.title}》{year_text}{units_label}\n"
+            f"来自 {candidate.site_id} 的「{candidate.title[:60]}」\n"
+            f"{spec_text}",
             event="dispatch",
+            image_url=tmdb_push_image_url(item.backdrop_path, item.poster_path),
         )
     return True
 

--- a/src/movieclaw_api/services/subscription/wanted_fulfillment.py
+++ b/src/movieclaw_api/services/subscription/wanted_fulfillment.py
@@ -83,9 +83,14 @@ async def close_fulfilled_wanted(session: AsyncSession, media_item_id: int) -> i
         )
         await recompute_subscription_status(session, subscription, item)
         # IM 通道推送(微信/TG/Discord;fire-and-forget,失败不影响对账链路)
-        from movieclaw_api.services.channel_push import notify_channels
+        from movieclaw_api.services.channel_push import notify_channels, tmdb_push_image_url
 
-        notify_channels(f"🎬 已入库:《{item.title}》{units_text(wanted_rows)}", event="imported")
+        year_text = f"({item.year}) " if item.year else ""
+        notify_channels(
+            f"🎬 已入库:《{item.title}》{year_text}{units_text(wanted_rows)}",
+            event="imported",
+            image_url=tmdb_push_image_url(item.backdrop_path, item.poster_path),
+        )
         # 内容已进库，该订阅在途种子的落点告警（若有）自动熄灭
         from movieclaw_api.services.system_notice import resolve_notices
 

--- a/src/movieclaw_channel/adapter.py
+++ b/src/movieclaw_channel/adapter.py
@@ -32,7 +32,13 @@ class ChannelContext:
 
 
 class ChannelAdapter(Protocol):
-    """通道适配器:平台只需知道「怎么收字节、怎么发文本」。"""
+    """通道适配器:平台只需知道「怎么收字节、怎么发文本」。
+
+    可选能力 ``send_photo(reply, photo, caption)``:平台支持图文消息时
+    额外实现(Telegram/Discord 已实现),发送泵用 getattr 探测;未实现的
+    通道(微信 iLink 未开放图片上传)自动退回纯文本,推送不丢内容。
+    不进 Protocol 正文,避免逼所有平台实现空方法。
+    """
 
     channel_id: str
     #: 单条文本消息的长度上限(超长由发送泵分片)

--- a/src/movieclaw_channel/discord/adapter.py
+++ b/src/movieclaw_channel/discord/adapter.py
@@ -190,3 +190,10 @@ class DiscordAdapter:
             reply.user_id
         )
         await self._client.send_message(str(channel_id), text)
+
+    async def send_photo(self, reply: ReplyContext, photo: bytes, caption: str) -> None:
+        """图文消息(通道协议的可选能力,发送泵 getattr 探测后调用)。"""
+        channel_id = reply.token.get("dm_channel_id") or await self._client.get_dm_channel(
+            reply.user_id
+        )
+        await self._client.send_photo(str(channel_id), photo, caption)

--- a/src/movieclaw_channel/discord/client.py
+++ b/src/movieclaw_channel/discord/client.py
@@ -1,12 +1,13 @@
 """Discord 的最小 REST 客户端(收消息走 Gateway,见 adapter)。
 
-只封装用到的四个接口:校验 token(users/@me)、建私聊频道、发消息、typing。
-不引入 discord.py 这类重依赖。出口走 egress_transport("discord")。
+只封装用到的接口:校验 token(users/@me)、建私聊频道、发消息(文本/图文)、
+typing。不引入 discord.py 这类重依赖。出口走 egress_transport("discord")。
 """
 
 from __future__ import annotations
 
 import contextlib
+import json
 from typing import Any
 
 import httpx
@@ -42,6 +43,10 @@ class DiscordClient:
 
     async def _call(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
         resp = await self._http.request(method, f"{_API_BASE}{path}", json=payload)
+        return self._check(path, resp)
+
+    def _check(self, path: str, resp: httpx.Response) -> Any:
+        """REST 响应的统一校验:401 归类凭据错误,4xx/5xx 抛业务错。"""
         if resp.status_code == 401:
             raise DiscordApiError("Discord bot token 无效或已吊销(HTTP 401)", auth_failed=True)
         if resp.status_code >= 400:
@@ -68,6 +73,16 @@ class DiscordClient:
 
     async def send_message(self, channel_id: str, text: str) -> None:
         await self._call("POST", f"/channels/{channel_id}/messages", {"content": text})
+
+    async def send_photo(self, channel_id: str, photo: bytes, text: str) -> None:
+        """发送图文消息:图片作附件 multipart 上传,text 作正文。"""
+        path = f"/channels/{channel_id}/messages"
+        resp = await self._http.post(
+            f"{_API_BASE}{path}",
+            data={"payload_json": json.dumps({"content": text})},
+            files={"files[0]": ("poster.jpg", photo, "image/jpeg")},
+        )
+        self._check(path, resp)
 
     async def trigger_typing(self, channel_id: str) -> None:
         await self._call("POST", f"/channels/{channel_id}/typing", {})

--- a/src/movieclaw_channel/dispatcher.py
+++ b/src/movieclaw_channel/dispatcher.py
@@ -44,6 +44,9 @@ _MAX_CONCURRENT_RUNS = 2
 #: 出站发送失败的重试次数与间隔
 _SEND_RETRIES = 1
 _SEND_RETRY_DELAY_S = 2.0
+#: 图文消息的文案上限:Telegram caption 1024 字符是各平台里最紧的口径,
+#: 超过就放弃随图发送、退回纯文本分片(推送文案实际都很短,达不到)
+_PHOTO_CAPTION_LIMIT = 1000
 
 
 def split_message(text: str, limit: int) -> list[str]:
@@ -269,11 +272,35 @@ class ChannelDispatcher:
         await self._outbound.put(env)
 
     async def _outbound_pump(self) -> None:
-        """发送泵:串行取信封 → 分片 → 调 adapter 发送(带一次重试)。"""
+        """发送泵:串行取信封 → 图文优先 → 分片 → 调 adapter 发送(带一次重试)。"""
         while True:
             env = await self._outbound.get()
+            if env.photo is not None and await self._try_send_photo(env):
+                continue
             for chunk in split_message(env.text, self._adapter.max_text_len):
                 await self._send_with_retry(env.reply, chunk, env.origin)
+
+    async def _try_send_photo(self, env: OutboundEnvelope) -> bool:
+        """图文一体发送,返回是否成功。
+
+        adapter 无 send_photo 能力、文案超 caption 上限、发送抛错——
+        任何一种情况都返回 False,由发送泵退回纯文本路径:图可以丢,
+        文字不能丢。
+        """
+        send_photo = getattr(self._adapter, "send_photo", None)
+        if send_photo is None or len(env.text) > _PHOTO_CAPTION_LIMIT:
+            return False
+        try:
+            await send_photo(env.reply, env.photo, env.text)
+            return True
+        except Exception as exc:  # noqa: BLE001 -- 发图失败退纯文本,不能断推送
+            logger.warning(
+                "图文消息发送失败,退回纯文本 user=%s origin=%s err=%s",
+                env.reply.user_id,
+                env.origin,
+                exc,
+            )
+            return False
 
     async def _send_with_retry(self, reply: ReplyContext, text: str, origin: str) -> None:
         for attempt in range(_SEND_RETRIES + 1):

--- a/src/movieclaw_channel/telegram/adapter.py
+++ b/src/movieclaw_channel/telegram/adapter.py
@@ -112,6 +112,10 @@ class TelegramAdapter:
         # 主动推送时 token 里没有 chat_id,私聊场景 chat_id == user_id
         await self._client.send_message(reply.token.get("chat_id") or reply.user_id, text)
 
+    async def send_photo(self, reply: ReplyContext, photo: bytes, caption: str) -> None:
+        """图文消息(通道协议的可选能力,发送泵 getattr 探测后调用)。"""
+        await self._client.send_photo(reply.token.get("chat_id") or reply.user_id, photo, caption)
+
     @staticmethod
     async def _sleep(stop: asyncio.Event, seconds: float) -> None:
         with contextlib.suppress(TimeoutError):

--- a/src/movieclaw_channel/telegram/client.py
+++ b/src/movieclaw_channel/telegram/client.py
@@ -1,8 +1,9 @@
 """Telegram Bot API 的最小 HTTP 客户端。
 
-只封装本项目用到的四个方法(getMe / getUpdates / sendMessage / sendChatAction),
-不引入 python-telegram-bot 这类重依赖。出口走 egress_transport("telegram"):
-国内部署 api.telegram.org 被墙,用户在「设置 → 网络」勾选 telegram 走代理即可。
+只封装本项目用到的方法(getMe / getUpdates / sendMessage / sendPhoto /
+sendChatAction),不引入 python-telegram-bot 这类重依赖。出口走
+egress_transport("telegram"):国内部署 api.telegram.org 被墙,用户在
+「设置 → 网络」勾选 telegram 走代理即可。
 """
 
 from __future__ import annotations
@@ -42,6 +43,10 @@ class TelegramClient:
 
     async def _call(self, method: str, payload: dict[str, Any] | None = None) -> Any:
         resp = await self._http.post(f"{self._base}/{method}", json=payload or {})
+        return self._parse(method, resp)
+
+    def _parse(self, method: str, resp: httpx.Response) -> Any:
+        """Bot API 响应的统一解析:凭据错误分类 + ok=false 抛业务错。"""
         if resp.status_code in _AUTH_ERROR_STATUS:
             raise TelegramApiError(
                 f"Telegram bot token 无效或已吊销(HTTP {resp.status_code})", auth_failed=True
@@ -89,6 +94,15 @@ class TelegramClient:
         # 纯文本发送:Agent 输出是 Markdown,但 TG 的 parse_mode 对不配对的
         # 星号/下划线会整条报错,宁可裸发也不能丢消息
         await self._call("sendMessage", {"chat_id": chat_id, "text": text})
+
+    async def send_photo(self, chat_id: str | int, photo: bytes, caption: str) -> None:
+        """发送图文消息:图片字节 multipart 上传,文案作 caption(≤1024 字符)。"""
+        resp = await self._http.post(
+            f"{self._base}/sendPhoto",
+            data={"chat_id": str(chat_id), "caption": caption},
+            files={"photo": ("poster.jpg", photo)},
+        )
+        self._parse("sendPhoto", resp)
 
     async def send_chat_action(self, chat_id: str | int, action: str = "typing") -> None:
         await self._call("sendChatAction", {"chat_id": chat_id, "action": action})

--- a/src/movieclaw_channel/types.py
+++ b/src/movieclaw_channel/types.py
@@ -56,7 +56,7 @@ class InboundMessage:
 class OutboundEnvelope:
     """出站信封:发送泵唯一认识的载荷。
 
-    Agent 回复、命令回执、未来的主动推送(下载完成通知等)都走这一个口,
+    Agent 回复、命令回执、主动推送(下载/入库通知等)都走这一个口,
     保证同账号出站顺序与限流集中在发送泵一处。
     """
 
@@ -64,3 +64,6 @@ class OutboundEnvelope:
     text: str
     #: 来源标记,仅用于日志排障
     origin: Literal["agent", "system", "push"] = "agent"
+    #: 随消息附带的图片字节(主动推送的海报等);adapter 不支持发图时
+    #: 发送泵自动退回纯文本——图可以丢,文字不能丢
+    photo: bytes | None = None

--- a/tests/channel/test_dispatcher.py
+++ b/tests/channel/test_dispatcher.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from movieclaw_channel.dispatcher import make_dispatcher, split_message
-from movieclaw_channel.types import InboundMessage, ReplyContext
+from movieclaw_channel.types import InboundMessage, OutboundEnvelope, ReplyContext
 
 # ---------------------------------------------------------------------------
 # split_message(纯函数)
@@ -207,5 +207,97 @@ async def test_long_reply_is_chunked():
         await d.submit_inbound(_msg("hi", msg_id="m1"))
         await _drain(d, adapter, expect=2)
         assert all(len(t) <= 50 for _, t in adapter.sent)
+    finally:
+        await d.close()
+
+
+# ---------------------------------------------------------------------------
+# 图文推送(send_photo 可选能力与纯文本回退)
+# ---------------------------------------------------------------------------
+
+
+class FakePhotoAdapter(FakeAdapter):
+    """带 send_photo 能力的假 adapter;fail_photo 置位时模拟发图失败。"""
+
+    def __init__(self, *, fail_photo: bool = False) -> None:
+        super().__init__()
+        self.sent_photos: list[tuple[str, bytes, str]] = []
+        self._fail_photo = fail_photo
+
+    async def send_photo(self, reply: ReplyContext, photo: bytes, caption: str) -> None:
+        if self._fail_photo:
+            raise RuntimeError("模拟发图失败")
+        self.sent_photos.append((reply.user_id, photo, caption))
+
+
+def _push_env(text: str, photo: bytes | None) -> OutboundEnvelope:
+    reply = ReplyContext(channel_id="weixin", account_id="bot1", user_id="u1@im.wechat")
+    return OutboundEnvelope(reply=reply, text=text, origin="push", photo=photo)
+
+
+async def _drain_photos(adapter: FakePhotoAdapter, *, expect: int, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while len(adapter.sent_photos) < expect:
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError(f"等待发图超时:已发 {len(adapter.sent_photos)}/{expect}")
+        await asyncio.sleep(0.01)
+
+
+async def _noop_agent(msg, emit):  # pragma: no cover - 图文测试不走 Agent
+    raise AssertionError("不应进入 Agent")
+
+
+async def test_photo_sent_with_caption():
+    """有发图能力时图文一条发出,不再走文本路径。"""
+    adapter = FakePhotoAdapter()
+    d = make_dispatcher(adapter, is_allowed=lambda _u: True, run_agent=_noop_agent)
+    d.start()
+    try:
+        await d.push_outbound(_push_env("已入库:《某片》", b"\x89PNG"))
+        await _drain_photos(adapter, expect=1)
+        assert adapter.sent_photos == [("u1@im.wechat", b"\x89PNG", "已入库:《某片》")]
+        assert adapter.sent == []
+    finally:
+        await d.close()
+
+
+async def test_photo_falls_back_without_capability():
+    """adapter 无 send_photo 时(微信),照常发纯文本。"""
+    adapter = FakeAdapter()
+    d = make_dispatcher(adapter, is_allowed=lambda _u: True, run_agent=_noop_agent)
+    d.start()
+    try:
+        await d.push_outbound(_push_env("已入库:《某片》", b"\x89PNG"))
+        await _drain(d, adapter, expect=1)
+        assert adapter.sent == [("u1@im.wechat", "已入库:《某片》")]
+    finally:
+        await d.close()
+
+
+async def test_photo_send_failure_falls_back_to_text():
+    """发图抛错时退回纯文本,文字不丢。"""
+    adapter = FakePhotoAdapter(fail_photo=True)
+    d = make_dispatcher(adapter, is_allowed=lambda _u: True, run_agent=_noop_agent)
+    d.start()
+    try:
+        await d.push_outbound(_push_env("已入库:《某片》", b"\x89PNG"))
+        await _drain(d, adapter, expect=1)
+        assert adapter.sent == [("u1@im.wechat", "已入库:《某片》")]
+        assert adapter.sent_photos == []
+    finally:
+        await d.close()
+
+
+async def test_oversized_caption_skips_photo():
+    """文案超 caption 上限(1000 字符)时放弃随图发送,走文本分片。"""
+    adapter = FakePhotoAdapter()
+    adapter.max_text_len = 3900
+    d = make_dispatcher(adapter, is_allowed=lambda _u: True, run_agent=_noop_agent)
+    d.start()
+    try:
+        await d.push_outbound(_push_env("字" * 1001, b"\x89PNG"))
+        await _drain(d, adapter, expect=1)
+        assert adapter.sent_photos == []
+        assert adapter.sent[0][1] == "字" * 1001
     finally:
         await d.close()


### PR DESCRIPTION
## 动机

订阅推送目前是两行纯文本(「开始下载:《xx》」/「已入库:《xx》」),信息量偏少。本 PR 把推送升级为带作品配图的图文消息,文案补齐年份与规格。

## 设计

**通道层**
- `OutboundEnvelope` 新增可选 `photo` 字节字段;`send_photo(reply, photo, caption)` 作为 adapter 的**可选能力**(不进 Protocol 正文,避免逼所有平台实现空方法),发送泵 `getattr` 探测
- Telegram:`sendPhoto` multipart 上传;Discord:附件 multipart 上传;微信 iLink 未开放图片上传接口 → 发送泵自动退回纯文本,**图可以丢,文字不能丢**
- caption 超 1000 字符(Telegram 1024 上限留余量)时放弃随图发送,走原文本分片路径

**推送服务层**
- `notify_channels(text, event, image_url)`:配图经现有 ImageCache 取字节(缓存命中免回源,回源复用图片代理的 SSRF 防护与代理出口);取图失败降级纯文本,不影响业务主链路

**配图选型:横版剧照(w780)优先,海报(w500)兜底**
- 真机实测发现:IM 客户端图片气泡宽度随文案长短伸缩,竖版海报会导致不同推送显示大小不一(长种子名撑宽气泡);TMDB 剧照强制 16:9(w780 恒为 780×439),渲染规格恒定
- 实测方法:同一张图配长/短文案分别发送,TG 服务端存储尺寸完全一致,证明差异纯属客户端气泡布局

## 测试

- 新增发送泵图文路径单测 4 例:能力探测发图、无能力回退、发图异常回退、caption 超限回退;`tests/channel/` 31 例全过
- 真实数据端到端实测:生产库副本 + 真实 bot token,`ImageCache → TelegramAdapter.send_photo → 真实 TG API` 图文消息落地,横版配图渲染规格一致
- `ruff check src tests` 干净

## 兼容性

- 无数据库迁移、无新增运行时依赖(未动 runtime-version)
- `notify_channels` 旧调用(纯文本)行为不变;设置页「消息推送」开关语义不变
- 前端零改动