### PR TITLE
fix(jellyfin): 对照真 Jellyfin 修齐下载语义与协议兜底

### DIFF
--- a/src/movieclaw_jellyfin/catalog.py
+++ b/src/movieclaw_jellyfin/catalog.py
@@ -180,6 +180,11 @@ def _list_load_columns(
         LibraryFile.episode_number,
         LibraryFile.duration_seconds,
         LibraryFile.created_at,
+        # 叶子条目的恒输出字段（Container/VideoType 等，_apply_leaf_media_fields）
+        # 在列表路径也要读；都是短字符串列，不在"大 JSON 列"限制之列
+        LibraryFile.file_path,
+        LibraryFile.container,
+        LibraryFile.resolution,
     ]
     if options.has("ParentId"):
         file_columns.append(LibraryFile.library_id)
@@ -235,6 +240,7 @@ async def load_bundles(
     *,
     library_id: int | None = None,
     include_people: bool = False,
+    include_fileless: bool = False,
     dto_options: DtoOptions | None = None,
 ) -> dict[int, ItemBundle]:
     """批量装载条目素材。library_id 限定时只装该库的文件行。
@@ -334,7 +340,10 @@ async def load_bundles(
             # 演员在前（按剧组主次序），导演/主创随后——对齐 Jellyfin People 惯例
             b.people.sort(key=lambda t: (0 if t[0] == "cast" else 1, t[2]))
 
-    # 没有任何在位文件的条目不对外呈现
+    # 没有任何在位文件的条目不对外呈现；标记类接口除外（include_fileless）——
+    # 真 Jellyfin 里文件丢失的条目仍可手动标记已看，响应体要能算聚合 UserData
+    if include_fileless:
+        return bundles
     return {k: v for k, v in bundles.items() if v.files}
 
 
@@ -779,10 +788,57 @@ def _apply_item_images(
     dto["BackdropImageTags"] = [backdrop] if backdrop else []
 
 
+# 标称分辨率 → 常见宽高（探测层未落 width/height，与 _video_stream 同源）
+_RESOLUTION_WH = {
+    "4320p": (7680, 4320),
+    "2160p": (3840, 2160),
+    "1440p": (2560, 1440),
+    "1080p": (1920, 1080),
+    "720p": (1280, 720),
+    "480p": (720, 480),
+}
+
+
+def _apply_leaf_media_fields(
+    dto: dict[str, Any], files: list[LibraryFile], options: DtoOptions
+) -> None:
+    """可播叶子（Movie/Episode）的下载与介质字段（对齐 DtoService）。
+
+    CanDownload 是客户端渲染"下载按钮"的依据：真 Jellyfin 里只有 Video
+    子类返回 true、Series/Season 等 Folder 恒 false——缺了它，客户端退回
+    只看 Policy.EnableContentDownloading，会在剧集层级也放行下载，打到
+    /Videos/{seriesGuid}/stream 得到 404 空 body 存成 0 字节"成品"。
+    CanDelete 按现有 Policy（EnableContentDeletion=false）恒为 false。
+    LocationType/VideoType/Container 是真 Jellyfin 的恒输出字段；strm 不给
+    Container（浏览态偏离，见 media_source_dto）。
+    """
+    if options.has("CanDownload"):
+        # 有在位文件才可下载；strm 对齐真 Jellyfin（Path 是本地文件 → true）
+        dto["CanDownload"] = bool(files)
+    if options.has("CanDelete"):
+        dto["CanDelete"] = False
+    dto["LocationType"] = "FileSystem"
+    dto["VideoType"] = "VideoFile"
+    if files:
+        f = files[0]
+        if f.container and not is_strm(f.file_path):
+            dto["Container"] = f.container
+        wh = _RESOLUTION_WH.get(f.resolution or "")
+        if wh:
+            if options.has("Width"):
+                dto["Width"] = wh[0]
+            if options.has("Height"):
+                dto["Height"] = wh[1]
+            # 真 Jellyfin 只在为 true 时输出 IsHD
+            if options.has("IsHD") and wh[1] >= 720:
+                dto["IsHD"] = True
+
+
 def movie_dto(ctx: DtoContext, bundle: ItemBundle, options: DtoOptions) -> dict[str, Any]:
     guid = item_guid(bundle.item.id)
     dto = _common(ctx, guid, bundle.item.title, "Movie", "Video")
     dto["IsFolder"] = False
+    _apply_leaf_media_fields(dto, bundle.files.get((0, 0), []), options)
     if bundle.item.year:
         dto["ProductionYear"] = bundle.item.year
     runtime_ms = bundle.unit_runtime_ms(0, 0)
@@ -819,6 +875,13 @@ def series_dto(ctx: DtoContext, bundle: ItemBundle, options: DtoOptions) -> dict
     guid = item_guid(bundle.item.id)
     dto = _common(ctx, guid, bundle.item.title, "Series", "Unknown")
     dto["IsFolder"] = True
+    # Folder 不可整体下载（BaseItem.CanDownload 恒 false）；缺失时部分客户端
+    # 退回 Policy 全局开关误放行，见 _apply_leaf_media_fields 注释
+    if options.has("CanDownload"):
+        dto["CanDownload"] = False
+    if options.has("CanDelete"):
+        dto["CanDelete"] = False
+    dto["LocationType"] = "FileSystem"
     if bundle.item.year:
         dto["ProductionYear"] = bundle.item.year
     status = (bundle.item.status or "").lower()
@@ -853,9 +916,20 @@ def season_dto(
     )
     dto = _common(ctx, guid, name, "Season", "Unknown")
     dto["IsFolder"] = True
+    if options.has("CanDownload"):
+        dto["CanDownload"] = False
+    if options.has("CanDelete"):
+        dto["CanDelete"] = False
+    dto["LocationType"] = "FileSystem"
     dto["IndexNumber"] = season
     dto["SeriesId"] = item_guid(bundle.item.id)
     dto["SeriesName"] = bundle.item.title
+    # 真 Jellyfin 对 Season 的 ChildCount 不受 fields 门控（DtoService 短路分支
+    # ChildCount = RecursiveItemCount），恒输出该季集数
+    season_units = [u for u in bundle.units if u[0] == season]
+    dto["ChildCount"] = len(season_units)
+    if options.has("RecursiveItemCount"):
+        dto["RecursiveItemCount"] = len(season_units)
     _apply_parent_id(dto, item_guid(bundle.item.id), options)
     if row and row.air_date:
         dto["PremiereDate"] = row.air_date.strftime("%Y-%m-%dT00:00:00.0000000Z")
@@ -894,6 +968,7 @@ def episode_dto(
     name = (row.name if row else "") or f"Episode {episode}"
     dto = _common(ctx, guid, name, "Episode", "Video")
     dto["IsFolder"] = False
+    _apply_leaf_media_fields(dto, bundle.files.get((season, episode), []), options)
     dto["IndexNumber"] = episode
     dto["ParentIndexNumber"] = season
     dto["SeriesId"] = item_guid(bundle.item.id)

--- a/src/movieclaw_jellyfin/router.py
+++ b/src/movieclaw_jellyfin/router.py
@@ -33,6 +33,7 @@ NAMESPACE_PREFIXES = {
     "videos",
     "shows",
     "sessions",
+    "livestreams",
     "playingitems",
     "branding",
     "quickconnect",
@@ -73,6 +74,7 @@ _KNOWN_QUERY_KEYS = [
     "personIds",
     "groupItems",
     "static",
+    "container",
     "mediaSourceId",
     "ApiKey",
     "api_key",
@@ -163,9 +165,21 @@ def register(app: FastAPI) -> None:
     async def jellyfin_case_normalizer(request: Request, call_next):  # type: ignore[no-untyped-def]
         path = request.scope.get("path", "")
         parts = path.split("/")
-        if len(parts) > 1 and parts[1].lower() in NAMESPACE_PREFIXES:
+        in_namespace = len(parts) > 1 and parts[1].lower() in NAMESPACE_PREFIXES
+        if in_namespace:
             request.scope["path"] = "/".join(_normalize_segment(p) for p in parts)
             raw_query = request.scope.get("query_string", b"")
             if raw_query:
                 request.scope["query_string"] = _normalize_query(raw_query)
-        return await call_next(request)
+        response = await call_next(request)
+        # 命名空间内未实现的路径/方法（/LiveStreams/Open、master.m3u8 等）会
+        # 落到业务统一处理器，返回 RESOURCE_NOT_FOUND 业务信封——这是最容易
+        # 暴露"不是真 Jellyfin"的地方。路由未匹配（scope 无 route）时改按
+        # 协议形态应答：404/405 空 body，对齐 ASP.NET 终结点兜底
+        if (
+            in_namespace
+            and response.status_code in (404, 405)
+            and "route" not in request.scope
+        ):
+            return Response(status_code=response.status_code)
+        return response

--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -142,7 +142,10 @@ async def video_stream(
     path = Path(f.file_path)
     if not path.is_file():
         raise not_found()
-    media_type = container_mime_type(container or f.container or path.suffix)
+    # MIME 优先级对齐 StreamingHelpers：URL 后缀 → ?container= query → 真实容器
+    media_type = container_mime_type(
+        container or request.query_params.get("container") or f.container or path.suffix
+    )
     # 停止播放并不保证客户端立刻关闭 Range 连接。按已认证设备登记这条流，
     # 让 /Sessions/Playing/Stopped 能主动停止读盘；TCP 断连仍是第二道兜底。
     device_id = identity.device.device_id

--- a/src/movieclaw_jellyfin/routes/playstate.py
+++ b/src/movieclaw_jellyfin/routes/playstate.py
@@ -86,6 +86,13 @@ async def _resolve_units(ref: EntityRef) -> list[playback_state.Unit]:
             LibraryFile.missing_since.is_(None),
         )
         rows = list((await session.execute(q)).all())
+        if not rows and ref.kind in (EntityKind.ITEM, EntityKind.SEASON):
+            # 文件全部丢失的剧：真 Jellyfin 只要条目存在就允许手动标记已看
+            # （走元数据级联），不应因文件不在位而 404。退回元数据集清单
+            eq = select(
+                MediaEpisode.season_number, MediaEpisode.episode_number
+            ).where(MediaEpisode.media_item_id == ref.entity_id)
+            rows = list((await session.execute(eq)).all())
     units = sorted({(ref.entity_id, s, e) for s, e in rows})
     if ref.kind == EntityKind.EPISODE:
         return [(ref.entity_id, ref.season, ref.episode)]
@@ -273,8 +280,10 @@ async def playing_stopped(
     # VidHub 的 Stopped 不代表它已立即关闭此前发出的 Range 请求。先取消同设备
     # 的活跃流，避免机械盘继续为已退出的播放器预读；失败停止同样必须收口。
     stop_device_streams(identity.device.device_id)
-    if body.get("failed") is True:
-        # 播放失败的上报不落库（SessionManager.cs:1164-1167）
+    failed = body.get("failed")
+    if failed is True or (isinstance(failed, str) and failed.lower() == "true"):
+        # 播放失败的上报不落库（SessionManager.cs:1164-1167）；字符串 "true"
+        # 一并接住——真 Jellyfin 对它 400，我们静默落库会把失败记成正常观看
         return Response(status_code=204)
     ref = _decode_item_ref(body.get("itemid"))
     if ref is not None:
@@ -356,7 +365,7 @@ async def _user_data_response(ref: EntityRef, guid_raw: str) -> JSONResponse:
     据此原地刷新角标，不必重拉列表。"""
     guid = guid_raw.lower().replace("-", "")
     async with get_database().session() as session:
-        bundles = await load_bundles(session, [ref.entity_id])
+        bundles = await load_bundles(session, [ref.entity_id], include_fileless=True)
     bundle = bundles.get(ref.entity_id)
     if bundle is None:
         return JSONResponse(

--- a/tests/jellyfin/test_audit_regressions.py
+++ b/tests/jellyfin/test_audit_regressions.py
@@ -716,3 +716,119 @@ def test_media_source_etag_comes_from_ledger(client: TestClient, seeded: dict) -
     body = client.get(f"/Items/{guid}", params={"ApiKey": token}).json()
     local = next(s for s in body["MediaSources"] if s["Protocol"] == "File")
     assert local["ETag"] == hashlib.md5(b"1723800000123456789").hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# 下载语义审计（对照 DtoService/BaseItem/Video 的 CanDownload 规则）
+# ---------------------------------------------------------------------------
+
+
+def test_can_download_leaf_true_folder_false(client: TestClient, seeded: dict) -> None:
+    """CanDownload：Movie/Episode 为 true，Series/Season 恒 false。
+
+    缺失该字段时 VidHub 等客户端退回 Policy.EnableContentDownloading 全局
+    放行，在剧集层级也显示下载按钮，打到 /Videos/{seriesGuid}/stream 得到
+    404 空 body 存成 0 字节"成品"（三体下载翻车的根因）。
+    """
+    token = jf_login(client)
+    auth = {"ApiKey": token, "fields": "CanDownload,CanDelete"}
+
+    movie = client.get(f"/Items/{item_guid(seeded['movie'])}", params=auth).json()
+    assert movie["CanDownload"] is True and movie["CanDelete"] is False
+
+    show = client.get(f"/Items/{item_guid(seeded['show'])}", params=auth).json()
+    assert show["CanDownload"] is False
+
+    season = client.get(f"/Items/{season_guid(seeded['show'], 1)}", params=auth).json()
+    assert season["CanDownload"] is False
+
+    ep = client.get(f"/Items/{episode_guid(seeded['show'], 1, 1)}", params=auth).json()
+    assert ep["CanDownload"] is True
+
+
+def test_leaf_constant_fields_present(client: TestClient, seeded: dict) -> None:
+    """真 Jellyfin 恒输出的字段：LocationType/VideoType/顶层 Container；
+    Season 的 ChildCount 不受 fields 门控（DtoService 短路分支）。"""
+    token = jf_login(client)
+    auth = {"ApiKey": token}
+
+    movie = client.get(f"/Items/{item_guid(seeded['movie'])}", params=auth).json()
+    assert movie["LocationType"] == "FileSystem"
+    assert movie["VideoType"] == "VideoFile"
+    assert movie["Container"] == "mkv"
+
+    season = client.get(f"/Items/{season_guid(seeded['show'], 1)}", params=auth).json()
+    assert season["ChildCount"] == 2  # S01 两集，无需 fields 请求
+
+    # 列表路径（最小列集）也必须能输出这些恒有字段，不得触发惰性加载
+    listing = client.get(
+        "/Items",
+        params={
+            "ApiKey": token,
+            "parentId": library_guid(seeded["movie_lib"]),
+            "recursive": "true",
+            "includeItemTypes": "Movie",
+        },
+    ).json()
+    assert listing["Items"][0]["Container"] == "mkv"
+
+
+def test_width_height_ishd_gated(client: TestClient, seeded: dict) -> None:
+    """Width/Height/IsHD 按 fields 门控输出，值从标称分辨率派生。"""
+    token = jf_login(client)
+    guid = item_guid(seeded["movie"])
+    body = client.get(
+        f"/Items/{guid}", params={"ApiKey": token, "fields": "Width,Height,IsHD"}
+    ).json()
+    assert (body["Width"], body["Height"]) == (3840, 2160)
+    assert body["IsHD"] is True
+
+
+def test_namespace_unknown_route_is_bare_404(client: TestClient) -> None:
+    """命名空间内未实现的路径不得漏出业务 JSON 信封（RESOURCE_NOT_FOUND）。"""
+    token = jf_login(client)
+    resp = client.get("/Videos/whatever/master.m3u8", params={"ApiKey": token})
+    assert resp.status_code == 404
+    assert resp.content == b""
+    resp = client.post("/LiveStreams/Open", params={"ApiKey": token})
+    assert resp.status_code in (404, 405)
+    assert resp.content == b""
+
+
+def test_mark_played_survives_missing_files(client: TestClient, seeded: dict) -> None:
+    """文件全部丢失的剧仍可手动标记已看（真 Jellyfin 语义：条目在即 200）。"""
+    import os
+    import sqlite3
+
+    token = jf_login(client)
+    db_path = os.environ["DATABASE_URL"].split("///", 1)[1]
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE library_file SET missing_since = '2026-08-07 00:00:00' "
+            "WHERE media_item_id = ?",
+            (seeded["show"],),
+        )
+        conn.commit()
+
+    resp = client.post(
+        f"/Users/{'0' * 32}/PlayedItems/{item_guid(seeded['show'])}",
+        params={"ApiKey": token},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["Played"] is True
+
+
+def test_stopped_failed_string_true_skips_persistence(
+    client: TestClient, seeded: dict
+) -> None:
+    """Failed 为字符串 "true" 的 Stopped 同样不落库（不得记成正常观看）。"""
+    token = jf_login(client)
+    ep = episode_guid(seeded["show"], 2, 1)
+    resp = client.post(
+        "/Sessions/Playing/Stopped",
+        params={"ApiKey": token},
+        json={"ItemId": ep, "PositionTicks": 66 * 600_000_000, "Failed": "true"},
+    )
+    assert resp.status_code == 204
+    ud = client.get(f"/Items/{ep}", params={"ApiKey": token}).json()["UserData"]
+    assert ud["PlaybackPositionTicks"] == 0 and ud["Played"] is False


### PR DESCRIPTION
## 背景

用户在 VidHub 上对剧集条目发起下载，得到无法打开的 0 字节文件。clone 真 Jellyfin 源码逐字段/逐端点对照审计兼容层后，定位根因并一并修复六处行为差异。

## 根因

条目 DTO 从不输出 `CanDownload`。真 Jellyfin 中该字段只有 Video 子类（Movie/Episode）为 true，Series/Season 恒 false（`BaseItem.cs:895` / `Video.cs:444`）。字段缺失时客户端退回 `Policy.EnableContentDownloading` 全局放行 → 剧集层级也显示下载按钮 → 打到 `/Videos/{剧集GUID}/stream` 拿 404 空 body → 存成 0 字节文件。

## 修复

| # | 差异 | 修复 |
|---|---|---|
| 1 | `CanDownload` 缺失 | 电影/单集 true（有在位文件）、剧集/季恒 false |
| 2 | Season 缺 `ChildCount`（真 Jellyfin 不受 fields 门控） | 恒输出该季集数，`RecursiveItemCount` 按门控 |
| 3 | 缺恒输出字段 | 叶子补 `LocationType`/`VideoType`/顶层 `Container`；门控的 `Width`/`Height`/`IsHD`/`CanDelete` |
| 4 | 未实现路径漏业务 JSON 信封 | 命名空间内路由未匹配时回裸 404/405（最易暴露"不是真 Jellyfin"处） |
| 5 | 文件全丢的剧标记已看 404 | 改 200，退元数据集清单级联（对齐真 Jellyfin） |
| 6 | `Failed:"true"` 字符串被记成正常观看 | 一并跳过落库；顺带补 stream 的 `?container=` MIME 层级 |

审计确认无差异/属有意偏离的未动：UserData 聚合、RunTimeTicks 语义、strm 302 直链、stream 去 Content-Length（提前停流需 chunked 收尾）。

## 验证

- `tests/jellyfin` 82 通过，含 6 个新回归测试（每处修复一个）
- 全量 pytest 1150 通过（`test_system_logs` 的 error 在干净主干同样复现，既有隔离 flake，与本 PR 无关）
- `ruff check` 全绿
- dev 服务上模拟 VidHub 实测：剧集条目 `CanDownload=False`、单集 `True`、Season `ChildCount` 正确、`/LiveStreams/Open` 裸 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)