### PR TITLE
feat(tracker): 支持 TJUPT 账号密码登录

### DIFF
--- a/src/movieclaw_tracker/auth.py
+++ b/src/movieclaw_tracker/auth.py
@@ -257,6 +257,7 @@ class CredentialAuthProvider(AuthProvider):
         if self._selectors is not None:
             return self._selectors
         from movieclaw_tracker.selectors import LoginSelectors
+
         return LoginSelectors()
 
     def _url(self, path: str) -> str:
@@ -266,6 +267,39 @@ class CredentialAuthProvider(AuthProvider):
                 "CredentialAuthProvider 尚未绑定站点，请通过 create_site 创建或手动调用 bind()",
             )
         return f"{self._base_url}/{path.lstrip('/')}"
+
+    @staticmethod
+    def _form_action(form: Selector | None, form_url: str) -> str:
+        """解析同源登录表单 action；缺失或空值时回退到登录页 URL。"""
+        action = form.css("::attr(action)").get("").strip() if form else ""
+        post_url = urllib.parse.urljoin(form_url, action or form_url)
+        form_origin = urllib.parse.urlsplit(form_url)
+        post_origin = urllib.parse.urlsplit(post_url)
+
+        def normalized_origin(
+            parts: urllib.parse.SplitResult,
+        ) -> tuple[str, str | None, int | None]:
+            default_port = {"http": 80, "https": 443}.get(parts.scheme)
+            return parts.scheme, parts.hostname, parts.port or default_port
+
+        if normalized_origin(form_origin) != normalized_origin(post_origin):
+            raise TrackerAuthError("登录表单 action 指向跨站地址，已拒绝提交凭据")
+        return post_url
+
+    @staticmethod
+    def _login_form(doc: Selector, sel: LoginSelectors) -> Selector | None:
+        """选择同时包含配置用户名和密码控件的登录表单。"""
+        for form in doc.css("form"):
+            field_names = {node.attrib.get("name", "") for node in form.css("[name]")}
+            if sel.username_field in field_names and sel.password_field in field_names:
+                return form
+        return None
+
+    @staticmethod
+    def _set_form_field(form_data: list[tuple[str, str]], name: str, value: str) -> None:
+        """覆盖同名表单字段，同时保留其他字段的原始顺序和重复值。"""
+        form_data[:] = [(key, current) for key, current in form_data if key != name]
+        form_data.append((name, value))
 
     async def authenticate(self, client: HttpClient) -> AuthResult:
         """执行用户名/密码登录流程。"""
@@ -312,9 +346,7 @@ class CredentialAuthProvider(AuthProvider):
                 logger.info("验证码识别结果：%s", captcha_text)
 
                 # 提取 imagehash 隐藏字段
-                hash_input = doc.css(
-                    f'input[name="{sel.captcha_hash_field}"]::attr(value)'
-                )
+                hash_input = doc.css(f'input[name="{sel.captcha_hash_field}"]::attr(value)')
                 captcha_hash = hash_input.get()
 
                 # 也尝试从验证码 URL 的查询参数中提取 imagehash
@@ -327,24 +359,33 @@ class CredentialAuthProvider(AuthProvider):
                         captcha_hash = hash_values[0]
 
             # 3. 构造登录表单
-            form_data: dict[str, str] = {
-                sel.username_field: self._username,
-                sel.password_field: self._password,
-            }
+            # NexusPHP 站点通常把 logout 等参数放在 hidden input 中；
+            # 保留重复字段并忽略 disabled 控件，与浏览器 successful controls 语义一致。
+            form = self._login_form(doc, sel)
+            form_data: list[tuple[str, str]] = []
+            for input_el in form.css("input[type='hidden'][name]:not([disabled])") if form else ():
+                form_data.append((input_el.attrib["name"], input_el.attrib.get("value", "")))
+
+            self._set_form_field(form_data, sel.username_field, self._username)
+            self._set_form_field(form_data, sel.password_field, self._password)
+            for select_name, default_value in sel.select_defaults:
+                if form and form.css(f"select[name='{select_name}']"):
+                    self._set_form_field(form_data, select_name, default_value)
 
             # 验证码相关字段
             if captcha_text:
-                form_data[sel.captcha_field] = captcha_text
+                self._set_form_field(form_data, sel.captcha_field, captcha_text)
             if captcha_hash:
