### PR TITLE
feat(jellyfin): 补齐整文件下载接口，修复 VidHub 下载无法开始

### DIFF
--- a/docs/design/jellyfin-compat.md
+++ b/docs/design/jellyfin-compat.md
@@ -138,6 +138,7 @@ P2 兜底兼容。**凡列出 legacy 别名的都必须与新路由一起实现*
 | `GET /Branding/Configuration`、`GET /QuickConnect/Enabled` | 匿名轻量 JSON（固定值） |
 | `GET /Branding/Css` + `/Branding/Css.css` | 匿名，**`text/css` 裸文本**（空串即可），非 JSON |
 | `GET /Sessions` → `[]`、`DELETE /Videos/ActiveEncodings` → 204、`GET /System/Endpoint` → `{"IsLocal":true,"IsInNetwork":true}` | 敷衍实现防客户端卡启动/退出（Fileball/VidHub 退出时会无条件发 ActiveEncodings 清理） |
+| `GET\|HEAD /Items/{itemId}/Download` 与 `/Items/{itemId}/File` | 整文件下载。Policy 宣告了 `EnableContentDownloading:true`，VidHub 等客户端的下载按钮打 Download，缺失则下载 404 无法开始。本地文件回 FileResponse（Download 带 attachment 文件名，File 不带，均支持 Range 断点续传）；strm 偏离真 Jellyfin（后者回 .strm 文本）：302 到云端直链 |
 
 **P2 兜底**：legacy `POST /PlayingItems/{itemId}`、`POST /PlayingItems/{itemId}/Progress`、
 **`DELETE /PlayingItems/{itemId}`**（停止是 DELETE 不是 POST）及 `/Users/{userId}/PlayingItems/*`

--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -1,4 +1,4 @@
-"""播放链路（设计文档 §6）：PlaybackInfo 与取流。
+"""播放链路（设计文档 §6）：PlaybackInfo、取流与整文件下载。
 
 - PlaybackInfo：不解析 DeviceProfile，恒返回未经设备适配的 MediaSources
   （等价于"无转码权限的 Jellyfin"，协议合法）；
@@ -135,3 +135,48 @@ async def video_stream(
     media_type = container_mime_type(container or f.container or path.suffix)
     # FileResponse 原生处理 Range/206/If-Range/HEAD（starlette >= 0.36）
     return FileResponse(path, media_type=media_type)
+
+
+@router.get("/Items/{item_id}/Download")
+@router.head("/Items/{item_id}/Download")
+@router.get("/Items/{item_id}/File")
+@router.head("/Items/{item_id}/File")
+async def download_item(request: Request, item_id: str) -> Response:
+    """整文件下载（Jellyfin LibraryController 的 Download/File 两条路由）。
+
+    我们在 UserDto.Policy 里宣告了 ``EnableContentDownloading: true``，客户端
+    （VidHub 等）据此显示下载按钮，点击后打的就是 /Items/{id}/Download——
+    不实现它下载会直接 404 失败。语义对齐播放取流：
+
+    - 本地文件回 FileResponse（原生 Range/206，下载器可断点续传）；
+      Download 按真 Jellyfin 带 attachment 文件名，File 不带；
+    - strm 条目与取流同策略（偏离，真 Jellyfin 会回 .strm 文本本身）：
+      302 到云端直链，客户端下载到的是真实媒体文件，服务器零流量；
+    - ``mediaSourceId`` 为超集扩展：真 Jellyfin 此接口只认条目主文件，
+      我们允许客户端指定下载某个版本，缺省取第一个。
+    """
+    ref = decode_guid(item_id)
+    if ref is None or ref.kind not in (EntityKind.ITEM, EntityKind.EPISODE):
+        raise not_found()
+
+    files = await _files_for_ref(ref)
+    selected = _select_source(files, request.query_params.get("mediaSourceId"), item_id)
+    if not selected:
+        raise not_found()
+    f = selected[0]
+
+    if is_strm(f.file_path):
+        url = resolve_strm_url(f.file_path)
+        if url is None:
+            raise not_found()
+        return RedirectResponse(url, status_code=302)
+
+    path = Path(f.file_path)
+    if not path.is_file():
+        raise not_found()
+    is_download = request.url.path.lower().endswith("/download")
+    return FileResponse(
+        path,
+        media_type=container_mime_type(f.container or path.suffix),
+        filename=path.name if is_download else None,
+    )

--- a/tests/jellyfin/test_http_flow.py
+++ b/tests/jellyfin/test_http_flow.py
@@ -381,6 +381,58 @@ def test_stream_strm_redirects_without_proxy(client: TestClient, seeded: dict) -
     assert head.status_code == 302
 
 
+def test_download_local_file_with_attachment(client: TestClient, seeded: dict) -> None:
+    token = jf_login(client)
+    guid = item_guid(seeded["movie"])
+    info = client.post(f"/Items/{guid}/PlaybackInfo", params={"ApiKey": token}).json()
+    local = next(s for s in info["MediaSources"] if s["Protocol"] == "File")
+
+    resp = client.get(
+        f"/Items/{guid}/Download",
+        params={"ApiKey": token, "mediaSourceId": local["Id"]},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "video/x-matroska"
+    assert "attachment" in resp.headers["content-disposition"]
+    assert len(resp.content) == 4096
+
+    # 下载器断点续传：Range 语义与取流一致
+    partial = client.get(
+        f"/Items/{guid}/Download",
+        params={"ApiKey": token, "mediaSourceId": local["Id"]},
+        headers={"Range": "bytes=0-1023"},
+    )
+    assert partial.status_code == 206
+    assert len(partial.content) == 1024
+
+    # /File 变体：裸文件，不带 attachment
+    raw = client.get(
+        f"/Items/{guid}/File",
+        params={"ApiKey": token, "mediaSourceId": local["Id"]},
+    )
+    assert raw.status_code == 200
+    assert "content-disposition" not in raw.headers
+
+    # 无 token → 401
+    anon = client.get(f"/Items/{guid}/Download")
+    assert anon.status_code == 401
+
+
+def test_download_strm_redirects_to_cloud(client: TestClient, seeded: dict) -> None:
+    token = jf_login(client)
+    guid = item_guid(seeded["movie"])
+    info = client.post(f"/Items/{guid}/PlaybackInfo", params={"ApiKey": token}).json()
+    remote = next(s for s in info["MediaSources"] if s["Protocol"] == "Http")
+
+    resp = client.get(
+        f"/Items/{guid}/Download",
+        params={"ApiKey": token, "mediaSourceId": remote["Id"]},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "https://pan.example.com/inception-1080p.mp4"
+
+
 def test_progress_reporting_flow(client: TestClient, seeded: dict) -> None:
     token = jf_login(client)
     auth = {"ApiKey": token}


### PR DESCRIPTION
UserDto.Policy 一直宣告 EnableContentDownloading:true，客户端据此显示
下载按钮，但兼容层从未实现 Jellyfin 的下载路由，VidHub 点击下载后请求
GET /Items/{itemId}/Download 得到 404，下载无法开始。

- 新增 GET|HEAD /Items/{itemId}/Download 与 /Items/{itemId}/File：
  本地文件回 FileResponse（Download 带 attachment 文件名，File 不带，
  原生 Range/206 支持断点续传）；strm 条目与取流同策略 302 到云端直链
  （偏离真 Jellyfin 回 .strm 文本的行为，服务器零流量）
- mediaSourceId 作为超集扩展支持指定下载版本，缺省取第一个
- 设计文档 §2 P1 清单补充该接口，新增 2 个协议测试

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N5En4Zny8trqYzLVAX3Y8a