### PR TITLE
fix(tracker): 修正 PTTime 用户资料解析

### DIFF
--- a/src/movieclaw_tracker/frameworks/nexusphp.py
+++ b/src/movieclaw_tracker/frameworks/nexusphp.py
@@ -509,4 +509,7 @@ class NexusPHPSite(BaseSite):
         try:
             return float(cleaned)
         except ValueError:
-            return None
+            # 数值可能被说明文字或符号包裹（如魔力值 "]:1651637.4["），
+            # 退回提取首个数字再解析。
+            match = re.search(r"-?\d+(?:\.\d+)?", cleaned)
+            return float(match.group()) if match else None

--- a/src/movieclaw_tracker/sites/configs/pttime.yaml
+++ b/src/movieclaw_tracker/sites/configs/pttime.yaml
@@ -47,16 +47,18 @@ selectors:
   detail_size_css: "td.rowhead:contains('基本信息') + td.rowfollow > b::next_sibling_text"
 
   # ---------- 用户资料 ----------
-  # 全部从顶部导航栏提取，兼容 userdetails.php 不带 id 的情况
-  profile_uid_css: "a[class*='_Name']::attr(href)"
-  profile_username_css: "a[class*='_Name'] b"
-  profile_class_css: "a[class*='_Name']::attr(class)"
-  profile_uploaded_css: "font.color_uploaded::next_sibling_text"
-  profile_downloaded_css: "font.color_downloaded::next_sibling_text"
-  profile_ratio_css: "font.color_ratio::next_sibling_text"
-  profile_bonus_css: "font.color_bonus"
-  profile_seeding_css: "img.arrowup::next_sibling_text"
-  profile_leeching_css: "img.arrowdown::next_sibling_text"
+  # 用户名/UID 限定在 #info_block 顶栏当前用户链接，禁止全页宽匹配 a[class*='_Name']
+  # （会误匹配评论区等其他用户）。等级取资料区「用户等级」字段的真实文字；
+  # 上传/下载/分享率/做种/下载数都在 #info_block 右侧新统计区域（原 font.color_* 已废弃）。
+  profile_uid_css: "#info_block span.medium a[href*='userdetails.php']::attr(href)"
+  profile_username_css: "#info_block span.medium a[href*='userdetails.php'] b"
+  profile_class_css: "td.rowhead:contains('用户等级') + td b::text"
+  profile_uploaded_css: "#info_block font:contains('上传:')::next_sibling_text"
+  profile_downloaded_css: "#info_block font:contains('下载:')::next_sibling_text"
+  profile_ratio_css: "#info_block font:contains('分享率:')::next_sibling_text"
+  profile_bonus_css: "#info_block a[href='mybonus.php']::next_sibling_text"
+  profile_seeding_css: "#info_block font[title='当前做种']::next_sibling_text"
+  profile_leeching_css: "#info_block font[title='当前下载']::next_sibling_text"
 categories:
   movie: [401]
   tv: [402, 403]

--- a/src/movieclaw_tracker/sites/configs/tjupt.yaml
+++ b/src/movieclaw_tracker/sites/configs/tjupt.yaml
@@ -2,7 +2,7 @@
 # 页面结构经 2026-08-12 实抓校准。会话凭据为 access_token JWT Cookie；
 # Cookie 模式可使用浏览器同步的最新令牌，credential 模式通过登录表单获取。
 site_id: tjupt
-display_name: 北洋园 TJUPT
+display_name: 北洋园
 base_url: https://tjupt.org
 framework: nexusphp
 

