### PR TITLE
fix(search): 站点搜索的扩充计算移入工作线程，避免阻塞事件循环

### DIFF
--- a/src/movieclaw_api/lifespan.py
+++ b/src/movieclaw_api/lifespan.py
@@ -108,10 +108,11 @@ def build_lifespan(settings: Settings):
 
         await rebuild_agent_session_index()
         # 扩充属性重算：提取器升级（ENRICH_VERSION +1）后，把存量种子行按新
-        # 逻辑重算——纯本地推导秒级完成，失败不阻断启动（内部自吞异常）
-        from movieclaw_api.services.enrich_backfill import reenrich_stale_torrents
+        # 逻辑重算。enrich 含 NER 推理，大库重算可达分钟级——排成后台任务，
+        # 不占启动就绪窗口（硬约束与并发权衡见 enrich_backfill 模块注释）
+        from movieclaw_api.services.enrich_backfill import start_enrich_backfill
 
-        await reenrich_stale_torrents()
+        start_enrich_backfill()
         # 旧版更新提醒清场：更新提醒曾写进「待处理事项」，现已改为侧栏常驻徽标，
         # 存量告警行再无任何路径去消退它，会永远挂在告警面板上（见函数注释）
         from movieclaw_api.services.app_update import (
@@ -220,6 +221,10 @@ def build_lifespan(settings: Settings):
             await close_job_dispatcher()
             # 先停止 Agent，避免它在下游 HTTP 客户端和数据库开始释放后继续工作。
             await close_agent_run_registry()
+            # 取消后台的扩充属性重算（须在数据库释放前；已提交批次保留，下次续算）
+            from movieclaw_api.services.enrich_backfill import close_enrich_backfill
+
+            await close_enrich_backfill()
             if settings.scheduler_enabled:
                 from movieclaw_api.services.app_update import close_startup_check
 

--- a/src/movieclaw_api/services/enrich_backfill.py
+++ b/src/movieclaw_api/services/enrich_backfill.py
@@ -2,15 +2,27 @@
 
 提取逻辑改动时只需把 ``movieclaw_enrich.ENRICH_VERSION`` +1；应用启动阶段调用
 本模块，把库里 ``enrich_version`` 落后（或从未扩充）的种子行按当前提取器重算。
-attrs 是从行内已有的 title/subtitle 纯本地推导的，不发任何站点请求，
-几万行也只是秒级——因此直接在启动流程里同步执行，不搞后台任务的复杂度。
+
+``enrich`` 自 v3 起含同步 NER 模型推理（CPU 密集，弱机型单条可达几十毫秒），
+存量几万行的重算可能长达分钟级甚至更久，因此有两条硬约束：
+
+1. **不阻塞启动**：入口脚本对后端就绪有超时（默认 300 秒，应用内更新的快速
+   重启窗口只有 60 秒），在 lifespan 里同步等完重算会在「大库 + 版本升级」时
+   把启动拖过超时、被判启动失败而反复重启。故由 ``start_enrich_backfill``
+   排成后台任务：应用先就绪，重算在后台进行。
+2. **不阻塞事件循环**：每批的模型推理放入工作线程执行，循环保持响应
+   （健康检查、页面请求不受影响，不会触发容器看门狗）。
 
 分批提交：每批一个短会话 + commit，避免超大库时单事务过长；任一批失败只记
-可读中文日志，不阻断启动（下次启动会重试，行为幂等）。
+可读中文日志，不阻断（下次启动会重试，行为幂等）。后台重算期间种子同步可能
+并发刷新同一行——attrs 只由 title/subtitle/category 纯函数推导，两边算出的
+内容一致，覆盖无害。
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 
 from sqlalchemy import or_
@@ -23,6 +35,16 @@ from movieclaw_enrich import ENRICH_VERSION, enrich
 logger = logging.getLogger("movieclaw_api.enrich_backfill")
 
 _BATCH_SIZE = 500
+
+_backfill_task: asyncio.Task | None = None
+
+
+def _enrich_batch(inputs: list[tuple[str, str | None, str | None]]) -> list[dict]:
+    """整批扩充计算（含 NER 推理），供工作线程调用。"""
+    return [
+        enrich(title, subtitle, category).model_dump(mode="json", exclude_defaults=True)
+        for title, subtitle, category in inputs
+    ]
 
 
 async def reenrich_stale_torrents() -> int:
@@ -50,16 +72,42 @@ async def reenrich_stale_torrents() -> int:
                 )
                 if not rows:
                     break
