### PR TITLE
feat: add 8 PT site configs (hdarea/hddolby/hdfans/hdtime/nicept/piggo/pttime/soulvoice)

### DIFF
--- a/src/movieclaw_tracker/sites/configs/hdarea.yaml
+++ b/src/movieclaw_tracker/sites/configs/hdarea.yaml
@@ -1,0 +1,66 @@
+# HDArea 高清视界
+# 所有选择器均基于 2026-08-05 浏览器实登页面（torrents.php / userdetails.php /
+# details.php）逐项验证，命中率见注释。请勿参考其它 PT 工具的站点文件直接套用。
+
+site_id: hdarea
+display_name: 高清视界 HDArea
+base_url: https://www.hdarea.club
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 10：1=分类 2=标题 3=评论 4=?  5=时间 6=大小 7=做种 8=下载 9=完成 10=发布者
+  # 逗号组写法同时兼容 httpx 原始 HTML（无 tbody）与浏览器渲染 DOM（有 tbody）
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  # 框架默认 a[href*='details.php'] 会误取到 <a> 的 title；取 <b> 内文更准（100/100）
+  torrent_title_css: "table.torrentname a b"
+  torrent_subtitle_css: "td.embedded > div[title]::attr(title)"   # 100/100
+  # 框架默认 td:nth-child(1) img::attr(class) 取到 "c_movie" 无数字，_extract_category_id 必失败
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 100/100
+  torrent_time_css: "td:nth-child(5) > span::attr(title)"          # 100/100
+  torrent_time_fallback_css: "td:nth-child(5)"
+  torrent_size_css: "td:nth-child(6)"
+  torrent_seeders_css: "td:nth-child(7)"
+  torrent_leechers_css: "td:nth-child(8)"
+  torrent_snatched_css: "td:nth-child(9)"
+  torrent_uploader_css: "td:nth-child(10)"   # 多为「匿名」，用整列文本而非 a
+  # NexusPHP 首页是 page=0，框架默认 offset 0 会漏掉第一页
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+    "img.pro_free2up": 0
+  promo_upload_rules:
+    "img.pro_free2up": 2
+  # 实抓页面未出现 H&R 标记，留空表示「未知」，避免误报成「无考核」
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  # 「基本信息」整格含大小/类型/媒介…，取第一个 <b> 后的文本节点即纯大小
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie: [300, 401, 410, 411, 412, 413, 414, 415, 416, 417]
+  tv: [402, 403]
+  documentary: [404]
+  anime: [405]
+  music: [406, 408]
+  other: [407, 409]   # 407=Sports（枚举无 sports，归 other）409=Misc

--- a/src/movieclaw_tracker/sites/configs/hdarea.yaml
+++ b/src/movieclaw_tracker/sites/configs/hdarea.yaml
@@ -10,7 +10,7 @@ framework: nexusphp
 auth:
   supported: [cookie, credential]
 
-min_request_interval: 5.0
+min_request_interval: 60.0
 
 selectors:
   # ---------- 种子列表 ----------

--- a/src/movieclaw_tracker/sites/configs/hddolby.yaml
+++ b/src/movieclaw_tracker/sites/configs/hddolby.yaml
@@ -1,0 +1,62 @@
+# HDDolby 高清杜比
+# 选择器基于 2026-08-05 浏览器实登页面逐项验证。
+# 本站魔力值叫「鲸币」，等级 title 带前缀（如「(士兵)User」）。
+
+site_id: hddolby
+display_name: 高清杜比 HDDolby
+base_url: https://www.hddolby.com
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 10：1=分类 2=标题 3=评论 4=时间 5=大小 6=做种 7=下载 8=完成 9=? 10=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"                       # 100/100
+  torrent_subtitle_css: "td.embedded span[style*='float:left']"    # 100/100
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 100/100
+  torrent_time_css: "td:nth-child(4) > span::attr(title)"          # 100/100
+  torrent_time_fallback_css: "td:nth-child(4)"
+  torrent_size_css: "td:nth-child(5)"
+  torrent_seeders_css: "td:nth-child(6)"
+  torrent_leechers_css: "td:nth-child(7)"
+  torrent_snatched_css: "td:nth-child(8)"
+  torrent_uploader_css: "td:nth-child(10)"
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+    "img.pro_free2up": 0
+    "img.pro_50pctdown": 0.5
+  promo_upload_rules:
+    "img.pro_free2up": 2
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie: [401]
+  tv: [402, 403]
+  documentary: [404]
+  anime: [405]
+  music: [406, 408]
+  game: [410]
+  other: [407, 409, 411]   # 407=体育 411=学习

