### PR TITLE
perf(jellyfin): 优化首页媒体库查询

### DIFF
--- a/src/movieclaw_api/services/library/cover.py
+++ b/src/movieclaw_api/services/library/cover.py
@@ -20,7 +20,7 @@ import hashlib
 import logging
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from movieclaw_api.core.config import get_settings
 from movieclaw_db.engine import get_database
@@ -50,43 +50,29 @@ async def select_cover_posters(library_id: int) -> list[Path]:
     """选出该库最近入库、有本地海报资产的至多 4 部作品的海报绝对路径。"""
     root = _assets_root()
     async with get_database().session() as session:
+        # 只需要海报路径与入库时间：整行读取会反序列化每部作品的简介、演员等
+        # 大字段；VidHub 的根级 Items 每次启动都会走这里，大库上代价不可接受。
         rows = (
             await session.execute(
                 select(
-                    LibraryFile.media_item_id,
-                    LibraryFile.created_at,
-                ).where(
-                    LibraryFile.library_id == library_id,
-                    LibraryFile.media_item_id.is_not(None),
-                    LibraryFile.missing_since.is_(None),
+                    MediaMetadata.poster_file,
+                    func.max(LibraryFile.created_at).label("latest_created_at"),
                 )
+                .join(
+                    LibraryFile,
+                    LibraryFile.media_item_id == MediaMetadata.media_item_id,
+                )
+                .where(
+                    LibraryFile.library_id == library_id,
+                    LibraryFile.missing_since.is_(None),
+                    MediaMetadata.poster_file.is_not(None),
+                )
+                .group_by(MediaMetadata.media_item_id, MediaMetadata.poster_file)
+                .order_by(func.max(LibraryFile.created_at).desc())
             )
         ).all()
-        if not rows:
-            return []
-        # 每个条目取最近一次入库时间，按新→旧排
-        latest: dict[int, object] = {}
-        for item_id, created_at in rows:
-            if item_id not in latest or created_at > latest[item_id]:
-                latest[item_id] = created_at
-        ordered_ids = [i for i, _ in sorted(latest.items(), key=lambda kv: kv[1], reverse=True)]
-
-        posters = {
-            m.media_item_id: m.poster_file
-            for m in (
-                await session.execute(
-                    select(MediaMetadata).where(
-                        MediaMetadata.media_item_id.in_(ordered_ids),
-                        MediaMetadata.poster_file.is_not(None),
-                    )
-                )
-            ).scalars()
-        }
     result: list[Path] = []
-    for item_id in ordered_ids:
-        rel = posters.get(item_id)
-        if not rel:
-            continue
+    for rel, _created_at in rows:
         path = root / rel
         if path.is_file():
             result.append(path)

--- a/src/movieclaw_jellyfin/catalog.py
+++ b/src/movieclaw_jellyfin/catalog.py
@@ -7,8 +7,9 @@
     Episode = media_episode ⋈ library_file（(item, season, episode) 数字对）
 
 只输出"有文件"的内容：missing_since 非空或未识别（media_item_id NULL）的
-文件行不进任何列表。规模假设是家用 NAS（万级条目），过滤/排序/分页在
-内存完成——SQL 只做粗筛，正确性优先于极限吞吐。
+文件行不进任何列表。复杂 Jellyfin 筛选/排序仍在内存完成；首页高频的
+电影列表、Latest 与播放状态查询先在 SQL 取轻量候选，最后才水合 bundle。
+这样在不牺牲兼容性的前提下避免读取整库详情 JSON。
 """
 
 from __future__ import annotations
@@ -20,7 +21,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import load_only
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from movieclaw_db.models import (
@@ -106,12 +108,134 @@ class ItemBundle:
         return None
 
 
+@dataclass(frozen=True)
+class LatestUnitCandidate:
+    """Latest 的轻量候选行；只含排序、分组和播放过滤所需字段。"""
+
+    created_at: datetime
+    media_item_id: int
+    kind: str
+    season_number: int
+    episode_number: int
+
+
+@dataclass(frozen=True)
+class ResumeUnitCandidate:
+    """Resume 的轻量候选行，避免为未进入分页的条目水合完整 bundle。"""
+
+    media_item_id: int
+    season_number: int
+    episode_number: int
+
+
+def _list_load_columns(
+    options: DtoOptions,
+) -> tuple[list[Any], list[Any], list[Any], list[Any], list[Any]]:
+    """列举列表 DTO、筛选和排序真正会读取的列。
+
+    ``load_bundles`` 的结果会在 session 关闭后才构建 DTO，不能依赖 SQLAlchemy
+    的惰性加载；因此这个列集必须覆盖所有列表路径。演员档案、媒体流 JSON 等
+    大字段只在客户端明确请求时加入，避免大库首页白白反序列化数千段 JSON。
+    """
+    item_columns = [
+        MediaItem.id,
+        MediaItem.kind,
+        MediaItem.tmdb_id,
+        MediaItem.imdb_id,
+        MediaItem.title,
+        MediaItem.original_title,
+        MediaItem.year,
+        MediaItem.aliases,
+        MediaItem.status,
+        MediaItem.created_at,
+    ]
+    metadata_columns = [
+        MediaMetadata.id,
+        MediaMetadata.media_item_id,
+        MediaMetadata.content_rating,
+        MediaMetadata.vote_average,
+        MediaMetadata.release_date,
+        MediaMetadata.runtime_minutes,
+        MediaMetadata.genres,
+    ]
+    if options.enable_images:
+        metadata_columns.extend(
+            [
+                MediaMetadata.poster_file,
+                MediaMetadata.backdrop_file,
+                MediaMetadata.updated_at,
+            ]
+        )
+    if options.has("Overview"):
+        metadata_columns.append(MediaMetadata.overview)
+    if options.has("Studios"):
+        metadata_columns.append(MediaMetadata.studios)
+    if options.has("Taglines"):
+        metadata_columns.append(MediaMetadata.tagline)
+
+    file_columns = [
+        LibraryFile.id,
+        LibraryFile.media_item_id,
+        LibraryFile.season_number,
+        LibraryFile.episode_number,
+        LibraryFile.duration_seconds,
+        LibraryFile.created_at,
+    ]
+    if options.has("ParentId"):
+        file_columns.append(LibraryFile.library_id)
+    if options.has("MediaSources") or options.has("MediaStreams"):
+        file_columns.extend(
+            [
+                LibraryFile.file_path,
+                LibraryFile.size_bytes,
+                LibraryFile.file_mtime_ns,
+                LibraryFile.container,
+                LibraryFile.resolution,
+                LibraryFile.video_codec,
+                LibraryFile.hdr,
+                LibraryFile.bit_depth,
+                LibraryFile.bit_rate,
+                LibraryFile.audio_streams,
+                LibraryFile.subtitle_streams,
+            ]
+        )
+    elif options.has("Path"):
+        file_columns.append(LibraryFile.file_path)
+
+    season_columns = [
+        MediaSeason.id,
+        MediaSeason.media_item_id,
+        MediaSeason.season_number,
+        MediaSeason.name,
+        MediaSeason.air_date,
+    ]
+    if options.enable_images:
+        season_columns.extend([MediaSeason.poster_file, MediaSeason.updated_at])
+
+    episode_columns = [
+        MediaEpisode.id,
+        MediaEpisode.media_item_id,
+        MediaEpisode.season_number,
+        MediaEpisode.episode_number,
+        MediaEpisode.name,
+        MediaEpisode.air_date,
+        MediaEpisode.runtime_minutes,
+        MediaEpisode.vote_average,
+    ]
+    if options.enable_images:
+        episode_columns.extend([MediaEpisode.still_file, MediaEpisode.updated_at])
+    if options.has("Overview"):
+        episode_columns.append(MediaEpisode.overview)
+    return item_columns, metadata_columns, file_columns, season_columns, episode_columns
+
+
 async def load_bundles(
     session: AsyncSession,
     item_ids: list[int],
     *,
     library_id: int | None = None,
     include_people: bool = False,
+    dto_options: DtoOptions | None = None,
 ) -> dict[int, ItemBundle]:
     """批量装载条目素材。library_id 限定时只装该库的文件行。
 