-                for row in rows:
-                    row.attrs = enrich(row.title, row.subtitle, row.category).model_dump(
-                        mode="json", exclude_defaults=True
-                    )
+                # 行字段在主线程读齐，工作线程只做纯函数推理——ORM 对象不跨线程
+                inputs = [(row.title, row.subtitle, row.category) for row in rows]
+                attrs_list = await asyncio.to_thread(_enrich_batch, inputs)
+                for row, attrs in zip(rows, attrs_list, strict=True):
+                    row.attrs = attrs
                     row.enrich_version = ENRICH_VERSION
                 await session.commit()
                 total += len(rows)
-        except Exception:  # noqa: BLE001 -- 重算失败不阻断启动，下次启动幂等重试
+        except Exception:  # noqa: BLE001 -- 重算失败不阻断，下次启动幂等重试
             logger.warning("扩充属性重算中断（已完成 %d 条），下次启动将继续", total, exc_info=True)
             break
     if total:
         logger.info("已按提取器 v%d 重算 %d 条种子的扩充属性", ENRICH_VERSION, total)
     return total
+
+
+def start_enrich_backfill() -> None:
+    """把存量重算排成后台任务（lifespan 启动阶段调用，不等待完成）。"""
+    global _backfill_task
+    _backfill_task = asyncio.get_running_loop().create_task(_run_backfill())
+
+
+async def _run_backfill() -> None:
+    try:
+        await reenrich_stale_torrents()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 -- reenrich 内部已自吞异常，这里是最后兜底
+        logger.warning("扩充属性后台重算异常退出（下次启动将重试）", exc_info=True)
+
+
+async def close_enrich_backfill() -> None:
+    """停机时取消未完成的重算（已提交的批次保留，下次启动续算）。"""
+    global _backfill_task
+    if _backfill_task is not None:
+        _backfill_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _backfill_task
+        _backfill_task = None

--- a/src/movieclaw_api/services/site_search.py
+++ b/src/movieclaw_api/services/site_search.py
@@ -41,10 +41,34 @@ from movieclaw_db.engine import get_database
 from movieclaw_db.models.site_credential import ConfigStatus, SiteCredential
 from movieclaw_db.repositories.credential_repo import CredentialRepository
 from movieclaw_enrich import enrich
-from movieclaw_tracker.models import SearchQuery, TorrentCategory
+from movieclaw_tracker.models import SearchQuery, TorrentCategory, TorrentListItem
 from movieclaw_tracker.registry import SiteNotFoundError, get_site_config
 
 logger = logging.getLogger("movieclaw_api.site_search")
+
+
+def _build_hits(site_id: str, name: str, items: list[TorrentListItem]) -> list[TorrentHit]:
+    """把单站结果映射为 TorrentHit（含扩充属性计算）。**必须在工作线程调用**。
+
+    ``enrich`` 自 v3 起含同步 NER 模型推理（CPU 密集，弱机型单条可达几十毫秒），
+    整页上百条在事件循环里内联算会卡住 SSE 流、健康检查与其它并发请求——
+    口径与种子同步侧一致（torrent_sync._to_observations）。多站并发完成时本函数
+    会在多个线程同时执行：模型层的懒加载有锁，ONNX session 与 tokenizer 的
+    推理调用本身线程安全。
+    """
+    return [
+        TorrentHit(
+            site_id=site_id,
+            site_name=name,
+            attrs=enrich(
+                item.title,
+                item.subtitle,
+                item.category.value if item.category else None,
+            ),
+            **item.model_dump(),
+        )
+        for item in items
+    ]
 
 
 def _display_name(site_id: str) -> str:
