### PR TITLE
fix(library): 落位改为 rename 发布，修复极空间极影视识别不到硬链接文件

### DIFF
--- a/src/movieclaw_api/services/library/fsops.py
+++ b/src/movieclaw_api/services/library/fsops.py
@@ -1,0 +1,67 @@
+"""文件落位原语：防覆盖改名（renameat2 RENAME_NOREPLACE）。
+
+入库/整理的落位统一走「先在目标目录备好内容，再 rename 发布到最终名」，
+而不是直接 ``os.link`` 到最终名。两个原因：
+
+1. **防覆盖**：``os.rename`` 会静默覆盖已存在的目标；RENAME_NOREPLACE 让
+   rename 在目标已存在时原子失败（EEXIST），与旧实现借 ``os.link`` 的
+   EEXIST 语义完全等价——「计划检查后、执行前恰有同名文件落地」的并发
+   覆盖窗口依然被堵死；
+2. **极空间兼容（issue #103）**：极空间的存储是自研 FUSE 文件系统
+   （zfuse.zfsv*），极影视的媒体索引只感知 create/write/rename 这类目录
+   元数据变更，硬链接新增的目录项**不产生索引事件**——直接 link 到最终名
+   的文件在极影视里永远"不存在"。rename 必然更新目录元数据、会被索引
+   感知（NAStool/MoviePilot 对极空间的适配同一原理，MoviePilot #667）。
+
+回退语义：RENAME_NOREPLACE 需要文件系统支持（ext4/btrfs/xfs/overlayfs 均
+支持；FUSE 类——恰好包括极空间——可能不支持，返回 EINVAL/ENOSYS/ENOTSUP）。
+回退路径是「先查存在再普通 rename」，留下单次系统调用宽度的竞态窗口；
+**绝不回退到 os.link**——那会在极空间上重新引入本模块要修的索引盲区。
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+from pathlib import Path
+
+# renameat2 的 flag 与 dirfd 常量（Linux 内核 ABI，不随 libc 版本变化）
+_RENAME_NOREPLACE = 1
+_AT_FDCWD = -100
+
+# glibc >= 2.28 提供 renameat2 封装（运行镜像 Debian bookworm 为 2.36）。
+# 拿不到符号时置 None，永远走回退路径——功能不缺失，只是防覆盖不再原子
+try:
+    _libc = ctypes.CDLL(None, use_errno=True)
+    _renameat2 = _libc.renameat2
+except (OSError, AttributeError):  # pragma: no cover -- 非 Linux/远古 libc
+    _renameat2 = None
+
+# 「文件系统不支持 NOREPLACE」的 errno：EINVAL（FUSE 未实现 RENAME2）、
+# ENOSYS（旧内核无此系统调用）、ENOTSUP（Linux 上与 EOPNOTSUPP 同值 95）
+_UNSUPPORTED_ERRNOS = {errno.EINVAL, errno.ENOSYS, errno.ENOTSUP}
+
+
+def rename_no_replace(src: Path, dst: Path) -> None:
+    """原子防覆盖改名：目标已存在抛 FileExistsError，其余错误原样抛 OSError。
+
+    src 与 dst 必须在同一文件系统（跨设备抛 EXDEV，与 os.rename 一致）。
+    """
+    if _renameat2 is not None:
+        res = _renameat2(
+            _AT_FDCWD, os.fsencode(src), _AT_FDCWD, os.fsencode(dst), _RENAME_NOREPLACE
+        )
+        if res == 0:
+            return
+        err = ctypes.get_errno()
+        if err == errno.EEXIST:
+            raise FileExistsError(err, os.strerror(err), str(src), None, str(dst))
+        if err not in _UNSUPPORTED_ERRNOS:
+            raise OSError(err, os.strerror(err), str(src), None, str(dst))
+        # 落到这里 = 文件系统不支持 NOREPLACE，走下方回退
+    if dst.exists():
+        raise FileExistsError(
+            errno.EEXIST, os.strerror(errno.EEXIST), str(src), None, str(dst)
+        )
+    os.rename(src, dst)

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -71,8 +71,11 @@
 
 幂等与安全：
 - 源文件**永不改动**：硬链保种零占用（需与主根同盘），复制适合跨盘；
-- 搬运用 ``os.link`` 原子防覆盖落位（同 library_organize），目标已存在
-  且内容不同时按多版本约定加 " - 版本标签" 后缀，仍冲突则跳过不覆盖；
+- 搬运落位统一「备好内容 → rename 发布」（fsops.rename_no_replace，原子
+  防覆盖，同 library_organize；直接 link 到最终名在极空间的 FUSE 文件
+  系统上不产生索引事件，极影视会永远看不到该文件，见 fsops 模块头）；
+  目标已存在且内容不同时按多版本约定加 " - 版本标签" 后缀，仍冲突则
+  跳过不覆盖；
 - 台账逐条目收口：源文件留在监听目录，没有台账每轮都会重复处理。
 
 与扫描/整理的并发：本模块只**新建**规范命名文件（与订阅入库管线同性质），
@@ -91,12 +94,14 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
+from uuid import uuid4
 
 from sqlalchemy import update
 from sqlmodel import select
 
 from movieclaw_api.services.import_watch_config import rule_target_label
 from movieclaw_api.services.library.config import derive_entry_dir, derive_save_path
+from movieclaw_api.services.library.fsops import rename_no_replace
 from movieclaw_api.services.library.layout import (
     IN_PROGRESS_MARKERS,
     VIDEO_EXTS,
@@ -993,8 +998,10 @@ def _transfer(src: Path, dst: Path, strategy: str, version_label: str) -> Path |
     """把源文件按策略搬到目标；返回最终落位路径，None = 同内容已在库。
 
     目标已存在且内容不同时按多版本约定退让到 ``… - 版本标签.ext``；