-                form_data[sel.captcha_hash_field] = captcha_hash
+                self._set_form_field(form_data, sel.captcha_hash_field, captcha_hash)
 
             # 站点特殊的额外表单字段
             for key, value in sel.extra_form_data:
-                form_data[key] = value
+                self._set_form_field(form_data, key, value)
 
             # 4. POST 登录
             headers = {"Referer": login_url}
-            res = await client.raw_post(login_url, data=form_data, headers=headers)
+            post_url = self._form_action(form, login_url)
+            res = await client.raw_post(post_url, data=form_data, headers=headers)
             response_text = res.text
 
             # 5. 判定登录结果

--- a/src/movieclaw_tracker/registry.py
+++ b/src/movieclaw_tracker/registry.py
@@ -145,11 +145,19 @@ def _parse_selectors(raw: dict[str, Any], selector_cls: type) -> Any:
     """
     defaults = selector_cls()
     overrides = raw.get("selectors", {})
-    for rule_key in ("promo_download_rules", "promo_upload_rules"):
+    for rule_key in (
+        "promo_download_rules",
+        "promo_upload_rules",
+        "login_extra_form_data",
+        "login_select_defaults",
+    ):
         if rule_key in overrides and isinstance(overrides[rule_key], dict):
             overrides[rule_key] = tuple(
-                (css, float(factor)) for css, factor in overrides[rule_key].items()
+                (key, str(value)) for key, value in overrides[rule_key].items()
             )
+    for rule_key in ("promo_download_rules", "promo_upload_rules"):
+        if rule_key in overrides and isinstance(overrides[rule_key], tuple):
+            overrides[rule_key] = tuple((css, float(factor)) for css, factor in overrides[rule_key])
     return dataclasses.replace(defaults, **overrides) if overrides else defaults
 
 

--- a/src/movieclaw_tracker/selectors.py
+++ b/src/movieclaw_tracker/selectors.py
@@ -31,6 +31,8 @@ class LoginSelectors:
     # 额外的固定登录表单参数（站点特殊字段）
     # 示例：ttg 需要 (("passan", ""), ("passid", "0"), ("lang", "0"))
     extra_form_data: tuple[tuple[str, str], ...] = ()
+    # select 字段的默认值。登录页表单中存在该字段时才会提交。
+    select_defaults: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -47,6 +49,8 @@ class NexusPHPSelectors:
     login_password_field: str = "password"
     login_error_css: str = "td.text"
     login_success_css: str = "a[href*='logout']"
+    login_extra_form_data: tuple[tuple[str, str], ...] = ()
+    login_select_defaults: tuple[tuple[str, str], ...] = ()
 
     # -- 种子列表 --
     torrent_list_path: str = "torrents.php"
@@ -157,6 +161,8 @@ class NexusPHPSelectors:
             password_field=self.login_password_field,
             success_css=self.login_success_css,
             error_css=self.login_error_css,
+            extra_form_data=self.login_extra_form_data,
+            select_defaults=self.login_select_defaults,
         )
 
     def replace(self, **kwargs: str) -> NexusPHPSelectors:

--- a/src/movieclaw_tracker/sites/configs/tjupt.yaml
+++ b/src/movieclaw_tracker/sites/configs/tjupt.yaml
@@ -1,0 +1,51 @@
+# 北洋园 TJUPT（天津大学）
+# 页面结构经 2026-08-12 实抓校准。会话凭据为 access_token JWT Cookie；
+# Cookie 模式可使用浏览器同步的最新令牌，credential 模式通过登录表单获取。
+site_id: tjupt
+display_name: 北洋园 TJUPT
+base_url: https://tjupt.org
+framework: nexusphp
+
+auth:
+  supported: [cookie, credential]
+
+min_request_interval: 5.0
+
+selectors:
+  # ---------- 登录 ----------
+  # form action 为相对路径 takelogin.php，由通用认证流程解析。
+  login_path: login.php
+  login_username_field: username
+  login_password_field: password
+  login_success_css: "a[href*='logout.php']"
+  login_select_defaults:
+    logout: "7"
+
+  # ---------- 种子列表 ----------
+  # 每行共有 15 个后代 td，但外层 table.torrents 行只有 9 个直接列；
+  # 第 2 列内嵌 6 个 td，nth-child 必须按外层 9 列定位。
+  torrent_row_css: "table.torrents > tr:not(:first-child)"
+  torrent_title_css: ":scope > td:nth-child(2) a[href*='details.php']"
+  torrent_category_css: ":scope > td:nth-child(1) a::attr(href)"
+  torrent_time_css: ":scope > td:nth-child(4)"
+  torrent_time_fallback_css: ""
+  torrent_size_css: ":scope > td:nth-child(5)"
+  torrent_seeders_css: ":scope > td:nth-child(6)"
+  torrent_leechers_css: ":scope > td:nth-child(7)"
+  torrent_snatched_css: ":scope > td:nth-child(8)"
+  torrent_uploader_css: ":scope > td:nth-child(9)"
+  torrent_hr_css: ""
+
+  # ---------- 用户资料 ----------
+  profile_path: userdetails.php
+  profile_uid_css: "a.User_Name::attr(href)"
+  profile_username_css: "a.User_Name b"
+  profile_class_css: "td.rowhead:contains('等级') + td img::attr(title)"
+  profile_bonus_css: "td.rowhead:contains('魔力值') + td"
+  profile_uploaded_css: "td.rowhead:contains('上传量') + td::text"
+
+  # 以下统计由 AJAX 动态加载，初始 HTML 不提供静态值。
+  profile_downloaded_css: ""
+  profile_ratio_css: ""
+  profile_seeding_css: ""
+  profile_leeching_css: ""

--- a/tests/tracker/unit/test_credential_auth.py
+++ b/tests/tracker/unit/test_credential_auth.py
@@ -2,12 +2,14 @@
 
 所有测试通过 Mock HttpClient 完成，不发送真实 HTTP 请求。
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import httpx
 import pytest
+from parsel import Selector
 
 from movieclaw_tracker.auth import CredentialAuthProvider
 from movieclaw_tracker.exceptions import TrackerAuthError
@@ -24,6 +26,48 @@ LOGIN_PAGE_NO_CAPTCHA = """
   <input name="username" />
   <input name="password" type="password" />
   <input type="submit" value="Login" />