@@ -81,20 +105,8 @@ async def _search_one(
     try:
         site = await get_site_access().get(site_id)  # 已认证共享实例，勿 close
         result = await site.search(query)
-        # 给每条结果挂上来源站点标识 + 扩充属性（纯本地正则，微秒级，直接内联算）
-        hits = [
-            TorrentHit(
-                site_id=site_id,
-                site_name=name,
-                attrs=enrich(
-                    item.title,
-                    item.subtitle,
-                    item.category.value if item.category else None,
-                ),
-                **item.model_dump(),
-            )
-            for item in result.items
-        ]
+        # 给每条结果挂上来源站点标识 + 扩充属性；扩充含 NER 推理，整批进工作线程
+        hits = await asyncio.to_thread(_build_hits, site_id, name, result.items)
         return hits, SiteSearchStatus(
             site_id=site_id, site_name=name, count=len(hits), elapsed_ms=elapsed()
         )

--- a/src/movieclaw_enrich/inference.py
+++ b/src/movieclaw_enrich/inference.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import threading
+from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -209,8 +210,33 @@ def _decode_spans(labels: list[str], probs, ids, offsets, sequence_ids) -> list[
     ]
 
 
+# 推理结果缓存条数。同一进程内模型不变，同输入必同输出，缓存永不失真。
+# 命中场景都是高频重复：种子同步每个 tick 重复观测首页的已知种子、媒体库
+# 扫描对同一目录名跨文件反复推理、用户重复搜索同一批结果。单条推理在弱
+# 机型上可达几十毫秒，命中后变成微秒级查表。条目是两段短文本 + 小字典，
+# 4096 条约几 MB 内存。
+_INFER_CACHE_SIZE = 4096
+
+
 def extract_with_model(title: str, subtitle: str = "") -> dict[str, object]:
-    """双段联合推理，返回 TorrentAttrs 对应字段的部分字典（模型缺席返回空字典）。"""
+    """双段联合推理，返回 TorrentAttrs 对应字段的部分字典（模型缺席返回空字典）。
+
+    结果经进程内 LRU 缓存（见 ``_INFER_CACHE_SIZE``）。出口对字典和其中的
+    列表做拷贝：调用方会就地改写返回值（enrich 的护栏否决会 pop 能力位、
+    替换语言列表），不能让这些改写污染缓存。
+    """
+    session, _tokenizer, _meta = _MODEL.get()
+    if session is None:
+        return {}  # 模型缺席时不占缓存：空结果没有复用价值
+    fields = _extract_cached(title, subtitle or "")
+    return {
+        key: list(value) if isinstance(value, list) else value
+        for key, value in fields.items()
+    }
+
+
+@lru_cache(maxsize=_INFER_CACHE_SIZE)
+def _extract_cached(title: str, subtitle: str) -> dict[str, object]:
     session, tokenizer, meta = _MODEL.get()
     if session is None:
         return {}

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -172,6 +172,31 @@ def test_search_rejects_invalid_category(client: TestClient) -> None:
     assert r.status_code == 422
 
 
+async def test_search_offloads_enrichment_to_worker_thread(monkeypatch) -> None:
+    """单站结果的扩充必须在工作线程执行——enrich 含同步 NER 推理，在事件循环
+    里内联算会卡住 SSE 流、健康检查与其它并发请求（口径与种子同步侧一致）。"""
+    import threading
+
+    caller_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    real_enrich = site_search.enrich
+
+    def spy_enrich(title, subtitle="", category=None):
+        worker_threads.append(threading.get_ident())
+        return real_enrich(title, subtitle, category)
+
+    monkeypatch.setattr(site_search, "enrich", spy_enrich)
+    fake_sites = {"mteam": _FakeSite(items=[_item("m1", "沙丘"), _item("m2", "沙丘2")])}
+    monkeypatch.setattr(site_search, "get_site_access", lambda: _FakeManager(fake_sites))
+
+    hits, status = await site_search._search_one(_Cred("mteam"), SearchQuery(keyword="沙丘"))
+
+    assert status.error is None
+    assert len(hits) == 2
+    assert worker_threads
+    assert all(thread_id != caller_thread for thread_id in worker_threads)
+
+
 def test_search_items_carry_enriched_attrs(client: TestClient, monkeypatch) -> None:
     """搜索结果的每条种子都带数据扩充层产出的结构化属性（端到端）。"""
     rich_item = TorrentListItem(

--- a/tests/enrich/test_backfill.py
+++ b/tests/enrich/test_backfill.py
@@ -107,3 +107,32 @@ async def test_backfill_reenriches_stale_rows(db):
 
     # 幂等：再跑一遍没有可重算的行
     assert await reenrich_stale_torrents() == 0
+
+
+async def test_backfill_offloads_enrich_to_worker_thread(db, monkeypatch):
+    """重算的模型推理必须在工作线程执行——enrich 含同步 NER 推理，大库重算
+    在事件循环里跑会长时间卡住健康检查（重算已改为启动后的后台任务）。"""
+    import threading
+
+    import movieclaw_api.services.enrich_backfill as backfill
+
+    caller_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    real_enrich = backfill.enrich
+
+    def spy_enrich(title, subtitle="", category=None):
+        worker_threads.append(threading.get_ident())
+        return real_enrich(title, subtitle, category)
+
+    monkeypatch.setattr(backfill, "enrich", spy_enrich)
+
+    async with db.session() as session:
+        session.add(SiteTorrent(
+            site_id="demo", torrent_id="stale1", source=TorrentSource.LIST,
+            title="Dune.2021.1080p.BluRay.x265-WiKi",
+        ))
+        await session.commit()
+
+    assert await reenrich_stale_torrents() == 1
+    assert worker_threads
+    assert all(thread_id != caller_thread for thread_id in worker_threads)

--- a/tests/enrich/test_enrich.py
+++ b/tests/enrich/test_enrich.py
@@ -439,3 +439,31 @@ class TestModelDeclChannel:
         attrs = enrich("Some.Show.2026.1080p.WEB-DL", "示例 | 内封简中字幕")
         assert attrs.subtitle_languages == ["zh-Hans"]
         assert attrs.audio_languages == []
+
+
+class TestInferenceCache:
+    """模型通道的进程内 LRU 缓存：命中省推理、改写不污染。"""
+
+    def test_repeat_inference_hits_cache_without_pollution(self):
+        from movieclaw_enrich import inference
+
+        if inference._MODEL.get()[0] is None:
+            pytest.skip("NER 模型缺席，缓存路径不生效")
+
+        inference._extract_cached.cache_clear()
+        title = "Dune.Part.Two.2024.2160p.UHD.BluRay.REMUX.HEVC-CHD"
+        first = inference.extract_with_model(title, "沙丘2 | 国语中字")
+        assert inference._extract_cached.cache_info().misses == 1
+
+        # 调用方就地改写返回值（enrich 的护栏否决正是这么做的），不能污染缓存
+        first["year"] = 9999
+        for value in first.values():
+            if isinstance(value, list):
+                value.append("污染")
+
+        second = inference.extract_with_model(title, "沙丘2 | 国语中字")
+        assert inference._extract_cached.cache_info().hits == 1
+        assert second.get("year") == 2024
+        assert all(
+            "污染" not in value for value in second.values() if isinstance(value, list)
+        )


### PR DESCRIPTION
enrich 自 v3 起含同步 NER 模型推理（弱机型单条可达几十毫秒），此前在
_search_one 里对整页结果内联计算，M-Team 单页可达 200 条，会卡住 SSE
流、健康检查与其它并发请求——与种子同步侧已修复的阻塞（PR #134）同源。
现把单站结果的映射与扩充整批放入 asyncio.to_thread，多站并发完成时模型
层的懒加载锁与 ONNX/tokenizer 的线程安全推理保证正确性。

顺带修正"纯本地正则，微秒级"的过时注释，并补线程卸载的回归测试。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B2d74ybqKFu7JJVCXymE6Y