-    落位一律走 ``os.link`` 原子防覆盖（复制策略先写 .part 临时文件——
-    库根的 watchdog/扫描不认 .part 后缀，不会看到半成品）。
+    落位一律「先在目标目录写 .part 临时名（复制=copyfile、硬链=os.link），
+    再 rename_no_replace 发布到最终名」——rename 保证极空间等 FUSE 存储的
+    索引能看到新文件（见 fsops 模块头），NOREPLACE 保证不静默覆盖；
+    库根的 watchdog/扫描不认 .part 后缀，不会看到半成品。
     """
     final = dst
     if final.exists():
@@ -1014,7 +1021,7 @@ def _transfer(src: Path, dst: Path, strategy: str, version_label: str) -> Path |
         part = final.with_name(final.name + ".part")
         try:
             shutil.copyfile(src, part)
-            os.link(part, final)
+            rename_no_replace(part, final)
         except FileExistsError as exc:
             raise IngestError(f"目标已存在同名文件，跳过以免覆盖：{final.name}") from exc
         except OSError as exc:
@@ -1023,8 +1030,12 @@ def _transfer(src: Path, dst: Path, strategy: str, version_label: str) -> Path |
             part.unlink(missing_ok=True)
         return final
 
+    # 硬链临时名带随机段：同名条目的失败重试/并发不会互踩残留；崩溃残留的
+    # .part 对扫描不可见且不占空间（硬链接），下次同条目重试不受其影响
+    tmp = final.with_name(f"{final.name}.{uuid4().hex[:8]}.part")
     try:
-        os.link(src, final)
+        os.link(src, tmp)
+        rename_no_replace(tmp, final)
     except FileExistsError as exc:
         raise IngestError(f"目标已存在同名文件，跳过以免覆盖：{final.name}") from exc
     except OSError as exc:
@@ -1034,6 +1045,8 @@ def _transfer(src: Path, dst: Path, strategy: str, version_label: str) -> Path |
                 "请把该监听目录的策略改为「复制」，或把两者放到同一存储卷"
             ) from exc
         raise IngestError(f"硬链接失败（{exc.strerror}）：{src.name} → {final}") from exc
+    finally:
+        tmp.unlink(missing_ok=True)
     return final
 
 

--- a/src/movieclaw_api/services/library/organize.py
+++ b/src/movieclaw_api/services/library/organize.py
@@ -11,10 +11,11 @@
 - **预览与执行分离**：``build_organize_plan`` 是纯计算（只读磁盘不写），
   预览接口直接返回完整清单；执行时**重新计算**计划——预览到确认之间
   磁盘可能已变化，执行永远以最新状态为准；
-- **防覆盖改名**：同文件系统内用 ``os.link + os.unlink`` 代替 ``os.rename``
-  ——link 遇到目标已存在会原子失败（EEXIST），不会像 rename 那样静默
-  覆盖（与入库管线并发写入同一规范名时的兜底）；不支持硬链的文件系统
-  退回"先查存在再 rename"；
+- **防覆盖改名**：``os.rename`` 会静默覆盖已存在的目标，这里用
+  ``fsops.rename_no_replace``（renameat2 RENAME_NOREPLACE）——目标已存在
+  会原子失败（EEXIST），堵死与入库管线并发写入同一规范名的覆盖窗口；
+  且 rename 会被极空间等 FUSE 存储的索引感知（旧实现的 os.link 不会，
+  改名后文件会从极影视里消失，见 fsops 模块头）；
 - **逐文件收口**：每改名成功一个立即随迁台账（repo.relocate），中途失败
   不会留下"账实不符"的批量烂摊子，单文件失败记入 errors 不断整轮；
 - **只清理自己搬空的目录**：改名后仅对被搬走文件的原目录（及其空祖先）
@@ -45,13 +46,13 @@ from __future__ import annotations
 import asyncio
 import errno
 import logging
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from sqlmodel import select
 
 from movieclaw_api.services.library.config import sanitize_folder_name
+from movieclaw_api.services.library.fsops import rename_no_replace
 from movieclaw_api.services.library.layout import SCAN_VIDEO_EXTS, entry_base_name
 from movieclaw_api.services.task_state import TaskState
 from movieclaw_db.engine import get_database
@@ -440,10 +441,9 @@ async def _organize(library_id: int, summary: OrganizeSummary) -> OrganizeSummar
 def _move_no_clobber(src: Path, dst: Path) -> None:
     """同文件系统内的防覆盖改名（线程池内运行）。
 