@@ -119,22 +243,36 @@ async def load_bundles(
     单条目全字段）：演职员是量最大的关联（条目数 × 十余人的 join +
     ORM 水合），列表请求默认不带 fields=People，装了也是白装——1200 部
     电影的库这一项就要秒级开销（issue #88）。
+
+    ``dto_options`` 仅由列表接口传入。它触发最小列集读取，避免列表在不输出
+    演员、音轨和字幕时仍反序列化这些大 JSON 列；全字段详情和未迁移的调用
+    保持原有整行读取语义。
     """
     if not item_ids:
         return {}
+    summary_columns = (
+        _list_load_columns(dto_options)
+        if dto_options is not None and not dto_options.all_fields
+        else None
+    )
+    if dto_options is not None:
+        include_people = include_people or dto_options.has("People")
+
+    item_q = select(MediaItem).where(MediaItem.id.in_(item_ids))
+    if summary_columns is not None:
+        item_q = item_q.options(load_only(*summary_columns[0]))
     items = (
-        (await session.execute(select(MediaItem).where(MediaItem.id.in_(item_ids))))
+        (await session.execute(item_q))
         .scalars()
         .all()
     )
     bundles = {i.id: ItemBundle(item=i) for i in items}
 
+    metadata_q = select(MediaMetadata).where(MediaMetadata.media_item_id.in_(item_ids))
+    if summary_columns is not None:
+        metadata_q = metadata_q.options(load_only(*summary_columns[1]))
     metas = (
-        (
-            await session.execute(
-                select(MediaMetadata).where(MediaMetadata.media_item_id.in_(item_ids))
-            )
-        )
+        (await session.execute(metadata_q))
         .scalars()
         .all()
     )
@@ -148,6 +286,8 @@ async def load_bundles(
     )
     if library_id is not None:
         file_q = file_q.where(LibraryFile.library_id == library_id)
+    if summary_columns is not None:
+        file_q = file_q.options(load_only(*summary_columns[2]))
     for f in (await session.execute(file_q)).scalars():
         b = bundles.get(f.media_item_id)
         if b is not None:
@@ -155,17 +295,15 @@ async def load_bundles(
 
     tv_ids = [i.id for i in items if i.kind == "tv"]
     if tv_ids:
-        for s in (
-            await session.execute(
-                select(MediaSeason).where(MediaSeason.media_item_id.in_(tv_ids))
-            )
-        ).scalars():
+        season_q = select(MediaSeason).where(MediaSeason.media_item_id.in_(tv_ids))
+        if summary_columns is not None:
+            season_q = season_q.options(load_only(*summary_columns[3]))
+        for s in (await session.execute(season_q)).scalars():
             bundles[s.media_item_id].seasons[s.season_number] = s
-        for e in (
-            await session.execute(
-                select(MediaEpisode).where(MediaEpisode.media_item_id.in_(tv_ids))
-            )
-        ).scalars():
+        episode_q = select(MediaEpisode).where(MediaEpisode.media_item_id.in_(tv_ids))
+        if summary_columns is not None:
+            episode_q = episode_q.options(load_only(*summary_columns[4]))
+        for e in (await session.execute(episode_q)).scalars():
             bundles[e.media_item_id].episodes[(e.season_number, e.episode_number)] = e
 
     for st in (
@@ -198,6 +336,194 @@ async def load_bundles(
 
     # 没有任何在位文件的条目不对外呈现
     return {k: v for k, v in bundles.items() if v.files}
+
+
+async def latest_unit_candidates(
+    session: AsyncSession,
+    *,
+    library_id: int | None = None,
+    is_played: bool | None = None,
+) -> list[LatestUnitCandidate]:
+    """只查询 Latest 的排序单元，延后到选页后再装载 bundle。
+
+    旧路径先把整个库的 ``MediaItem``、元数据、文件和播放状态全部水合，
+    然后才按 ``created_at`` 排序并取 20 条。这里把同一条目/季/集的文件
+    聚合成一行，播放状态也在数据库侧筛掉；返回固定的小标量列，不会
+    触发列表 DTO 不需要的 JSON 反序列化。``min(file.id)`` 只用于复现旧
+    路径在入库时间相同的情况下的稳定顺序，不参与业务语义。
+    """
+    latest_created = func.max(LibraryFile.created_at).label("latest_created")
+    q = (
+        select(
+            LibraryFile.media_item_id,
+            LibraryFile.season_number,
+            LibraryFile.episode_number,
+            MediaItem.kind,
+            latest_created,
+        )
+        .join(MediaItem, MediaItem.id == LibraryFile.media_item_id)
+        .where(
+            LibraryFile.media_item_id.is_not(None),
+            LibraryFile.missing_since.is_(None),
+        )
+    )
+    if library_id is not None:
+        q = q.where(LibraryFile.library_id == library_id)
+    if is_played is not None:
+        q = q.outerjoin(
+            PlaybackState,
+            and_(
+                PlaybackState.media_item_id == LibraryFile.media_item_id,
+                PlaybackState.season_number == LibraryFile.season_number,
+                PlaybackState.episode_number == LibraryFile.episode_number,
+            ),
+        )
+        if is_played:
+            q = q.where(PlaybackState.played.is_(True))
+        else:
+            q = q.where(
+                or_(PlaybackState.id.is_(None), PlaybackState.played.is_(False))
+            )
+    q = q.group_by(
+        LibraryFile.media_item_id,
+        LibraryFile.season_number,
+        LibraryFile.episode_number,
+        MediaItem.kind,
+    ).order_by(
+        latest_created.desc(),
+        func.min(LibraryFile.id).asc(),
+        LibraryFile.media_item_id.asc(),
+        LibraryFile.season_number.asc(),
+        LibraryFile.episode_number.asc(),
+    )
+    rows = (await session.execute(q)).all()
+    return [
+        LatestUnitCandidate(
+            created_at=row.latest_created,
+            media_item_id=row.media_item_id,
+            kind=row.kind,
+            season_number=row.season_number,
+            episode_number=row.episode_number,
+        )
+        for row in rows
+    ]
+
+
+async def resume_unit_candidates(session: AsyncSession) -> list[ResumeUnitCandidate]:
+    """查询有续播位置且文件仍在位的单元，不加载未进入结果页的 bundle。"""
+    file_exists = (
+        select(LibraryFile.id)
+        .where(
+            LibraryFile.media_item_id == PlaybackState.media_item_id,
+            LibraryFile.season_number == PlaybackState.season_number,
+            LibraryFile.episode_number == PlaybackState.episode_number,
+            LibraryFile.missing_since.is_(None),
+        )
+        .exists()
+    )
+    q = (
+        select(
+            PlaybackState.media_item_id,
+            PlaybackState.season_number,
+            PlaybackState.episode_number,
+        )
+        .join(MediaItem, MediaItem.id == PlaybackState.media_item_id)
+        .where(
+            PlaybackState.position_ms > 0,
+            file_exists,
+            or_(
+                and_(
+                    MediaItem.kind == "movie",
+                    PlaybackState.season_number == 0,
+                    PlaybackState.episode_number == 0,
+                ),
+                MediaItem.kind == "tv",
+            ),
+        )
+        .order_by(
+            func.coalesce(PlaybackState.last_played_at, MediaItem.created_at).desc(),
+            PlaybackState.media_item_id.asc(),
+            PlaybackState.season_number.asc(),
+            PlaybackState.episode_number.asc(),
+        )
+    )
+    rows = (await session.execute(q)).all()
+    return [
+        ResumeUnitCandidate(
+            media_item_id=row.media_item_id,
+            season_number=row.season_number,
+            episode_number=row.episode_number,
+        )
+        for row in rows
+    ]
+
+
+async def next_up_item_ids(
+    session: AsyncSession, *, series_id: int | None = None
+) -> list[int]:
+    """返回有在位文件和播放活动的剧集 id，供 NextUp 延后加载。"""
+    file_exists = (
+        select(LibraryFile.id)
+        .where(
+            LibraryFile.media_item_id == PlaybackState.media_item_id,
+            LibraryFile.season_number == PlaybackState.season_number,
+            LibraryFile.episode_number == PlaybackState.episode_number,
+            LibraryFile.missing_since.is_(None),
+        )
+        .exists()
+    )
+    q = (
+        select(PlaybackState.media_item_id)
+        .join(MediaItem, MediaItem.id == PlaybackState.media_item_id)
+        .where(
+            MediaItem.kind == "tv",
+            PlaybackState.season_number != 0,
+            or_(PlaybackState.played.is_(True), PlaybackState.position_ms > 0),
+            file_exists,
+        )
+        .distinct()
+        .order_by(PlaybackState.media_item_id.asc())
+    )
+    if series_id is not None:
+        q = q.where(PlaybackState.media_item_id == series_id)
+    return list((await session.execute(q)).scalars())
+
+
+async def movie_library_page(
+    session: AsyncSession,
+    library_id: int,
+    *,
+    start_index: int,
+    limit: int,
+) -> tuple[int, list[int]]:
+    """电影库无筛选列表的 SQL 计数和分页，只返回最终要装载的条目 id。"""
+    file_exists = (
+        select(LibraryFile.id)
+        .where(
+            LibraryFile.library_id == library_id,
+            LibraryFile.media_item_id == MediaItem.id,
+            LibraryFile.season_number == 0,
+            LibraryFile.episode_number == 0,
+            LibraryFile.missing_since.is_(None),
+        )
+        .exists()
+    )
+    condition = and_(MediaItem.kind == "movie", file_exists)
+    total = int(
+        (
+            await session.execute(
+                select(func.count()).select_from(MediaItem).where(condition)
+            )
+        ).scalar_one()
+    )
+    q = (
+        select(MediaItem.id)
+        .where(condition)
+        .order_by(MediaItem.id.asc())
+        .offset(start_index)
+        .limit(limit)
+    )
+    return total, list((await session.execute(q)).scalars())
 
 
 async def item_ids_with_files(
@@ -467,7 +793,8 @@ def movie_dto(ctx: DtoContext, bundle: ItemBundle, options: DtoOptions) -> dict[
     _apply_metadata_fields(dto, bundle, options)
     _apply_provider_ids(dto, bundle, options)
     _apply_item_images(dto, ctx, bundle, options)
-    _apply_parent_id(dto, _item_library_guid(bundle), options)
+    if options.has("ParentId"):
+        _apply_parent_id(dto, _item_library_guid(bundle), options)
     _apply_people(dto, bundle, options)
     if options.has("Path"):
         files = bundle.files.get((0, 0), [])
@@ -504,7 +831,8 @@ def series_dto(ctx: DtoContext, bundle: ItemBundle, options: DtoOptions) -> dict
     _apply_metadata_fields(dto, bundle, options)
     _apply_provider_ids(dto, bundle, options)
     _apply_item_images(dto, ctx, bundle, options)
-    _apply_parent_id(dto, _item_library_guid(bundle), options)
+    if options.has("ParentId"):
+        _apply_parent_id(dto, _item_library_guid(bundle), options)
     _apply_people(dto, bundle, options)
     if options.has("ChildCount"):
         dto["ChildCount"] = len({s for s, _ in bundle.units})
@@ -581,7 +909,7 @@ def episode_dto(
     runtime_ms = bundle.unit_runtime_ms(season, episode)
     if runtime_ms:
         dto["RunTimeTicks"] = runtime_ms * TICKS_PER_MS
-    if row and row.overview and options.has("Overview"):
+    if options.has("Overview") and row and row.overview:
         dto["Overview"] = row.overview
     if row and row.vote_average and row.vote_average > 0:
         dto["CommunityRating"] = round(row.vote_average, 1)

--- a/src/movieclaw_jellyfin/routes/library.py
+++ b/src/movieclaw_jellyfin/routes/library.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import logging
+from time import perf_counter
 from typing import Any
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -18,13 +20,19 @@ from movieclaw_jellyfin.catalog import (
     DtoContext,
     DtoOptions,
     ItemBundle,
+    LatestUnitCandidate,
+    ResumeUnitCandidate,
     episode_dto,
     item_ids_with_files,
+    latest_unit_candidates,
     library_view_dto,
     list_libraries,
     load_bundles,
     load_library_stats,
     movie_dto,
+    movie_library_page,
+    next_up_item_ids,
+    resume_unit_candidates,
     season_dto,
     series_dto,
 )
@@ -46,9 +54,78 @@ from movieclaw_jellyfin.routes.common import (
 from movieclaw_jellyfin.security import require_device
 
 router = APIRouter(dependencies=[Depends(require_device)])
+logger = logging.getLogger("movieclaw_jellyfin.library")
+
+# 正常大库请求应进入亚秒级；只记录越线请求，既保留部署侧定位证据，也避免
+# VidHub 的高频首页轮询淹没访问日志。
+SLOW_BROWSE_REQUEST_MS = 1_000
+
+# 仅记录协议中实际支持且不携带用户内容的字段名。fields 是客户端原样输入，
+# 不能直接写日志：未知字段可能被用来夹带标题、路径或令牌。
+_LOG_SAFE_FIELDS = frozenset(
+    {
+        "ChildCount",
+        "DateCreated",
+        "Genres",
+        "MediaSources",
+        "MediaStreams",
+        "OriginalTitle",
+        "Overview",
+        "ParentId",
+        "Path",
+        "People",
+        "ProviderIds",
+        "RecursiveItemCount",
+        "Studios",
+        "Taglines",
+    }
+)
 
 # (type, bundle, season, episode)：查询管线里的一条候选
 Entry = tuple[str, ItemBundle, int, int]
+
+
+def _logged_field_summary(options: DtoOptions) -> str:
+    """返回不含客户端原始内容的字段摘要，供慢请求日志使用。"""
+    known = sorted(options.fields & _LOG_SAFE_FIELDS)
+    unknown_count = len(options.fields - _LOG_SAFE_FIELDS)
+    if unknown_count:
+        known.append(f"other={unknown_count}")
+    return ",".join(known) or "-"
+
+
+def _log_slow_browse(
+    *,
+    route: str,
+    scope: str,
+    options: DtoOptions,
+    candidates: int,
+    returned: int,
+    load_ms: float,
+    build_ms: float,
+    encode_ms: float,
+    cover_ms: float = 0,
+    started_at: float,
+) -> None:
+    """只为慢首页请求输出脱敏的分段耗时，辅助定位部署环境差异。"""
+    total_ms = (perf_counter() - started_at) * 1000
+    if total_ms < SLOW_BROWSE_REQUEST_MS:
+        return
+    logger.warning(
+        "Jellyfin 媒体库浏览请求较慢：route=%s scope=%s fields=%s "
+        "candidates=%d returned=%d load_ms=%.2f build_ms=%.2f encode_ms=%.2f "
+        "cover_ms=%.2f total_ms=%.2f",
+        route,
+        scope,
+        _logged_field_summary(options),
+        candidates,
+        returned,
+        load_ms,
+        build_ms,
+        encode_ms,
+        cover_ms,
+        total_ms,
+    )
 
 
 async def _items_with_persons(
@@ -272,6 +349,7 @@ def _entry_dto(ctx: DtoContext, entry: Entry, options: DtoOptions) -> dict[str, 
 
 
 async def _query_items(request: Request) -> JSONResponse:
+    started_at = perf_counter()
     q = request.query_params
     ctx = await dto_context()
     options = dto_options(
@@ -285,11 +363,63 @@ async def _query_items(request: Request) -> JSONResponse:
     parent_raw = q.get("parentId")
     ids_raw = parse_comma(q.get("ids"))
     search_term = q.get("searchTerm")
+    person_ids_raw = parse_comma(q.get("personIds"))
+    start_index = _parse_int(q.get("startIndex"))
+    limit = _parse_int(q.get("limit"), default=-1)
+    sort_by = parse_comma(q.get("sortBy"))
+    sort_order = parse_comma(q.get("sortOrder"))
 
-    include_people = options.has("People")
+    # 电影库的默认列表只需条目 id 和文件存在性；在没有筛选、排序和
+    # personIds 时，数据库即可完成 count/offset/limit，最终页才水合 bundle。
+    simple_movie_page = False
+    simple_total = 0
+
+    load_started_at = perf_counter()
     async with get_database().session() as session:
-        if ids_raw:
-            entries = await _entries_for_ids(session, ids_raw, include_people=include_people)
+        page_entries: list[Entry] | None = None
+        parent_ref = decode_guid(parent_raw or "") if parent_raw else None
+        can_page_movies = (
+            not ids_raw
+            and parent_ref is not None
+            and parent_ref.kind == EntityKind.LIBRARY
+            and include_types in (set(), {"Movie"})
+            and not exclude_types
+            and not search_term
+            and not parse_comma(q.get("years"))
+            and not parse_pipe(q.get("genres"))
+            and not parse_pipe(q.get("officialRatings"))
+            and not parse_comma(q.get("filters"))
+            and parse_bool(q.get("isPlayed")) is None
+            and parse_bool(q.get("isFavorite")) is not True
+            and not person_ids_raw
+            and not sort_by
+            and start_index >= 0
+            and limit >= 0
+        )
+        if can_page_movies and parent_ref is not None:
+            library = await session.get(Library, parent_ref.entity_id)
+            can_page_movies = library is not None and library.kind == "movie"
+        if can_page_movies and parent_ref is not None:
+            simple_total, page_ids = await movie_library_page(
+                session,
+                parent_ref.entity_id,
+                start_index=start_index,
+                limit=limit,
+            )
+            bundles = await load_bundles(
+                session,
+                page_ids,
+                library_id=parent_ref.entity_id,
+                dto_options=options,
+            )
+            page_entries = [
+                ("Movie", bundles[item_id], 0, 0)
+                for item_id in page_ids
+                if item_id in bundles and (0, 0) in bundles[item_id].files
+            ]
+            simple_movie_page = True
+        elif ids_raw:
+            entries = await _entries_for_ids(session, ids_raw, options=options)
         else:
             entries = await _entries_for_parent(
                 session,
@@ -297,76 +427,112 @@ async def _query_items(request: Request) -> JSONResponse:
                 include_types=include_types,
                 recursive=recursive,
                 has_search=bool(search_term),
-                include_people=include_people,
+                options=options,
             )
             if entries is None:
                 # 根级：返回视图列表
                 libraries = await list_libraries(session)
                 stats = await load_library_stats(session)
+                load_ms = (perf_counter() - load_started_at) * 1000
+                cover_started_at = perf_counter()
                 dtos = [
                     library_view_dto(
                         ctx, lib, stats.get(lib.id), await _cover_tag(lib.id)
                     )
                     for lib in libraries
                 ]
-                return JSONResponse(query_result(dtos, len(dtos)))
+                cover_ms = (perf_counter() - cover_started_at) * 1000
+                response_started_at = perf_counter()
+                response = JSONResponse(query_result(dtos, len(dtos)))
+                _log_slow_browse(
+                    route="items",
+                    scope="root",
+                    options=options,
+                    candidates=len(libraries),
+                    returned=len(dtos),
+                    load_ms=load_ms,
+                    build_ms=0,
+                    encode_ms=(perf_counter() - response_started_at) * 1000,
+                    cover_ms=cover_ms,
+                    started_at=started_at,
+                )
+                return response
 
-        person_ids_raw = parse_comma(q.get("personIds"))
-        if person_ids_raw:
+        if not simple_movie_page and person_ids_raw:
             member_ids = await _items_with_persons(session, person_ids_raw)
             entries = [e for e in entries if e[1].item.id in member_ids]
+    load_ms = (perf_counter() - load_started_at) * 1000
+    build_started_at = perf_counter()
 
-    if exclude_types:
-        entries = [e for e in entries if e[0] not in exclude_types]
+    if simple_movie_page:
+        entries = page_entries or []
+        total = simple_total
+        page = entries
+    else:
+        if exclude_types:
+            entries = [e for e in entries if e[0] not in exclude_types]
 
-    # ---- 过滤 -------------------------------------------------------------
-    if search_term:
-        entries = [e for e in entries if _search_match(e[1], search_term)]
-    years = {int(y) for y in parse_comma(q.get("years")) if y.isdigit()}
-    if years:
-        entries = [e for e in entries if e[1].item.year in years]
-    genres = set(parse_pipe(q.get("genres")))
-    if genres:
-        entries = [
-            e
-            for e in entries
-            if e[1].metadata and genres & set(e[1].metadata.genres or [])
-        ]
-    ratings = set(parse_pipe(q.get("officialRatings")))
-    if ratings:
-        entries = [
-            e for e in entries if e[1].metadata and e[1].metadata.content_rating in ratings
-        ]
+        # ---- 过滤 ---------------------------------------------------------
+        if search_term:
+            entries = [e for e in entries if _search_match(e[1], search_term)]
+        years = {int(y) for y in parse_comma(q.get("years")) if y.isdigit()}
+        if years:
+            entries = [e for e in entries if e[1].item.year in years]
+        genres = set(parse_pipe(q.get("genres")))
+        if genres:
+            entries = [
+                e
+                for e in entries
+                if e[1].metadata and genres & set(e[1].metadata.genres or [])
+            ]
+        ratings = set(parse_pipe(q.get("officialRatings")))
+        if ratings:
+            entries = [
+                e
+                for e in entries
+                if e[1].metadata and e[1].metadata.content_rating in ratings
+            ]
 
-    filters = set(parse_comma(q.get("filters")))
-    is_played = parse_bool(q.get("isPlayed"))
-    if "IsPlayed" in filters or is_played is True:
-        entries = [e for e in entries if _entry_played(e)]
-    if "IsUnplayed" in filters or is_played is False:
-        entries = [e for e in entries if not _entry_played(e)]
-    if "IsResumable" in filters:
-        entries = [e for e in entries if _entry_resumable(e)]
-    if "IsFavorite" in filters or parse_bool(q.get("isFavorite")) is True:
-        entries = [e for e in entries if _entry_favorite(e)]
+        filters = set(parse_comma(q.get("filters")))
+        is_played = parse_bool(q.get("isPlayed"))
+        if "IsPlayed" in filters or is_played is True:
+            entries = [e for e in entries if _entry_played(e)]
+        if "IsUnplayed" in filters or is_played is False:
+            entries = [e for e in entries if not _entry_played(e)]
+        if "IsResumable" in filters:
+            entries = [e for e in entries if _entry_resumable(e)]
+        if "IsFavorite" in filters or parse_bool(q.get("isFavorite")) is True:
+            entries = [e for e in entries if _entry_favorite(e)]
 
-    # ---- 排序 / 分页 / DTO -------------------------------------------------
-    entries = _sort_entries(
-        entries, parse_comma(q.get("sortBy")), parse_comma(q.get("sortOrder"))
-    )
-    total = len(entries)
-    start_index = _parse_int(q.get("startIndex"))
-    limit = _parse_int(q.get("limit"), default=-1)
-    page = entries[start_index : start_index + limit] if limit >= 0 else entries[start_index:]
+        # ---- 排序 / 分页 / DTO -------------------------------------------
+        entries = _sort_entries(entries, sort_by, sort_order)
+        total = len(entries)
+        page = entries[start_index : start_index + limit] if limit >= 0 else entries[start_index:]
+
     dtos = [_entry_dto(ctx, e, options) for e in page]
-    return JSONResponse(query_result(dtos, total, start_index))
+    build_ms = (perf_counter() - build_started_at) * 1000
+    response_started_at = perf_counter()
+    response = JSONResponse(query_result(dtos, total, start_index))
+    _log_slow_browse(
+        route="items",
+        scope="ids" if ids_raw else ("parent" if parent_raw else "root"),
+        options=options,
+        candidates=total,
+        returned=len(dtos),
+        load_ms=load_ms,
+        build_ms=build_ms,
+        encode_ms=(perf_counter() - response_started_at) * 1000,
+        started_at=started_at,
+    )
+    return response
 
 
 async def _entries_for_ids(
-    session: AsyncSession, ids_raw: list[str], *, include_people: bool = False
+    session: AsyncSession, ids_raw: list[str], *, options: DtoOptions
 ) -> list[Entry]:
     refs = [r for r in (decode_guid(i) for i in ids_raw) if r is not None]
     scoped = {r.entity_id for r in refs if r.kind != EntityKind.LIBRARY}
-    bundles = await load_bundles(session, list(scoped), include_people=include_people)
+    bundles = await load_bundles(session, list(scoped), dto_options=options)
     entries: list[Entry] = []
     for ref in refs:
         bundle = bundles.get(ref.entity_id)
@@ -390,7 +556,7 @@ async def _entries_for_parent(
     include_types: set[str],
     recursive: bool | None,
     has_search: bool,
-    include_people: bool = False,
+    options: DtoOptions,
 ) -> list[Entry] | None:
     """按 parentId 语义展开候选。返回 None 表示"根级 → 视图列表"。"""
     if not parent_raw or is_empty_guid(parent_raw):
@@ -398,7 +564,7 @@ async def _entries_for_parent(
             # 无 parent 的全局搜索/类型查询：跨全部库递归
             types = include_types or {"Movie", "Series"}
             ids = await item_ids_with_files(session)
-            bundles = await load_bundles(session, ids, include_people=include_people)
+            bundles = await load_bundles(session, ids, dto_options=options)
             return _build_entries(bundles, types)
         return None
 
@@ -427,17 +593,17 @@ async def _entries_for_parent(
             types = (include_types & default_types) if include_types else default_types
         ids = await item_ids_with_files(session, library_id=ref.entity_id)
         bundles = await load_bundles(
-            session, ids, library_id=ref.entity_id, include_people=include_people
+            session, ids, library_id=ref.entity_id, dto_options=options
         )
         return _build_entries(bundles, types)
 
     if ref.kind == EntityKind.ITEM:
-        bundles = await load_bundles(session, [ref.entity_id], include_people=include_people)
+        bundles = await load_bundles(session, [ref.entity_id], dto_options=options)
         types = include_types or {"Season"}
         return _build_entries(bundles, types)
 
     if ref.kind == EntityKind.SEASON:
-        bundles = await load_bundles(session, [ref.entity_id], include_people=include_people)
+        bundles = await load_bundles(session, [ref.entity_id], dto_options=options)
         return _build_entries(bundles, {"Episode"}, season_scope=ref.season)
 
     raise not_found()
@@ -462,6 +628,7 @@ async def items_latest(
     limit: int = Query(default=20),
     groupItems: bool = Query(default=True),  # noqa: N803 —— 对齐协议参数名
 ) -> JSONResponse:
+    started_at = perf_counter()
     q = request.query_params
     ctx = await dto_context()
     options = dto_options(
@@ -479,57 +646,82 @@ async def items_latest(
     if is_played is None:
         is_played = False  # HidePlayedInLatest=True 的默认语义
 
+    load_started_at = perf_counter()
     async with get_database().session() as session:
-        ids = await item_ids_with_files(session, library_id=library_id)
-        bundles = await load_bundles(
-            session, ids, library_id=library_id, include_people=options.has("People")
+        # 先读每个最新单元的 5 个标量列；只有通过 limit/groupItems 的最终
+        # 条目才进入 load_bundles。这样 1200 部电影不会先水合整库 JSON。
+        latest_units = await latest_unit_candidates(
+            session, library_id=library_id, is_played=is_played
         )
+        selected_units: list[LatestUnitCandidate] = []
+        grouped_series: dict[int, int] = {}
+        for candidate in latest_units:
+            if len(selected_units) >= limit:
+                break
+            if candidate.kind == "movie":
+                selected_units.append(candidate)
+                continue
+            # 剧集：两态简化（设计文档偏离⑥），同剧多集新入库聚合为 Series。
+            if not groupItems:
+                selected_units.append(candidate)
+                continue
+            if candidate.media_item_id in grouped_series:
+                grouped_series[candidate.media_item_id] += 1
+                continue
+            grouped_series[candidate.media_item_id] = 1
+            selected_units.append(candidate)
 
-    # 每个"最新单元"= 文件入库时间最大的 (bundle, season, episode)
-    latest_units: list[tuple[Any, ItemBundle, int, int]] = []
-    for bundle in bundles.values():
-        for (season, episode), files in bundle.files.items():
-            created = max(f.created_at for f in files)
-            latest_units.append((created, bundle, season, episode))
-    latest_units.sort(key=lambda t: t[0], reverse=True)
+        selected_ids = list(dict.fromkeys(c.media_item_id for c in selected_units))
+        bundles = await load_bundles(
+            session,
+            selected_ids,
+            library_id=library_id,
+            dto_options=options,
+        )
+    load_ms = (perf_counter() - load_started_at) * 1000
+    build_started_at = perf_counter()
 
     dtos: list[dict[str, Any]] = []
-    grouped_series: dict[int, int] = {}
-    for _created, bundle, season, episode in latest_units:
-        if len(dtos) >= limit:
-            break
-        if bundle.item.kind == "movie":
-            entry: Entry = ("Movie", bundle, 0, 0)
-            if is_played is not None and _entry_played(entry) is not is_played:
-                continue
+    dto_candidates: list[LatestUnitCandidate] = []
+    for candidate in selected_units:
+        bundle = bundles.get(candidate.media_item_id)
+        if bundle is None:
+            continue
+        season = candidate.season_number
+        episode = candidate.episode_number
+        if candidate.kind == "movie":
             dtos.append(movie_dto(ctx, bundle, options))
-            continue
-        # 剧集：两态简化（设计文档偏离⑥）——同剧多集新入库聚合为 Series
-        entry = ("Episode", bundle, season, episode)
-        if is_played is not None and _entry_played(entry) is not is_played:
-            continue
-        if not groupItems:
+        else:
             dtos.append(episode_dto(ctx, bundle, season, episode, options))
-            continue
-        if bundle.item.id in grouped_series:
-            grouped_series[bundle.item.id] += 1
-            continue
-        grouped_series[bundle.item.id] = 1
-        dtos.append(episode_dto(ctx, bundle, season, episode, options))
+        dto_candidates.append(candidate)
 
     if groupItems:
         # 同剧 ≥2 个新单元 → 用 Series 条目替换该剧的 Episode 占位
-        for i, dto in enumerate(dtos):
+        for i, (candidate, dto) in enumerate(zip(dto_candidates, dtos, strict=True)):
             if dto.get("Type") != "Episode":
                 continue
-            ref = decode_guid(dto["SeriesId"])
-            if ref and grouped_series.get(ref.entity_id, 0) > 1:
-                bundle = bundles[ref.entity_id]
+            count = grouped_series.get(candidate.media_item_id, 0)
+            if count > 1:
+                bundle = bundles[candidate.media_item_id]
                 series = series_dto(ctx, bundle, options)
-                series["ChildCount"] = grouped_series[ref.entity_id]
+                series["ChildCount"] = count
                 dtos[i] = series
 
-    return JSONResponse(dtos)
+    build_ms = (perf_counter() - build_started_at) * 1000
+    response_started_at = perf_counter()
+    response = JSONResponse(dtos)
+    _log_slow_browse(
+        route="latest",
+        scope="parent" if library_id is not None else "all_libraries",
+        options=options,
+        candidates=len(latest_units),
+        returned=len(dtos),
+        load_ms=load_ms,
+        build_ms=build_ms,
+        encode_ms=(perf_counter() - response_started_at) * 1000,
+        started_at=started_at,
+    )
+    return response
 
 
 @router.get("/UserItems/Resume")
@@ -543,29 +735,44 @@ async def items_resume(request: Request, user_id: str | None = None) -> JSONResp
         enable_images=q.get("enableImages"),
     )
     media_types = set(parse_comma(q.get("mediaTypes")))
-
-    async with get_database().session() as session:
-        ids = await item_ids_with_files(session)
-        bundles = await load_bundles(session, ids, include_people=options.has("People"))
-
-    entries = _build_entries(bundles, {"Movie", "Episode"})
-    if media_types and "Video" not in media_types:
-        entries = []
-    # 服务端强制语义：可续播 = 位置 > 0；按最近播放降序（客户端不可覆盖）
-    resumable = [e for e in entries if _entry_resumable(e)]
-    resumable.sort(
-        key=lambda e: e[1].state(e[2], e[3]).last_played_at or e[1].item.created_at,
-        reverse=True,
-    )
-
-    total = len(resumable)
     start_index = _parse_int(q.get("startIndex"))
     limit = _parse_int(q.get("limit"), default=-1)
-    page = (
-        resumable[start_index : start_index + limit]
-        if limit >= 0
-        else resumable[start_index:]
-    )
+    candidates: list[ResumeUnitCandidate] = []
+    if not media_types or "Video" in media_types:
+        async with get_database().session() as session:
+            # 播放状态表通常远小于媒体库；只为有续播点的单元查询 bundle。
+            candidates = await resume_unit_candidates(session)
+            page_candidates = (
+                candidates[start_index : start_index + limit]
+                if limit >= 0
+                else candidates[start_index:]
+            )
+            selected_ids = list(dict.fromkeys(c.media_item_id for c in page_candidates))
+            bundles = await load_bundles(session, selected_ids, dto_options=options)
+    else:
+        page_candidates = []
+        bundles = {}
+
+    # 服务端强制语义：可续播 = 位置 > 0；候选查询已按最近活动降序排列。
+    page: list[Entry] = []
+    for candidate in page_candidates:
+        bundle = bundles.get(candidate.media_item_id)
+        if bundle is None:
+            continue
+        if bundle.item.kind == "movie":
+            if (0, 0) in bundle.files:
+                page.append(("Movie", bundle, 0, 0))
+        elif (candidate.season_number, candidate.episode_number) in bundle.files:
+            page.append(
+                (
+                    "Episode",
+                    bundle,
+                    candidate.season_number,
+                    candidate.episode_number,
+                )
+            )
+
+    total = len(candidates)
     dtos = [_entry_dto(ctx, e, options) for e in page]
     return JSONResponse(query_result(dtos, total, start_index))
 
@@ -697,7 +904,7 @@ async def get_item(request: Request, item_id: str, user_id: str | None = None) -
                 )
             )
         # 单条目是全字段语义，People 恒输出
-        bundles = await load_bundles(session, [ref.entity_id], include_people=True)
+        bundles = await load_bundles(session, [ref.entity_id], dto_options=options)
 
     bundle = bundles.get(ref.entity_id)
     if bundle is None:
@@ -741,8 +948,11 @@ async def shows_next_up(request: Request) -> JSONResponse:
     series_filter = decode_guid(q.get("seriesId") or "") if q.get("seriesId") else None
 
     async with get_database().session() as session:
-        ids = await item_ids_with_files(session, kind="tv")
-        bundles = await load_bundles(session, ids, include_people=options.has("People"))
+        ids = await next_up_item_ids(
+            session,
+            series_id=series_filter.entity_id if series_filter else None,
+        )
+        bundles = await load_bundles(session, ids, dto_options=options)
 
     candidates: list[tuple[Any, dict[str, Any]]] = []
     for bundle in bundles.values():
@@ -801,9 +1011,7 @@ async def shows_seasons(request: Request, series_id: str) -> JSONResponse:
     if ref is None or ref.kind != EntityKind.ITEM:
         raise not_found()
     async with get_database().session() as session:
-        bundles = await load_bundles(
-            session, [ref.entity_id], include_people=options.has("People")
-        )
+        bundles = await load_bundles(session, [ref.entity_id], dto_options=options)
     bundle = bundles.get(ref.entity_id)
     if bundle is None or bundle.item.kind != "tv":
         raise not_found()
@@ -843,9 +1051,7 @@ async def shows_episodes(request: Request, series_id: str) -> JSONResponse:
             season_scope = int(season_param)
 
     async with get_database().session() as session:
-        bundles = await load_bundles(
-            session, [target_item_id], include_people=options.has("People")
-        )
+        bundles = await load_bundles(session, [target_item_id], dto_options=options)
     bundle = bundles.get(target_item_id)
     if bundle is None or bundle.item.kind != "tv":
         raise not_found_message("Series not found")

--- a/tests/jellyfin/test_audit_regressions.py
+++ b/tests/jellyfin/test_audit_regressions.py
@@ -313,6 +313,298 @@ def test_people_in_item_detail(client: TestClient, seeded: dict) -> None:
     assert len(gated["People"]) == 3
 
 
+def test_list_queries_skip_unused_json_columns(client: TestClient, seeded: dict) -> None:
+    """大库列表不应读取 DTO 用不到的演员和媒体流 JSON。"""
+    from sqlalchemy import event
+
+    from movieclaw_db.engine import get_database
+
+    token = jf_login(client)
+    statements: list[str] = []
+
+    def capture(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+        statements.append(statement.lower())
+
+    engine = get_database().engine.sync_engine
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        plain = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "parentId": library_guid(seeded["movie_lib"]),
+                "includeItemTypes": "Movie",
+            },
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+
+    assert plain.status_code == 200
+    sql = "\n".join(statements)
+    assert "media_metadata.cast" not in sql
+    assert "media_metadata.directors" not in sql
+    assert "library_file.audio_streams" not in sql
+    assert "library_file.subtitle_streams" not in sql
+
+    statements.clear()
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        sources = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "parentId": library_guid(seeded["movie_lib"]),
+                "includeItemTypes": "Movie",
+                "fields": "MediaSources",
+            },
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+
+    assert sources.status_code == 200
+    assert len(sources.json()["Items"][0]["MediaSources"]) == 2
+    sql = "\n".join(statements)
+    assert "library_file.audio_streams" in sql
+    assert "library_file.subtitle_streams" in sql
+
+    statements.clear()
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        views = client.get("/UserViews", params={"ApiKey": token})
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+
+    assert views.status_code == 200
+    sql = "\n".join(statements)
+    assert "media_metadata.poster_file" in sql
+    assert "media_metadata.cast" not in sql
+    assert "media_metadata.overview" not in sql
+
+
+def test_large_library_list_skips_large_json_columns(
+    client: TestClient, seeded: dict, monkeypatch
+) -> None:
+    """1,200 部电影携带大 JSON 时，首页仍走最小列集并正确分页。"""
+    import json
+    import os
+    import sqlite3
+
+    from sqlalchemy import event
+
+    from movieclaw_db.engine import get_database
+
+    db_path = os.environ["DATABASE_URL"].split("///", 1)[1]
+    timestamp = "2026-08-06 00:00:00.000000"
+    large_json = json.dumps(["x" * 2_048])
+    item_ids = range(10_000, 11_200)
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO media_item
+                (id, kind, tmdb_id, title, original_title, aliases, created_at, updated_at)
+            VALUES (?, 'movie', ?, ?, ?, '[]', ?, ?)
+            """,
+            [
+                (
+                    item_id,
+                    item_id,
+                    f"Large library item {item_id}",
+                    f"Item {item_id}",
+                    timestamp,
+                    timestamp,
+                )
+                for item_id in item_ids
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO media_metadata
+                (media_item_id, genres, genre_ids, origin_countries, studios, directors, cast,
+                 poster_locked, backdrop_locked, scrape_language, created_at, updated_at)
+            VALUES (?, '[]', '[]', ?, ?, ?, ?, 0, 0, '', ?, ?)
+            """,
+            [
+                (item_id, large_json, large_json, large_json, large_json, timestamp, timestamp)
+                for item_id in item_ids
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO library_file
+                (library_id, media_item_id, season_number, episode_number, file_path, size_bytes,
+                 audio_streams, subtitle_streams, source, created_at, updated_at)
+            VALUES (?, ?, 0, 0, ?, 0, ?, ?, 'scanned', ?, ?)
+            """,
+            [
+                (
+                    seeded["movie_lib"],
+                    item_id,
+                    f"/large-media/item-{item_id}.mkv",
+                    large_json,
+                    large_json,
+                    timestamp,
+                    timestamp,
+                )
+                for item_id in item_ids
+            ],
+        )
+
+    token = jf_login(client)
+    statements: list[str] = []
+    loaded_bundle_sizes: list[int] = []
+
+    from movieclaw_jellyfin.routes import library as library_routes
+
+    original_load_bundles = library_routes.load_bundles
+
+    async def track_load_bundles(session, item_ids, **kwargs):
+        loaded_bundle_sizes.append(len(item_ids))
+        return await original_load_bundles(session, item_ids, **kwargs)
+
+    monkeypatch.setattr(library_routes, "load_bundles", track_load_bundles)
+
+    def capture(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+        statements.append(statement.lower())
+
+    engine = get_database().engine.sync_engine
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        response = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "parentId": library_guid(seeded["movie_lib"]),
+                "includeItemTypes": "Movie",
+                "limit": "20",
+            },
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["TotalRecordCount"] == 1_201
+    assert len(body["Items"]) == 20
+    # 默认电影库 Items 的 count/page 已在 SQL 完成，不能回退成 1,201 个 bundle。
+    assert loaded_bundle_sizes == [20]
+    sql = "\n".join(statements)
+    assert "media_metadata.cast" not in sql
+    assert "media_metadata.directors" not in sql
+    assert "media_metadata.origin_countries" not in sql
+    assert "library_file.audio_streams" not in sql
+    assert "library_file.subtitle_streams" not in sql
+
+    statements.clear()
+    loaded_bundle_sizes.clear()
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        latest = client.get(
+            "/Items/Latest",
+            params={
+                "ApiKey": token,
+                "parentId": library_guid(seeded["movie_lib"]),
+                "limit": "20",
+            },
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+
+    assert latest.status_code == 200
+    assert len(latest.json()) == 20
+    # Latest 先扫描轻量最新单元，再只装载最终的 20 个条目。
+    assert loaded_bundle_sizes == [20]
+    sql = "\n".join(statements)
+    assert "media_metadata.cast" not in sql
+    assert "media_metadata.directors" not in sql
+    assert "media_metadata.origin_countries" not in sql
+    assert "library_file.audio_streams" not in sql
+    assert "library_file.subtitle_streams" not in sql
+
+
+def test_slow_browse_log_is_segmented_and_deidentified(
+    client: TestClient, seeded: dict, monkeypatch, caplog
+) -> None:
+    """部署侧慢日志能定位阶段耗时，且不泄漏媒体标题和路径。"""
+    import logging
+
+    from movieclaw_jellyfin.routes import library as library_routes
+
+    monkeypatch.setattr(library_routes, "SLOW_BROWSE_REQUEST_MS", 0)
+    caplog.set_level(logging.WARNING, logger="movieclaw_jellyfin.library")
+    token = jf_login(client)
+
+    client.get(
+        "/Items",
+        params={
+            "ApiKey": token,
+            "parentId": library_guid(seeded["movie_lib"]),
+            "includeItemTypes": "Movie",
+            "fields": "People,/media/private/token,secret-token",
+        },
+    )
+    client.get("/Items/Latest", params={"ApiKey": token})
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "movieclaw_jellyfin.library"
+    ]
+    assert any("route=items" in message for message in messages)
+    assert any("route=latest" in message for message in messages)
+    assert all(
+        "candidates=" in message
+        and "returned=" in message
+        and "load_ms=" in message
+        and "build_ms=" in message
+        and "encode_ms=" in message
+        for message in messages
+    )
+    assert all("盗梦空间" not in message for message in messages)
+    assert all("/media/" not in message for message in messages)
+    assert all("secret-token" not in message for message in messages)
+    assert any("fields=People,other=2" in message for message in messages)
+
+
+def test_home_playback_queries_only_load_active_series(
+    client: TestClient, seeded: dict, monkeypatch
+) -> None:
+    """Resume/NextUp 不能为无播放活动的整库条目加载 bundle。"""
+    from movieclaw_jellyfin.routes import library as library_routes
+
+    token = jf_login(client)
+    auth = {"ApiKey": token}
+    episode = episode_guid(seeded["show"], 1, 1)
+    runtime_ticks = 47 * 60 * 1000 * TICKS_PER_MS
+    assert (
+        client.post(
+            "/Sessions/Playing/Progress",
+            params=auth,
+            json={"ItemId": episode, "PositionTicks": runtime_ticks // 2},
+        ).status_code
+        == 204
+    )
+
+    calls: list[list[int]] = []
+    original_load_bundles = library_routes.load_bundles
+
+    async def track_load_bundles(session, item_ids, **kwargs):
+        calls.append(list(item_ids))
+        return await original_load_bundles(session, item_ids, **kwargs)
+
+    monkeypatch.setattr(library_routes, "load_bundles", track_load_bundles)
+
+    resume = client.get("/UserItems/Resume", params=auth).json()
+    assert resume["TotalRecordCount"] == 1
+    assert resume["Items"][0]["Id"] == episode
+    assert calls == [[seeded["show"]]]
+
+    calls.clear()
+    next_up = client.get("/Shows/NextUp", params=auth).json()
+    assert next_up["TotalRecordCount"] == 1
+    assert next_up["Items"][0]["Id"] == episode
+    assert calls == [[seeded["show"]]]
+
+
 def test_person_item_and_filter(client: TestClient, seeded: dict) -> None:
     """点开演员：人物条目可取，personIds 反查参演作品。"""
     from movieclaw_jellyfin.ids import person_guid


### PR DESCRIPTION
## 背景

VidHub 打开媒体库首页时会并发请求 `/Items`、`/Items/Latest`、`/Items/Resume` 和 `/Shows/NextUp`。

原实现会先为整个媒体库加载 `MediaItem`、媒体元数据、文件规格和播放状态，再在内存中筛选、排序和分页。对于千级电影库，这会额外读取并反序列化列表响应并不需要的演员、音轨、字幕等大型 JSON 字段，导致首页接口耗时达到数秒。

## 解决方案

- 为列表 DTO 增加最小列集加载，仅在请求 `People`、`MediaSources`、`MediaStreams` 等字段时读取对应的大字段。
- `/Items/Latest` 先通过 SQL 查询轻量候选单元，完成分组和分页后仅加载最终返回条目的 bundle。
- 默认电影库分页 `/Items` 在 SQL 层完成总数统计、offset 和 limit，避免为整库条目水合完整对象。
- `/Items/Resume` 与 `/Shows/NextUp` 仅查询存在播放活动的媒体条目。
- 库封面候选查询改为只读取海报路径和入库时间，避免根级媒体库浏览水合完整元数据。
- 为慢请求增加脱敏的分段耗时日志，便于区分数据加载、DTO 构建、封面处理和响应编码耗时。

## 验证

- `ruff check .`
- `pytest tests/jellyfin`：`73 passed`
- 新增 1,200 条大媒体库回归测试，断言普通列表和 Latest 仅加载当前页所需 bundle。
- 新增 Resume / NextUp 回归测试，断言不会加载无播放活动的整库条目。

## 线上观测

约 1,200 部电影媒体库实测：

- `/Items/Latest`：约 138-342 ms
- `/Items/Resume`：约 70-129 ms
- `/Shows/NextUp`：约 46-73 ms
- `/Items`：多数约 291 ms，冷路径约 913 ms