+</form>
+</body></html>
+"""
+
+LOGIN_PAGE_TJUPT = """
+<html><body>
+<form action="takelogin.php" method="post">
+  <input type="hidden" name="logout" value="7" />
+  <input name="username" />
+  <input name="password" type="password" />
+</form>
+</body></html>
+"""
+
+LOGIN_PAGE_WITH_EMPTY_ACTION = """
+<html><body>
+<form action="" method="post">
+  <input type="hidden" name="logout" value="7" />
+  <input name="username" />
+  <input name="password" type="password" />
+</form>
+</body></html>
+"""
+
+LOGIN_PAGE_WITH_LEADING_SEARCH_FORM = """
+<html><body>
+<form action="search.php" method="get"><input name="query" /></form>
+<form action="takelogin.php" method="post">
+  <input type="hidden" name="token" value="first" />
+  <input type="hidden" name="token" value="second" />
+  <input type="hidden" name="disabled-token" value="ignored" disabled />
+  <input name="username" />
+  <input name="password" type="password" />
+</form>
+</body></html>
+"""
+
+LOGIN_PAGE_WITH_CROSS_ORIGIN_ACTION = """
+<html><body>
+<form action="https://attacker.example/collect" method="post">
+  <input name="username" />
+  <input name="password" type="password" />
 </form>
 </body></html>
 """
@@ -149,8 +193,97 @@ async def test_login_success_no_captcha() -> None:
 
     # 验证 POST 提交了正确的表单数据
     call_kwargs = client.raw_post.call_args
-    assert call_kwargs.kwargs["data"]["username"] == "user"
-    assert call_kwargs.kwargs["data"]["password"] == "pass"
+    assert call_kwargs.args[0] == "https://example.com/login.php"
+    assert ("username", "user") in call_kwargs.kwargs["data"]
+    assert ("password", "pass") in call_kwargs.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_login_posts_to_form_action_and_includes_hidden_fields() -> None:
+    """登录页声明相对 form action 时，应提交到该 action 并带上隐藏字段。"""
+    login_page_resp = _make_response(LOGIN_PAGE_TJUPT)
+    success_resp = _make_response(SUCCESS_PAGE)
+
+    client = MagicMock()
+    client.raw_get = AsyncMock(return_value=login_page_resp)
+    client.raw_post = AsyncMock(return_value=success_resp)
+    type(client).cookies = PropertyMock(return_value=httpx.Cookies({"access_token": "jwt-fixture"}))
+
+    provider = CredentialAuthProvider(username="user", password="pass")
+    provider.bind(base_url="https://tjupt.org", login_selectors=LoginSelectors())
+
+    result = await provider.authenticate(client)
+
+    assert result.success is True
+    assert result.cookies == {"access_token": "jwt-fixture"}
+    assert client.raw_post.call_args.args[0] == "https://tjupt.org/takelogin.php"
+    assert ("logout", "7") in client.raw_post.call_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_empty_form_action_falls_back_to_login_path() -> None:
+    """空 form action 应保持原有 login_path 行为。"""
+    client = MagicMock()
+    client.raw_get = AsyncMock(return_value=_make_response(LOGIN_PAGE_WITH_EMPTY_ACTION))
+    client.raw_post = AsyncMock(return_value=_make_response(SUCCESS_PAGE))
+    type(client).cookies = PropertyMock(return_value=httpx.Cookies())
+
+    provider = CredentialAuthProvider(username="user", password="pass")
+    provider.bind(base_url="https://example.com", login_selectors=LoginSelectors())
+
+    await provider.authenticate(client)
+
+    assert client.raw_post.call_args.args[0] == "https://example.com/login.php"
+
+
+@pytest.mark.asyncio
+async def test_login_selects_form_with_configured_credential_fields() -> None:
+    """页面有多个 form 时，只能使用同时包含用户名和密码字段的登录表单。"""
+    client = MagicMock()
+    client.raw_get = AsyncMock(return_value=_make_response(LOGIN_PAGE_WITH_LEADING_SEARCH_FORM))
+    client.raw_post = AsyncMock(return_value=_make_response(SUCCESS_PAGE))
+    type(client).cookies = PropertyMock(return_value=httpx.Cookies())
+
+    provider = CredentialAuthProvider(username="user", password="pass")
+    provider.bind(base_url="https://example.com")
+
+    await provider.authenticate(client)
+
+    assert client.raw_post.call_args.args[0] == "https://example.com/takelogin.php"
+    assert client.raw_post.call_args.kwargs["data"] == [
+        ("token", "first"),
+        ("token", "second"),
+        ("username", "user"),
+        ("password", "pass"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_cross_origin_form_action() -> None:
+    """登录页不能把账号密码提交到其他 origin。"""
+    client = MagicMock()
+    client.raw_get = AsyncMock(return_value=_make_response(LOGIN_PAGE_WITH_CROSS_ORIGIN_ACTION))
+    client.raw_post = AsyncMock()
+    type(client).cookies = PropertyMock(return_value=httpx.Cookies())
+
+    provider = CredentialAuthProvider(username="user", password="pass")
+    provider.bind(base_url="https://example.com")
+
+    with pytest.raises(TrackerAuthError, match="跨站"):
+        await provider.authenticate(client)
+
+    client.raw_post.assert_not_called()
+
+
+def test_form_action_treats_explicit_default_port_as_same_origin() -> None:
+    """显式默认端口与省略端口应视为同源。"""
+    form = Selector(text='<form action="https://example.com:443/takelogin.php"></form>').css(
+        "form"
+    )[0]
+
+    assert CredentialAuthProvider._form_action(form, "https://example.com/login.php") == (
+        "https://example.com:443/takelogin.php"
+    )
 
 
 @pytest.mark.asyncio
@@ -174,7 +307,9 @@ async def test_login_success_with_captcha() -> None:
     type(client).cookies = PropertyMock(return_value=cookie_jar)
 
     provider = CredentialAuthProvider(
-        username="user", password="pass", captcha_solver=solver,
+        username="user",
+        password="pass",
+        captcha_solver=solver,
     )
     provider.bind(base_url="https://example.com")
 
@@ -186,8 +321,8 @@ async def test_login_success_with_captcha() -> None:
 
     # 验证表单中包含验证码字段
     form_data = client.raw_post.call_args.kwargs["data"]
-    assert form_data["imagestring"] == "x7k9"
-    assert form_data["imagehash"] == "abc123"
+    assert ("imagestring", "x7k9") in form_data
+    assert ("imagehash", "abc123") in form_data
 
 
 @pytest.mark.asyncio
@@ -237,7 +372,9 @@ async def test_login_captcha_retry() -> None:
     type(client).cookies = PropertyMock(return_value=cookie_jar)
 
     provider = CredentialAuthProvider(
-        username="user", password="pass", captcha_solver=solver,
+        username="user",
+        password="pass",
+        captcha_solver=solver,
     )
     provider.bind(base_url="https://example.com")
 
@@ -333,6 +470,34 @@ async def test_extra_form_data() -> None:
 
     assert result.success is True
     form_data = client.raw_post.call_args.kwargs["data"]
-    assert form_data["passan"] == ""
-    assert form_data["passid"] == "0"
-    assert form_data["lang"] == "0"
+    assert ("passan", "") in form_data
+    assert ("passid", "0") in form_data
+    assert ("lang", "0") in form_data
+
+
+@pytest.mark.asyncio
+async def test_select_defaults_only_submit_fields_present_in_form() -> None:
+    """站点配置的 select 默认值只应写入实际存在的表单字段。"""
+    page = _make_response(
+        LOGIN_PAGE_NO_CAPTCHA.replace(
+            '  <input type="submit" value="Login" />',
+            '  <select name="logout"><option value="7">7 days</option></select>\n'
+            '  <input type="submit" value="Login" />',
+        )
+    )
+    client = MagicMock()
+    client.raw_get = AsyncMock(return_value=page)
+    client.raw_post = AsyncMock(return_value=_make_response(SUCCESS_PAGE))
+    type(client).cookies = PropertyMock(return_value=httpx.Cookies())
+
+    provider = CredentialAuthProvider(username="user", password="pass")
+    provider.bind(
+        base_url="https://example.com",
+        login_selectors=LoginSelectors(select_defaults=(("logout", "7"), ("missing", "x"))),
+    )
+
+    await provider.authenticate(client)
+
+    form_data = client.raw_post.call_args.kwargs["data"]
+    assert ("logout", "7") in form_data
+    assert not any(key == "missing" for key, _ in form_data)

--- a/tests/tracker/unit/test_tjupt_config.py
+++ b/tests/tracker/unit/test_tjupt_config.py
@@ -1,0 +1,98 @@
+"""TJUPT 配置与 NexusPHP 用户资料解析回归测试。"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from parsel import Selector
+
+from movieclaw_tracker import load_all_sites
+from movieclaw_tracker.frameworks.nexusphp import NexusPHPSite
+from movieclaw_tracker.registry import get_site_config
+from movieclaw_tracker.selectors import NexusPHPSelectors
+
+
+def test_tjupt_yaml_loads_credential_configuration() -> None:
+    load_all_sites()
+
+    config = get_site_config("tjupt")
+
+    assert config.site_class is NexusPHPSite
+    assert config.display_name == "北洋园 TJUPT"
+    assert config.base_url == "https://tjupt.org"
+    assert config.min_request_interval == 5.0
+    assert config.supported_auth_types == ("cookie", "credential")
+    assert isinstance(config.selectors, NexusPHPSelectors)
+    assert config.selectors.login_select_defaults == (("logout", "7"),)
+    assert config.selectors.profile_username_css == "a.User_Name b"
+    assert config.selectors.profile_uid_css.endswith("::attr(href)")
+    assert config.selectors.torrent_time_css == ":scope > td:nth-child(4)"
+    assert config.selectors.torrent_size_css == ":scope > td:nth-child(5)"
+    assert config.selectors.torrent_seeders_css == ":scope > td:nth-child(6)"
+    assert config.selectors.profile_seeding_css == ""
+    assert config.selectors.profile_leeching_css == ""
+
+
+def test_tjupt_nine_outer_column_fixture_parses_torrent_row() -> None:
+    """页面虽含 15 个后代 td，字段定位必须按 9 个外层列计算。"""
+    load_all_sites()
+    config = get_site_config("tjupt")
+    assert isinstance(config.selectors, NexusPHPSelectors)
+    site = NexusPHPSite(
+        selectors=config.selectors,
+        category_map=config.category_map,
+        site_id=config.site_id,
+        base_url=config.base_url,
+        client=MagicMock(),
+        auth_manager=MagicMock(),
+    )
+    doc = Selector(
+        text="""
+        <table class="torrents"><tr><th>类型</th></tr><tr>
+          <td><a href="?cat=401"><img></a></td>
+          <td><table><tr><td></td><td></td><td></td><td>
+            <a href="details.php?id=42">Fixture title</a>
+            <a href="download.php?id=42">download</a>
+          </td><td></td><td></td></tr></table></td>
+          <td>0</td><td>2026-08-12<br>09:11:34</td><td>1.50 GB</td>
+          <td><a href="details.php?id=42">7</a></td><td>2</td><td>9</td><td>fixture-uploader</td>
+        </tr></table>
+        """
+    )
+
+    [item] = site._parse_torrent_rows(doc)
+
+    assert item.torrent_id == "42"
+    assert item.title == "Fixture title"
+    assert item.site_category_id == "401"
+    assert item.size == "1.50 GB"
+    assert item.seeders == 7
+    assert item.leechers == 2
+    assert item.snatched == 9
+    assert item.upload_time is not None
+
+
+async def test_tjupt_profile_fixture_extracts_username_and_uid() -> None:
+    load_all_sites()
+    config = get_site_config("tjupt")
+    assert isinstance(config.selectors, NexusPHPSelectors)
+    client = MagicMock()
+    response = MagicMock()
+    response.text = """
+    <a class="User_Name" href="userdetails.php?id=314159"><b>fixture-user</b></a>
+    """
+    client.get = AsyncMock(return_value=response)
+    site = NexusPHPSite(
+        selectors=config.selectors,
+        category_map=config.category_map,
+        site_id=config.site_id,
+        base_url=config.base_url,
+        client=client,
+        auth_manager=MagicMock(),
+    )
+
+    profile = await site.get_user_profile()
+
+    assert profile.username == "fixture-user"
+    assert profile.user_id == "314159"
+    client.get.assert_awaited_once_with("https://tjupt.org/userdetails.php", params={})


