### PR TITLE
修复：升级后自动补偿部分入库漏集

### DIFF
--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -38,6 +38,9 @@
 - **环境故障 = 失败（failed）**：探测失败/搬运出错/TMDB 不可达，时间
   驱动的重试有意义，小时级退避 + 告警；告警按**源目录聚合**成一条
   （"某目录 N 个条目失败"），逐条目刷红灯在存量场景是灾难；
+- **部分入库不冒充完成**：季包只要还有文件因季集解析失败而跳过，就保留
+  pending；只要还有探测/搬运故障，就保留 failed。升级后的首轮补扫会自动
+  重试旧版误标成 imported 的同类记录，正常完成记录仍按指纹短路；
 - 识别顺序：订阅工单认领（info_hash）→ NFO 身份声明（第三方整理过的
   内容常自带 tmdbid，与扫描器同一解析器）→ 名称解析 + TMDB 收敛。
 
@@ -158,6 +161,15 @@ _BRIEFS_TTL_SECONDS = 15.0
 # 太大又会让取消/更新等待过久；NAS 上 64 MiB 通常在数秒内完成。
 _INGEST_COPY_CHUNK_BYTES = 64 * 1024 * 1024
 
+# Job 处理逻辑修订号不仅用于审计，也作为“升级后是否值得自动重试”的边界。
+# 修改季集解析/部分入库收口逻辑时必须递增；同一修订内的待处理条目不反复重跑。
+_INGEST_HANDLER_REVISION = "library.ingest.v2"
+
+# v0.10.0 以前，季包只要成功搬运一个文件就会被记成 imported，即使 message
+# 已明确写着其余文件因季集号解析失败而未入库。保留稳定中文片段用于识别这类
+# 历史脏状态；两种原因都不是作品身份歧义，解析能力升级后应自动补偿。
+_PARSER_GAP_MARKERS = ("解析不出集号，未入库", "解析不出季号，未入库")
+
 # 文件名含这些标记的视频不入库（与入库管线同口径）
 _IGNORE_MARKERS = ("sample",)
 
@@ -187,6 +199,11 @@ class IngestError(Exception):
 
 class IngestSourceChanged(Exception):
     """复制期间源文件继续变化；保留作业意图，等下载稳定后重新执行。"""
+
+
+def _has_parser_gap(record: IngestEntry | None) -> bool:
+    """台账是否仍有因季集解析失败而未入库的文件。"""
+    return bool(record and any(marker in (record.message or "") for marker in _PARSER_GAP_MARKERS))
 
 
 @dataclass