--- a/src/movieclaw_tracker/sites/configs/hdfans.yaml
+++ b/src/movieclaw_tracker/sites/configs/hdfans.yaml
@@ -1,0 +1,61 @@
+# HDFans
+# 选择器基于 2026-08-05 浏览器实登页面逐项验证。
+
+site_id: hdfans
+display_name: HDFans
+base_url: https://hdfans.org
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 9：1=分类 2=标题 3=评论 4=时间 5=大小 6=做种 7=下载 8=完成 9=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"                       # 51/51
+  torrent_subtitle_css: "td.embedded br::next_sibling_text"        # 51/51
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 51/51
+  torrent_time_css: "td:nth-child(4) > span::attr(title)"          # 51/51
+  torrent_time_fallback_css: "td:nth-child(4)"
+  torrent_size_css: "td:nth-child(5)"
+  torrent_seeders_css: "td:nth-child(6)"
+  torrent_leechers_css: "td:nth-child(7)"
+  torrent_snatched_css: "td:nth-child(8)"
+  torrent_uploader_css: "td:nth-child(9)"
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+    "img.pro_free2up": 0
+    "img.pro_50pctdown": 0.5
+  promo_upload_rules:
+    "img.pro_free2up": 2
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie: [401]
+  tv: [402, 416]        # 416=TV Shows/综艺
+  documentary: [403]
+  anime: [417]
+  music: [406, 407, 408]  # 407=Music Videos 408=Concert
+  game: [421]
+  other: [404, 405, 409, 410, 418, 419, 423]  # 418=Sports 419=软件 423=电子书

--- a/src/movieclaw_tracker/sites/configs/hdtime.yaml
+++ b/src/movieclaw_tracker/sites/configs/hdtime.yaml
@@ -1,0 +1,58 @@
+# HDTime
+# 选择器基于 2026-08-05 浏览器实登页面逐项验证。
+
+site_id: hdtime
+display_name: HDTime
+base_url: https://hdtime.org
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 9：1=分类 2=标题 3=评论 4=时间 5=大小 6=做种 7=下载 8=完成 9=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"                       # 50/50
+  torrent_subtitle_css: "td.embedded br::next_sibling_text"        # 50/50
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 50/50
+  torrent_time_css: "td:nth-child(4) > span::attr(title)"          # 50/50
+  torrent_time_fallback_css: "td:nth-child(4)"
+  torrent_size_css: "td:nth-child(5)"
+  torrent_seeders_css: "td:nth-child(6)"
+  torrent_leechers_css: "td:nth-child(7)"
+  torrent_snatched_css: "td:nth-child(8)"
+  torrent_uploader_css: "td:nth-child(9)"
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+  promo_upload_rules: {}
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie: [401, 424]    # 424=Blu-Ray 原盘
+  tv: [402, 403]
+  documentary: [404]
+  anime: [405]
+  music: [406, 408]
+  game: [410]
+  other: [407, 409, 411, 414]   # 407=体育 411=文档 414=软件