### PR DESCRIPTION
## 概要

- 新增北洋园 TJUPT 的 NexusPHP 声明式站点配置，支持 Cookie 与账号密码授权
- CredentialAuthProvider 从包含账号密码字段的登录表单读取 action，并正确解析相对地址
- 自动提交 hidden input 与站点配置的 select 默认值，保留重复 hidden 字段并忽略 disabled 控件
- 拒绝向跨 origin 的 form action 提交凭据
- 适配 TJUPT 的 9 个外层列（15 个后代 td）种子列表结构，以及用户名、UID、等级、魔力值和上传量

## 设计说明

TJUPT 的登录页位于 `login.php`，但实际表单提交到相对路径 `takelogin.php`。本次改动将 form action 解析做成 CredentialAuthProvider 的通用能力，而不是按 `site_id` 硬编码。若 action 缺失或为空，仍回退到原 `login_path`，因此现有站点保持原行为。

登录成功后，HttpClient 的 Cookie Jar 会保存站点返回的 `access_token` Cookie；AuthManager 继续使用现有缓存机制复用该会话。代码不假设 Cookie 名称。

TJUPT 每条种子行包含 15 个后代 `td`，但外层行只有 9 个直接列，第 2 列内嵌 6 个 `td`。选择器使用 `:scope > td:nth-child(...)`，避免误匹配嵌套表格。