-    ``os.rename`` 会静默覆盖已存在的目标，这里用 ``os.link + os.unlink``：
-    link 遇到目标已存在会原子失败（EEXIST），杜绝"计划检查后、执行前恰有
-    同名文件落地（如入库管线并发硬链）"的覆盖窗口。不支持硬链的文件系统
-    （极少数网络挂载）退回"先查存在再 rename"。
+    ``fsops.rename_no_replace`` 一步到位：目标已存在会原子失败（EEXIST），
+    杜绝"计划检查后、执行前恰有同名文件落地（如入库管线并发落位）"的
+    覆盖窗口；rename 同时保证极空间等 FUSE 存储的索引能跟上改名。
     """
     if not src.exists():
         raise _MoveError(f"源文件已不在原位，跳过：{src}")
@@ -452,22 +452,13 @@ def _move_no_clobber(src: Path, dst: Path) -> None:
     except OSError as exc:
         raise _MoveError(f"创建目标目录失败（{exc.strerror}）：{dst.parent}") from exc
     try:
-        os.link(src, dst)
+        rename_no_replace(src, dst)
+    except FileExistsError as exc:
+        raise _MoveError(f"目标路径已被占用，跳过以免覆盖：{dst}") from exc
     except OSError as exc:
-        if exc.errno == errno.EEXIST:
-            raise _MoveError(f"目标路径已被占用，跳过以免覆盖：{dst}") from exc
         if exc.errno == errno.EXDEV:
             raise _MoveError(f"目标与源不在同一文件系统，无法改名归位：{src} → {dst}") from exc
-        if exc.errno in (errno.EPERM, errno.ENOTSUP):
-            if dst.exists():
-                raise _MoveError(f"目标路径已被占用，跳过以免覆盖：{dst}") from exc
-            try:
-                os.rename(src, dst)
-            except OSError as exc2:
-                raise _MoveError(f"改名失败（{exc2.strerror}）：{src} → {dst}") from exc2
-            return
         raise _MoveError(f"改名失败（{exc.strerror}）：{src} → {dst}") from exc
-    os.unlink(src)
 
 
 def _prune_emptied_dirs(dirty_parents: set[Path], roots: list[str]) -> int:

--- a/tests/api/test_library_fsops.py
+++ b/tests/api/test_library_fsops.py
@@ -1,0 +1,233 @@
+"""落位原语（fsops.rename_no_replace）与三处调用点的防回退测试。
+
+背景（issue #103）：极空间的 FUSE 存储对硬链接不产生索引事件，直接
+os.link 到最终名的文件极影视永远看不到，落位因此改为「备好内容 →
+rename 发布」。本文件锁死改造后的关键语义：
+
+- 原语：改名成功 / 目标已存在原子拒绝 / NOREPLACE 不支持时的回退路径
+  行为一致 / 回退路径绝不使用 os.link；
+- ingest._transfer：硬链与复制的最终产物不变（inode 关系、内容）、
+  临时文件必被清理、发布竞态输为 IngestError 不覆盖；
+- organize._move_no_clobber：改名生效、占用拒绝、EXDEV 中文报错。
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+
+import pytest
+
+import movieclaw_api.services.library.fsops as fsops
+import movieclaw_api.services.library.ingest as ingest_mod
+import movieclaw_api.services.library.organize as organize_mod
+from movieclaw_api.services.library.fsops import rename_no_replace
+from movieclaw_api.services.library.ingest import IngestError, _transfer
+from movieclaw_api.services.library.organize import _move_no_clobber, _MoveError
+
+# ---------------------------------------------------------------------------
+# rename_no_replace 原语
+# ---------------------------------------------------------------------------
+
+
+def test_rename_no_replace_moves_file(tmp_path):
+    src = tmp_path / "a.mkv"
+    src.write_bytes(b"payload")
+    dst = tmp_path / "b.mkv"
+    rename_no_replace(src, dst)
+    assert not src.exists()
+    assert dst.read_bytes() == b"payload"
+
+
+def test_rename_no_replace_refuses_existing_target(tmp_path):
+    src = tmp_path / "a.mkv"
+    src.write_bytes(b"new")
+    dst = tmp_path / "b.mkv"
+    dst.write_bytes(b"old")
+    with pytest.raises(FileExistsError):
+        rename_no_replace(src, dst)
+    # 源与目标都原样：既没搬走也没覆盖
+    assert src.read_bytes() == b"new"
+    assert dst.read_bytes() == b"old"
+
+
+@pytest.fixture
+def force_fallback(monkeypatch):
+    """模拟文件系统不支持 RENAME_NOREPLACE（极空间的 zfuse 场景）。"""
+
+    def _unsupported(*args):
+        import ctypes
+
+        ctypes.set_errno(errno.EINVAL)
+        return -1
+
+    monkeypatch.setattr(fsops, "_renameat2", _unsupported)
+
+
+def test_fallback_moves_file(tmp_path, force_fallback):
+    src = tmp_path / "a.mkv"
+    src.write_bytes(b"payload")
+    dst = tmp_path / "b.mkv"
+    rename_no_replace(src, dst)
+    assert not src.exists()
+    assert dst.read_bytes() == b"payload"
+
+
+def test_fallback_refuses_existing_target(tmp_path, force_fallback):
+    src = tmp_path / "a.mkv"
+    src.write_bytes(b"new")
+    dst = tmp_path / "b.mkv"
+    dst.write_bytes(b"old")
+    with pytest.raises(FileExistsError):
+        rename_no_replace(src, dst)
+    assert dst.read_bytes() == b"old"
+
+
+def test_fallback_never_uses_link(tmp_path, force_fallback, monkeypatch):
+    """回退路径若退回 os.link，等于在极空间上重新引入索引盲区——锁死。"""
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("回退路径不得调用 os.link")
+
+    monkeypatch.setattr(os, "link", _forbidden)
+    src = tmp_path / "a.mkv"
+    src.write_bytes(b"payload")
+    rename_no_replace(src, tmp_path / "b.mkv")
+
+
+def test_real_oserror_propagates(tmp_path):
+    # 跨设备等真实错误必须原样抛出（EXDEV 由调用方翻译成中文引导）
+    src = tmp_path / "a.mkv"
+    src.write_bytes(b"x")
+    with pytest.raises(OSError) as exc_info:
+        rename_no_replace(src, tmp_path / "no-such-dir" / "b.mkv")
+    assert not isinstance(exc_info.value, FileExistsError)
+    assert src.exists()
+
+
+# ---------------------------------------------------------------------------
+# ingest._transfer
+# ---------------------------------------------------------------------------
+
+
+def _no_leftover_tmp(directory) -> bool:
+    return not list(directory.glob("*.part"))
+
+
+def test_transfer_hardlink_same_inode_and_clean(tmp_path):
+    src = tmp_path / "inbox" / "movie.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data")
+    dst = tmp_path / "lib" / "电影 (2024)" / "电影 (2024).mkv"
+    final = _transfer(src, dst, "hardlink", "v2")
+    assert final == dst
+    assert dst.stat().st_ino == src.stat().st_ino  # 仍是硬链接：保种零占用
+    assert _no_leftover_tmp(dst.parent)  # 临时名不残留
+
+
+def test_transfer_copy_new_inode_and_clean(tmp_path):
+    src = tmp_path / "inbox" / "movie.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data")
+    dst = tmp_path / "lib" / "电影 (2024)" / "电影 (2024).mkv"
+    final = _transfer(src, dst, "copy", "v2")
+    assert final == dst
+    assert dst.read_bytes() == b"data"
+    assert dst.stat().st_ino != src.stat().st_ino
+    assert _no_leftover_tmp(dst.parent)
+
+
+def test_transfer_dedupes_same_payload(tmp_path):
+    src = tmp_path / "inbox" / "movie.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data")
+    dst = tmp_path / "lib" / "电影 (2024).mkv"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.link(src, dst)  # 已入库（同 inode）
+    assert _transfer(src, dst, "hardlink", "v2") is None
+
+
+def test_transfer_version_label_on_conflict(tmp_path):
+    src = tmp_path / "inbox" / "movie.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data-1080p!")
+    dst = tmp_path / "lib" / "电影 (2024).mkv"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_bytes(b"other")  # 已有不同内容的同名文件
+    final = _transfer(src, dst, "hardlink", "1080p")
+    assert final == dst.with_name("电影 (2024) - 1080p.mkv")
+    assert final.stat().st_ino == src.stat().st_ino
+
+
+def test_transfer_publish_race_raises_not_clobbers(tmp_path, monkeypatch):
+    """exists 预检通过后、发布前目标恰好落地（并发整理）：报冲突不覆盖。"""
+    src = tmp_path / "inbox" / "movie.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data")
+    dst = tmp_path / "lib" / "电影 (2024).mkv"
+
+    def _race(a, b):
+        raise FileExistsError(errno.EEXIST, "File exists", str(a), None, str(b))
+
+    monkeypatch.setattr(ingest_mod, "rename_no_replace", _race)
+    with pytest.raises(IngestError, match="跳过以免覆盖"):
+        _transfer(src, dst, "hardlink", "v2")
+    assert _no_leftover_tmp(dst.parent)  # 失败路径同样不残留临时名
+
+
+def test_transfer_failure_cleans_tmp(tmp_path, monkeypatch):
+    src = tmp_path / "inbox" / "movie.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data")
+    dst = tmp_path / "lib" / "电影 (2024).mkv"
+
+    def _boom(a, b):
+        raise OSError(errno.EIO, "I/O error")
+
+    monkeypatch.setattr(ingest_mod, "rename_no_replace", _boom)
+    with pytest.raises(IngestError):
+        _transfer(src, dst, "hardlink", "v2")
+    assert _no_leftover_tmp(dst.parent)
+
+
+# ---------------------------------------------------------------------------
+# organize._move_no_clobber
+# ---------------------------------------------------------------------------
+
+
+def test_move_no_clobber_renames(tmp_path):
+    src = tmp_path / "root" / "旧名.mkv"
+    src.parent.mkdir()
+    src.write_bytes(b"data")
+    dst = tmp_path / "root" / "电影 (2024)" / "电影 (2024).mkv"
+    _move_no_clobber(src, dst)
+    assert not src.exists()
+    assert dst.read_bytes() == b"data"
+
+
+def test_move_no_clobber_refuses_occupied_target(tmp_path):
+    src = tmp_path / "旧名.mkv"
+    src.write_bytes(b"new")
+    dst = tmp_path / "规范名.mkv"
+    dst.write_bytes(b"old")
+    with pytest.raises(_MoveError, match="跳过以免覆盖"):
+        _move_no_clobber(src, dst)
+    assert dst.read_bytes() == b"old"
+    assert src.exists()
+
+
+def test_move_no_clobber_exdev_message(tmp_path, monkeypatch):
+    src = tmp_path / "旧名.mkv"
+    src.write_bytes(b"data")
+
+    def _exdev(a, b):
+        raise OSError(errno.EXDEV, "Invalid cross-device link")
+
+    monkeypatch.setattr(organize_mod, "rename_no_replace", _exdev)
+    with pytest.raises(_MoveError, match="不在同一文件系统"):
+        _move_no_clobber(src, tmp_path / "新名.mkv")
+
+
+def test_move_no_clobber_missing_source(tmp_path):
+    with pytest.raises(_MoveError, match="源文件已不在原位"):
+        _move_no_clobber(tmp_path / "不存在.mkv", tmp_path / "新名.mkv")


