### PR TITLE
fix(docker): 健康监督日志外显失败原因并加大前端重启轮询窗口

### DIFF
--- a/apps/web/components/app-config-section.tsx
+++ b/apps/web/components/app-config-section.tsx
@@ -104,7 +104,9 @@ export function AppConfigSection() {
     }
     // 先给停机留出时间，避免轮询打到「还没退出的旧进程」造成误判
     await new Promise((r) => setTimeout(r, 4000));
-    for (let i = 0; i < 45; i++) {
+    // 轮询窗口需覆盖 entrypoint 重启链路的最坏情况（收尾宽限 + 后端就绪 +
+    // 前端就绪各阶段的超时之和约 140s），否则会误报「超时」而服务随后自行恢复
+    for (let i = 0; i < 75; i++) {
       try {
         await getHealth();
         window.location.reload();

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -226,6 +226,24 @@ except Exception:
 ' "$1" >/dev/null 2>&1
 }
 
+# 与 probe_health 同一探测，但输出失败的具体原因（连接拒绝/超时/HTTP 状态码）。
+# 这是给非开发者看的诊断日志：只说「失败」没法判断该查哪一层。
+describe_health_failure() {
+    "$PYTHON_BIN" -c '
+import sys
+from urllib.request import urlopen
+
+try:
+    with urlopen(sys.argv[1], timeout=2) as response:
+        if 200 <= response.status < 300:
+            print("已恢复正常")
+        else:
+            print(f"HTTP {response.status}")
+except Exception as exc:
+    print(f"{type(exc).__name__}: {exc}"[:200])
+' "$1" 2>/dev/null || echo "健康探测进程自身异常"
+}
+
 # 在等待健康接口时同步观察进程是否提前退出，避免后端 import/迁移报错后还白等
 # 到超时。WAIT_FAILURE_CODE 保存真实退出码；正常退出却未就绪也按失败码 1 处理。
 wait_for_health() {
@@ -304,7 +322,7 @@ start_web() {
 # 退出，Docker 才能可靠地拉起一个全新的进程组。
 start_health_watchdog() {
     (
-        local failures=0
+        local failures=0 reason segment
         while true; do
             sleep "$HEALTHCHECK_INTERVAL_SECONDS"
             if probe_health "$WEB_HEALTH_URL"; then
@@ -312,7 +330,15 @@ start_health_watchdog() {
                 continue
             fi
             failures=$(( failures + 1 ))
-            echo "[entrypoint] 完整健康链路检查失败（$failures/${HEALTHCHECK_FAILURE_THRESHOLD}）：$WEB_HEALTH_URL" >&2
+            # 失败时补一次后端直连探测做分段归因：完整链路断了，先分清是
+            # 后端故障还是前端/反代故障，用户贴日志时就能直接定位到出问题的层。
+            reason="$(describe_health_failure "$WEB_HEALTH_URL")"
+            if probe_health "$API_HEALTH_URL"; then
+                segment="后端直连正常，疑似前端或反代故障"
+            else
+                segment="后端直连亦失败，疑似后端故障"
+            fi
+            echo "[entrypoint] 完整健康链路检查失败（$failures/${HEALTHCHECK_FAILURE_THRESHOLD}）：$WEB_HEALTH_URL（原因：$reason；$segment）" >&2
             if [ "$failures" -ge "$HEALTHCHECK_FAILURE_THRESHOLD" ]; then
                 echo "[entrypoint] 完整健康链路连续失败，停止容器以触发 Docker 重启。" >&2
                 exit "$HEALTH_WATCHDOG_EXIT_CODE"

--- a/tests/docker/test_entrypoint_supervision.py
+++ b/tests/docker/test_entrypoint_supervision.py
@@ -285,6 +285,10 @@ def test_unhealthy_full_proxy_chain_exits_container(entrypoint_env: dict[str, st
 
     assert process.returncode == 1, output
     assert "完整健康链路连续失败" in output
+    # 失败日志必须带可读的原因与分段归因：假 API 返回 500，直连同样失败，
+    # 应归因到后端而不是前端反代。
+    assert "原因：" in output
+    assert "后端直连亦失败" in output
 
 
 def test_restart_code_before_ready_is_startup_failure(entrypoint_env: dict[str, str]) -> None:


### PR DESCRIPTION
## 概要

PR #129 的跟进改进，只涉及日志可观测性与前端轮询参数，不改变 entrypoint 进程契约（无需 bump runtime version）。

## 改动

- **探测失败原因外显**：新增 `describe_health_failure`，看门狗探测失败时输出具体原因（连接拒绝/超时/HTTP 状态码），符合"日志要让非开发者看懂"的项目规范；此前 `probe_health` 把所有输出丢弃，日志里只有"失败"二字。
- **看门狗分段归因**：完整链路探测失败时补一次后端直连（8000）探测，日志直接写明"后端直连正常，疑似前端或反代故障"或"后端直连亦失败，疑似后端故障"，用户贴日志即可定位到出问题的层。
- **前端重启轮询窗口加大**：设置页重启轮询从 45 次（约 94s）扩到 75 次（约 154s），覆盖 entrypoint 重启链路最坏情况（收尾宽限 20s + 后端就绪 60s + 前端就绪 60s），避免误报"超时"而服务随后自行恢复。
- 监督测试补充失败原因与归因日志的断言。

## 验证

- `bash -n docker/entrypoint.sh`
- `ruff check tests/docker/test_entrypoint_supervision.py`
- `pytest -q tests/docker`（17 项全部通过）
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012z1zqsXhyq528jnGGTXZur

---
_Generated by [Claude Code](https://claude.ai/code/session_012z1zqsXhyq528jnGGTXZur)_