--- a/src/movieclaw_tracker/sites/configs/nicept.yaml
+++ b/src/movieclaw_tracker/sites/configs/nicept.yaml
@@ -1,0 +1,60 @@
+# NicePT
+# 选择器基于 2026-08-05 浏览器实登页面逐项验证。
+# 注意：本站界面为繁体中文，「等級 / 副標題 / 基本資訊」不能写成简体，否则 :contains 落空。
+
+site_id: nicept
+display_name: NicePT
+base_url: https://www.nicept.net
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 9：1=分类 2=标题 3=评论 4=时间 5=大小 6=做种 7=下载 8=完成 9=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"                       # 50/50
+  torrent_subtitle_css: "td.embedded br::next_sibling_text"        # 39/50（部分种子确无副标题）
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 50/50
+  torrent_time_css: "td:nth-child(4) > span::attr(title)"          # 50/50
+  torrent_time_fallback_css: "td:nth-child(4)"
+  torrent_size_css: "td:nth-child(5)"
+  torrent_seeders_css: "td:nth-child(6)"
+  torrent_leechers_css: "td:nth-child(7)"
+  torrent_snatched_css: "td:nth-child(8)"
+  torrent_uploader_css: "td:nth-child(9)"
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+    "img.pro_50pctdown": 0.5
+    "img.pro_50pctdown2up": 0.5
+    "img.pro_30pctdown": 0.3
+  promo_upload_rules:
+    "img.pro_50pctdown2up": 2
+    "img.pro_2up": 2
+  # 本站确实使用 H&R 标记（实抓 50/50 行命中），可安全启用
+  torrent_hr_css: "img.hitandrun"
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副標題') + td::text"
+  detail_size_css: "td.rowhead:contains('基本資訊') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  # 全站为成人内容，统一归入 av
+  av: [401, 402, 403, 404, 500, 501, 503, 504]

--- a/src/movieclaw_tracker/sites/configs/piggo.yaml
+++ b/src/movieclaw_tracker/sites/configs/piggo.yaml
@@ -1,0 +1,64 @@
+# Piggo 猪猪网
+# 选择器基于 2026-08-05 浏览器实登页面逐项验证。
+#
+# ⚠️ 运行须知：本站前置了雷池（Safeline）WAF。用普通 HTTP 客户端（httpx / curl_cffi，
+#    含 TLS 指纹伪装）直连会被返回 HTTP 468 挑战页，只有真实浏览器能通过。
+#    页面快照是靠驱动本机 Chrome 拿到的。movieclaw 走 httpx，实际同步时很可能被拦，
+#    如遇 468 需要另配代理/浏览器会话，不是本配置文件的选择器问题。
+
+site_id: piggo
+display_name: 猪猪网 Piggo
+base_url: https://piggo.me
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+# WAF 站点，放慢一点更安全
+min_request_interval: 8.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 9：1=分类 2=标题 3=评论 4=时间 5=大小 6=做种 7=下载 8=完成 9=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"                       # 101/101
+  torrent_subtitle_css: "td.embedded br::next_sibling_text"        # 101/101
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 101/101
+  torrent_time_css: "td:nth-child(4) > span::attr(title)"          # 101/101
+  torrent_time_fallback_css: "td:nth-child(4)"
+  torrent_size_css: "td:nth-child(5)"
+  torrent_seeders_css: "td:nth-child(6)"
+  torrent_leechers_css: "td:nth-child(7)"
+  torrent_snatched_css: "td:nth-child(8)"
+  torrent_uploader_css: "td:nth-child(9)"
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+    "img.pro_50pctdown": 0.5
+  promo_upload_rules: {}
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie: [401]
+  tv: [402, 403]
+  documentary: [404]
+  anime: [405]
+  music: [406, 408]
+  other: [407, 409, 912]   # 407=体育 912=有声