用户详情页中的当前做种与当前下载由 AJAX 动态加载，本 PR 不增加额外资料请求，相关字段保持现有未知/0 语义，不影响认证、搜索和投递。

## 兼容性

- 默认登录表单仍提交到 `login_path`
- action 缺失或为空时仍回退到 `login_path`
- Cookie 和 API-Key Provider 未修改
- 现有验证码与额外表单字段逻辑保留
- 登录 action 必须与登录页同源，避免凭据被跨站表单转发
- 其他 NexusPHP 站点若也使用独立 form action，可直接复用，无需站点专用代码

## 测试

```bash
.venv/bin/ruff check src/movieclaw_tracker tests/tracker
.venv/bin/ruff format --check \
  src/movieclaw_tracker/auth.py \
  src/movieclaw_tracker/selectors.py \
  src/movieclaw_tracker/registry.py \
  tests/tracker/unit/test_credential_auth.py \
  tests/tracker/unit/test_tjupt_config.py
.venv/bin/pytest -m 'not integration' -q tests/tracker
git diff --check
```

结果：

- Ruff lint：通过
- Ruff format：通过
- Tracker 非集成测试：`43 passed`
- `git diff --check`：通过

所有自动化测试使用 mock HTTP 和脱敏 fixture，不访问真实 TJUPT，也不包含真实账号、密码、Cookie、JWT 或其他凭据。

## 风险

- TJUPT 页面结构变化后，需要更新 YAML 选择器
- AJAX 动态加载的做种/下载数量暂不抓取
- 本 PR 不声称自动化测试在真实站点执行；线上行为仅依赖公开页面结构和 mock/fixture 覆盖
