### PR TITLE
fix(bug)：避免种子同步阻塞健康检查并触发容器退出

### DIFF
--- a/src/movieclaw_api/services/torrent_sync.py
+++ b/src/movieclaw_api/services/torrent_sync.py
@@ -20,6 +20,7 @@ per-site 的自适应节奏藏在 ``SiteSyncCursor`` 里，对调度器透明。
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime
 
@@ -117,7 +118,7 @@ def _to_observation(
         upload_volume_factor=item.upload_volume_factor if trust_volatile else None,
         free_deadline=item.free_deadline,
         hit_and_run=item.hit_and_run,
-        # 扩充属性在入库前算好（纯本地正则，微秒级）。exclude_defaults 只存
+        # 扩充属性在入库前算好（本地正则 + NER 推理）。exclude_defaults 只存
         # 真提取到的字段——没提取到任何字段时是 {}，与"从未扩充"（NULL）可区分
         attrs=enrich(item.title, item.subtitle, category_value).model_dump(
             mode="json", exclude_defaults=True
@@ -125,6 +126,15 @@ def _to_observation(
         enrich_version=ENRICH_VERSION,
         detail_url=item.detail_url,
         download_url=item.download_url,
+    )
+
+
+async def _to_observations(
+    site_id: str, items: list[TorrentListItem], *, trust_volatile: bool
+) -> list[TorrentObservation]:
+    """在线程池完成整页扩充，避免同步 NER 推理阻塞 API 事件循环。"""
+    return await asyncio.to_thread(
+        lambda: [_to_observation(site_id, item, trust_volatile=trust_volatile) for item in items]
     )
 
 
@@ -217,7 +227,7 @@ async def _fetch_pages(site, site_id: str, *, is_first_sync: bool):
                 site_id,
                 page_num,
             )
-        observations.extend(_to_observation(site_id, it, trust_volatile=trust) for it in items)
+        observations.extend(await _to_observations(site_id, items, trust_volatile=trust))
 
         if page_num == 1:
             first_page_all_new = not reached_known and len(ids) > 0

--- a/src/movieclaw_db/repositories/torrent_repo.py
+++ b/src/movieclaw_db/repositories/torrent_repo.py
@@ -248,14 +248,40 @@ class TorrentRepository:
         return False
 
     async def bulk_upsert(self, observations: list[TorrentObservation]) -> UpsertStats:
-        """批量 upsert，返回统计。同一批内按 torrent_id 去重（保留首条）。"""
+        """批量 upsert，返回统计。同一批内按 torrent_id 去重（保留首条）。
+
+        先按站点批量取回已有行，避免逐条 ``SELECT``。站点首刷/回补可能一次写入
+        数百至数千条；逐条查询会无谓延长任务并放大 SQLite 争用。每批 ID 控制在
+        900 个以内，兼容 SQLite 的绑定参数上限。
+        """
         stats = UpsertStats()
         seen: set[str] = set()
+        unique: list[TorrentObservation] = []
         for obs in observations:
             if obs.torrent_id in seen:
                 continue
             seen.add(obs.torrent_id)
-            row = await self.get(obs.site_id, obs.torrent_id)
+            unique.append(obs)
+
+        ids_by_site: dict[str, list[str]] = {}
+        for obs in unique:
+            ids_by_site.setdefault(obs.site_id, []).append(obs.torrent_id)
+
+        existing: dict[tuple[str, str], SiteTorrent] = {}
+        for site_id, torrent_ids in ids_by_site.items():
+            for offset in range(0, len(torrent_ids), 900):
+                batch_ids = torrent_ids[offset : offset + 900]
+                result = await self._session.execute(
+                    select(SiteTorrent).where(
+                        SiteTorrent.site_id == site_id,
+                        SiteTorrent.torrent_id.in_(batch_ids),  # type: ignore[attr-defined]
+                    )
+                )
+                for row in result.scalars().all():
+                    existing[(row.site_id, row.torrent_id)] = row
+
+        for obs in unique:
+            row = existing.get((obs.site_id, obs.torrent_id))
             if row is None:
                 self._session.add(self._build_new(obs))
                 stats.inserted += 1

--- a/tests/api/test_sites.py
+++ b/tests/api/test_sites.py
@@ -4,6 +4,7 @@
 更新重验、删除连带清理。验证流程被替换为"假验证"，不发真实网络请求，
 使状态流转可确定性断言。
 """
+
 from __future__ import annotations
 
 import httpx
@@ -361,6 +362,81 @@ async def test_sync_stats_view_handles_count_without_cursor(db) -> None:
     assert view.torrent_count == 5
     assert view.last_sync_at is None
     assert view.sync_interval_seconds is None
+
+
+async def test_bulk_upsert_batches_existing_row_lookup(db) -> None:
+    """批量同步只做批次级查询，不能随种子数逐条 SELECT 而拖死事件循环。"""
+    from sqlalchemy import event
+
+    from movieclaw_db.models.site_torrent import TorrentSource
+    from movieclaw_db.repositories.torrent_repo import (
+        TorrentObservation,
+        TorrentRepository,
+    )
+
+    def observation(torrent_id: str, *, seeders: int) -> TorrentObservation:
+        return TorrentObservation(
+            site_id="mteam",
+            torrent_id=torrent_id,
+            title=f"种子{torrent_id}",
+            source=TorrentSource.LIST,
+            seeders=seeders,
+        )
+
+    async with db.session() as session:
+        await TorrentRepository(session).upsert(observation("known", seeders=1))
+
+    selects: list[str] = []
+
+    def record_select(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+        if statement.lstrip().upper().startswith("SELECT") and "site_torrent" in statement:
+            selects.append(statement)
+
+    event.listen(db.engine.sync_engine, "before_cursor_execute", record_select)
+    try:
+        async with db.session() as session:
+            stats = await TorrentRepository(session).bulk_upsert(
+                [
+                    observation("known", seeders=2),
+                    observation("new-1", seeders=3),
+                    observation("new-2", seeders=4),
+                    observation("new-2", seeders=999),  # 同批重复仍保留首条
+                ]
+            )
+    finally:
+        event.remove(db.engine.sync_engine, "before_cursor_execute", record_select)
+
+    assert stats.inserted == 2
+    assert stats.updated == 1
+    assert len(selects) == 1
+
+    async with db.session() as session:
+        repo = TorrentRepository(session)
+        assert (await repo.get("mteam", "known")).seeders == 2
+        assert (await repo.get("mteam", "new-2")).seeders == 4
+
+
+async def test_torrent_sync_offloads_page_enrichment(monkeypatch) -> None:
+    """整页 NER 扩充必须在线程池执行，不能阻塞 FastAPI 的健康检查。"""
+    import threading
+
+    import movieclaw_api.services.torrent_sync as torrent_sync
+
+    caller_thread = threading.get_ident()
+    worker_threads: list[int] = []
+
+    def fake_to_observation(site_id, item, *, trust_volatile):
+        assert site_id == "mteam"
+        assert trust_volatile is True
+        worker_threads.append(threading.get_ident())
+        return item
+
+    monkeypatch.setattr(torrent_sync, "_to_observation", fake_to_observation)
+    items = [object(), object()]
+
+    assert await torrent_sync._to_observations("mteam", items, trust_volatile=True) == items
+    assert worker_threads
+    assert all(thread_id != caller_thread for thread_id in worker_threads)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题现象

MovieClaw v0.10.0 在 NAS 上执行 M-Team 种子同步时，容器会被 watchdog 判定为失活并主动终止，最终表现为应用“意外停止”。

## 根因

1. M-Team 同步会合并普通区和成人区结果，单页可能包含约 200 条种子。
2. 每条种子的标题扩充都会同步执行正则解析和 NER 模型推理。该逻辑运行在 FastAPI 主事件循环中，连续处理整页时会阻塞 `/api/v1/health`。
3. 健康检查长时间无法得到响应后，容器内 watchdog 会把事件循环阻塞误判成服务失活，并终止进程。
4. 扩充完成后，`bulk_upsert()` 还会为每条种子单独执行一次 SQLite `SELECT`，进一步延长同步时间并增加数据库争用。

现场日志与这条路径一致：两次 M-Team 查询各返回 200 条后，健康检查日志停止；约两分钟后 watchdog 发起 shutdown，APScheduler 的取消堆栈停在种子同步入库阶段。

## 修复内容

- 把整页种子的正则解析和 NER 扩充放入工作线程，避免阻塞 FastAPI 事件循环。
- 把 `SiteTorrent` 已有记录查询改为批量读取，每批最多 900 个 ID，替代逐条 `SELECT`。
- 保留原有的合并、去重和入库语义。
- 增加回归测试，确认扩充不在事件循环线程执行，且批量入库不会随种子数量逐条查询。

## 验证结果

- 相关测试：34 passed
- Ruff：通过
- Ruff format check：通过
- `git diff --check`：通过

完整测试套件也已在 GitHub Actions 中运行；本地全量测试中剩余失败来自已有环境问题（现有 venv 缺少 `pysubs2`，以及监督测试使用的本地 3000 端口已被占用），与本次三个改动文件无关。
