### PR TITLE
fix(jellyfin): 播放停止后终止残留读盘

### DIFF
--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -276,7 +276,9 @@ def _arm_rescan(library_id: int, delay: float) -> None:
 
 async def _rescan_later(library_id: int, delay: float) -> None:
     await asyncio.sleep(delay)
-    await scan_library(library_id)
+    # 这一轮只为接住刚写完的新文件；历史规格补探必须由用户主动扫描触发，
+    # 否则下载期间一次短暂的 mtime 波动也会重新扫到整库未补探的旧文件。
+    await scan_library(library_id, backfill_existing_specs=False)
 
 
 def last_scan(library_id: int) -> tuple | None:
@@ -292,8 +294,17 @@ def scan_progress(library_id: int) -> ScanState | None:
     return _scan_tasks.state_of(library_id)
 
 
-async def scan_library(library_id: int) -> ScanSummary:
-    """扫描一个库的全部根路径（后台任务入口；自开会话，不向外抛异常）。"""
+async def scan_library(
+    library_id: int, *, backfill_existing_specs: bool = True
+) -> ScanSummary:
+    """扫描一个库的全部根路径（后台任务入口；自开会话，不向外抛异常）。
+
+    ``backfill_existing_specs`` 只应由用户主动发起的扫描保持开启。历史规格
+    补探会对每个 ``audio_streams IS NULL`` 的在位文件运行一次 ffprobe；把它
+    绑到 watchdog、写入静默补扫或 6 小时对账，会让一次很小的目录事件演变为
+    对整个机械盘媒体库的长时间读取。新入库文件仍在主流程中即时探测，不受此
+    开关影响。
+    """
     from movieclaw_api.services.library.organize import is_organizing
     from movieclaw_api.services.library.transfer import is_transferring
 
@@ -321,7 +332,12 @@ async def scan_library(library_id: int) -> ScanSummary:
     state = ScanState(phase=ScanPhase.WALKING)
     _scan_tasks.try_start(library_id, state)
     try:
-        return await _scan(library_id, summary, state)
+        return await _scan(
+            library_id,
+            summary,
+            state,
+            backfill_existing_specs=backfill_existing_specs,
+        )
     except Exception:  # noqa: BLE001 -- 后台任务兜底
         logger.exception("媒体库 #%s 扫描时发生未知错误", library_id)
         summary.errors.append("扫描中断：发生未知错误（详见后端日志）")
@@ -334,7 +350,13 @@ async def scan_library(library_id: int) -> ScanSummary:
             _arm_rescan(library_id, summary.recheck_delay_seconds)
 
 
-async def _scan(library_id: int, summary: ScanSummary, state: ScanState) -> ScanSummary:
+async def _scan(
+    library_id: int,
+    summary: ScanSummary,
+    state: ScanState,
+    *,
+    backfill_existing_specs: bool,
+) -> ScanSummary:
     db = get_database()
     async with db.session() as session:
         library = await session.get(Library, library_id)
@@ -552,7 +574,8 @@ async def _scan(library_id: int, summary: ScanSummary, state: ScanState) -> Scan
         # 已识别且在位的行在上面的循环里整体秒过，永远走不到探测那一步。
         # 没有这一步，「装好 ffmpeg 再重新扫描」这个最直觉的动作就是无效的，
         # 用户只能一个条目一个条目点开、靠详情页那点限量补探慢慢磨。
-        await _probe_backfill(session, library_id, summary, state)
+        if backfill_existing_specs:
+            await _probe_backfill(session, library_id, summary, state)
 
     if min_remaining is not None:
         summary.recheck_delay_seconds = max(5.0, min(min_remaining + 1.0, NEW_FILE_QUIET_SECONDS))
@@ -1958,7 +1981,9 @@ async def reconcile_libraries() -> None:
         libraries = list((await session.execute(select(Library))).scalars().all())
     for library in libraries:
         assert library.id is not None