--- a/src/movieclaw_tracker/sites/configs/pttime.yaml
+++ b/src/movieclaw_tracker/sites/configs/pttime.yaml
@@ -1,0 +1,67 @@
+# PTTime
+# 本站是 8 个站里结构改动最大的：列数 12（比标准多 3 列）、促销用 <font> 而非 <img>、
+# 上传下载/分享率/做种数只在顶栏 #info_block 里，userdetails 表格里没有。
+# 选择器基于 2026-08-05 浏览器实登页面逐项验证。
+
+site_id: pttime
+display_name: PTTime
+base_url: https://www.pttime.org
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 页面列数 12：1=分类 … 5=时间 6=大小 7=做种 8=下载 9=完成 … 11=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"                       # 50/50
+  torrent_subtitle_css: "td.embedded font[title]::attr(title)"     # 50/50
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"  # 50/50
+  torrent_time_css: "td:nth-child(5) > span::attr(title)"          # 50/50
+  torrent_time_fallback_css: "td:nth-child(5)"
+  torrent_size_css: "td:nth-child(6)"
+  torrent_seeders_css: "td:nth-child(7)"
+  torrent_leechers_css: "td:nth-child(8)"
+  torrent_snatched_css: "td:nth-child(9)"
+  torrent_uploader_css: "td:nth-child(11)"
+  page_offset: -1
+
+  # 本站促销标记是 <font class="promotion free"> 这种复合类，不是标准 img.pro_*。
+  # 必须写成 font.promotion.free（两段类名同时匹配）——只写 font.promotion 会误伤
+  # font.promotion.bb（那是「字幕/附件」徽章，不是促销）。
+  promo_download_rules:
+    "font.promotion.free": 0
+    "font.promotion.twoupfree": 0
+    "font.promotion.halfdown": 0.5
+  promo_upload_rules:
+    "font.promotion.twoupfree": 2
+    "font.promotion.twoup": 2
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie: [401]
+  tv: [402, 403]
+  documentary: [404]
+  anime: [406]
+  music: [408]
+  game: [421]
+  other: [100, 405, 407, 409, 411, 412, 420, 422, 423, 430]  # 405=体育 420=编程 422=软件

--- a/src/movieclaw_tracker/sites/configs/soulvoice.yaml
+++ b/src/movieclaw_tracker/sites/configs/soulvoice.yaml
@@ -1,0 +1,75 @@
+# 聆音（SoulVoice）站点配置
+# 官网：https://pt.soulvoice.club/
+# 数据来源：PT-depiler definitions/soulvoice.ts + 其它 9 个 NexusPHP 站的验证模式
+#
+# ⚠️⚠️⚠️ 本配置【未实测 / UNVERIFIED】⚠️⚠️⚠️
+#   截至 2026-08-05，pt.soulvoice.club 的 DNS 已失效（curl 返回 HTTP 000，
+#   本地 Chrome 亦无法直连），无法抓取真实页面逐项验证选择器。本文件是按
+#   「标准 9 列 NexusPHP 布局 + 已验证通用的解析模式」推导的最佳猜测，
+#   通过概率较高，但不保证一次验证通过。
+#
+#   上线前请：① 等 DNS 恢复后用实登页面复核下列选择器；或 ② 把一份
+#   torrents.html / userdetails.html / details.php 页面源码交给我逐项校验。
+#
+#   已知差异点（请重点复核）：
+#   - 旧配置里 torrent_category_css 用 a[href^='?cat=']，本站沿用更稳健的
+#     td:nth-child(1) a[href*='cat=']::attr(href)（同时兼容 ?cat= 与 xxx.php?cat=）。
+#   - 本站有「主分区(torrents.php)」与「阅听分区(special.php, cat 499/500)」
+#     两个入口，movieclaw 单 search_path 只覆盖主分区，阅听分区需后续扩展。
+#   - 旧配置曾用无效的 `sports: [407]`；407 实为「教学」，已并入 other。
+
+site_id: soulvoice
+display_name: 聆音
+base_url: https://pt.soulvoice.club
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 种子列表 ----------
+  # 标准 9 列布局（参考 hdtime 等已验证站点）：1=分类 2=标题 3=评论
+  # 4=时间 5=大小 6=做种 7=下载 8=完成 9=发布者
+  torrent_row_css: "table.torrents > tr, table.torrents > tbody > tr"
+  torrent_title_css: "table.torrentname a b"
+  torrent_subtitle_css: "td.embedded br::next_sibling_text"
+  torrent_category_css: "td:nth-child(1) a[href*='cat=']::attr(href)"
+  torrent_time_css: "td:nth-child(4) > span::attr(title)"
+  torrent_time_fallback_css: "td:nth-child(4)"
+  torrent_size_css: "td:nth-child(5)"
+  torrent_seeders_css: "td:nth-child(6)"
+  torrent_leechers_css: "td:nth-child(7)"
+  torrent_snatched_css: "td:nth-child(8)"
+  torrent_uploader_css: "td:nth-child(9)"
+  page_offset: -1
+
+  promo_download_rules:
+    "img.pro_free": 0
+  promo_upload_rules: {}
+  torrent_hr_css: ""
+
+  # ---------- 详情页 ----------
+  detail_title_css: "h1#top"
+  detail_subtitle_css: "td.rowhead:contains('副标题') + td::text"
+  detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
+
+  # ---------- 用户资料 ----------
+  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
+  profile_uid_css: "a[class*='_Name']::attr(href)"
+  profile_username_css: "a[class*='_Name'] b"
+  profile_class_css: "a[class*='_Name']::attr(class)"
+  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
+  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
+  profile_ratio_css: "font.color_ratio::next_sibling_text"
+  profile_bonus_css: "font.color_bonus"
+  profile_seeding_css: "img.arrowup::next_sibling_text"
+  profile_leeching_css: "img.arrowdown::next_sibling_text"
+categories:
+  movie:       [401, 424]
+  tv:          [402, 403]
+  documentary: [404]
+  anime:       [405]
+  music:       [406, 408]
+  other:       [407, 409, 499, 500]