--- a/tests/tracker/unit/test_pttime_config.py
+++ b/tests/tracker/unit/test_pttime_config.py
@@ -1,0 +1,138 @@
+"""PTTime 用户资料解析回归测试。
+
+PTTime 个人中心页的用户名、UID、等级、上传/下载/分享率/做种/下载数都集中在
+顶部 ``#info_block`` 或资料区表格里；旧配置用 ``a[class*='_Name']`` 全页宽匹配，
+会把页面里出现的其他用户（如评论区作者）一并拼进用户名，且 ``font.color_*``
+旧样式已被站点替换为 ``#info_block`` 新统计区域，导致上传/下载/分享率取不到值。
+
+本文件用脱敏 HTML fixture 覆盖这些字段，并显式断言结果中不会出现其他用户名。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from movieclaw_tracker import load_all_sites
+from movieclaw_tracker.frameworks.nexusphp import NexusPHPSite
+from movieclaw_tracker.registry import get_site_config
+from movieclaw_tracker.selectors import NexusPHPSelectors
+
+PTTIME_PROFILE_HTML = """<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>PTT :: fixture_user - 个人中心</title>
+</head>
+<body>
+  <table id="info_block" cellpadding="4" cellspacing="0" border="0" width="97%">
+    <tr>
+      <td class="bottom clearfix" align="left">
+        <span class="medium left">嗨,
+          <a  href="userdetails.php?id=12345" class='PowerUser_Name'><b>fixture_user</b></a><b title='发布者：0级'>🎈</b>[UID=12345][(小学)Power User][<a href="userdetails.php?id=12345" class="fcb PowerUser">个人中心</a>]
+          [<a href="logout.php"><b>退出</b></a>]
+          <span>[<a href="bookmarks.php?inclbookmarked=1&amp;incldead=0">收藏</a>]</span>
+          <span>[<a href="myrss.php">RSS下载筐</a>]</span>
+        </span>
+      </td>
+    </tr>
+    <tr>
+      <td class="bottom clearfix" align="right">
+        <div class="left">
+          <span class='mr5'><font class="">分享率:</font>3.14</span>
+          <span class='mr5'><font class='fcg'>上传:</font>12.34TB</span>
+          <span class='mr5'><font class='fcr'> 下载:</font>5.67TB</span>
+          <span class='mr5'><font>活动:</font>
+            <font title="当前做种" class="fcg">⬆</font>12
+            <font title="当前下载" class="fcr">⬇</font>3</span>
+          <span class='mr5'>可连接：<font color="green">是</font></span>
+          <span class='mr5'><font>魔力值(0魔力/小时)</font>
+            [<a href="mybonus.php" class="fcb">使用&amp;说明</a>]: 987654.3[<a href="attendance.php?type=sign&amp;uid=12345" class="fcb">签到领魔力</a>]</span>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <!-- 资料区：用户名、用户等级字段（真实结构，等级文字后还跟着校验链接等杂项） -->
+  <table class="main" width="100%">
+    <tr>
+      <td class="rowhead nowrap">用户名</td>
+      <td class="rowfollow">
+        <a  href="userdetails.php?id=12345" class='PowerUser_Name'><b>fixture_user</b></a>
+        <b title='发布者：0级'>🎈</b>
+      </td>
+    </tr>
+    <tr>
+      <td class="rowhead nowrap">用户等级</td>
+      <td class="rowfollow">
+        <b class="fcr" alt="(小学)Power User" title="(小学)Power User">(小学)Power User</b>
+        <a class='fcb' href='action.php?type=vertify_class'>🩺校验等级</a>
+      </td>
+    </tr>
+  </table>
+  <!-- 关键回归场景：页面还会出现其他用户，旧 a[class*='_Name'] 会误匹配 -->
+  <section id="comments">
+    <a href="userdetails.php?id=67890" class="CrazyUser_Name">
+      <b>another_user</b>
+    </a>
+    发布了一条评论。
+  </section>
+  <!-- 同一账号在页面中的其他重复链接 -->
+  <footer>
+    <a href="userdetails.php?id=12345" class="PowerUser_Name">
+      <b>fixture_user</b>
+    </a>
+  </footer>
+</body>
+</html>
+"""
+
+
+def _build_pttime_site() -> tuple[NexusPHPSite, MagicMock]:
+    load_all_sites()
+    config = get_site_config("pttime")
+    assert isinstance(config.selectors, NexusPHPSelectors)
+    client = MagicMock()
+    response = MagicMock()
+    response.text = PTTIME_PROFILE_HTML
+    client.get = AsyncMock(return_value=response)
+    site = NexusPHPSite(
+        selectors=config.selectors,
+        category_map=config.category_map,
+        site_id=config.site_id,
+        base_url=config.base_url,
+        client=client,
+        auth_manager=MagicMock(),
+    )
+    return site, client
+
+
+async def test_pttime_profile_fixture_parses_all_fields() -> None:
+    site, client = _build_pttime_site()
+
+    profile = await site.get_user_profile()
+
+    assert profile.username == "fixture_user"
+    assert profile.user_id == "12345"
+    assert profile.user_class == "(小学)Power User"
+    assert profile.ratio == 3.14
+    # 字节数由 _parse_size_bytes 取整返回（"12.34TB" → int(12.34 * 1024**4)）。
+    assert profile.uploaded_bytes == int(12.34 * 1024**4)
+    assert profile.downloaded_bytes == int(5.67 * 1024**4)
+    assert profile.bonus == 987654.3
+    assert profile.seeding_count == 12
+    assert profile.leeching_count == 3
+
+    client.get.assert_awaited_once_with(
+        "https://www.pttime.org/userdetails.php", params={}
+    )
+
+
+async def test_pttime_profile_never_leaks_other_users() -> None:
+    """旧 a[class*='_Name'] 全页宽匹配会把评论区其他用户拼进用户名，必须杜绝。"""
+    site, _ = _build_pttime_site()
+
+    profile = await site.get_user_profile()
+
+    assert profile.username == "fixture_user"
+    assert "another_user" not in profile.username
+    assert "mcc1127" not in profile.username
+    assert profile.user_id == "12345"

--- a/tests/tracker/unit/test_pttime_config.py
+++ b/tests/tracker/unit/test_pttime_config.py
@@ -28,7 +28,9 @@ PTTIME_PROFILE_HTML = """<!DOCTYPE html>
     <tr>
       <td class="bottom clearfix" align="left">
         <span class="medium left">嗨,
