### PR TITLE
perf(jellyfin): 浏览类请求不再碰媒体文件本体，修复大库列表 20 余秒的卡顿

### DIFF
--- a/alembic/versions/20260805_1400_f3a7c8d21b45_add_library_file_mtime_ns.py
+++ b/alembic/versions/20260805_1400_f3a7c8d21b45_add_library_file_mtime_ns.py
@@ -1,0 +1,36 @@
+"""add library_file.file_mtime_ns
+
+媒体文件 mtime（纳秒）落库：扫描/入库时随 stat 顺手记录，Jellyfin 兼容层的
+MediaSource ETag 改为直接由它派生。此前 ETag 在每次列表/详情请求里现场
+stat 媒体文件本体，云盘挂载上一次 stat 就是一次网络往返——1200 部电影的
+列表请求要 20 多秒（issue #88）。纯加列、可空，向前兼容：旧行 NULL 时
+省略 ETag（纯缓存语义），下次扫描自动补齐。
+
+Revision ID: f3a7c8d21b45
+Revises: e9f2b5da1728
+Create Date: 2026-08-05 14:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a7c8d21b45"
+down_revision: str | None = "e9f2b5da1728"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("library_file", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("file_mtime_ns", sa.BigInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("library_file", schema=None) as batch_op:
+        batch_op.drop_column("file_mtime_ns")

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
@@ -115,7 +115,6 @@ export function LibraryItemDetailView({
     setDetail(null);
     setReidentifyResult(null);
     setReidentifyError(null);
-    probeRetries.current = 0; // 换条目重置静默补拉的重试预算
     reload();
   }, [reload]);
 
@@ -123,7 +122,7 @@ export function LibraryItemDetailView({
 
   // 沉浸模式：进入详情页把全站背景（body 大图 + 玻璃折射纹理）临时换成
   // 该片剧照，玻璃 UI 整体染上影片氛围；离开页面自动恢复用户配置的背景。
-  // 依赖 URL 字符串而非 detail 对象：规格补拉刷新 detail 时背景不重挂
+  // 依赖 URL 字符串而非 detail 对象：刮削轮询刷新 detail 时背景不重挂
   const { setOverrideBackdrop } = useBackdrop();
   const immersiveUrl = detail ? imageUrl(detail.backdrop_url ?? detail.poster_url) : "";
   useEffect(() => {
@@ -144,23 +143,6 @@ export function LibraryItemDetailView({
     },
     detail?.scraping ? 2000 : null,
   );
-
-  // 介质规格的静默补拉：后端把 ffprobe 补探挪到了响应之后的后台任务
-  // （网络挂载上探测是秒级/文件，不能拖首屏），"尚未探测"的文件在页面
-  // 打开后每 3 秒补拉一次详情呈现结果，最多三次（ffprobe 缺失时不空转）
-  const probeRetries = useRef(0);
-  useEffect(() => {
-    if (!detail) return;
-    const pending = detail.files.some((f) => !f.missing && f.audio_streams === null);
-    if (!pending || probeRetries.current >= 3) return;
-    const timer = setTimeout(() => {
-      probeRetries.current += 1;
-      getLibraryItemDetail(libraryId, mediaItemId)
-        .then(setDetail)
-        .catch(() => {});
-    }, 3000);
-    return () => clearTimeout(timer);
-  }, [detail, libraryId, mediaItemId]);
 
   // 兜底态（加载中/失败）的顶栏：条目标题未知，末项留空——渲染 PageNav 是为了
   // 向外壳登记「本页自带顶栏」，否则移动端全局顶栏（☰ + logo）会先显示再消失，
@@ -834,8 +816,8 @@ function SpecRows({ file }: { file: LibraryItemFile }) {
       <SpecRow label="音频">
         {file.audio_streams === null ? (
           <span className="text-sub text-[var(--text-muted)]">
-            尚未探测——后台正在读取，稍候自动刷新；持续为空请检查文件是否可达，
-            以及（源码部署时）是否装了 ffmpeg
+            尚未探测——在媒体库页对本库执行「重新扫描」即可补齐规格；
+            扫描后仍为空请检查文件是否可达，以及（源码部署时）是否装了 ffmpeg
           </span>
         ) : file.audio_streams.length === 0 ? (
           <span className="text-sub text-[var(--text-muted)]">文件内没有音轨</span>

--- a/docs/design/jellyfin-compat.md
+++ b/docs/design/jellyfin-compat.md
@@ -688,7 +688,12 @@ MediaInfoHelper.cs:305-317：仅当用户被显式赋予该权限时才禁用远
 我们两层处理（偏离②）：
 
 1. PlaybackInfo 里 strm 条目输出 `Protocol:"Http"` + `Path:<strm 内容 URL>` +
-   `IsRemote:true`，主流客户端直连云端，服务器零流量；
+   `IsRemote:true`，主流客户端直连云端，服务器零流量。**strm 只在
+   PlaybackInfo 与 /stream 这两个播放场景现读**（直链多带时效签名，须现读
+   现用）；浏览场景（列表/单条目的 `fields=MediaSources`）**不读 strm 文件**
+   ——`Path` 保留 .strm 占位路径、`Protocol/IsRemote` 照常输出。每个 strm
+   条目读一次文件在云盘挂载上就是一次网络往返，千余条目的列表请求曾因此
+   耗时 20 余秒（issue #88），而浏览场景根本用不到直链；
 2. 兜底：客户端仍请求 `/Videos/{id}/stream` 时，读 strm 内容后返回
    **302 重定向**（不做反向代理）。302 注意：HEAD 同样 302；不塞 body；
    重定向目标须自己支持 Range（CloudDrive/Alist 直链均支持）。
@@ -868,7 +873,12 @@ id），调同一套领域服务——**不**让自家前端去消费 Jellyfin �
    strm 场景 Path 也可指向我们的 stream 端点（302 每次现读 strm 文件），
    牺牲一跳换稳定；两种模式做成库级开关，默认直连。
 5. **性能**：/Items 大库分页 + fields 门控天然限量；图片缩放有缓存；台账
-   查询已有热路径索引。无新增风险面。
+   查询已有热路径索引。**浏览零媒体 IO 原则**（issue #88 后的硬约束）：
+   入库完成后，除非用户主动扫描/刷新元数据，浏览类请求不对媒体文件本体
+   做任何文件系统调用——本地文件的 `ETag` 由台账 `file_mtime_ns` 派生
+   （扫描/入库时随 stat 落库，旧行 NULL 省略、重扫回填），strm 只在播放
+   场景现读，图片 tag 由资产相对路径 + 所属行 `updated_at` 派生，演职员
+   只在 `fields=People` 时装载。
 
 ## 10. 分期实施与验收
 

--- a/src/movieclaw_api/api/routes/libraries.py
+++ b/src/movieclaw_api/api/routes/libraries.py
@@ -68,7 +68,6 @@ from movieclaw_api.services import media_scrape
 from movieclaw_api.services.library import claim as library_claim
 from movieclaw_api.services.library.config import LibraryConfigService
 from movieclaw_api.services.library.items import (
-    backfill_streams_for_files,
     build_item_detail,
     build_library_index,
     build_library_wall,
@@ -1218,20 +1217,18 @@ def _file_view(row: LibraryFile, external_subs: list[str]) -> LibraryFileView:
 async def get_library_item(
     library_id: int,
     media_item_id: int,
-    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_session),
 ) -> ApiResponse[LibraryItemDetailView]:
     """媒体库条目详情页的数据源。规格来自 ffprobe 对文件本体的探测，