### PR DESCRIPTION
## 新增 8 个 PT 站点配置

基于最新 upstream/main 创建，仅新增 8 个 YAML 配置文件（513 行），无删除。

| 站点 | site_id | base_url | 备注 |
|------|---------|----------|------|
| 高清视界 | hdarea | https://www.hdarea.club | 10 列布局，含 auth/min_request_interval |
| 高清杜比 | hddolby | https://www.hddolby.com | 10 列布局，魔力值叫「鲸币」 |
| HDFans | hdfans | https://hdfans.org | 9 列布局 |
| HDTime | hdtime | https://hdtime.org | 9 列布局 |
| NicePT | nicept | https://www.nicept.net | 繁体界面（detail 用繁体 :contains）；有 H&R 标记；全站内容归 av |
| 猪猪网 | piggo | https://piggo.me | WAF 站点，min_request_interval=8.0 |
| PTTime | pttime | https://www.pttime.org | 12 列布局，促销用 font.promotion.* 复合类 |
| 聆音 | soulvoice | https://pt.soulvoice.club | ⚠️ 未实测（DNS 失效），选择器为推导配置 |

### 验证
- 8 个文件 YAML 语法可解析，必填字段齐全
- 全部 selectors 键名经 `NexusPHPSite` 的 `dataclasses.replace` 实测通过（模拟 registry 加载逻辑，非仅正则比对）
- 促销规则 dict→tuple 转换正常；categories 键均在 `TorrentCategory` 枚举内（体育等均归入合法键）；auth.supported 均为合法类型；min_request_interval 数值合法
- site_id 与文件名一致，8 个站点无重复、与上游现有 14 个站点无冲突
- 均配置 `page_offset: -1`（分页从 0 开始）

### 注意
- **soulvoice 未实测**：文件内注明截至 2026-08-05 DNS 失效无法验证，选择器按标准 NexusPHP 布局推导，建议上线前复核。
- piggo 前置雷池 WAF（HTTP 468），实际同步可能被拦，文件内已注明。