-          <a  href="userdetails.php?id=12345" class='PowerUser_Name'><b>fixture_user</b></a><b title='发布者：0级'>🎈</b>[UID=12345][(小学)Power User][<a href="userdetails.php?id=12345" class="fcb PowerUser">个人中心</a>]
+          <a  href="userdetails.php?id=12345" class='PowerUser_Name'><b>fixture_user</b></a>
+          <b title='发布者：0级'>🎈</b>[UID=12345][(小学)Power User]
+          [<a href="userdetails.php?id=12345" class="fcb PowerUser">个人中心</a>]
           [<a href="logout.php"><b>退出</b></a>]
           <span>[<a href="bookmarks.php?inclbookmarked=1&amp;incldead=0">收藏</a>]</span>
           <span>[<a href="myrss.php">RSS下载筐</a>]</span>
@@ -46,7 +48,8 @@ PTTIME_PROFILE_HTML = """<!DOCTYPE html>
             <font title="当前下载" class="fcr">⬇</font>3</span>
           <span class='mr5'>可连接：<font color="green">是</font></span>
           <span class='mr5'><font>魔力值(0魔力/小时)</font>
-            [<a href="mybonus.php" class="fcb">使用&amp;说明</a>]: 987654.3[<a href="attendance.php?type=sign&amp;uid=12345" class="fcb">签到领魔力</a>]</span>
+            [<a href="mybonus.php" class="fcb">使用&amp;说明</a>]: 987654.3
+            [<a href="attendance.php?type=sign&amp;uid=12345" class="fcb">签到领魔力</a>]</span>
         </div>
       </td>
     </tr>

--- a/tests/tracker/unit/test_tjupt_config.py
+++ b/tests/tracker/unit/test_tjupt_config.py
@@ -18,7 +18,7 @@ def test_tjupt_yaml_loads_credential_configuration() -> None:
     config = get_site_config("tjupt")
 
     assert config.site_class is NexusPHPSite
-    assert config.display_name == "北洋园 TJUPT"
+    assert config.display_name == "北洋园"
     assert config.base_url == "https://tjupt.org"
     assert config.min_request_interval == 5.0
     assert config.supported_auth_types == ("cookie", "credential")


### PR DESCRIPTION
## 改动

### PTTime 用户资料解析修复

PTTime 把资料统计从 `font.color_*` 旧样式迁移到了 `#info_block` 新结构，导致旧选择器失效：

- **用户名/UID**：旧 `a[class*='_Name']` 全页宽匹配，会把评论区等其他用户的链接拼进用户名；改为限定 `#info_block` 顶栏当前用户链接。
- **等级**：旧 `::attr(class)` 取到的是 `PowerUser_Name` 这类 CSS 类名；改为资料区「用户等级」字段的真实文字。
- **上传/下载/分享率/做种/下载数**：旧 `font.color_*` 样式已被站点废弃；改为 `#info_block` 右侧新统计区域。
- **魔力值**：数字在「使用&说明」链接之后的文本节点里，不是简单相邻文本；`_parse_float` 增加正则 fallback 提取首个数字。

### TJUPT 显示名缩短

`display_name` 由 `北洋园 TJUPT` 缩短为 `北洋园`（用户反馈显示名过长）。

## 测试

- 新增 `test_pttime_config.py`：用脱敏的真实页面结构 HTML fixture，覆盖用户名/UID/等级/分享率/上传/下载/魔力值/做种/下载全部字段，并显式断言结果中不出现其他用户名（防全页宽匹配回归）。
- tracker 全量测试通过。

## 说明

- fixture 已脱敏：用户名、UID、邀请码、邮箱、微信及所有统计数值均已替换为占位值，不含真实账号数据。
- 另发现一个既有隐患（未在本次改动）：`selectors.py` 中 `profile_class_css` 的默认值 `td.rowhead:contains('等级') + td::text` 在 parsel 中无法命中（组合符后直接跟 `::text` 伪元素不生效），PTTime 已用 `+ td b::text` 绕过，其他使用默认值的站点若遇同结构会踩同一坑。