### PR DESCRIPTION
## 背景（#103）

极空间的存储是自研 FUSE 文件系统（`zfuse.zfsv*`），极影视的媒体索引只感知 create/write/rename 这类目录元数据变更，硬链接新增的目录项**不产生索引事件**——直接 `os.link` 到最终名落位的文件，在极影视里永远"不存在"。NAStool/MoviePilot 对极空间的适配同一原理（jxxghp/MoviePilot#667：先 link 到临时名、再 rename 成最终名，rename 会被索引感知）。

## 改动

新增 `fsops.rename_no_replace`（`renameat2 RENAME_NOREPLACE`；文件系统不支持时回退「先查存在再 rename」，**绝不回退 `os.link`**——那会在极空间上重新引入索引盲区），三处落位统一为「备好内容 → rename 发布」：

| 调用点 | 之前 | 之后 |
|---|---|---|
| ingest 硬链策略 | `os.link` 直达最终名 | link 到目标目录随机临时名（`.part`）→ rename 发布，`finally` 清理 |
| ingest 复制策略 | copyfile 到 `.part` → `os.link(part, final)` | copyfile 到 `.part` → rename 发布（少一次 link） |
| organize 改名 | `os.link + os.unlink` 两步 | 一次 `rename_no_replace`（顺带修复该处在极空间上"改名后文件从极影视消失"的同源问题） |