@@ -317,7 +334,7 @@ async def enqueue_ingest_job(
         resources=resources,
         dedupe_key=_ingest_dedupe_key(str(entry)),
         conflict_policy="return_existing",
-        handler_revision="library.ingest.v1",
+        handler_revision=_INGEST_HANDLER_REVISION,
         # 下载落地后的环境故障按小时退避；给足一天自动自愈窗口，超过后
         # 明确失败等待用户处理，不能无限占住活跃任务。
         max_attempts=24,
@@ -680,7 +697,24 @@ async def _process_entry(
             _failed_retry.pop(path_str, None)  # 失败后被人工忽略：不再退避重试
             return  # 用户拍板（或存量基线）永久忽略：指纹变化也不复活，恢复走接口
         latest_job = None if execute_inline else await _latest_ingest_job(session, path_str)
+        parser_retry = _has_parser_gap(record)
         if latest_job is not None and latest_job.status in ACTIVE_JOB_STATUSES:
+            if (
+                parser_retry
+                and latest_job.status == JobStatus.BLOCKED
+                and latest_job.handler_revision != _INGEST_HANDLER_REVISION
+            ):
+                # 旧处理器因季集解析能力不足而 blocked：新版本只自动唤醒一次。
+                # 同修订号不重跑，避免每轮巡检/每次重启反复消耗 NAS IO。
+                latest_job.handler_revision = _INGEST_HANDLER_REVISION
+                await jobs.retry_job(
+                    session,
+                    latest_job,
+                    actor_kind="system",
+                    actor_name="MovieClaw 升级补偿",
+                    origin="system",
+                )
+                logger.info("升级后重新尝试部分入库条目：%s（job=%s）", entry.name, latest_job.id)
             # Job 已接管后不再反复遍历条目树；运行、等待重试与待人工认领
             # 都以统一状态机为事实源，巡检只负责发现新的内容变化。
             _stability.pop(path_str, None)
@@ -713,10 +747,12 @@ async def _process_entry(
             return
 
         if record is not None and record.fingerprint == snap.fingerprint:
-            if record.status != IngestStatus.FAILED:
+            if record.status != IngestStatus.FAILED and not parser_retry:
                 return  # 已处理且没变化（pending 等的是人工拍板，不是时间）
+            if parser_retry:
+                logger.info("升级后重新检查旧版部分入库记录：%s", entry.name)
             elapsed = (utcnow() - record.attempted_at).total_seconds()
-            if elapsed < FAILED_RETRY_SECONDS:
+            if record.status == IngestStatus.FAILED and elapsed < FAILED_RETRY_SECONDS:
                 # 环境故障退避中。进程重启会丢失失败重试表——在此按已过的
                 # 退避时间补记，保证退避到点仍有第三唤醒源接得住
                 _failed_retry.setdefault(path_str, time.monotonic() - elapsed)
@@ -957,6 +993,7 @@ async def _ingest_entry(
     # 逐文件的失败按性质分档：环境故障（探测失败/搬运出错）→ failed 退避
     # 重试；解析不出季集 → pending 等人（重试改变不了解析结果，改名才行）
     env_error = False
+    parser_gap = False
     if kind is MediaKind.MOVIE and len(snap.videos) > 1:
         notes.append(f"已取最大文件为正片，忽略其余 {len(snap.videos) - 1} 个视频")
 
@@ -978,10 +1015,12 @@ async def _ingest_entry(
             season, episode = _unit(file, entry)
             if not episode:
                 notes.append(f"「{file.name}」解析不出集号，未入库")
+                parser_gap = True
                 completed_bytes += file.stat().st_size
                 continue
             if season is None:
                 notes.append(f"「{file.name}」解析不出季号，未入库")
+                parser_gap = True
                 completed_bytes += file.stat().st_size
                 continue
         if staging is not None and (season, episode) in owned_units:
@@ -1131,7 +1170,14 @@ async def _ingest_entry(
             message += f"；{skipped_owned} 个文件的内容已在媒体库，跳过"
         if notes:
             message += "；" + "；".join(notes)
-        return await conclude(IngestStatus.IMPORTED, message, imported)
+        status = (
+            IngestStatus.FAILED
+            if env_error
+            else IngestStatus.PENDING
+            if parser_gap
+            else IngestStatus.IMPORTED
+        )
+        return await conclude(status, message, imported)
     elif notes:
         # 一个文件都没进：环境故障退避重试；纯解析问题进待处理等人拍板/改名
         return await conclude(
@@ -1698,13 +1744,18 @@ async def _run_ingest_job(
             }
         if record is not None and record.fingerprint == snap.fingerprint:
             await _attach_ingest_entry_resource(context, record)
-            if record.status in {IngestStatus.IMPORTED, IngestStatus.SKIPPED}:
+            parser_retry = _has_parser_gap(record)
+            if record.status in {IngestStatus.IMPORTED, IngestStatus.SKIPPED} and not parser_retry:
                 return {
                     "message": record.message or "监听条目已处理",
                     "entry_id": record.id,
                     "status": record.status,
                 }
-            if record.status == IngestStatus.PENDING and record.claimed_tmdb_id is None:
+            if (
+                record.status == IngestStatus.PENDING
+                and record.claimed_tmdb_id is None
+                and not parser_retry
+            ):
                 raise jobs.JobBlocked(
                     record.message or "无法自动识别该条目，请到监听导入清单认领",
                     code="INGEST_IDENTITY_REQUIRED",
@@ -1735,13 +1786,14 @@ async def _run_ingest_job(
         await refresh_source_notice(session, rule.source_path)
 
     if record.status == IngestStatus.PENDING:
+        parser_gap = _has_parser_gap(record)
         raise jobs.JobBlocked(
             record.message or "监听条目需要人工确认",
-            code="INGEST_IDENTITY_REQUIRED",
+            code="INGEST_EPISODE_PARSE_REQUIRED" if parser_gap else "INGEST_IDENTITY_REQUIRED",
             actions=[
                 {
                     "type": "open_settings",
-                    "label": "去监听导入认领",
+                    "label": "查看监听导入" if parser_gap else "去监听导入认领",
                     "target": "import-watch",
                 }
             ],

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -471,7 +471,7 @@ async def test_manual_download_identity_claim_via_info_hash(db, tmp_path, monkey
 
 @pytest.mark.asyncio
 async def test_probe_gate_applies_per_file(db, tmp_path, monkeypatch):
-    """探测门禁逐文件生效：季包里残缺的单集被拦下，完整的集照常入库。"""
+    """季包部分探测失败：完整集照常入库，但条目保留 failed 供自动重试。"""
     root, watch = tmp_path / "tv", tmp_path / "watch"
     watch.mkdir()
     library_id = await _make_library(db, kind=MediaKind.TV, root=root)
@@ -498,9 +498,103 @@ async def test_probe_gate_applies_per_file(db, tmp_path, monkeypatch):
     assert not (season_dir / "测试剧集 (2024) - S01E02.mkv").exists()
     async with db.session() as session:
         record = (await session.execute(select(IngestEntry))).scalar_one()
-    assert record.status == IngestStatus.IMPORTED
+    assert record.status == IngestStatus.FAILED
     assert record.imported_count == 1
     assert "探测失败" in (record.message or "")
+
+
+@pytest.mark.asyncio
+async def test_partial_episode_parse_stays_pending(db, tmp_path, monkeypatch):
+    """季包部分解析失败不能冒充完整入库；已成功的文件仍保留且累计。"""
+    root, watch = tmp_path / "tv", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.TV, root=root)
+    item = await _make_item(db, kind=MediaKind.TV, title="测试剧集", year=2024)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+    monkeypatch.setattr(
+        ingest_mod,
+        "_unit",
+        lambda file, _entry: (1, 1) if file.stem == "ep1" else (1, 0),
+    )
+
+    entry = watch / "测试剧集 S01"
+    entry.mkdir()
+    (entry / "ep1.mkv").write_bytes(b"episode-1")
+    (entry / "ep2.mkv").write_bytes(b"episode-2")
+
+    await _sweep_twice(db, library_id, watch)
+
+    season_dir = root / "测试剧集 (2024)" / "Season 01"
+    assert (season_dir / "测试剧集 (2024) - S01E01.mkv").exists()
+    assert not (season_dir / "测试剧集 (2024) - S01E02.mkv").exists()
+    async with db.session() as session:
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+    assert record.status == IngestStatus.PENDING
+    assert record.imported_count == 1
+    assert "硬链接 1 个文件" in (record.message or "")
+    assert "ep2.mkv」解析不出集号，未入库" in (record.message or "")
+
+
+@pytest.mark.asyncio
+async def test_upgrade_retries_legacy_partial_import_through_job(db, tmp_path, monkeypatch):
+    """旧版误标 imported 的部分入库记录在升级补扫后新建 Job，并补齐漏集。"""
+    root, watch = tmp_path / "tv", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.TV, root=root)
+    await _make_rule(db, library_id=library_id, source=watch)
+    item = await _make_item(db, kind=MediaKind.TV, title="测试剧集", year=2024)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+
+    parser_ready = False
+
+    def parse_unit(file, _entry):
+        if file.stem == "ep1" or parser_ready:
+            return 1, int(file.stem.removeprefix("ep"))
+        return 1, 0
+
+    async def no_assets(_media_item_id: int) -> None:
+        return None
+
+    monkeypatch.setattr(ingest_mod, "_unit", parse_unit)
+    monkeypatch.setattr("movieclaw_api.services.media_scrape.ensure_assets", no_assets)
+
+    entry = watch / "测试剧集 S01"
+    entry.mkdir()
+    (entry / "ep1.mkv").write_bytes(b"episode-1")
+    (entry / "ep2.mkv").write_bytes(b"episode-2")
+
+    # 先用当前语义制造“成功一集、漏一集”的真实台账，再改成旧版错误状态。
+    await _sweep_twice(db, library_id, watch)
+    async with db.session() as session:
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+        assert record.status == IngestStatus.PENDING
+        record.status = IngestStatus.IMPORTED
+        await session.commit()
+
+    parser_ready = True
+    async with db.session() as session:
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+        library = await session.get(Library, library_id)
+        assert library is not None
+    await ingest_mod._sweep_dir(rule, library)
+    await ingest_mod._sweep_dir(rule, library)
+
+    async with db.session() as session:
+        job = (await session.execute(select(Job))).scalar_one()
+    assert job.handler_revision == ingest_mod._INGEST_HANDLER_REVISION
+    await jobs.init_job_dispatcher(max_parallel=1)
+    await _wait_job_status(job.id, JobStatus.SUCCEEDED)
+
+    season_dir = root / "测试剧集 (2024)" / "Season 01"
+    assert (season_dir / "测试剧集 (2024) - S01E01.mkv").exists()
+    assert (season_dir / "测试剧集 (2024) - S01E02.mkv").exists()
+    async with db.session() as session:
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+    assert record.status == IngestStatus.IMPORTED
+    assert record.imported_count == 2
+    assert "解析不出" not in (record.message or "")
 
 
 @pytest.mark.asyncio
@@ -843,6 +937,75 @@ async def test_pending_ingest_claim_unblocks_same_job(db, tmp_path, monkeypatch)
     completed = await _wait_job_status(job.id, JobStatus.SUCCEEDED)
     assert completed.id == job.id
     assert (root / "认领后入库 (2026)" / "认领后入库 (2026).mkv").exists()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_unblocks_old_revision_parser_gap_job(db, tmp_path, monkeypatch):
+    """旧处理器因季集解析挂起的 Job，升级后只唤醒原 Job，不制造重复任务。"""
+    root, watch = tmp_path / "tv", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.TV, root=root)
+    await _make_rule(db, library_id=library_id, source=watch)
+    item = await _make_item(db, kind=MediaKind.TV, title="补偿剧集", year=2026)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+
+    parser_ready = False
+
+    def parse_unit(file, _entry):
+        if file.stem == "ep1" or parser_ready:
+            return 1, int(file.stem.removeprefix("ep"))
+        return 1, 0
+
+    async def no_assets(_media_item_id: int) -> None:
+        return None
+
+    monkeypatch.setattr(ingest_mod, "_unit", parse_unit)
+    monkeypatch.setattr("movieclaw_api.services.media_scrape.ensure_assets", no_assets)
+
+    entry = watch / "补偿剧集 S01"
+    entry.mkdir()
+    (entry / "ep1.mkv").write_bytes(b"episode-1")
+    (entry / "ep2.mkv").write_bytes(b"episode-2")
+    async with db.session() as session:
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+        library = await session.get(Library, library_id)
+        assert library is not None
+    await ingest_mod._sweep_dir(rule, library)
+    await ingest_mod._sweep_dir(rule, library)
+
+    async with db.session() as session:
+        job = (await session.execute(select(Job))).scalar_one()
+    await jobs.init_job_dispatcher(max_parallel=1)
+    blocked = await _wait_job_status(job.id, JobStatus.BLOCKED)
+    assert blocked.error["code"] == "INGEST_EPISODE_PARSE_REQUIRED"
+
+    await ingest_mod._sweep_dir(rule, library)
+    async with db.session() as session:
+        unchanged = await session.get(Job, job.id)
+        assert unchanged is not None
+        assert unchanged.status == JobStatus.BLOCKED
+        assert unchanged.handler_revision == ingest_mod._INGEST_HANDLER_REVISION
+
+    # 模拟解析能力升级：旧 revision 的 blocked Job 应原地恢复；同一 revision
+    # 后续再扫只会短路，避免每次启动都重新跑一遍。
+    async with db.session() as session:
+        stored = await session.get(Job, job.id)
+        assert stored is not None
+        stored.handler_revision = "library.ingest.v1"
+        await session.commit()
+    parser_ready = True
+    await ingest_mod._sweep_dir(rule, library)
+    completed = await _wait_job_status(job.id, JobStatus.SUCCEEDED)
+    assert completed.id == job.id
+
+    async with db.session() as session:
+        all_jobs = list((await session.execute(select(Job))).scalars())
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+    assert len(all_jobs) == 1
+    assert record.status == IngestStatus.IMPORTED
+    assert record.imported_count == 2
+    assert (root / "补偿剧集 (2026)" / "Season 01" / "补偿剧集 (2026) - S01E02.mkv").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

季包只要有一个文件成功搬运，旧逻辑就会把整条记录标成 `imported`，即使消息已经明确写着其余文件“解析不出集号，未入库”。

这会产生两个后果：

1. 页面看起来像已完成，但订阅工单仍停在“等待入库”；
2. 后续解析模型即使已经能识别该文件，只要源文件指纹没有变化，启动补扫和持久化 Job 都会直接短路，漏集永远不会自动补入。

本次现场中的 S01E64 就是这条通用缺陷的一个实例，不是路径映射或硬链接配置错误。

## 修复内容

- 部分成功不再冒充完整成功：
  - 剩余文件存在季集解析缺口时，记录保留为 `pending`；
  - 剩余文件存在探测或搬运故障时，记录保留为 `failed`，继续走自动退避重试；
  - 已成功入库的文件和累计数量保持不变。
- 升级后的首次监听补扫会识别旧版误标为 `imported` 的解析缺口记录，并重新进入持久化入库 Job。
- 持久化 Job 同样绕过旧的“已完成”短路，确保补偿不是只在巡检层生效。
- 旧 revision 的解析缺口 Job 会原地解除 `blocked` 并复用原 Job；同一 revision 不会反复唤醒。
- 正常 `imported`、人工取消和人工忽略记录仍保持原有幂等与终态，不会被升级补扫复活。

## 升级后的行为

安装包含本提交的镜像并重启后，监听器会对已配置源目录执行一次启动补扫。命中旧版解析缺口记录时会自动补偿；若下载器仍保留已完成任务，可立即进入 Job，否则按原有静默窗口确认源目录稳定后执行。

不需要修改下载器路径映射，也不需要移动或重命名源文件。

## 测试

新增并覆盖：

- 部分季集解析失败时保留 `pending`；
- 部分文件探测失败时保留 `failed`；
- 旧版 `imported` 脏状态在文件指纹未变化时仍会自动新建补偿 Job；
- 旧 revision 的 `blocked` Job 原地恢复且不产生重复 Job；
- 同 revision 不重复唤醒；
- 既有正常入库幂等、取消不复活、下载完成检测等回归。

本地结果：

- `pytest -q tests/api/test_library_ingest.py`：27 passed
- `ruff check .`：passed
- 改动文件 `ruff format --check`：passed
- `pnpm web:lint`：passed
- `pnpm web:typecheck`：passed
- v0.10 模型实测 S01E63 / S01E64 / S01E65 均解析为正确季集号

全量测试在本机另有两类与本改动无关的环境噪声：固定端口 3000 被常驻 BirdClaw 占用；一个媒体库删除用例在全量串行中偶发 409，但隔离重跑通过。等待 GitHub CI 在干净环境复核。
