### PR TITLE
fix(web): reliably restore list scroll position after navigation

### DIFF
--- a/apps/web/components/collection-grid-view.tsx
+++ b/apps/web/components/collection-grid-view.tsx
@@ -7,8 +7,25 @@ import { SearchIcon } from "@/components/icons";
 import { PosterCard } from "@/components/poster-card";
 import { fetchDoubanCollection } from "@/lib/api/discover";
 import type { MediaItem } from "@/lib/media-types";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 const PAGE_SIZE = 50;
+const MAX_COLLECTION_VISIBLE_COUNTS = 32;
+const collectionVisibleCounts = new Map<string, number>();
+
+function getCollectionVisibleCount(collectionId: string) {
+  return collectionVisibleCounts.get(collectionId) ?? PAGE_SIZE;
+}
+
+function rememberCollectionVisibleCount(collectionId: string, count: number) {
+  collectionVisibleCounts.delete(collectionId);
+  collectionVisibleCounts.set(collectionId, count);
+  while (collectionVisibleCounts.size > MAX_COLLECTION_VISIBLE_COUNTS) {
+    const oldest = collectionVisibleCounts.keys().next().value;
+    if (oldest === undefined) break;
+    collectionVisibleCounts.delete(oldest);
+  }
+}
 
 /**
  * 豆瓣完整榜单落地页（「看全部」的目的地）：用纵向网格承载大量条目，
@@ -25,12 +42,27 @@ export function CollectionGridView({
   /** 榜单展示名，用于标题与返回导航 */
   title: string;
 }) {
+  const scrollRef = useScrollRestoration(`collection:${collectionId}`);
   const [items, setItems] = useState<MediaItem[] | null>(null);
   const [query, setQuery] = useState("");
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [visibleCount, setVisibleCount] = useState(() => getCollectionVisibleCount(collectionId));
   const [error, setError] = useState<string | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
+  const previousCollectionId = useRef(collectionId);
+
+  useEffect(() => {
+    // 同一组件实例切换榜单时，先切换到新 key 的窗口；不要把旧榜单的数量
+    // 在这一轮 effect 中写进新 key。
+    if (previousCollectionId.current !== collectionId) {
+      previousCollectionId.current = collectionId;
+      setVisibleCount(getCollectionVisibleCount(collectionId));
+      setQuery("");
+      setSelectedGenres([]);
+      return;
+    }
+    rememberCollectionVisibleCount(collectionId, visibleCount);
+  }, [collectionId, visibleCount]);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,7 +151,7 @@ export function CollectionGridView({
   };
 
   return (
-    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto px-6 pb-12 max-md:px-4">
+    <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto px-6 pb-12 max-md:px-4">
       {/* 顶栏：返回发现电影（保留豆瓣数据源视角）+ 吸顶榜单名；
           容器已有 px-6，用 -mx-6 让吸顶蒙版铺满整宽 */}
       <PageNav

--- a/apps/web/components/discover-view.tsx
+++ b/apps/web/components/discover-view.tsx
@@ -24,6 +24,7 @@ import {
 import { HttpError } from "@/lib/http";
 import { useMediaDetail } from "@/lib/media-detail";
 import { usePageChrome } from "@/lib/page-chrome";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 import { useIsMobile } from "@/lib/use-media-query";
 import { useTapGuard } from "@/lib/use-tap-guard";
 import type {
@@ -90,6 +91,7 @@ export function DiscoverView({
 }) {
   const router = useRouter();
   const cacheKey = `${mediaType}:${source}`;
+  const scrollRef = useScrollRestoration(`discover:${cacheKey}`);
   const [layout, setLayout] = useState<DiscoverLayoutData | null>(
     () => layoutCache.get(cacheKey) ?? null,
   );
@@ -227,7 +229,7 @@ export function DiscoverView({
     );
   }
   return (
-    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
+    <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       {toolbar}
       {/* Hero 区：布局声明有 Hero 时先占位，数据到达后换成轮播；失败/无则收起 */}
       {layout.hasHero && hero === undefined && (

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
@@ -69,6 +69,12 @@ import { usePermissions } from "@/lib/permissions";
 import { useVisiblePolling } from "@/lib/use-visible-polling";
 import { useJobs } from "@/lib/jobs";
 import {
+  getLibraryDetailSnapshot,
+  setLibraryDetailSnapshot,
+  type LibraryDetailSnapshot,
+} from "@/lib/library-detail-snapshot";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
+import {
   subscriptionProgressNote,
   subscriptionStatusMeta,
 } from "@/lib/subscription-ui";
@@ -97,35 +103,49 @@ function busyText(progress: ScanProgress | null): string {
  */
 /** 海报墙每次向服务端要的格数（首屏一批，滚到底再追加一批）。 */
 const WALL_PAGE_SIZE = 60;
+/** 后端单次分页的硬上限；轮询已加载窗口时按此上限分块请求。 */
+const WALL_API_PAGE_SIZE = 200;
 
 export function LibraryDetailView({ libraryId }: { libraryId: number }) {
+  const initialSnapshot = getLibraryDetailSnapshot(libraryId);
+  const restoredFromSnapshot = useRef(initialSnapshot !== undefined);
   const { canManageLibraries } = usePermissions();
   const { activeJobs } = useJobs();
+  const scrollRef = useScrollRestoration(`library:${libraryId}`, {
+    anchorAttribute: "data-library-item-id",
+  });
   const confirm = useConfirm();
-  const [libraries, setLibraries] = useState<MediaLibrary[] | null>(null);
-  const [items, setItems] = useState<LibraryItem[]>([]);
+  const [libraries, setLibraries] = useState<MediaLibrary[] | null>(initialSnapshot?.libraries ?? null);
+  const [items, setItems] = useState<LibraryItem[]>(initialSnapshot?.items ?? []);
   // 服务端还有没有下一页；滚动加载的哨兵据此决定是否继续观察
-  const [wallHasMore, setWallHasMore] = useState(false);
+  const [wallHasMore, setWallHasMore] = useState(initialSnapshot?.wallHasMore ?? false);
   // 本库全部条目 id：海报墙分页后这份名单仍要完整——「追踪中」要靠它把
   // 已入库的订阅剔掉，而已入库的那部可能在第 5 页上，光看当前页会误判
-  const [ownedIds, setOwnedIds] = useState<Set<number>>(() => new Set());
+  const [ownedIds, setOwnedIds] = useState<Set<number>>(
+    () => initialSnapshot?.ownedIds ?? new Set(),
+  );
   // A-Z 索引条的分档（按标题排序时才有意义）
-  const [wallIndex, setWallIndex] = useState<LibraryIndexEntry[]>([]);
+  const [wallIndex, setWallIndex] = useState<LibraryIndexEntry[]>(initialSnapshot?.wallIndex ?? []);
   // 当前窗口在整份排序里的起点：0 = 从头开始；点字母跳转后是该档的 offset。
   // 轮询要按这个起点重拉，否则每 3 秒把用户拽回墙首
-  const [wallStart, setWallStart] = useState(0);
-  const [unidentified, setUnidentified] = useState<UnidentifiedGroup[]>([]);
-  const [review, setReview] = useState<ReviewGroup[]>([]);
-  const [ignored, setIgnored] = useState<UnidentifiedGroup[]>([]);
-  const [missing, setMissing] = useState<MissingItem[]>([]);
-  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [wallStart, setWallStart] = useState(initialSnapshot?.wallStart ?? 0);
+  const [unidentified, setUnidentified] = useState<UnidentifiedGroup[]>(initialSnapshot?.unidentified ?? []);
+  const [review, setReview] = useState<ReviewGroup[]>(initialSnapshot?.review ?? []);
+  const [ignored, setIgnored] = useState<UnidentifiedGroup[]>(initialSnapshot?.ignored ?? []);
+  const [missing, setMissing] = useState<MissingItem[]>(initialSnapshot?.missing ?? []);
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>(initialSnapshot?.subscriptions ?? []);
   const [failed, setFailed] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [editing, setEditing] = useState<MediaLibrary | null>(null);
   // 整理文件名对话框的目标库；null = 关闭
   const [organizeTarget, setOrganizeTarget] = useState<MediaLibrary | null>(null);
   // 整库元数据刷新进度（进行中每 3 秒轮询，结束自动刷新库存）
-  const [metaRefresh, setMetaRefresh] = useState<MetadataRefreshProgress | null>(null);
+  const [metaRefresh, setMetaRefresh] = useState<MetadataRefreshProgress | null>(
+    initialSnapshot?.metaRefresh ?? null,
+  );
+  // 删除/转移等详情页操作会把旧窗口标记为过期。先保留它供滚动锚点落脚，
+  // 后台对账成功后再清除标记；请求失败时下次返回仍会重试。
+  const [snapshotStale, setSnapshotStale] = useState(initialSnapshot?.stale ?? false);
   // 工单抽屉：从哪个胶囊点进来就落在哪个 tab；null = 关闭
   const [issueTab, setIssueTab] = useState<IssueTab | null>(null);
 
@@ -134,23 +154,73 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   const reloadSeq = useRef(0);
   // 海报墙已加载的格数：轮询按这个数重拉第一页，用户滚到第几屏就刷新到第几屏
   // ——否则每轮轮询都把墙缩回首屏，正在看的位置被抽走
-  const wallLoaded = useRef(WALL_PAGE_SIZE);
+  const wallLoaded = useRef(initialSnapshot?.wallLoaded ?? WALL_PAGE_SIZE);
   // 当前排序（扫描补探阶段切到「待补探优先」）。放 ref 而不进依赖：reload
   // 每轮都读最新值，不必为切排序重建回调链
-  const wallSort = useRef<LibraryItemSort>("title");
+  const wallSort = useRef<LibraryItemSort>(initialSnapshot?.wallSort ?? "title");
   // 当前窗口起点的 ref 版：reload 每轮读它，不进依赖（同 wallSort）
-  const wallOffset = useRef(0);
+  const wallOffset = useRef(initialSnapshot?.wallOffset ?? 0);
+  const snapshotRef = useRef<LibraryDetailSnapshot | null>(null);
+  snapshotRef.current = libraries
+    ? {
+        libraries,
+        items,
+        wallHasMore,
+        ownedIds,
+        wallIndex,
+        wallStart,
+        unidentified,
+        review,
+        ignored,
+        missing,
+        subscriptions,
+        metaRefresh,
+        wallLoaded: wallLoaded.current,
+        wallSort: wallSort.current,
+        wallOffset: wallOffset.current,
+        stale: snapshotStale,
+      }
+    : null;
+
+  // 布局提交后就更新快照，路由切换的下一棵树可以在首帧直接读取它；不能只在
+  // 卸载 cleanup 中写入，因为新路由的首次 render 可能早于被动 effect 的 cleanup。
+  useLayoutEffect(() => {
+    if (snapshotRef.current) setLibraryDetailSnapshot(libraryId, snapshotRef.current);
+  }, [
+    ignored,
+    items,
+    libraries,
+    libraryId,
+    metaRefresh,
+    missing,
+    ownedIds,
+    review,
+    subscriptions,
+    snapshotStale,
+    unidentified,
+    wallHasMore,
+    wallIndex,
+    wallStart,
+  ]);
+
   const reload = useCallback(() => {
     const seq = ++reloadSeq.current;
     const wanted = wallLoaded.current;
     const from = wallOffset.current;
+    const itemPages = Array.from(
+      { length: Math.ceil(wanted / WALL_API_PAGE_SIZE) },
+      (_, page) => {
+        const offset = from + page * WALL_API_PAGE_SIZE;
+        return listLibraryItems(libraryId, {
+          sort: wallSort.current,
+          limit: Math.min(WALL_API_PAGE_SIZE, wanted - page * WALL_API_PAGE_SIZE),
+          offset,
+        });
+      },
+    );
     Promise.all([
       listLibraries(),
-      listLibraryItems(libraryId, {
-        sort: wallSort.current,
-        limit: wanted,
-        offset: from,
-      }).catch(() => []),
+      Promise.all(itemPages).then((pages) => pages.flat()),
       listLibraryItemIds(libraryId).catch(() => []),
       listLibraryItemIndex(libraryId).catch(() => []),
       canManageLibraries ? listUnidentified(libraryId).catch(() => []) : Promise.resolve([]),
@@ -161,6 +231,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
     ])
       .then(([libs, libraryItems, ids, index, unknown, reviewGroups, ignoredGroups, missingItems, subs]) => {
         if (seq !== reloadSeq.current) return;
+        setSnapshotStale(false);
         setFailed(false);
         // 轮询快照内容没变时复用旧引用：库存墙逐条目复用（配合 InventoryCell
         // 的 memo，只有真正变化的格子重渲染），其余列表整体复用。否则扫描期间
@@ -194,8 +265,13 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   }, [canManageLibraries, libraryId]);
 
   useEffect(() => {
-    reload();
-  }, [reload]);
+    // 从详情页返回时，已加载分页窗口就在会话快照中。立刻重拉会先把墙缩成
+    // 首批 60 条，深处的滚动目标又会失去高度；之后仍由可见页轮询负责对账。
+    if (!restoredFromSnapshot.current || snapshotStale) {
+      restoredFromSnapshot.current = true;
+      reload();
+    }
+  }, [reload, snapshotStale]);
 
   // 海报墙滚到底时向服务端追加一页。并发闸门用 ref：哨兵在快速滚动中会
   // 连续触发几次，不挡住就是同一页被拉好几遍
@@ -203,9 +279,13 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   const loadMore = useCallback(() => {
     if (loadingMore.current) return;
     loadingMore.current = true;
+    // 分页请求开始后作废正在路上的轮询响应；否则旧轮询可能先/后返回，
+    // 用较短的窗口覆盖刚追加的页面，把用户滚动到的内容又截回首批。
+    const requestSeq = ++reloadSeq.current;
     const offset = wallOffset.current + wallLoaded.current;
     listLibraryItems(libraryId, { sort: wallSort.current, limit: WALL_PAGE_SIZE, offset })
       .then((next) => {
+        if (requestSeq !== reloadSeq.current) return;
         wallLoaded.current += next.length;
         // 追加与轮询可能交叠着回来，同一条目被拿到两次——按 id 去重再拼
         setItems((current) => {
@@ -214,7 +294,9 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
         });
         setWallHasMore(next.length >= WALL_PAGE_SIZE);
       })
-      .catch(() => setWallHasMore(false))
+      .catch(() => {
+        if (requestSeq === reloadSeq.current) setWallHasMore(false);
+      })
       .finally(() => {
         loadingMore.current = false;
       });
@@ -504,7 +586,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   ) : null;
 
   return (
-    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
+    <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       {/* 顶栏：返回媒体库 + 吸顶库名 + 库操作 ⋯（无 pt——顶边与侧栏卡片顶边齐平） */}
       <PageNav
         items={[{ label: "媒体库", href: "/library" }, { label: library.name }]}
@@ -958,7 +1040,10 @@ const InventoryCell = memo(function InventoryCell({
   return (
     // content-visibility：视口外的格子跳过布局与绘制，大库海报墙的滚动/更新
     // 成本只与可见格数相关；intrinsic-size 占住尺寸，滚动条不跳
-    <div className="[contain-intrinsic-size:auto_270px] [content-visibility:auto]">
+    <div
+      data-library-item-id={item.media_item_id}
+      className="[contain-intrinsic-size:auto_270px] [content-visibility:auto]"
+    >
       {/* 后台正在处理的那一格自己点亮：进度面板/胶囊列的是总数或片名，
           海报墙上也要能一眼看到"正在弄这部"，否则用户得在两处之间对片名 */}
       <div className="relative">

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -53,6 +53,7 @@ import { getDiscoveryReturnPath } from "@/lib/discovery-return-path";
 import { formatBytes } from "@/lib/format";
 import { resolveRequestUrl } from "@/lib/http";
 import { cachedImageUrl } from "@/lib/image-proxy";
+import { invalidateLibraryDetailSnapshot } from "@/lib/library-detail-snapshot";
 import { refreshItemConfirm } from "@/lib/library-confirm";
 import { usePermissions } from "@/lib/permissions";
 import { formatRelativeTime } from "@/lib/time";
@@ -111,6 +112,14 @@ export function LibraryItemDetailView({
   const [deleteFileTarget, setDeleteFileTarget] = useState<LibraryItemFile | null>(null);
   // 转移到其他库的弹窗（选库 → 预览 → 执行 → 进度 → 结论）
   const [transferOpen, setTransferOpen] = useState(false);
+
+  const handleTransferFinished = useCallback(
+    (targetLibraryId: number) => {
+      invalidateLibraryDetailSnapshot(libraryId);
+      invalidateLibraryDetailSnapshot(targetLibraryId);
+    },
+    [libraryId],
+  );
 
   const reload = useCallback(() => {
     setFailed(false);
@@ -438,7 +447,10 @@ export function LibraryItemDetailView({
         open={deleteOpen}
         detail={detail}
         onClose={() => setDeleteOpen(false)}
-        onDeleted={() => router.replace(`/library/${libraryId}` as Route)}
+        onDeleted={() => {
+          invalidateLibraryDetailSnapshot(libraryId);
+          router.replace(`/library/${libraryId}` as Route);
+        }}
         libraryId={libraryId}
       />}
 
@@ -449,7 +461,10 @@ export function LibraryItemDetailView({
         onClose={() => setDeleteFileTarget(null)}
         onDeleted={(deletedItem) => {
           setDeleteFileTarget(null);
-          if (deletedItem) router.replace(`/library/${libraryId}` as Route);
+          invalidateLibraryDetailSnapshot(libraryId);
+          if (deletedItem) {
+            router.replace(`/library/${libraryId}` as Route);
+          }
           else reload();
         }}
       />}
@@ -460,9 +475,10 @@ export function LibraryItemDetailView({
         libraryId={libraryId}
         sourceLibraryName={library?.name ?? null}
         onClose={() => setTransferOpen(false)}
-        onTransferred={(targetLibraryId) =>
-          router.replace(`/library/${targetLibraryId}/item/${mediaItemId}` as Route)
-        }
+        onFinished={handleTransferFinished}
+        onTransferred={(targetLibraryId) => {
+          router.replace(`/library/${targetLibraryId}/item/${mediaItemId}` as Route);
+        }}
       />}
 
       {canManageLibraries && <ReidentifyDialog
@@ -478,7 +494,10 @@ export function LibraryItemDetailView({
             reload();
           }
         }}
-        onApplied={() => setReidentifyDirty(true)}
+        onApplied={() => {
+          invalidateLibraryDetailSnapshot(libraryId);
+          setReidentifyDirty(true);
+        }}
       />}
 
       {canManageLibraries && <ArtworkPickerDialog
@@ -1410,6 +1429,7 @@ function TransferDialog({
   detail,
   libraryId,
   sourceLibraryName,
+  onFinished,
   onClose,
   onTransferred,
 }: {
@@ -1417,6 +1437,7 @@ function TransferDialog({
   detail: LibraryItemDetail;
   libraryId: number;
   sourceLibraryName: string | null;
+  onFinished: (targetLibraryId: number) => void;
   onClose: () => void;
   onTransferred: (targetLibraryId: number) => void;
 }) {
@@ -1464,11 +1485,16 @@ function TransferDialog({
     if (!open || !running) return;
     const timer = setInterval(() => {
       getTransferStatus(libraryId)
-        .then(setStatus)
+        .then((next) => {
+          setStatus(next);
+          if (!next.running && next.errors.length === 0 && next.target_library_id != null) {
+            onFinished(next.target_library_id);
+          }
+        })
         .catch(() => {});
     }, 1000);
     return () => clearInterval(timer);
-  }, [open, running, libraryId]);
+  }, [open, running, libraryId, onFinished]);
 
   const run = async () => {
     if (targetId == null) return;
@@ -1476,7 +1502,11 @@ function TransferDialog({
     setError(null);
     try {
       await transferLibraryItem(libraryId, detail.media_item_id, targetId);
-      setStatus(await getTransferStatus(libraryId));
+      const next = await getTransferStatus(libraryId);
+      setStatus(next);
+      if (!next.running && next.errors.length === 0 && next.target_library_id != null) {
+        onFinished(next.target_library_id);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "转移失败，请稍后重试");
     } finally {

--- a/apps/web/components/library-search-results.tsx
+++ b/apps/web/components/library-search-results.tsx
@@ -11,6 +11,7 @@ import {
   type LibrarySearchGroup,
 } from "@/lib/api/libraries";
 import { imageUrl } from "@/lib/image-proxy";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /**
  * 搜索结果页「媒体库」垂直：跨全部媒体库搜索已入库条目，按库分区展示。
@@ -30,6 +31,7 @@ export function LibrarySearchResults({
   /** 切到「影视」垂直（空态时的出口：库里没有 → 去找来） */
   onSwitchToMedia?: () => void;
 }) {
+  const scrollRef = useScrollRestoration(`search:library:${keyword}`);
   // null = 加载中；[] = 无结果；error 非空 = 请求失败
   const [groups, setGroups] = useState<LibrarySearchGroup[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -61,7 +63,10 @@ export function LibrarySearchResults({
         </h1>
       </header>
 
-      <div className="scroll-thin scroll-safe relative min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
+      <div
+        ref={scrollRef}
+        className="scroll-thin scroll-safe relative min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4"
+      >
         {groups === null && !error && <LibrarySearchSkeleton />}
         {(error || empty) && (
           <div className="flex flex-col items-center pt-24 text-center">

--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -43,6 +43,7 @@ import { imageUrl } from "@/lib/image-proxy";
 import type { MediaItem, MediaType } from "@/lib/media-types";
 import { usePermissions } from "@/lib/permissions";
 import { useVisiblePolling } from "@/lib/use-visible-polling";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /** 库类型 → 展示名与图标 */
 export const LIBRARY_KIND_META: Record<MediaType, { label: string; Icon: typeof FilmIcon }> = {
@@ -202,6 +203,7 @@ export function effectiveLibraryId(
  */
 export function LibraryView() {
   const { canManageLibraries } = usePermissions();
+  const scrollRef = useScrollRestoration("library");
   const [libraries, setLibraries] = useState<MediaLibrary[] | null>(null);
   const [itemsByLibrary, setItemsByLibrary] = useState<Map<number, LibraryItem[]>>(
     new Map(),
@@ -355,7 +357,7 @@ export function LibraryView() {
   );
 
   return (
-    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
+    <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       <div className="flex items-start justify-between gap-4 px-6 pt-2 max-md:flex-col max-md:items-stretch max-md:gap-3 max-md:px-4">
         <div>
           <h2 className="text-on-image text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[21px]">
@@ -594,6 +596,7 @@ function LibraryCard({
     <div className="group/lib relative">
       <Link
         href={`/library/${library.id}` as Route}
+        scroll={false}
         aria-label={`打开「${library.name}」`}
         className="block overflow-hidden rounded-2xl ring-1 ring-white/10 outline-none transition duration-300 hover:ring-white/35 focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
       >

--- a/apps/web/components/media-search-results.tsx
+++ b/apps/web/components/media-search-results.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/api/discover";
 import { fetchMediaSearchSnapshot } from "@/lib/api/search";
 import { formatRelativeTime } from "@/lib/time";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /**
  * 搜索结果页「影视」垂直：豆瓣 + TMDB 双来源搜索，上下两个分区展示。
@@ -46,6 +47,7 @@ export function MediaSearchResults({
   /** 切到「站点资源」垂直（空态/出错时的逃生入口） */
   onSwitchToTorrent?: () => void;
 }) {
+  const scrollRef = useScrollRestoration(`search:media:${keyword}:${snapshotId ?? "live"}`);
   // 每个来源各自三态：null = 加载中；[] = 无结果；error 非空 = 该分区失败
   const [douban, setDouban] = useState<MediaSearchItem[] | null>(null);
   const [doubanError, setDoubanError] = useState<string | null>(null);
@@ -148,7 +150,10 @@ export function MediaSearchResults({
         </div>
       </header>
 
-      <div className="scroll-thin scroll-safe relative min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
+      <div
+        ref={scrollRef}
+        className="scroll-thin scroll-safe relative min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4"
+      >
         {allEmpty ? (
           <MediaSearchEmpty
             title={anyError ? "影视搜索出错" : "没有找到相关影视条目"}

--- a/apps/web/components/page-nav.tsx
+++ b/apps/web/components/page-nav.tsx
@@ -170,7 +170,13 @@ export function PageNav({
             </button>
           )}
           {parent ? (
-            <Link href={parent.href as Route} aria-label={backLabel} title={backLabel} className={backClass}>
+            <Link
+              href={parent.href as Route}
+              scroll={false}
+              aria-label={backLabel}
+              title={backLabel}
+              className={backClass}
+            >
               <ChevronLeftIcon className="size-[18px] max-md:size-[22px]" />
             </Link>
           ) : (

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -164,6 +164,7 @@ export function PosterCardVisual({
     return (
       <Link
         href={href}
+        scroll={false}
         ref={rootRef as React.Ref<HTMLAnchorElement>}
         {...tapGuard}
         onClick={onLinkClick}

--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -27,6 +27,7 @@ import { getSubscription, grabForSubscription } from "@/lib/api/subscriptions";
 import { cachedImageUrl } from "@/lib/image-proxy";
 import { usePermissions } from "@/lib/permissions";
 import { formatDateTime, formatRelativeTime } from "@/lib/time";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /**
  * 搜索结果页（主内容区）——消费 SSE 流式搜索，结果渐进渲染。
@@ -617,6 +618,9 @@ function collectEntities(items: TorrentHit[]): Map<string, EntityGroup> {
 }
 
 export function SearchResults({ query, onResearch, grabForSubscriptionId }: SearchResultsProps) {
+  const scrollRef = useScrollRestoration(
+    `search:torrent:${query.keyword}:${query.scope.label ?? "all"}:${query.scope.categories.join(",")}:${query.scope.siteIds.join(",")}:${query.snapshotId ?? "live"}`,
+  );
   const [phase, setPhase] = useState<Phase>("connecting");
   // 手动选种模式：拉一次订阅标题供横幅与按钮提示；订阅不存在则静默退出该模式
   const [grabTarget, setGrabTarget] = useState<{ id: number; title: string } | null>(null);
@@ -1056,7 +1060,10 @@ export function SearchResults({ query, onResearch, grabForSubscriptionId }: Sear
       </header>
 
       {/* 主体：结果随 site_result 事件渐进出现，首批结果到达前保持骨架屏 */}
-      <div className="scroll-thin scroll-safe relative z-0 min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4">
+      <div
+        ref={scrollRef}
+        className="scroll-thin scroll-safe relative z-0 min-h-0 flex-1 overflow-y-auto px-6 pb-6 max-md:px-4"
+      >
         {streaming && items.length === 0 && (
           <SkeletonList siteCount={siteProgress.length} />
         )}

--- a/apps/web/components/subscriptions-view.tsx
+++ b/apps/web/components/subscriptions-view.tsx
@@ -18,6 +18,7 @@ import {
   subscriptionStatusMeta,
 } from "@/lib/subscription-ui";
 import { useIsMobile } from "@/lib/use-media-query";
+import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /**
  * 订阅页：用户全部订阅的海报墙。
@@ -33,6 +34,7 @@ import { useIsMobile } from "@/lib/use-media-query";
  */
 export function SubscriptionsView() {
   const { canManageSubscriptions, canSubscribe } = usePermissions();
+  const scrollRef = useScrollRestoration("subscriptions");
   const [mediaType, setMediaType] = useState<"movie" | "tv">("movie");
   const { subscriptions, refresh } = useSubscribeEntry();
   const [failed, setFailed] = useState(false);
@@ -72,7 +74,7 @@ export function SubscriptionsView() {
   const visible = (subscriptions ?? []).filter((s) => s.media.kind === mediaType);
 
   return (
-    <div className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
+    <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
       <div className="flex items-start justify-between gap-4 px-6 pt-2 max-md:px-4">
         <div>
           <h2 className="text-on-image text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[21px]">

--- a/apps/web/lib/library-detail-snapshot.ts
+++ b/apps/web/lib/library-detail-snapshot.ts
@@ -1,0 +1,68 @@
+import type {
+  LibraryIndexEntry,
+  LibraryItem,
+  LibraryItemSort,
+  MediaLibrary,
+  MetadataRefreshProgress,
+  MissingItem,
+  ReviewGroup,
+  UnidentifiedGroup,
+} from "@/lib/api/libraries";
+import type { Subscription } from "@/lib/api/subscriptions";
+
+/**
+ * 单库页离开再返回时的会话快照。
+ *
+ * 媒体详情与库存墙是两个路由，Next 切换时会卸载库存墙组件。快照保留
+ * 已加载的分页窗口，让返回时先恢复原来的视觉位置，再在后台与服务端对账。
+ */
+export interface LibraryDetailSnapshot {
+  libraries: MediaLibrary[];
+  items: LibraryItem[];
+  wallHasMore: boolean;
+  ownedIds: Set<number>;
+  wallIndex: LibraryIndexEntry[];
+  wallStart: number;
+  unidentified: UnidentifiedGroup[];
+  review: ReviewGroup[];
+  ignored: UnidentifiedGroup[];
+  missing: MissingItem[];
+  subscriptions: Subscription[];
+  metaRefresh: MetadataRefreshProgress | null;
+  wallLoaded: number;
+  wallSort: LibraryItemSort;
+  wallOffset: number;
+  /** 删除或转移等操作后标记为过期；保留旧窗口只为让滚动恢复有落脚点。 */
+  stale: boolean;
+}
+
+const MAX_LIBRARY_DETAIL_SNAPSHOTS = 20;
+const snapshots = new Map<number, LibraryDetailSnapshot>();
+
+export function getLibraryDetailSnapshot(libraryId: number) {
+  return snapshots.get(libraryId);
+}
+
+export function setLibraryDetailSnapshot(
+  libraryId: number,
+  snapshot: LibraryDetailSnapshot,
+) {
+  // 重新写入时移到 Map 尾部，超限时优先淘汰最久未更新的库。
+  snapshots.delete(libraryId);
+  snapshots.set(libraryId, snapshot);
+  while (snapshots.size > MAX_LIBRARY_DETAIL_SNAPSHOTS) {
+    const oldest = snapshots.keys().next().value;
+    if (oldest === undefined) break;
+    snapshots.delete(oldest);
+  }
+}
+
+/**
+ * 让返回后的页面保留旧窗口但必须重新向服务端对账。
+ * 没有快照时无需额外记录：首次进入本来就会执行完整加载。
+ */
+export function invalidateLibraryDetailSnapshot(libraryId: number) {
+  const snapshot = snapshots.get(libraryId);
+  if (!snapshot || snapshot.stale) return;
+  setLibraryDetailSnapshot(libraryId, { ...snapshot, stale: true });
+}

--- a/apps/web/lib/media-detail.tsx
+++ b/apps/web/lib/media-detail.tsx
@@ -86,6 +86,7 @@ export function useMediaDetail(): MediaDetailNav {
           source === "douban"
             ? (`/media/douban/${item.id}` as Route)
             : (`/media/${item.type}/${item.id}` as Route),
+          { scroll: false },
         );
       },
       close() {

--- a/apps/web/lib/use-scroll-restoration.ts
+++ b/apps/web/lib/use-scroll-restoration.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useLayoutEffect, useState } from "react";
+
+/**
+ * 列表页的滚动位置只在当前浏览会话内保留，不写入 localStorage：
+ * 位置属于一次导航上下文，刷新页面后重新从列表顶部开始更符合预期。
+ */
+interface ScrollAnchor {
+  id: string;
+  /** 锚点顶边相对滚动容器可视区顶边的偏移。 */
+  offset: number;
+}
+
+interface ScrollPosition {
+  top: number;
+  anchor?: ScrollAnchor;
+}
+
+const positions = new Map<string, ScrollPosition>();
+const MAX_SCROLL_POSITIONS = 100;
+const MAX_RESTORE_MS = 5000;
+const MAX_ANCHOR_SETTLE_MS = 800;
+
+function rememberScrollPosition(key: string, position: ScrollPosition) {
+  // 位置只服务于当前浏览会话，限制条目数避免用户在大量列表间导航时无限增长。
+  positions.delete(key);
+  positions.set(key, position);
+  while (positions.size > MAX_SCROLL_POSITIONS) {
+    const oldest = positions.keys().next().value;
+    if (oldest === undefined) break;
+    positions.delete(oldest);
+  }
+}
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false;
+  return (
+    target.matches("input, textarea, select") ||
+    target.closest("input, textarea, select, [contenteditable='true']") !== null
+  );
+}
+
+interface ScrollRestorationOptions {
+  /**
+   * 列表项的稳定标识属性。传入后优先恢复首个可见项，而不是单纯恢复像素位置。
+   * 海报图片与分页窗口会让同一像素位置对应到不同条目，条目锚点才能保持视觉位置。
+   */
+  anchorAttribute?: string;
+}
+
+/**
+ * 记住一个内部滚动容器的位置，并在返回该列表时恢复。
+ *
+ * 列表数据可能在挂载后异步到达，第一次设置 scrollTop 可能被浏览器
+ * 截断到当前内容高度。因此恢复过程会在 DOM 变化和下一帧继续尝试，
+ * 直到内容足够或超过短暂的等待上限。
+ */
+export function useScrollRestoration(key: string, options: ScrollRestorationOptions = {}) {
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+  const ref = useCallback((node: HTMLDivElement | null) => setElement(node), []);
+  const anchorAttribute = options.anchorAttribute;
+
+  useLayoutEffect(() => {
+    if (!element) return;
+
+    let frame = 0;
+    // 新容器挂载时，Next 可能先触发一次归零滚动。恢复目标必须在此刻
+    // 固定下来，不能再从 positions 读取，否则这次初始化事件会把目标覆盖成 0。
+    let pendingPosition = positions.get(key);
+    let anchorSettleDeadline = 0;
+    const deadline = performance.now() + MAX_RESTORE_MS;
+    const capturePosition = (): ScrollPosition => {
+      const position: ScrollPosition = { top: element.scrollTop };
+      if (!anchorAttribute) return position;
+
+      const containerRect = element.getBoundingClientRect();
+      const anchor = Array.from(
+        element.querySelectorAll<HTMLElement>(`[${anchorAttribute}]`),
+      ).find((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return rect.bottom > containerRect.top && rect.top < containerRect.bottom;
+      });
+      const id = anchor?.getAttribute(anchorAttribute);
+      if (anchor && id) {
+        position.anchor = {
+          id,
+          offset: anchor.getBoundingClientRect().top - containerRect.top,
+        };
+      }
+      return position;
+    };
+    const restore = () => {
+      frame = 0;
+      const saved = pendingPosition;
+      if (saved == null) return;
+      const savedAnchor = saved.anchor;
+      if (savedAnchor && anchorAttribute) {
+        const anchor = Array.from(
+          element.querySelectorAll<HTMLElement>(`[${anchorAttribute}]`),
+        ).find((candidate) => candidate.getAttribute(anchorAttribute) === savedAnchor.id);
+        if (anchor) {
+          const containerTop = element.getBoundingClientRect().top;
+          element.scrollTop += anchor.getBoundingClientRect().top - containerTop - savedAnchor.offset;
+          // content-visibility 与图片尺寸会在挂载后的短暂窗口内补齐。持续复核
+          // 锚点，防止高度修正把用户带到相邻的一行海报。
+          if (!anchorSettleDeadline) {
+            anchorSettleDeadline = performance.now() + MAX_ANCHOR_SETTLE_MS;
+          }
+          if (performance.now() < anchorSettleDeadline) {
+            frame = requestAnimationFrame(restore);
+          } else {
+            pendingPosition = undefined;
+          }
+          return;
+        }
+      }
+      // 内容还没撑到目标高度时先不写入，避免浏览器把目标截断后触发
+      // scroll 监听，误把截断值保存成新的位置。
+      const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+      if (saved.top > maxScrollTop) {
+        if (performance.now() < deadline) {
+          frame = requestAnimationFrame(restore);
+        } else {
+          // 数据最终不足以撑到旧位置时，放弃旧值，让之后的真实滚动继续记忆。
+          pendingPosition = undefined;
+          rememberScrollPosition(key, capturePosition());
+        }
+        return;
+      }
+      element.scrollTop = saved.top;
+      pendingPosition = undefined;
+    };
+    const scheduleRestore = () => {
+      if (!frame) frame = requestAnimationFrame(restore);
+    };
+    const cancelRestore = () => {
+      if (pendingPosition == null) return;
+      pendingPosition = undefined;
+      anchorSettleDeadline = 0;
+      if (frame) cancelAnimationFrame(frame);
+      frame = 0;
+    };
+    const remember = () => {
+      // 等待异步列表数据期间，忽略框架初始化的归零滚动，保住本次返回目标。
+      if (pendingPosition != null) return;
+      rememberScrollPosition(key, capturePosition());
+    };
+    const resizes =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleRestore);
+    const observeResizedChildren = () => {
+      if (!resizes) return;
+      resizes.observe(element);
+      for (const child of element.children) resizes.observe(child);
+    };
+    const mutations = new MutationObserver((records) => {
+      if (resizes) {
+        for (const record of records) {
+          for (const node of record.addedNodes) {
+            if (node instanceof Element && node.parentElement === element) {
+              resizes.observe(node);
+            }
+          }
+        }
+      }
+      scheduleRestore();
+    });
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) return;
+      if (["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) {
+        cancelRestore();
+      }
+    };
+
+    element.addEventListener("scroll", remember, { passive: true });
+    element.addEventListener("wheel", cancelRestore, { passive: true });
+    element.addEventListener("touchstart", cancelRestore, { passive: true });
+    element.addEventListener("pointerdown", cancelRestore, { passive: true });
+    window.addEventListener("keydown", handleKeyDown, true);
+    mutations.observe(element, { childList: true, subtree: true });
+    observeResizedChildren();
+    scheduleRestore();
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      element.removeEventListener("scroll", remember);
+      element.removeEventListener("wheel", cancelRestore);
+      element.removeEventListener("touchstart", cancelRestore);
+      element.removeEventListener("pointerdown", cancelRestore);
+      window.removeEventListener("keydown", handleKeyDown, true);
+      mutations.disconnect();
+      resizes?.disconnect();
+      // 路由跳转期间框架可能先把当前容器复位到顶部，再卸载本页；这里若再
+      // 读取 scrollTop 会把已由 scroll 事件保存的真实位置覆盖成 0。
+    };
+  }, [anchorAttribute, element, key]);
+
+  return ref;
+}


### PR DESCRIPTION
### 背景

媒体库和榜单页面使用独立的内部滚动容器。用户从列表深处进入媒体详情，再返回列表时，页面组件会重新挂载，原有的 `scrollTop` 和已加载分页窗口也会被重置，导致：

- 返回后回到列表顶部；
- 榜单只渲染前 50 条，无法恢复深处位置；
- 媒体库删除或转移条目后，旧快照可能继续显示已不存在的内容；
- 异步加载、图片尺寸变化期间，自动恢复可能覆盖用户主动滚动。

### 本次修改

- 新增通用滚动位置恢复 hook，支持异步布局、锚点和用户主动操作。
- 记忆每个榜单的已加载数量，支持深滚动返回。
- 为媒体库详情页增加会话快照，并在删除、重新识别、转移后自动失效刷新。
- 为滚动位置、榜单窗口和媒体库快照增加容量限制。

### 验证

已通过 TypeScript、ESLint、Next.js 生产构建和 `git diff --check`。