防覆盖语义不变：`RENAME_NOREPLACE` 在目标已存在时原子失败（EEXIST），与旧实现借 `os.link` 的 EEXIST 拒绝完全等价，入库与整理并发写同一规范名的覆盖窗口仍被堵死。`transfer` 模块本就走 `os.rename`，不受影响；库根 watchdog 对 moved 事件的处理已有覆盖（`watch.py` 起点/终点任一视频扩展名即触发），无需改动。

不涉及运行时依赖/数据库迁移，无需 bump `docker/runtime-version`。

## 测试

- 新增 `tests/api/test_library_fsops.py` 16 例：原语的改名/占用原子拒绝/NOREPLACE 不支持回退路径/「回退禁用 os.link」防倒退锁；`_transfer` 硬链同 inode、复制新 inode、同内容去重、多版本退让、发布竞态报冲突不覆盖、失败路径临时名必清理；`_move_no_clobber` 改名/占用/EXDEV/源缺失
- 存量回归：ingest×4 / organize / transfer 六套件 52 例全过（含既有「硬链后同 inode」「复制后不同 inode」断言）
- `ruff check .`、`pnpm web:lint`、`pnpm web:typecheck` 通过；全量 `pytest` 1279 过，39 个失败经在基线 `d4a2bc8` 复跑确认全部为环境原因（沙箱缺 NER 模型文件、注入 `HTTPS_PROXY`），与本改动无关

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLLbf4qcgEBYicAGpW31QV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLLbf4qcgEBYicAGpW31QV)_