-    简介/评分/演职员本地 NFO 优先、TMDB 兜底（经持久缓存）。旧台账没探测
-    过音轨的**响应后**后台补探（ffprobe 在网络挂载上是秒级/文件，不能拖首屏），
-    前端对"尚未探测"的文件稍后静默补拉。"""
+    简介/评分/演职员本地 NFO 优先、TMDB 兜底（经持久缓存）。没探测过
+    音轨的行**不在此补探**——探测只发生在入库/扫描环节（浏览不碰媒体
+    文件本体，云盘挂载上读文件就是流量与延迟），前端对"尚未探测"的
+    文件提示用户重新扫描补齐。"""
 
     service = LibraryConfigService(session)
     library = await service.get(library_id)
     item, rows = await _item_rows(session, library_id, media_item_id)
     bundle = await build_item_detail(session, library, item, rows)
-    if bundle.pending_probe_ids:
-        background_tasks.add_task(backfill_streams_for_files, bundle.pending_probe_ids)
 
     base = get_settings().tmdb_image_base_url.rstrip("/")
     art_base = f"/libraries/{library_id}/items/{media_item_id}/artwork"

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -783,6 +783,8 @@ async def _ingest_entry(
             imported += 1
             continue
         assert dest_library is not None and dest_library.id is not None
+        # stat 落位后的目标文件（跨盘复制时 mtime 与源不同），size/mtime 一次拿全
+        final_stat = final.stat()
         await repo.upsert_by_path(
             LibraryFile(
                 library_id=dest_library.id,
@@ -790,7 +792,8 @@ async def _ingest_entry(
                 season_number=season,
                 episode_number=episode,
                 file_path=str(final),
-                size_bytes=file.stat().st_size,
+                size_bytes=final_stat.st_size,
+                file_mtime_ns=final_stat.st_mtime_ns,
                 container=final.suffix.lstrip(".").lower() or None,
                 resolution=file_spec.resolution if file_spec else None,
                 video_codec=file_spec.video_codec if file_spec else None,

--- a/src/movieclaw_api/services/library/items.py
+++ b/src/movieclaw_api/services/library/items.py
@@ -6,7 +6,8 @@
    基本信息（MediaItem）、本地刮削元数据（NFO：简介/评分/片长/演职员）、
    本地美术图（poster/fanart 优先于 TMDB 图床）、逐文件的真实介质规格
    （ffprobe：分辨率/音轨/内封字幕）与外挂字幕。旧台账没探测过音轨的，
-   详情页按需补探后回填（懒回填，不强迫用户整库重扫）。
+   **不在浏览时补探**（浏览不碰媒体文件本体，云盘挂载上读文件就是流量
+   与延迟）——前端提示用户重新扫描，由扫描的补探阶段统一回填。
 2. **本地美术图定位** ``find_local_artwork``：条目目录下按 Kodi/Emby 惯例
    命名的图片文件；找到即由 /libraries/.../artwork 接口直接回吐，
    没有时前端退回 TMDB 图床。
@@ -21,6 +22,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import shutil
@@ -80,10 +82,6 @@ _ART_EXTS = (".jpg", ".jpeg", ".png", ".webp")
 
 # 外挂字幕扩展名（同名或"同名.语言"命名，整理器的 sidecar 同一口径）
 _SUBTITLE_EXTS = {".srt", ".ass", ".ssa", ".sub", ".sup", ".vtt"}
-
-# 详情页单次请求最多补探的文件数：电影条目几个版本毫秒级完成；上百集的
-# 剧集首次打开只补一批，翻几次页自然补齐——不让一次请求卡几十秒
-_DETAIL_PROBE_LIMIT = 16
 
 # 补探过程中每探完这么多个文件提交一次：整库补探是小时级的活，不能攒成
 # 一个大事务（中途中断就全白探了），也不必一个一个提交
@@ -459,18 +457,15 @@ class ItemDetailBundle:
     local_poster_version: int
     local_fanart_version: int
     external_subtitles: dict[int, list[str]]  # file_id -> 外挂字幕文件名
-    # 待补探音轨的台账行（响应后由后台任务补探回填——ffprobe 在网络挂载上
-    # 一个文件就要秒级，放在请求路径里会把首屏拖成十几秒）
-    pending_probe_ids: list[int] = field(default_factory=list)
 
 
 async def build_item_detail(
     session: AsyncSession, library: Library, item: MediaItem, files: list[LibraryFile]
 ) -> ItemDetailBundle:
-    """装配条目详情：NFO 元数据 + 本地美术图 + 介质规格懒回填 + 外挂字幕。
+    """装配条目详情：NFO 元数据 + 本地美术图 + 外挂字幕（介质规格直接读台账）。
 
-    磁盘 IO（NFO 解析、目录列举、ffprobe 补探）全部放线程池；库根不可达时
-    各环节自然落空，页面仍能靠台账字段渲染。
+    磁盘 IO（NFO 解析、目录列举）全部放线程池；库根不可达时各环节自然
+    落空，页面仍能靠台账字段渲染。不触发 ffprobe——探测只在入库/扫描时做。
     """
     roots = [Path(p) for p in library.root_paths]
     kind = MediaKind(library.kind)
@@ -523,16 +518,6 @@ async def build_item_detail(
         local_poster_version=file_version(poster_art),
         local_fanart_version=file_version(fanart_art),
         external_subtitles=external,
-        # strm 占位文件不排后台补探——探了必失败，还会让详情页每次打开都
-        # 白排一次任务
-        pending_probe_ids=[
-            row.id
-            for row in files
-            if row.id is not None
-            and row.audio_streams is None
-            and row.missing_since is None
-            and not row.file_path.lower().endswith(STRM_EXT)
-        ][:_DETAIL_PROBE_LIMIT],
     )
 
 
@@ -857,47 +842,21 @@ async def _tmdb_fallback_meta(item: MediaItem) -> EntryMetadata | None:
     return meta if meta.has_content() else None
 
 
-async def backfill_streams_for_files(file_ids: list[int]) -> None:
-    """详情响应后的后台补探入口（自开会话；FastAPI BackgroundTasks 调用）。
-
-    探测结果落库后，前端对"尚未探测"的文件会静默补拉一次详情呈现结果
-    ——首屏不再被 ffprobe 拖住，规格晚几秒到但页面秒开。
-    """
-    if not file_ids:
-        return
-    from sqlmodel import select
-
-    from movieclaw_db.engine import get_database
-
-    db = get_database()
-    try:
-        async with db.session() as session:
-            rows = list(
-                (await session.execute(select(LibraryFile).where(LibraryFile.id.in_(file_ids))))  # type: ignore[attr-defined]
-                .scalars()
-                .all()
-            )
-            await backfill_streams(session, rows)
-    except Exception:  # noqa: BLE001 -- 后台任务兜底，失败下次打开详情页再试
-        logger.exception("后台补探介质规格失败（涉及台账行 %s）", file_ids)
-
-
 async def backfill_streams(
     session: AsyncSession,
     files: list[LibraryFile],
     *,
-    limit: int | None = _DETAIL_PROBE_LIMIT,
+    limit: int | None = None,
     on_probed: Callable[[], bool] | None = None,
 ) -> int:
     """给没探测过音轨/字幕轨的在位台账行按需补探并回填，返回实际探了几个。
 
     这是「ffprobe 后装」的唯一救赎路径——扫描对已识别且在位的行整体秒过，
-    不会回头重探。两个调用方：
-
-    - 详情页响应后的后台任务：``limit`` 取默认值限量，防止百集剧首开卡死；
-    - 扫描的补探阶段：``limit=None`` 不限量（那是有进度与停止按钮的后台
-      任务，慢没关系，半途而废才是问题），用 ``on_probed`` 汇报进度——
-      回调返回 False 即收尾（用户点了停止）。
+    不会回头重探。**只由扫描的补探阶段调用**（有进度与停止按钮的后台任务，
+    慢没关系，半途而废才是问题），用 ``on_probed`` 汇报进度——回调返回
+    False 即收尾（用户点了停止）。详情页曾经也会限量触发补探，已移除：
+    浏览不碰媒体文件本体（云盘挂载上 ffprobe 读文件就是流量与延迟），
+    未探测的行由前端提示用户重新扫描补齐。
 
     探测失败的行保持 NULL、下次再试：失败常常是暂时的（挂载还没就绪）。
     代价是永远探不出的坏文件每轮都会被重试一次，坏文件多的库要留意。
@@ -929,6 +888,10 @@ async def backfill_streams(
             row.bit_depth = row.bit_depth or spec.bit_depth
             row.duration_seconds = row.duration_seconds or spec.duration_seconds
             row.bit_rate = row.bit_rate or spec.bit_rate
+            if row.file_mtime_ns is None:
+                # 播放 ETag 用的 mtime 顺手回填（文件刚探测过，stat 是热的）
+                with contextlib.suppress(OSError):
+                    row.file_mtime_ns = Path(row.file_path).stat().st_mtime_ns
             row.updated_at = utcnow()
             since_commit += 1
         # 分批提交而不是攒到最后：整库补探可能要几个小时，中途断电/重启

--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -394,6 +394,7 @@ async def _scan(library_id: int, summary: ScanSummary, state: ScanState) -> Scan
         state.processed, state.total = 0, len(pending)
         now_ts = time.time()
         min_remaining: float | None = None
+        mtime_backfilled = 0
         for done, (root_path, file, is_disc) in enumerate(pending, start=1):
             # 每进入新的一窗，先把这一窗要用到的 TMDB 档案并发拉回来（详见
             # _PREFETCH_WINDOW 的说明）。串行链路本身一行不改，只是轮到它
@@ -459,6 +460,17 @@ async def _scan(library_id: int, summary: ScanSummary, state: ScanState) -> Scan
                         summary.errors.append(f"「{file.name}」身份复核失败：{exc}")
                 else:
                     summary.skipped_known += 1
+                # mtime 一次性回填：ETag 落库特性上线前的旧行没有 mtime，
+                # 趁扫描（用户主动发起）正在遍历目录顺手补上；补齐后的行
+                # 重扫不再 stat，秒过语义不变
+                if existing.file_mtime_ns is None:
+                    try:
+                        existing.file_mtime_ns = (
+                            await asyncio.to_thread(file.stat)
+                        ).st_mtime_ns
+                        mtime_backfilled += 1
+                    except OSError:
+                        pass
                 state.processed = done
                 continue
             # 完整性检测：mtime 太新 = 疑似写入中（下载/拷贝进行时），本轮
@@ -497,6 +509,9 @@ async def _scan(library_id: int, summary: ScanSummary, state: ScanState) -> Scan
                 logger.exception("扫描文件失败：%s", file)
                 summary.errors.append(f"「{file.name}」处理失败：{exc}")
             state.processed = done
+
+        if mtime_backfilled:
+            await session.commit()
 
         # 收尾感知删除：在位根路径下、台账有但本轮没遍历到 → 标记 missing。
         # 不存在的根整个不参与（挂载失败/掉盘时不误伤），文件回归时
@@ -843,8 +858,15 @@ async def _ingest_file(
     if is_disc:
         size_bytes = await asyncio.to_thread(_disc_total_size, file)
         container = "bluray" if (file / "BDMV").is_dir() else "dvd"
+        # 原盘条目 file_path 是目录，取目录 mtime——语义同样是"变了就变"
+        try:
+            file_mtime_ns: int | None = file.stat().st_mtime_ns
+        except OSError:
+            file_mtime_ns = None
     else:
-        size_bytes = file.stat().st_size
+        file_stat = file.stat()
+        size_bytes = file_stat.st_size
+        file_mtime_ns = file_stat.st_mtime_ns
         container = file.suffix.lstrip(".").lower() or None
 
     # 改名归并（走识别链之前）：新路径可能只是台账里某个旧文件被改了名，
@@ -912,6 +934,7 @@ async def _ingest_file(
             episode_number=episode,
             file_path=str(file),
             size_bytes=size_bytes,
+            file_mtime_ns=file_mtime_ns,
             container=container,
             resolution=spec.resolution if spec else None,
             video_codec=spec.video_codec if spec else None,

--- a/src/movieclaw_db/models/library_file.py
+++ b/src/movieclaw_db/models/library_file.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 
-from sqlalchemy import JSON, Column, ForeignKey, Index, Integer, Text
+from sqlalchemy import JSON, BigInteger, Column, ForeignKey, Index, Integer, Text
 from sqlmodel import Field
 
 from movieclaw_db.models.base import TimestampMixin
@@ -115,6 +115,15 @@ class LibraryFile(TimestampMixin, table=True):
         description="绝对路径（movieclaw 视角）",
     )
     size_bytes: int = Field(default=0, description="文件大小（字节）")
+    # 文件 mtime（纳秒）：扫描/入库时随 stat 顺手落库，播放接口的 ETag 直接
+    # 由它派生——浏览类请求不再对媒体文件本体做任何文件系统调用（云盘挂载
+    # 上一次 stat 就是一次网络往返，还会唤醒休眠盘）。NULL=旧数据未回填，
+    # 下次扫描自动补齐，期间 MediaSource 省略 ETag（纯缓存语义，无功能损失）
+    file_mtime_ns: int | None = Field(
+        default=None,
+        sa_column=Column(BigInteger, nullable=True),
+        description="文件 mtime（纳秒）；NULL=未回填（下次扫描补齐）",
+    )
     container: str | None = Field(default=None, description="容器格式（mkv/mp4/…）")
 
     # -- ffprobe 介质规格（探测失败保持 NULL）-------------------------------

--- a/src/movieclaw_db/repositories/library_file_repo.py
+++ b/src/movieclaw_db/repositories/library_file_repo.py
@@ -211,6 +211,7 @@ class LibraryFileRepository:
         existing.season_number = row.season_number
         existing.episode_number = row.episode_number
         existing.size_bytes = row.size_bytes
+        existing.file_mtime_ns = row.file_mtime_ns
         existing.container = row.container
         existing.resolution = row.resolution
         existing.video_codec = row.video_codec

--- a/src/movieclaw_jellyfin/catalog.py
+++ b/src/movieclaw_jellyfin/catalog.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import hashlib
 import random
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -106,9 +107,19 @@ class ItemBundle:
 
 
 async def load_bundles(
-    session: AsyncSession, item_ids: list[int], *, library_id: int | None = None
+    session: AsyncSession,
+    item_ids: list[int],
+    *,
+    library_id: int | None = None,
+    include_people: bool = False,
 ) -> dict[int, ItemBundle]:
-    """批量装载条目素材。library_id 限定时只装该库的文件行。"""
+    """批量装载条目素材。library_id 限定时只装该库的文件行。
+
+    ``include_people`` 只在输出会用到 People 时为 True（fields=People 或
+    单条目全字段）：演职员是量最大的关联（条目数 × 十余人的 join +
+    ORM 水合），列表请求默认不带 fields=People，装了也是白装——1200 部
+    电影的库这一项就要秒级开销（issue #88）。
+    """
     if not item_ids:
         return {}
     items = (
@@ -166,21 +177,24 @@ async def load_bundles(
         if b is not None:
             b.states[(st.season_number, st.episode_number)] = st
 
-    # 演职员：media_item_person ⋈ person（人物页同款数据，头像经图片代理）
-    people_rows = (
-        await session.execute(
-            select(MediaItemPerson, Person)
-            .join(Person, Person.id == MediaItemPerson.person_id)
-            .where(MediaItemPerson.media_item_id.in_(item_ids))
-        )
-    ).all()
-    for link, person in people_rows:
-        b = bundles.get(link.media_item_id)
-        if b is not None:
-            b.people.append((link.department, link.character, link.credit_order, person))
-    for b in bundles.values():
-        # 演员在前（按剧组主次序），导演/主创随后——对齐 Jellyfin People 惯例
-        b.people.sort(key=lambda t: (0 if t[0] == "cast" else 1, t[2]))
+    if include_people:
+        # 演职员：media_item_person ⋈ person（人物页同款数据，头像经图片代理）
+        people_rows = (
+            await session.execute(
+                select(MediaItemPerson, Person)
+                .join(Person, Person.id == MediaItemPerson.person_id)
+                .where(MediaItemPerson.media_item_id.in_(item_ids))
+            )
+        ).all()
+        for link, person in people_rows:
+            b = bundles.get(link.media_item_id)
+            if b is not None:
+                b.people.append(
+                    (link.department, link.character, link.credit_order, person)
+                )
+        for b in bundles.values():
+            # 演员在前（按剧组主次序），导演/主创随后——对齐 Jellyfin People 惯例
+            b.people.sort(key=lambda t: (0 if t[0] == "cast" else 1, t[2]))
 
     # 没有任何在位文件的条目不对外呈现
     return {k: v for k, v in bundles.items() if v.files}
@@ -258,16 +272,17 @@ async def load_library_stats(session: AsyncSession) -> dict[int, LibraryStats]:
 # ---------------------------------------------------------------------------
 
 
-def _asset_tag(assets_root: Path, rel_path: str | None) -> str | None:
-    """图片 tag：md5(相对路径 + mtime)——图变则 tag 变，纯缓存语义。"""
+def _asset_tag(rel_path: str | None, version: datetime | None) -> str | None:
+    """图片 tag：md5(相对路径 + 所属行 updated_at)——纯缓存语义，零文件系统调用。
+
+    图片由刮削管线写入，重刮必然刷新所属行的 updated_at，tag 随之改变。
+    此前按图片文件 mtime 现算，列表请求要对 data/ 逐图 stat 数千次，
+    data/ 挂在网络存储上时就是慢源之一（issue #88）。
+    """
     if not rel_path:
         return None
-    target = assets_root / rel_path
-    try:
-        mtime = target.stat().st_mtime_ns
-    except OSError:
-        return None
-    return hashlib.md5(f"{rel_path}:{mtime}".encode()).hexdigest()
+    stamp = version.isoformat() if version else ""
+    return hashlib.md5(f"{rel_path}:{stamp}".encode()).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -428,11 +443,13 @@ def _apply_item_images(
         return
     tags: dict[str, str] = {}
     meta = bundle.metadata
-    poster = _asset_tag(ctx.assets_root, meta.poster_file if meta else None)
+    poster = _asset_tag(meta.poster_file if meta else None, meta.updated_at if meta else None)
     if poster:
         tags["Primary"] = poster
     dto["ImageTags"] = tags
-    backdrop = _asset_tag(ctx.assets_root, meta.backdrop_file if meta else None)
+    backdrop = _asset_tag(
+        meta.backdrop_file if meta else None, meta.updated_at if meta else None
+    )
     dto["BackdropImageTags"] = [backdrop] if backdrop else []
 
 
@@ -517,18 +534,21 @@ def season_dto(
         dto["ProductionYear"] = row.air_date.year
     if options.enable_images:
         tags: dict[str, str] = {}
-        poster = _asset_tag(ctx.assets_root, row.poster_file if row else None)
+        poster = _asset_tag(
+            row.poster_file if row else None, row.updated_at if row else None
+        )
         if poster:
             tags["Primary"] = poster
         dto["ImageTags"] = tags
         dto["BackdropImageTags"] = []
+        meta = bundle.metadata
         series_poster = _asset_tag(
-            ctx.assets_root, bundle.metadata.poster_file if bundle.metadata else None
+            meta.poster_file if meta else None, meta.updated_at if meta else None
         )
         if series_poster:
             dto["SeriesPrimaryImageTag"] = series_poster
         series_backdrop = _asset_tag(
-            ctx.assets_root, bundle.metadata.backdrop_file if bundle.metadata else None
+            meta.backdrop_file if meta else None, meta.updated_at if meta else None
         )
         if series_backdrop:
             dto["ParentBackdropItemId"] = item_guid(bundle.item.id)
@@ -567,7 +587,9 @@ def episode_dto(
         dto["CommunityRating"] = round(row.vote_average, 1)
     if options.enable_images:
         tags = {}
-        still = _asset_tag(ctx.assets_root, row.still_file if row else None)
+        still = _asset_tag(
+            row.still_file if row else None, row.updated_at if row else None
+        )
         if still:
             tags["Primary"] = still
         dto["ImageTags"] = tags
@@ -575,9 +597,12 @@ def episode_dto(
         # 无自有图时客户端按 Parent* 字段退级：优先季海报，再剧海报/剧背景
         meta = bundle.metadata
         season_poster = _asset_tag(
-            ctx.assets_root, season_row.poster_file if season_row else None
+            season_row.poster_file if season_row else None,
+            season_row.updated_at if season_row else None,
         )
-        series_poster = _asset_tag(ctx.assets_root, meta.poster_file if meta else None)
+        series_poster = _asset_tag(
+            meta.poster_file if meta else None, meta.updated_at if meta else None
+        )
         if season_poster:
             dto["ParentPrimaryImageItemId"] = season_guid(bundle.item.id, season)
             dto["ParentPrimaryImageTag"] = season_poster
@@ -586,7 +611,9 @@ def episode_dto(
             dto["ParentPrimaryImageTag"] = series_poster
         if series_poster:
             dto["SeriesPrimaryImageTag"] = series_poster
-        series_backdrop = _asset_tag(ctx.assets_root, meta.backdrop_file if meta else None)
+        series_backdrop = _asset_tag(
+            meta.backdrop_file if meta else None, meta.updated_at if meta else None
+        )
         if series_backdrop:
             dto["ParentBackdropItemId"] = item_guid(bundle.item.id)
             dto["ParentBackdropImageTags"] = [series_backdrop]
@@ -790,13 +817,16 @@ def version_name(f: LibraryFile) -> str:
     return " ".join(parts) or Path(f.file_path).stem
 
 
-def media_source_dto(f: LibraryFile) -> dict[str, Any] | None:
+def media_source_dto(f: LibraryFile, *, resolve_strm: bool = False) -> dict[str, Any] | None:
     """单个文件版本 → MediaSourceInfo（含 v1.1 核实的 8 个恒输出字段）。
 
-    strm 条目：Path=云端 URL、Protocol=Http、IsRemote=true——客户端 DirectPlay
-    直连云端，服务器零流量。strm 内容解析失败（非法/被安全条款拒绝）时
-    返回 None，调用方把该版本从 MediaSources 里剔除（全部失败 →
-    NoCompatibleStream），不给客户端一个必然播不了的残源。
+    strm 条目：Protocol=Http、IsRemote=true——客户端 DirectPlay 直连云端，
+    服务器零流量。``resolve_strm`` 只在播放协商（PlaybackInfo）时为 True：
+    现读 strm 拿云端 URL（直链多带时效签名，不缓存），解析失败（非法/被
+    安全条款拒绝）返回 None，调用方把该版本剔除（全部失败 →
+    NoCompatibleStream）。列表/详情等浏览场景保持 False：**不读文件**——
+    每个 strm 条目读一次文件在云盘挂载上就是一次网络往返（issue #88），
+    而浏览场景根本用不到直链，Path 保留 strm 占位路径即可。
     """
     from movieclaw_jellyfin.ids import media_source_guid
     from movieclaw_playback.streaming import resolve_strm_url
@@ -846,29 +876,33 @@ def media_source_dto(f: LibraryFile) -> dict[str, Any] | None:
         source["DefaultAudioStreamIndex"] = audio_index
 
     if is_strm(f.file_path):
-        url = resolve_strm_url(f.file_path)
-        if url is None:
-            return None
-        source["Path"] = url
         source["Protocol"] = "Http"
         source["IsRemote"] = True
-        ext = Path(url.split("?", 1)[0]).suffix.lstrip(".").lower()
-        if ext:
-            source["Container"] = ext
+        if resolve_strm:
+            url = resolve_strm_url(f.file_path)
+            if url is None:
+                return None
+            source["Path"] = url
+            ext = Path(url.split("?", 1)[0]).suffix.lstrip(".").lower()
+            if ext:
+                source["Container"] = ext
     else:
-        files = bundle_etag(f)
-        if files:
-            source["ETag"] = files
+        etag = bundle_etag(f)
+        if etag:
+            source["ETag"] = etag
     return {k: v for k, v in source.items() if v is not None}
 
 
 def bundle_etag(f: LibraryFile) -> str | None:
-    """本地文件的 ETag（对齐 Jellyfin：mtime 派生的 md5）。"""
-    try:
-        mtime = Path(f.file_path).stat().st_mtime_ns
-    except OSError:
+    """本地文件的 ETag（对齐 Jellyfin：mtime 派生的 md5）。
+
+    mtime 来自台账列（扫描/入库时落库），**不做文件系统调用**——此前每次
+    列表/详情请求都对媒体文件本体逐个 stat，云盘挂载上千余部电影要 20
+    多秒（issue #88）。旧行未回填时省略 ETag（纯缓存语义），重扫自动补齐。
+    """
+    if f.file_mtime_ns is None:
         return None
-    return hashlib.md5(str(mtime).encode()).hexdigest()
+    return hashlib.md5(str(f.file_mtime_ns).encode()).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/src/movieclaw_jellyfin/routes/library.py
+++ b/src/movieclaw_jellyfin/routes/library.py
@@ -286,9 +286,10 @@ async def _query_items(request: Request) -> JSONResponse:
     ids_raw = parse_comma(q.get("ids"))
     search_term = q.get("searchTerm")
 
+    include_people = options.has("People")
     async with get_database().session() as session:
         if ids_raw:
-            entries = await _entries_for_ids(session, ids_raw)
+            entries = await _entries_for_ids(session, ids_raw, include_people=include_people)
         else:
             entries = await _entries_for_parent(
                 session,
@@ -296,6 +297,7 @@ async def _query_items(request: Request) -> JSONResponse:
                 include_types=include_types,
                 recursive=recursive,
                 has_search=bool(search_term),
+                include_people=include_people,
             )
             if entries is None:
                 # 根级：返回视图列表
@@ -359,10 +361,12 @@ async def _query_items(request: Request) -> JSONResponse:
     return JSONResponse(query_result(dtos, total, start_index))
 
 
-async def _entries_for_ids(session: AsyncSession, ids_raw: list[str]) -> list[Entry]:
+async def _entries_for_ids(
+    session: AsyncSession, ids_raw: list[str], *, include_people: bool = False
+) -> list[Entry]:
     refs = [r for r in (decode_guid(i) for i in ids_raw) if r is not None]
     scoped = {r.entity_id for r in refs if r.kind != EntityKind.LIBRARY}
-    bundles = await load_bundles(session, list(scoped))
+    bundles = await load_bundles(session, list(scoped), include_people=include_people)
     entries: list[Entry] = []
     for ref in refs:
         bundle = bundles.get(ref.entity_id)
@@ -386,6 +390,7 @@ async def _entries_for_parent(
     include_types: set[str],
     recursive: bool | None,
     has_search: bool,
+    include_people: bool = False,
 ) -> list[Entry] | None:
     """按 parentId 语义展开候选。返回 None 表示"根级 → 视图列表"。"""
     if not parent_raw or is_empty_guid(parent_raw):
@@ -393,7 +398,7 @@ async def _entries_for_parent(
             # 无 parent 的全局搜索/类型查询：跨全部库递归
             types = include_types or {"Movie", "Series"}
             ids = await item_ids_with_files(session)
-            bundles = await load_bundles(session, ids)
+            bundles = await load_bundles(session, ids, include_people=include_people)
             return _build_entries(bundles, types)
         return None
 
@@ -421,16 +426,18 @@ async def _entries_for_parent(
             # 非递归 = 只看直接子级，includeItemTypes 在其上做过滤（可为空集）
             types = (include_types & default_types) if include_types else default_types
         ids = await item_ids_with_files(session, library_id=ref.entity_id)
-        bundles = await load_bundles(session, ids, library_id=ref.entity_id)
+        bundles = await load_bundles(
+            session, ids, library_id=ref.entity_id, include_people=include_people
+        )
         return _build_entries(bundles, types)
 
     if ref.kind == EntityKind.ITEM:
-        bundles = await load_bundles(session, [ref.entity_id])
+        bundles = await load_bundles(session, [ref.entity_id], include_people=include_people)
         types = include_types or {"Season"}
         return _build_entries(bundles, types)
 
     if ref.kind == EntityKind.SEASON:
-        bundles = await load_bundles(session, [ref.entity_id])
+        bundles = await load_bundles(session, [ref.entity_id], include_people=include_people)
         return _build_entries(bundles, {"Episode"}, season_scope=ref.season)
 
     raise not_found()
@@ -474,7 +481,9 @@ async def items_latest(
 
     async with get_database().session() as session:
         ids = await item_ids_with_files(session, library_id=library_id)
-        bundles = await load_bundles(session, ids, library_id=library_id)
+        bundles = await load_bundles(
+            session, ids, library_id=library_id, include_people=options.has("People")
+        )
 
     # 每个"最新单元"= 文件入库时间最大的 (bundle, season, episode)
     latest_units: list[tuple[Any, ItemBundle, int, int]] = []
@@ -537,7 +546,7 @@ async def items_resume(request: Request, user_id: str | None = None) -> JSONResp
 
     async with get_database().session() as session:
         ids = await item_ids_with_files(session)
-        bundles = await load_bundles(session, ids)
+        bundles = await load_bundles(session, ids, include_people=options.has("People"))
 
     entries = _build_entries(bundles, {"Movie", "Episode"})
     if media_types and "Video" not in media_types:
@@ -687,7 +696,8 @@ async def get_item(request: Request, item_id: str, user_id: str | None = None) -
                     ctx, library, stats.get(library.id), await _cover_tag(library.id)
                 )
             )
-        bundles = await load_bundles(session, [ref.entity_id])
+        # 单条目是全字段语义，People 恒输出
+        bundles = await load_bundles(session, [ref.entity_id], include_people=True)
 
     bundle = bundles.get(ref.entity_id)
     if bundle is None:
@@ -732,7 +742,7 @@ async def shows_next_up(request: Request) -> JSONResponse:
 
     async with get_database().session() as session:
         ids = await item_ids_with_files(session, kind="tv")
-        bundles = await load_bundles(session, ids)
+        bundles = await load_bundles(session, ids, include_people=options.has("People"))
 
     candidates: list[tuple[Any, dict[str, Any]]] = []
     for bundle in bundles.values():
@@ -791,7 +801,9 @@ async def shows_seasons(request: Request, series_id: str) -> JSONResponse:
     if ref is None or ref.kind != EntityKind.ITEM:
         raise not_found()
     async with get_database().session() as session:
-        bundles = await load_bundles(session, [ref.entity_id])
+        bundles = await load_bundles(
+            session, [ref.entity_id], include_people=options.has("People")
+        )
     bundle = bundles.get(ref.entity_id)
     if bundle is None or bundle.item.kind != "tv":
         raise not_found()
@@ -831,7 +843,9 @@ async def shows_episodes(request: Request, series_id: str) -> JSONResponse:
             season_scope = int(season_param)
 
     async with get_database().session() as session:
-        bundles = await load_bundles(session, [target_item_id])
+        bundles = await load_bundles(
+            session, [target_item_id], include_people=options.has("People")
+        )
     bundle = bundles.get(target_item_id)
     if bundle is None or bundle.item.kind != "tv":
         raise not_found_message("Series not found")

--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -88,9 +88,14 @@ async def playback_info(request: Request, item_id: str) -> JSONResponse:
         return JSONResponse(
             {"MediaSources": [], "ErrorCode": "NoCompatibleStream"}
         )
+    # 播放协商是唯一现读 strm 的场景：直链多带时效签名，须现读现用；
+    # 解析失败的版本剔除，全部失败按"无可播源"应答
+    sources = [s for f in selected if (s := media_source_dto(f, resolve_strm=True))]
+    if not sources:
+        return JSONResponse({"MediaSources": [], "ErrorCode": "NoCompatibleStream"})
     return JSONResponse(
         {
-            "MediaSources": [media_source_dto(f) for f in selected],
+            "MediaSources": sources,
             "PlaySessionId": secrets.token_hex(16),
         }
     )

--- a/tests/api/test_library_item_detail.py
+++ b/tests/api/test_library_item_detail.py
@@ -381,7 +381,7 @@ async def test_item_detail_assembles_local_scrape(db, tmp_path, monkeypatch) -> 
     summary = await scan_library(library.id)
     assert summary.identified == 1  # NFO tmdbid=300 精确锚定
 
-    # 扫描时 ffprobe 对假字节探测失败（audio_streams=NULL）→ 后台补探回填
+    # 扫描时 ffprobe 对假字节探测失败（audio_streams=NULL）→ 等扫描补探回填
     monkeypatch.setattr(items_mod, "probe_media", lambda _path: _FAKE_SPEC)
 
     async with db.session() as session:
@@ -390,8 +390,7 @@ async def test_item_detail_assembles_local_scrape(db, tmp_path, monkeypatch) -> 
             .scalars()
             .one()
         )
-        tasks = BackgroundTasks()
-        resp = await get_library_item(library.id, item.id, tasks, session)
+        resp = await get_library_item(library.id, item.id, session)
         view = resp.data
 
     assert view.title == "某电影" and view.kind == "movie" and view.tmdb_id == 300
@@ -407,24 +406,25 @@ async def test_item_detail_assembles_local_scrape(db, tmp_path, monkeypatch) -> 
     assert view.local_meta is not None
     assert view.local_meta.rating == 8.2 and view.local_meta.runtime_minutes == 121
     assert [a.name for a in view.local_meta.actors] == ["演员甲", "演员乙"]
-    # 首屏不等探测：音轨保持"尚未探测"，但已把补探排进响应后的后台任务
+    # 详情页不再触发补探：音轨保持"尚未探测"（前端据此提示重新扫描），
+    # 浏览不碰媒体文件本体（云盘挂载上读文件就是流量与延迟）
     file = view.files[0]
     assert file.file_name == "某电影.2020.1080p.WEB-DL.mkv"
     assert file.audio_streams is None
-    assert len(tasks.tasks) == 1
     embedded = [s for s in file.subtitle_streams if not s.external]
     external = [s for s in file.subtitle_streams if s.external]
-    assert embedded == []  # 内封轨要等补探
+    assert embedded == []  # 内封轨要等扫描补探
     assert external[0].file_name == "某电影.2020.1080p.WEB-DL.chs&eng.srt"
     assert external[0].title == "chs&eng"
 
-    # 执行后台补探（模拟 BackgroundTasks 在响应后运行）→ 落库 → 再取即有
-    await tasks()
+    # 扫描的补探阶段回填 → 落库 → 再取即有
     async with db.session() as session:
+        rows = list((await session.execute(select(LibraryFile))).scalars().all())
+        await items_mod.backfill_streams(session, rows)
         row = (await session.execute(select(LibraryFile))).scalars().one()
         assert row.audio_streams and row.audio_streams[0]["codec"] == "eac3"
         assert row.subtitle_streams and row.subtitle_streams[0]["codec"] == "subrip"
-        resp2 = await get_library_item(library.id, item.id, BackgroundTasks(), session)
+        resp2 = await get_library_item(library.id, item.id, session)
         file2 = resp2.data.files[0]
         assert file2.audio_streams is not None and file2.audio_streams[0].codec == "eac3"
         assert file2.audio_streams[0].channels == 6
@@ -481,9 +481,8 @@ async def test_strm_rows_never_count_as_probe_pending(db, tmp_path) -> None:
         wall = await items_mod.build_library_wall(session, library.id)
         assert [v.probe_pending_count for v in wall] == [0]
         item_id = (await session.execute(select(MediaItem))).scalars().one().id
-        tasks = BackgroundTasks()
-        await get_library_item(library.id, item_id, tasks, session)
-        assert tasks.tasks == [], "strm 不该被排进详情页的后台补探任务"
+        # 详情页可正常打开（不再有任何补探副作用）
+        await get_library_item(library.id, item_id, session)
 
 
 async def test_item_detail_selfsufficient_after_scan(db, tmp_path) -> None:
@@ -510,7 +509,7 @@ async def test_item_detail_selfsufficient_after_scan(db, tmp_path) -> None:
             .scalars()
             .one()
         )
-        resp = await get_library_item(library.id, item.id, BackgroundTasks(), session)
+        resp = await get_library_item(library.id, item.id, session)
         view = resp.data
 
     # NFO 身份高置信（identity_source=nfo）→ 最小 NFO 被升级为完整版并回读
@@ -534,7 +533,7 @@ async def test_item_detail_selfsufficient_after_scan(db, tmp_path) -> None:
             .scalars()
             .one()
         )
-        resp = await get_library_item(library.id, item.id, BackgroundTasks(), session)
+        resp = await get_library_item(library.id, item.id, session)
         view = resp.data
 
     assert view.local_meta is not None and view.local_meta.source == "db"
@@ -577,7 +576,7 @@ async def test_item_detail_fills_missing_actor_thumbs_from_archive(db, tmp_path)
             .scalars()
             .one()
         )
-        resp = await get_library_item(library.id, item.id, BackgroundTasks(), session)
+        resp = await get_library_item(library.id, item.id, session)
         view = resp.data
 
     assert view.local_meta is not None and view.local_meta.source == "nfo"
@@ -620,7 +619,7 @@ async def test_item_detail_fills_person_ids_even_when_thumbs_complete(db, tmp_pa
             .scalars()
             .one()
         )
-        resp = await get_library_item(library.id, item.id, BackgroundTasks(), session)
+        resp = await get_library_item(library.id, item.id, session)
         view = resp.data
 
     assert view.local_meta is not None and view.local_meta.source == "nfo"
@@ -776,7 +775,7 @@ async def test_item_detail_reports_scraping_state(db, tmp_path) -> None:
             .scalars()
             .one()
         ).id
-        resp = await get_library_item(library.id, item_id, BackgroundTasks(), session)
+        resp = await get_library_item(library.id, item_id, session)
         assert resp.data.scraping is False
         assert resp.data.scraping_phase is None
 
@@ -784,7 +783,7 @@ async def test_item_detail_reports_scraping_state(db, tmp_path) -> None:
         # 阶段文案与整库刷新同一套，两处状态语言因此一致
         media_scrape._scraping[item_id] = "下载图片"
         try:
-            resp = await get_library_item(library.id, item_id, BackgroundTasks(), session)
+            resp = await get_library_item(library.id, item_id, session)
             assert resp.data.scraping is True
             assert resp.data.scraping_phase == "下载图片"
         finally:
@@ -885,7 +884,7 @@ async def test_delete_item_removes_whole_entry_dir(db, tmp_path) -> None:
         assert (await session.execute(select(LibraryFile))).scalars().all() == []
         resp404 = None
         try:
-            await get_library_item(library.id, item.id, BackgroundTasks(), session)
+            await get_library_item(library.id, item.id, session)
         except NotFoundException as exc:
             resp404 = exc
         assert resp404 is not None
@@ -984,7 +983,7 @@ async def test_delete_single_file_keeps_other_version(db, tmp_path) -> None:
     assert other.exists() and entry.exists()  # 另一版本与条目目录不动
     assert (entry / "movie.nfo").exists() and (entry / "poster.jpg").exists()
     async with db.session() as session:
-        detail = (await get_library_item(library.id, item.id, BackgroundTasks(), session)).data
+        detail = (await get_library_item(library.id, item.id, session)).data
         assert detail.file_count == 1
         assert detail.files[0].file_path == str(other)
 
@@ -1165,7 +1164,7 @@ async def test_tv_episodes_merge_local_and_tmdb(db, tmp_path) -> None:
             .scalars()
             .one()
         )
-        detail = (await get_library_item(library.id, item.id, BackgroundTasks(), session)).data
+        detail = (await get_library_item(library.id, item.id, session)).data
         assert detail.seasons == [1]
 
         resp = await list_item_episodes(library.id, item.id, 1, session)
@@ -1355,7 +1354,7 @@ async def test_actor_thumb_missing_only_when_tmdb_has_no_profile(db, tmp_path) -
                 .scalars()
                 .one()
             )
-            resp = await get_library_item(library.id, item.id, BackgroundTasks(), session)
+            resp = await get_library_item(library.id, item.id, session)
         return resp.data.local_meta
 
     # 1) NFO 路径（我们自己写出的完整 NFO：有图的写 <thumb>，没图的不写）

--- a/tests/api/test_library_scan.py
+++ b/tests/api/test_library_scan.py
@@ -277,6 +277,36 @@ async def test_scan_identifies_by_name_and_flags_unknown(db, tmp_path) -> None:
     assert summary2.retried == 1 and summary2.unidentified == 1
 
 
+async def test_scan_persists_file_mtime(db, tmp_path) -> None:
+    """扫描落 mtime（issue #88）：入账时随 stat 顺手记录 file_mtime_ns，
+    播放接口的 ETag 由它派生，浏览请求不再对媒体文件本体做文件系统调用。
+    特性上线前的旧行（NULL）由重扫的秒过分支一次性回填。"""
+    root = _make_tv_library(tmp_path)
+    async with db.session() as session:
+        library = await LibraryRepository(session).create(
+            name="剧集库", kind="tv", root_paths=[str(root)]
+        )
+    await scan_library(library.id)
+
+    async with db.session() as session:
+        files = list((await session.execute(select(LibraryFile))).scalars().all())
+        assert files and all(f.file_mtime_ns is not None for f in files)
+        for f in files:
+            assert f.file_mtime_ns == Path(f.file_path).stat().st_mtime_ns
+        # 模拟特性上线前的旧行：清掉 mtime
+        for f in files:
+            f.file_mtime_ns = None
+        await session.commit()
+
+    # 重扫：已识别行仍秒过，但 NULL 的 mtime 被顺手回填
+    summary = await scan_library(library.id)
+    assert summary.skipped_known == 2
+    async with db.session() as session:
+        files = list((await session.execute(select(LibraryFile))).scalars().all())
+        identified = [f for f in files if f.media_item_id is not None]
+        assert all(f.file_mtime_ns is not None for f in identified)
+
+
 async def test_scan_survives_paths_ledgered_under_another_library(db, tmp_path) -> None:
     """事故回归：路径已挂在另一个库名下时，扫描不得整轮崩掉。
 

--- a/tests/jellyfin/test_audit_regressions.py
+++ b/tests/jellyfin/test_audit_regressions.py
@@ -339,3 +339,72 @@ def test_person_item_and_filter(client: TestClient, seeded: dict) -> None:
     # 头像：测试环境图床离线 → 404 优雅降级（生产为图片代理缓存直出）
     avatar = client.get(f"/Items/{pguid}/Images/Primary", params={"ApiKey": token})
     assert avatar.status_code == 404
+
+
+def test_browse_never_touches_media_files(client: TestClient, seeded: dict) -> None:
+    """issue #88 回归：浏览类请求（列表/详情）不碰媒体文件本体。
+
+    把磁盘上的媒体文件全部删掉后再浏览——若代码仍在请求期 stat 文件或
+    现读 strm，这里的形态就会变（ETag 现身/消失、strm 源被剔除）。契约：
+
+    - strm 版本**不现读**：Path 保持 .strm 占位路径、Protocol=Http、
+      IsRemote=true，真实直链等 PlaybackInfo 播放协商时现读；
+    - 本地版本的 ETag 只来自台账 ``file_mtime_ns``（未回填时省略）。
+    """
+    import os
+    import sqlite3
+    from pathlib import Path
+
+    token = jf_login(client)
+    guid = item_guid(seeded["movie"])
+
+    db_path = os.environ["DATABASE_URL"].split("///", 1)[1]
+    with sqlite3.connect(db_path) as conn:
+        paths = [r[0] for r in conn.execute("SELECT file_path FROM library_file")]
+    for p in paths:
+        Path(p).unlink()
+
+    # 全字段单条目：MediaSources 两个版本俱在，strm 未被解析/剔除
+    body = client.get(f"/Items/{guid}", params={"ApiKey": token}).json()
+    sources = body["MediaSources"]
+    assert len(sources) == 2
+    remote = next(s for s in sources if s["Protocol"] == "Http")
+    assert remote["Path"].endswith(".strm")  # 占位路径，未现读云端直链
+    assert remote["IsRemote"] is True
+    local = next(s for s in sources if s["Protocol"] == "File")
+    assert "ETag" not in local  # mtime 未回填 → 省略，而不是现场 stat
+
+    # 列表带 fields=MediaSources 同样不碰文件
+    listing = client.get(
+        "/Items",
+        params={
+            "ApiKey": token,
+            "parentId": library_guid(seeded["movie_lib"]),
+            "recursive": "true",
+            "includeItemTypes": "Movie",
+            "fields": "MediaSources",
+        },
+    ).json()
+    assert len(listing["Items"][0]["MediaSources"]) == 2
+
+
+def test_media_source_etag_comes_from_ledger(client: TestClient, seeded: dict) -> None:
+    """ETag 由台账 file_mtime_ns 派生（扫描时落库），请求期零文件系统调用。"""
+    import hashlib
+    import os
+    import sqlite3
+
+    token = jf_login(client)
+    guid = item_guid(seeded["movie"])
+
+    db_path = os.environ["DATABASE_URL"].split("///", 1)[1]
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE library_file SET file_mtime_ns = 1723800000123456789 "
+            "WHERE file_path LIKE '%.mkv'"
+        )
+        conn.commit()
+
+    body = client.get(f"/Items/{guid}", params={"ApiKey": token}).json()
+    local = next(s for s in body["MediaSources"] if s["Protocol"] == "File")
+    assert local["ETag"] == hashlib.md5(b"1723800000123456789").hexdigest()


### PR DESCRIPTION
issue #88：vidhub 打开 1200 部电影的库要 22.8 秒。根因是列表/详情请求
对每个条目做同步文件系统调用（云盘挂载上一次 stat/读文件就是一次网络
往返）：MediaSource ETag 现场 stat 媒体文件、strm 逐个现读解析直链、
图片 tag 现场 stat 资产文件，且演职员 join 无条件全量装载。

确立"浏览零媒体 IO"原则——入库后除非用户主动扫描/刷新，浏览请求不对
媒体目录做任何文件系统调用，请求期需要的数据一律在扫描/入库时落库：

- library_file 新增 file_mtime_ns 列（向前兼容迁移）：扫描/入库随 stat
  顺手落库，ETag 由它派生；旧行 NULL 时省略 ETag，重扫秒过分支一次性回填
- strm 只在播放场景（PlaybackInfo / stream 302）现读；浏览场景的
  MediaSources 保留占位路径不读文件
- 图片 tag 改由资产相对路径 + 所属行 updated_at 派生，零 stat
- load_bundles 演职员按 fields=People 门控装载，列表默认不再拖
  条目数 × 十余人的 join
- 详情页不再触发 ffprobe 补探（浏览读媒体文件在云盘上就是流量），
  未探测的文件由前端提示重新扫描，扫描的补探阶段统一回填

1200 部电影实测：请求期文件系统调用 3600 次 → 0 次；模拟 5ms/次的
网络挂载延迟下 DTO 构建 19.9s → 0.08s，整条请求降至亚秒级。

Fixes #88

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UphG6oxZwW3iYvEwa1SL9c