-        summary = await scan_library(library.id)
+        # 对账负责让台账追上文件新增/删除；规格补探是可长达数小时的用户主动
+        # 维护任务，不能在空闲后台周期里抢占媒体盘。
+        summary = await scan_library(library.id, backfill_existing_specs=False)
         if summary.errors:
             logger.warning(
                 "媒体库「%s」对账补扫存在问题：%s", library.name, "；".join(summary.errors)

--- a/src/movieclaw_api/services/library/watch.py
+++ b/src/movieclaw_api/services/library/watch.py
@@ -198,7 +198,9 @@ class LibraryWatcher:
                     # 但入库硬链会）——正在扫就不叠加
                 logger.info("检测到媒体库 #%s 根路径变更，触发增量扫描", library_id)
                 try:
-                    await scan_library(library_id)
+                    # 文件事件只需同步台账；历史规格补探由用户手动扫描触发，
+                    # 不让一次播放/下载相关的目录事件变成整库 ffprobe。
+                    await scan_library(library_id, backfill_existing_specs=False)
                 except Exception:  # noqa: BLE001 -- 监控消费绝不崩
                     logger.exception("实时监控触发的扫描失败：库 #%s", library_id)
 

--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -13,7 +13,7 @@ import secrets
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from sqlalchemy import select
 
 from movieclaw_db.engine import get_database
@@ -21,8 +21,15 @@ from movieclaw_db.models import LibraryFile
 from movieclaw_jellyfin.catalog import media_source_dto
 from movieclaw_jellyfin.errors import bad_request_text, not_found
 from movieclaw_jellyfin.ids import EntityKind, decode_guid, media_source_guid
-from movieclaw_jellyfin.security import require_device
-from movieclaw_playback.streaming import container_mime_type, is_strm, resolve_strm_url
+from movieclaw_jellyfin.security import RequestIdentity, require_device
+from movieclaw_playback.streaming import (
+    DisconnectAwareFileResponse,
+    container_mime_type,
+    is_strm,
+    register_device_stream,
+    resolve_strm_url,
+    unregister_device_stream,
+)
 
 router = APIRouter(dependencies=[Depends(require_device)])
 
@@ -106,7 +113,10 @@ async def playback_info(request: Request, item_id: str) -> JSONResponse:
 @router.get("/Videos/{item_id}/stream.{container}")
 @router.head("/Videos/{item_id}/stream.{container}")
 async def video_stream(
-    request: Request, item_id: str, container: str | None = None
+    request: Request,
+    item_id: str,
+    container: str | None = None,
+    identity: RequestIdentity = Depends(require_device),
 ) -> Response:
     ref = decode_guid(item_id)
     if ref is None or ref.kind not in (EntityKind.ITEM, EntityKind.EPISODE):
@@ -133,5 +143,14 @@ async def video_stream(
     if not path.is_file():
         raise not_found()
     media_type = container_mime_type(container or f.container or path.suffix)
-    # FileResponse 原生处理 Range/206/If-Range/HEAD（starlette >= 0.36）
-    return FileResponse(path, media_type=media_type)
+    # 停止播放并不保证客户端立刻关闭 Range 连接。按已认证设备登记这条流，
+    # 让 /Sessions/Playing/Stopped 能主动停止读盘；TCP 断连仍是第二道兜底。
+    device_id = identity.device.device_id
+    session_stopped = register_device_stream(device_id)
+    return DisconnectAwareFileResponse(
+        path,
+        media_type=media_type,
+        is_disconnected=request.is_disconnected,
+        session_stopped=session_stopped,
+        on_close=lambda: unregister_device_stream(device_id, session_stopped),
+    )

--- a/src/movieclaw_jellyfin/routes/playstate.py
+++ b/src/movieclaw_jellyfin/routes/playstate.py
@@ -37,6 +37,7 @@ from movieclaw_playback.events import (
     build_marked_events,
     build_playback_event,
 )
+from movieclaw_playback.streaming import stop_device_streams
 
 router = APIRouter(dependencies=[Depends(require_device)])
 
@@ -269,6 +270,9 @@ async def playing_stopped(
     request: Request, identity: RequestIdentity = Depends(require_device)
 ) -> Response:
     body = await _read_body(request)
+    # VidHub 的 Stopped 不代表它已立即关闭此前发出的 Range 请求。先取消同设备
+    # 的活跃流，避免机械盘继续为已退出的播放器预读；失败停止同样必须收口。
+    stop_device_streams(identity.device.device_id)
     if body.get("failed") is True:
         # 播放失败的上报不落库（SessionManager.cs:1164-1167）
         return Response(status_code=204)
@@ -330,6 +334,7 @@ async def playing_stopped_legacy(
     identity: RequestIdentity = Depends(require_device),
 ) -> Response:
     ref = _decode_item_ref(item_id)
+    stop_device_streams(identity.device.device_id)
     if ref is not None:
         await _apply_progress(
             ref,

--- a/src/movieclaw_playback/streaming.py
+++ b/src/movieclaw_playback/streaming.py
@@ -11,15 +11,27 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from secrets import token_hex
 from urllib.parse import urlsplit
+
+import anyio
+from starlette.datastructures import MutableHeaders
+from starlette.responses import FileResponse
+from starlette.types import Receive, Scope, Send
 
 logger = logging.getLogger("movieclaw_playback.streaming")
 
 STRM_EXT = ".strm"
 
 _ALLOWED_STRM_SCHEMES = {"http", "https", "rtsp", "rtp"}
+
+# 一个播放器设备在停止播放后，可能仍保留若干 HTTP Range 连接。它们不一定马上
+# 触发 TCP disconnect，不能只靠 Request.is_disconnected() 才停止读盘。
+_active_stream_stops: dict[str, set[asyncio.Event]] = {}
 
 # 容器 → MIME（对齐 Jellyfin MimeTypes.cs 的常用子集；未知视频容器兜底 video/{ext}）
 _CONTAINER_MIME = {
@@ -37,6 +49,247 @@ _CONTAINER_MIME = {
     "mpeg": "video/mpeg",
     "iso": "application/x-iso9660-image",
 }
+
+
+def register_device_stream(device_id: str) -> asyncio.Event:
+    """登记设备的一条本地取流，并返回会话停止时置位的取消信号。"""
+    stopped = asyncio.Event()
+    _active_stream_stops.setdefault(device_id, set()).add(stopped)
+    return stopped
+
+
+def unregister_device_stream(device_id: str, stopped: asyncio.Event) -> None:
+    """回收已结束取流的取消信号，避免设备长期播放后积累无用引用。"""
+    streams = _active_stream_stops.get(device_id)
+    if streams is None:
+        return
+    streams.discard(stopped)
+    if not streams:
+        _active_stream_stops.pop(device_id, None)
+
+
+def stop_device_streams(device_id: str) -> int:
+    """停止一个播放器设备仍在读取的全部本地流，返回受影响的连接数。"""
+    streams = tuple(_active_stream_stops.get(device_id, ()))
+    for stopped in streams:
+        stopped.set()
+    if streams:
+        logger.info("播放器会话已停止，已取消 %d 条仍在读取的视频流", len(streams))
+    return len(streams)
+
+
+class DisconnectAwareFileResponse(FileResponse):
+    """客户端断开后立即停止读取本地媒体文件的 ``FileResponse``。
+
+    Uvicorn 检测到 TCP 连接断开后会静默丢弃后续 ASGI ``send`` 消息；而
+    Starlette 原生 ``FileResponse`` 不读取 ``receive``，仍会把整个 Range
+    循环从磁盘读完。对数十 GB 的机械盘媒体文件，这会表现为客户端已经退出、
+    服务端却持续高 CPU 和读盘。
+
+    该类沿用 Starlette 的 Range 头和分段规则，只在每次读取前后检查连接状态。
+    为了能在停止时以完整的 ASGI body 结束响应，非 HEAD 请求不发送
+    ``Content-Length``，由 HTTP 服务器使用 chunked 传输；``206`` 的
+    ``Content-Range`` 仍保留，因此客户端仍可校验请求区间。断开时最多多读
+    一个已在途的 64 KiB 块。
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        is_disconnected: Callable[[], Awaitable[bool]],
+        session_stopped: asyncio.Event | None = None,
+        on_close: Callable[[], None] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(path, **kwargs)
+        self._is_disconnected = is_disconnected
+        self._session_stopped = session_stopped
+        self._on_close = on_close
+        self._bytes_read = 0
+        self._disconnect_logged = False
+
+    async def _should_stop_reading(self) -> bool:
+        if self._session_stopped is not None and self._session_stopped.is_set():
+            reason = "播放器已上报停止"
+        elif await self._is_disconnected():
+            reason = "客户端已断开"
+        else:
+            return False
+        if not self._disconnect_logged:
+            self._disconnect_logged = True
+            logger.info(
+                "%s视频流，停止继续读取（本响应已读取 %d 字节）",
+                reason,
+                self._bytes_read,
+            )
+        return True
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """无论正常结束、客户端断开还是会话取消，都回收设备流登记。"""
+        # pathsend 会把文件路径交给 ASGI 服务器，之后应用层既不能观察 Stopped，
+        # 也无法中止服务器的持续读盘。视频流必须由本响应逐块读取和检查。
+        extensions = scope.get("extensions")
+        if extensions and "http.response.pathsend" in extensions:
+            scope = {
+                **scope,
+                "extensions": {
+                    key: value
+                    for key, value in extensions.items()
+                    if key != "http.response.pathsend"
+                },
+            }
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            if self._on_close is not None:
+                self._on_close()
+
+    def _stream_headers(
+        self, headers: list[tuple[bytes, bytes]] | None = None
+    ) -> list[tuple[bytes, bytes]]:
+        """移除长度头，使提前停止可以用 ASGI 结束帧正常结束 chunked 响应。"""
+        mutable_headers = MutableHeaders(raw=list(headers or self.raw_headers))
+        if "content-length" in mutable_headers:
+            del mutable_headers["content-length"]
+        return mutable_headers.raw
+
+    async def _finish_stopped_response(self, send: Send) -> None:
+        """已发送响应头后收尾，避免 ASGI 应用以未完成的 body 返回。"""
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    async def _handle_simple(
+        self, send: Send, send_header_only: bool, _send_pathsend: bool
+    ) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status_code,
+                "headers": self.raw_headers if send_header_only else self._stream_headers(),
+            }
+        )
+        if send_header_only:
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            return
+        if await self._should_stop_reading():
+            await self._finish_stopped_response(send)
+            return
+        async with await anyio.open_file(self.path, mode="rb") as file:
+            more_body = True
+            while more_body:
+                if await self._should_stop_reading():
+                    await self._finish_stopped_response(send)
+                    return
+                chunk = await file.read(self.chunk_size)
+                self._bytes_read += len(chunk)
+                more_body = len(chunk) == self.chunk_size
+                if await self._should_stop_reading():
+                    await self._finish_stopped_response(send)
+                    return
+                await send(
+                    {"type": "http.response.body", "body": chunk, "more_body": more_body}
+                )
+
+    async def _handle_single_range(
+        self, send: Send, start: int, end: int, file_size: int, send_header_only: bool
+    ) -> None:
+        headers = MutableHeaders(raw=list(self.raw_headers))
+        headers["content-range"] = f"bytes {start}-{end - 1}/{file_size}"
+        headers["content-length"] = str(end - start)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 206,
+                "headers": (
+                    headers.raw if send_header_only else self._stream_headers(headers.raw)
+                ),
+            }
+        )
+        if send_header_only:
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            return
+        if await self._should_stop_reading():
+            await self._finish_stopped_response(send)
+            return
+        async with await anyio.open_file(self.path, mode="rb") as file:
+            await file.seek(start)
+            more_body = True
+            while more_body:
+                if await self._should_stop_reading():
+                    await self._finish_stopped_response(send)
+                    return
+                chunk = await file.read(min(self.chunk_size, end - start))
+                self._bytes_read += len(chunk)
+                start += len(chunk)
+                more_body = len(chunk) == self.chunk_size and start < end
+                if await self._should_stop_reading():
+                    await self._finish_stopped_response(send)
+                    return
+                await send(
+                    {"type": "http.response.body", "body": chunk, "more_body": more_body}
+                )
+
+    async def _handle_multiple_ranges(
+        self,
+        send: Send,
+        ranges: list[tuple[int, int]],
+        file_size: int,
+        send_header_only: bool,
+    ) -> None:
+        boundary = token_hex(13)
+        content_length, header_generator = self.generate_multipart(
+            ranges, boundary, file_size, self.headers["content-type"]
+        )
+        headers = MutableHeaders(raw=list(self.raw_headers))
+        headers["content-type"] = f"multipart/byteranges; boundary={boundary}"
+        headers["content-length"] = str(content_length)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 206,
+                "headers": (
+                    headers.raw if send_header_only else self._stream_headers(headers.raw)
+                ),
+            }
+        )
+        if send_header_only:
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            return
+        if await self._should_stop_reading():
+            await self._finish_stopped_response(send)
+            return
+        async with await anyio.open_file(self.path, mode="rb") as file:
+            for start, end in ranges:
+                if await self._should_stop_reading():
+                    await self._finish_stopped_response(send)
+                    return
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": header_generator(start, end),
+                        "more_body": True,
+                    }
+                )
+                await file.seek(start)
+                while start < end:
+                    if await self._should_stop_reading():
+                        await self._finish_stopped_response(send)
+                        return
+                    chunk = await file.read(min(self.chunk_size, end - start))
+                    self._bytes_read += len(chunk)
+                    start += len(chunk)
+                    if await self._should_stop_reading():
+                        await self._finish_stopped_response(send)
+                        return
+                    await send({"type": "http.response.body", "body": chunk, "more_body": True})
+                await send({"type": "http.response.body", "body": b"\r\n", "more_body": True})
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": f"--{boundary}--".encode("latin-1"),
+                    "more_body": False,
+                }
+            )
 
 
 def container_mime_type(container: str | None) -> str:

--- a/tests/api/test_library_probe_backfill.py
+++ b/tests/api/test_library_probe_backfill.py
@@ -18,7 +18,7 @@ import movieclaw_api.services.library.scan as scan_mod
 import movieclaw_api.services.media_discover as discover_mod
 import movieclaw_api.services.media_probe as probe_mod
 from movieclaw_api.core.config import get_settings
-from movieclaw_api.services.library.scan import scan_library
+from movieclaw_api.services.library.scan import ScanSummary, scan_library
 from movieclaw_api.services.media_probe import MediaSpec
 from movieclaw_db.engine import dispose_db, get_database, init_db
 from movieclaw_db.migrations import run_migrations
@@ -163,6 +163,39 @@ async def test_backfill_is_idempotent(db, tmp_path, monkeypatch) -> None:
     summary = await scan_library(library_id)
     assert summary.probed == 0
     assert calls == []
+
+
+async def test_background_scan_skips_historical_spec_backfill(db, tmp_path, monkeypatch) -> None:
+    """后台对账和目录事件只盘点台账，不能对历史文件逐个启动 ffprobe。"""
+    _no_ffprobe(monkeypatch)
+    library_id = await _build(db, tmp_path)
+    await scan_library(library_id)
+
+    calls: list[str] = []
+    _with_ffprobe(monkeypatch, calls)
+    summary = await scan_library(library_id, backfill_existing_specs=False)
+
+    assert summary.probed == 0
+    assert calls == []
+    rows = await _rows(db)
+    assert all(row.audio_streams is None for row in rows)
+
+
+async def test_periodic_reconcile_skips_historical_spec_backfill(db, tmp_path, monkeypatch) -> None:
+    """定时对账传入关闭开关，避免后台周期扫到全库历史规格。"""
+    library_id = await _build(db, tmp_path, count=1)
+    calls: list[tuple[int, bool]] = []
+
+    async def fake_scan(
+        current_library_id: int, *, backfill_existing_specs: bool = True
+    ) -> ScanSummary:
+        calls.append((current_library_id, backfill_existing_specs))
+        return ScanSummary(library_id=current_library_id)
+
+    monkeypatch.setattr(scan_mod, "scan_library", fake_scan)
+    await scan_mod.reconcile_libraries()
+
+    assert calls == [(library_id, False)]
 
 
 async def test_backfill_skipped_when_ffprobe_missing(db, tmp_path, monkeypatch) -> None:

--- a/tests/jellyfin/test_http_flow.py
+++ b/tests/jellyfin/test_http_flow.py
@@ -457,6 +457,26 @@ def test_stopped_failed_skips_persistence(client: TestClient, seeded: dict) -> N
     assert ud["PlaybackPositionTicks"] == 0
 
 
+def test_stopped_cancels_device_streams_even_when_failed(
+    client: TestClient, seeded: dict, monkeypatch
+) -> None:
+    """Stopped 是取流停止信号；Failed 只跳过播放状态写入，不能留下预读。"""
+    from movieclaw_jellyfin.routes import playstate
+
+    token = jf_login(client)
+    calls: list[str] = []
+    monkeypatch.setattr(playstate, "stop_device_streams", calls.append)
+
+    response = client.post(
+        "/Sessions/Playing/Stopped",
+        params={"ApiKey": token},
+        json={"ItemId": item_guid(seeded["movie"]), "Failed": True},
+    )
+
+    assert response.status_code == 204
+    assert calls == ["test-device-1"]
+
+
 def test_mark_played_cascade_and_unplayed(client: TestClient, seeded: dict) -> None:
     token = jf_login(client)
     auth = {"ApiKey": token}

--- a/tests/playback/test_streaming.py
+++ b/tests/playback/test_streaming.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from movieclaw_playback.streaming import (
+    DisconnectAwareFileResponse,
+    register_device_stream,
+    stop_device_streams,
+    unregister_device_stream,
+)
+
+
+def _scope(
+    *, method: str = "GET", headers: list[tuple[bytes, bytes]] | None = None
+) -> dict[str, Any]:
+    return {
+        "type": "http",
+        "method": method,
+        "headers": headers or [],
+        "extensions": {},
+    }
+
+
+async def _receive() -> dict[str, Any]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _sender(messages: list[dict[str, Any]]):
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+
+    return send
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_skips_open_when_client_is_gone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"x" * 128)
+    messages: list[dict[str, Any]] = []
+
+    async def disconnected() -> bool:
+        return True
+
+    async def should_not_open(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("断开的客户端不应继续打开媒体文件")
+
+    monkeypatch.setattr("movieclaw_playback.streaming.anyio.open_file", should_not_open)
+    response = DisconnectAwareFileResponse(video, is_disconnected=disconnected)
+    await response(_scope(), _receive, _sender(messages))
+
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_disables_pathsend(
+    tmp_path: Path,
+) -> None:
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"x" * 128)
+    messages: list[dict[str, Any]] = []
+
+    async def connected() -> bool:
+        return False
+
+    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    await response(
+        {**_scope(), "extensions": {"http.response.pathsend": {}}},
+        _receive,
+        _sender(messages),
+    )
+
+    assert [message["type"] for message in messages] == [
+        "http.response.start",
+        "http.response.body",
+    ]
+    assert b"".join(message.get("body", b"") for message in messages) == video.read_bytes()
+    assert all(message["type"] != "http.response.pathsend" for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_stopped_playback_signal_skips_opening_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """播放器已上报 Stopped 时，即使 TCP 尚未断开也不能继续预读。"""
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"x" * 128)
+    messages: list[dict[str, Any]] = []
+    stopped = asyncio.Event()
+    stopped.set()
+
+    async def connected() -> bool:
+        return False
+
+    async def should_not_open(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Stopped 后不应继续打开媒体文件")
+
+    monkeypatch.setattr("movieclaw_playback.streaming.anyio.open_file", should_not_open)
+    response = DisconnectAwareFileResponse(
+        video,
+        is_disconnected=connected,
+        session_stopped=stopped,
+    )
+    await response(_scope(), _receive, _sender(messages))
+
+    assert [message["type"] for message in messages] == [
+        "http.response.start",
+        "http.response.body",
+    ]
+    assert messages[-1]["more_body"] is False
+
+
+def test_stop_device_streams_sets_all_active_streams() -> None:
+    """一个设备的停止上报要收口它并发建立的全部 Range 请求。"""
+    first = register_device_stream("device-a")
+    second = register_device_stream("device-a")
+    try:
+        assert stop_device_streams("device-a") == 2
+        assert first.is_set() and second.is_set()
+    finally:
+        unregister_device_stream("device-a", first)
+        unregister_device_stream("device-a", second)
+
+
+@pytest.mark.asyncio
+async def test_stopped_playback_signal_stops_active_stream_before_next_chunk(
+    tmp_path: Path,
+) -> None:
+    """Stopped 到达正在发送的流后，下一块读取前必须结束响应。"""
+    video = tmp_path / "movie.mkv"
+    content = b"x" * (DisconnectAwareFileResponse.chunk_size * 2)
+    video.write_bytes(content)
+    messages: list[dict[str, Any]] = []
+    stopped = asyncio.Event()
+
+    async def connected() -> bool:
+        return False
+
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+        if message.get("body") == content[: DisconnectAwareFileResponse.chunk_size]:
+            stopped.set()
+
+    response = DisconnectAwareFileResponse(
+        video,
+        is_disconnected=connected,
+        session_stopped=stopped,
+    )
+    await response(_scope(), _receive, send)
+
+    body = b"".join(message.get("body", b"") for message in messages)
+    assert body == content[: DisconnectAwareFileResponse.chunk_size]
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_stops_before_next_chunk(tmp_path: Path) -> None:
+    video = tmp_path / "movie.mkv"
+    content = b"x" * (DisconnectAwareFileResponse.chunk_size * 2)
+    video.write_bytes(content)
+    messages: list[dict[str, Any]] = []
+    checks = iter((False, False, False, True))
+
+    async def disconnected() -> bool:
+        return next(checks)
+
+    response = DisconnectAwareFileResponse(video, is_disconnected=disconnected)
+    await response(_scope(), _receive, _sender(messages))
+
+    body = b"".join(message.get("body", b"") for message in messages)
+    assert body == content[: DisconnectAwareFileResponse.chunk_size]
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_keeps_range_response(tmp_path: Path) -> None:
+    video = tmp_path / "movie.mkv"
+    content = b"0123456789" * 20_000
+    video.write_bytes(content)
+    messages: list[dict[str, Any]] = []
+
+    async def connected() -> bool:
+        return False
+
+    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    await response(
+        _scope(headers=[(b"range", b"bytes=100-69999")]),
+        _receive,
+        _sender(messages),
+    )
+
+    start = messages[0]
+    headers = {key.decode(): value.decode() for key, value in start["headers"]}
+    body = b"".join(message.get("body", b"") for message in messages[1:])
+    assert start["status"] == 206
+    assert headers["content-range"] == f"bytes 100-69999/{len(content)}"
+    assert "content-length" not in headers
+    assert body == content[100:70000]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_keeps_head_response(tmp_path: Path) -> None:
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"x" * 128)
+    messages: list[dict[str, Any]] = []
+
+    async def connected() -> bool:
+        return False
+
+    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    await response(_scope(method="HEAD"), _receive, _sender(messages))
+
+    headers = {key.decode(): value.decode() for key, value in messages[0]["headers"]}
+    assert headers["content-length"] == "128"
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_keeps_multiple_range_response(
+    tmp_path: Path,
+) -> None:
+    video = tmp_path / "movie.mkv"
+    content = b"0123456789" * 20
+    video.write_bytes(content)
+    messages: list[dict[str, Any]] = []
+
+    async def connected() -> bool:
+        return False
+
+    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    await response(
+        _scope(headers=[(b"range", b"bytes=0-9,100-109")]),
+        _receive,
+        _sender(messages),
+    )
+
+    headers = {key.decode(): value.decode() for key, value in messages[0]["headers"]}
+    body = b"".join(message.get("body", b"") for message in messages[1:])
+    assert messages[0]["status"] == 206
+    assert headers["content-type"].startswith("multipart/byteranges; boundary=")
+    assert "content-length" not in headers
+    assert b"Content-Range: bytes 0-9/200" in body
+    assert b"Content-Range: bytes 100-109/200" in body
+    assert content[:10] in body and content[100:110] in body
+    assert messages[-1]["more_body"] is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_aware_file_response_keeps_head_range_response(tmp_path: Path) -> None:
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"x" * 128)
+    messages: list[dict[str, Any]] = []
+
+    async def connected() -> bool:
+        return False
+
+    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    await response(
+        _scope(method="HEAD", headers=[(b"range", b"bytes=10-29")]),
+        _receive,
+        _sender(messages),
+    )
+
+    headers = {key.decode(): value.decode() for key, value in messages[0]["headers"]}
+    assert messages[0]["status"] == 206
+    assert headers["content-range"] == "bytes 10-29/128"
+    assert headers["content-length"] == "20"
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_stopped_playback_ends_multiple_range_response(tmp_path: Path) -> None:
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"x" * 128)
+    messages: list[dict[str, Any]] = []
+    stopped = asyncio.Event()
+    stopped.set()
+
+    async def connected() -> bool:
+        return False
+
+    response = DisconnectAwareFileResponse(
+        video,
+        is_disconnected=connected,
+        session_stopped=stopped,
+    )
+    await response(
+        _scope(headers=[(b"range", b"bytes=0-9,100-109")]),
+        _receive,
+        _sender(messages),
+    )
+
+    assert messages[0]["status"] == 206
+    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}


### PR DESCRIPTION
### 背景

VidHub 关闭播放窗口后，即使已经发送 `Sessions/Playing/Stopped`，服务端仍可能保留未完成的 HTTP Range 请求，继续读取机械硬盘并造成高 CPU 和高磁盘负载。

此外，实时监控、延迟补扫和定时对账可能触发历史媒体文件的批量 `ffprobe`，进一步放大磁盘压力。

### 解决方案

- 按认证设备登记活跃本地视频流。
- 收到 `Sessions/Playing/Stopped` 或 legacy 停止请求时，主动取消该设备的所有活跃流。
- 新增可感知 TCP 断连和播放器停止事件的 `FileResponse`。
- 逐块读取前后检查取消状态，最多多读取一个 64 KiB 块。
- 禁用 `http.response.pathsend`，确保服务器不会绕过取消检查直接读取文件。
- 保留 Range、206、`Content-Range` 和 HEAD 兼容语义。
- 后台监控、延迟补扫和定时对账默认跳过历史规格补探；用户主动扫描仍保留完整 `ffprobe`。
- 增加流停止、并发 Range、pathsend、HEAD 及后台扫描回归测试。

### 兼容性

- 不改变播放状态和 Jellyfin 播放接口响应契约。
- `Failed=true` 的停止上报仍不写入播放状态，但会取消残留视频流。
- 不涉及数据库迁移和运行时依赖变更。

### 验证

- `pytest`
- `ruff check .`
- `pnpm web:lint`
- `pnpm web:typecheck`