### PR TITLE
fix(subscription): 种子完成但缺承诺集数时退回重找，全集包不再承诺特别篇

### DIFF
--- a/src/movieclaw_api/services/download_progress.py
+++ b/src/movieclaw_api/services/download_progress.py
@@ -14,6 +14,11 @@
   落进了 movieclaw 不可达的位置（映射缺失/卷未挂载/用户在下载器里
   移动了文件）——记一条中文告警活动（去重只记一次），不退回重找
   （数据真实存在，重找只会重复下载到同一个黑洞）；
+- 种子已完成且落点可见 → **内容核验**：工单承诺的集数不在种子文件
+  清单里（而清单明确认得出其他集数）→ 缺失部分退回重新找资源——
+  全集/整季包的声明覆盖与物理内容不符时（真实案例：全集包被判定
+  覆盖特别篇，实际一个 SP 文件都没有），工单不能挂在永远等不来的
+  种子上，库存对账扫多少轮都关不掉它；
 - 其余情况（下载中/已完成且落点可见待入库）不做任何事。
 
 失败语义沿用：每组独立处理，单组失败不拖垮整轮，中文活动可回放。
@@ -23,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from datetime import timedelta
 from pathlib import Path
 
@@ -30,6 +36,7 @@ from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from movieclaw_api.services.subscription import units_text
 from movieclaw_api.services.system_notice import resolve_notices, upsert_notice
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import (
@@ -48,6 +55,7 @@ from movieclaw_db.models.system_notice import NoticeSeverity
 from movieclaw_db.repositories import SubscriptionRepository
 from movieclaw_db.repositories.downloader_repo import DownloaderRepository
 from movieclaw_downloader import DownloaderConfig, TorrentStatus, create_downloader
+from movieclaw_media.models import MediaKind
 from movieclaw_scheduler.registry import register_task
 
 logger = logging.getLogger("movieclaw_api.download_progress")
@@ -76,7 +84,8 @@ _IN_FLIGHT = (WantedStatus.GRABBED, WantedStatus.DOWNLOADED)
     interval_seconds=PROGRESS_TICK_SECONDS,
     description=(
         "照看订阅在途投递的种子：被手动删除或长期卡死的工单退回重新找资源；"
-        "已完成的核验落点，movieclaw 看不到文件时在时间线告警。"
+        "已完成的核验落点与内容——movieclaw 看不到文件时在时间线告警，"
+        "种子内容缺少承诺的集数时把缺失部分退回重新找资源。"
         "下载完成后的入库由监听导入/库扫描完成，工单由库存对账关闭。"
     ),
 )
@@ -227,10 +236,13 @@ async def _rescue_group(
             return
 
         if status.completed:
-            # 已完成：核验落点（movieclaw 侧看不到内容 → 告警活动），
-            # 搬运仍归监听导入/库扫描，工单仍归库存对账
+            # 已完成：先核验落点（movieclaw 侧看不到内容 → 告警活动），落点
+            # 可见再核验内容（承诺的集数不在文件清单里 → 缺失部分退回重找）。
+            # 搬运仍归监听导入/库扫描，清单里存在的集数仍归库存对账关单
             assert downloader_row is not None  # found 非 None 时二者同源
-            await _verify_landing(session, repo, rows, info_hash, downloader_row, status)
+            landed = await _verify_landing(session, repo, rows, info_hash, downloader_row, status)
+            if landed:
+                await _verify_content(session, repo, item, rows, info_hash, status)
             return
 
         logger.debug("《%s》的种子 %s：下载中", item.title, info_hash)
@@ -247,7 +259,7 @@ async def _verify_landing(
     info_hash: str,
     downloader: DownloaderClient,
     status,
-) -> None:
+) -> bool:
     """核验已完成种子的落点：movieclaw 侧看不到内容则记告警活动（去重）。
 
     判定：下载器上报的实际保存目录反向过路径映射翻译回 movieclaw 视角，
@@ -255,18 +267,21 @@ async def _verify_landing(
     文件落在 movieclaw 不可达的位置——映射缺失/卷未挂载/被人工移动，
     监听导入和库扫描永远等不到它，必须把问题亮到时间线上。
     不退回重找：数据真实存在，重找只会重复下载到同一个黑洞。
+
+    返回落点是否可见——只有确认可见（True）才有资格进入后续的内容核验；
+    宽限期内或证据不全一律返回 False（本轮不判，不代表落点有问题）。
     """
     from movieclaw_api.services.torrent_submit import translate_to_local
 
     # 宽限期内不判：刚完成的种子可能还在归位（qB 临时目录搬移等）
     threshold = utcnow() - timedelta(minutes=_LANDING_GRACE_MINUTES)
     if any((w.grabbed_at or w.updated_at) > threshold for w in rows):
-        return
+        return False
 
     local_dir = translate_to_local(status.save_path, downloader.path_mappings)
     root = status.files[0].path.split("/")[0] if status.files else status.name
     if not local_dir or not root:
-        return
+        return False
     if (Path(local_dir) / root).exists():
         # 落点可见，等监听导入/库扫描接管即可；此前若报过"看不到"（映射
         # 刚修好/卷刚挂上），问题已消失，红灯就地熄灭
@@ -274,7 +289,7 @@ async def _verify_landing(
             session,
             dedupe_key=f"subscription.landing:{rows[0].subscription_id}:{info_hash}",
         )
-        return
+        return True
 
     message = (
         f"「{status.name}」已下载完成，但 movieclaw 在 {local_dir} 看不到它——"
@@ -310,7 +325,7 @@ async def _verify_landing(
     for activity in existing:
         payload = activity.payload or {}
         if payload.get("info_hash") == info_hash and payload.get("reason") == "path_unreachable":
-            return
+            return False
 
     await repo.add_activity(
         SubscriptionActivity(
@@ -332,11 +347,83 @@ async def _verify_landing(
         local_dir,
         status.save_path,
     )
+    return False
 
 
-async def subscription_download_snapshot(
-    session: AsyncSession, subscription_id: int
-) -> list[dict]:
+# 种子内文件的季集声明：场景命名 SxxEyy。第二组抓整段集号串——连写
+# （E05E06）与区间简写（E05-E08）都收进来，展开规则见 _observed_units。
+# 裸数字段必须有分隔符引导（防止把 E05.1080p 的技术串吞进集号）
+_FILE_UNIT_RE = re.compile(r"[Ss](\d{1,2})((?:[Ee]\d{1,4})(?:(?:\s*[-~&+]\s*[Ee]?|[Ee])\d{1,4})*)")
+_FILE_EP_RE = re.compile(r"\d{1,4}")
+
+
+def _observed_units(files) -> set[tuple[int, int]]:
+    """种子文件清单里能认出的 (季, 集) 集合。
+
+    只认场景命名的 SxxEyy 高置信声明；恰好两个递增集号视为区间展开
+    （E05-E08 → 5..8，连写 E05E06 展开结果与列举一致），其余按列举。
+    季集识别的完整口径在库扫描侧（NER 模型），这里刻意不复用——救援
+    巡检要在无模型环境同样工作，而轻量正则的漏认只会让判定更保守
+    （认不出 → 不动），不会造成误退。
+    """
+    observed: set[tuple[int, int]] = set()
+    for file in files:
+        for match in _FILE_UNIT_RE.finditer(file.path):
+            season = int(match.group(1))
+            numbers = [int(n) for n in _FILE_EP_RE.findall(match.group(2))]
+            if len(numbers) == 2 and numbers[0] < numbers[1] <= numbers[0] + 200:
+                numbers = list(range(numbers[0], numbers[1] + 1))
+            observed.update((season, episode) for episode in numbers)
+    return observed
+
+
+async def _verify_content(
+    session: AsyncSession,
+    repo: SubscriptionRepository,
+    item: MediaItem,
+    rows: list[WantedItem],
+    info_hash: str,
+    status: TorrentStatus,
+) -> None:
+    """核验已完成种子的内容：承诺的集数不在文件清单里 → 缺失部分退回重找。
+
+    库存对账只认领真实存在的文件——种子里根本没有的集，扫多少轮都不会
+    入库，工单会以 grabbed 永远挂着，任务中心那条"等待入库"永不消失
+    （真实案例：全集包被判定覆盖特别篇 7 集，62 个文件全是正剧）。
+
+    判定刻意保守，证据不足一律不动：
+    - 电影不判（单元没有集号语义）；
+    - 文件清单为空（旧适配器不上报）不判；
+    - 清单里一个集数都认不出（原盘目录/非常规命名）不判——只有清单
+      "明确认得出集数、且明确没有这一集"时才断言缺失；
+    - 只退回缺失的工单，清单里存在的集数继续等对账正常关单。
+    """
+    if MediaKind(item.kind) is MediaKind.MOVIE:
+        return
+    if not status.files:
+        return
+    observed = _observed_units(status.files)
+    if not observed:
+        return
+    missing = [w for w in rows if (w.season_number, w.episode_number) not in observed]
+    if not missing:
+        return
+    await _requeue(
+        session,
+        repo,
+        item,
+        missing,
+        info_hash,
+        message=(
+            f"「{status.name}」已下载完成，但内容里没有 {units_text(missing)} 对应的"
+            f"文件（声明的覆盖范围与实际内容不符），这部分退回重新寻找资源；"
+            "种子内实际存在的集数不受影响，照常入库"
+        ),
+        reason="content_missing",
+    )
+
+
+async def subscription_download_snapshot(session: AsyncSession, subscription_id: int) -> list[dict]:
     """订阅详情页的实时下载进度快照。
 
     把该订阅的在途工单按种子分组，逐个到可用下载器里查当前状态（速度/ETA/

--- a/src/movieclaw_api/services/subscription/matching.py
+++ b/src/movieclaw_api/services/subscription/matching.py
@@ -232,7 +232,17 @@ def covered_units(
         return w.air_date <= published
 
     if match.is_complete_series:
-        return [w for w in open_units.values() if _airable(w, require_dated=True)]
+        # 全集包不承诺特别篇（season 0 的具体集）：市面上的"全集/合集"几乎
+        # 从不收录 SP/短剧集，赌它包含的代价是工单挂上一个永远等不来的种子
+        # （真实教训：绝命毒师全集包 62 个文件全是 S01-S05 正剧，S00 工单
+        # 以 grabbed 卡死"等待入库"）。特别篇只信显式声明——标题写明 S00/SP
+        # 时走 episodes / pack_seasons 通道覆盖。电影单元 (0, 0) 不受影响。
+        return [
+            w
+            for w in open_units.values()
+            if not (w.season_number == 0 and w.episode_number > 0)
+            and _airable(w, require_dated=True)
+        ]
     result = [
         w
         for key, w in open_units.items()

--- a/tests/api/test_download_rescue.py
+++ b/tests/api/test_download_rescue.py
@@ -1,0 +1,377 @@
+"""投递救援巡检的内容核验测试：种子完成但承诺集数不在文件清单 → 缺失部分退回。
+
+覆盖三层：
+- ``_observed_units`` 纯函数（场景命名解析：连写/区间/认不出）；
+- ``covered_units`` 的特别篇口径（全集包不承诺 season 0 的具体集）；
+- ``_rescue_group`` 完成分支的端到端语义（缺失退回/存在不动/证据不足不动/
+  电影不判/宽限期内不判）。下载器查询一律打桩，落点用真实临时目录。
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlmodel import select
+
+from movieclaw_api.core.config import get_settings
+from movieclaw_api.services import download_progress
+from movieclaw_api.services.download_progress import _observed_units, _rescue_group
+from movieclaw_api.services.media_library import MediaLibraryService
+from movieclaw_api.services.subscription import SubscriptionService
+from movieclaw_api.services.subscription.matching import covered_units
+from movieclaw_db.engine import dispose_db, get_database, init_db
+from movieclaw_db.migrations import run_migrations
+from movieclaw_db.models import ActivityType, SubscriptionActivity, WantedItem, WantedStatus
+from movieclaw_db.models.base import utcnow
+from movieclaw_downloader import TorrentStatus
+from movieclaw_downloader.models import TorrentFile
+from movieclaw_matcher.models import IdentityMatch
+from movieclaw_media.models import MediaKind
+from movieclaw_media.tmdb import TmdbClient
+
+_KEY = "0123456789abcdef0123456789abcdef"
+_HASH = "59e5ba444a1fdc482c0e090764436cfc89f9691d"
+
+_TODAY = utcnow().date()
+_AIRED = (_TODAY - timedelta(days=30)).isoformat()
+
+# 夹具剧集：S0 特别篇两集 + S1 正剧两集，全部已播
+_ROUTES = {
+    "/3/tv/300": {
+        "id": 300,
+        "name": "测试剧集",
+        "original_name": "Test Show",
+        "first_air_date": "2024-01-01",
+        "status": "Returning Series",
+        "external_ids": {},
+        "alternative_titles": {"results": []},
+        "translations": {"translations": []},
+        "seasons": [{"season_number": 0}, {"season_number": 1}],
+    },
+    "/3/tv/300/season/0": {
+        "name": "特别篇",
+        "air_date": _AIRED,
+        "episodes": [
+            {"episode_number": 1, "name": "SP1", "air_date": _AIRED},
+            {"episode_number": 2, "name": "SP2", "air_date": _AIRED},
+        ],
+    },
+    "/3/tv/300/season/1": {
+        "name": "第 1 季",
+        "air_date": _AIRED,
+        "episodes": [
+            {"episode_number": 1, "name": "E1", "air_date": _AIRED},
+            {"episode_number": 2, "name": "E2", "air_date": _AIRED},
+        ],
+    },
+    "/3/movie/100": {
+        "id": 100,
+        "title": "测试电影",
+        "original_title": "Test Movie",
+        "release_date": _AIRED,
+        "status": "Released",
+        "external_ids": {},
+        "alternative_titles": {"titles": []},
+        "translations": {"translations": []},
+    },
+}
+
+
+def _fake_tmdb() -> TmdbClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _ROUTES.get(request.url.path)
+        return httpx.Response(200 if payload else 404, json=payload or {})
+
+    return TmdbClient(_KEY, transport=httpx.MockTransport(handler))
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{tmp_path / 'rescue.db'}")
+    get_settings.cache_clear()
+    init_db(get_settings().database_url, echo=False)
+    await run_migrations()
+    yield get_database()
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+class _FakeDownloaderRow:
+    name = "测试下载器"
+    path_mappings = None
+
+
+async def _grabbed_subscription(session, kind: MediaKind, tmdb_id: int, **kw) -> int:
+    """建订阅并把全部工单置为在途（GRABBED + info_hash + 已过宽限期）。"""
+    service = SubscriptionService(session, MediaLibraryService(session, _fake_tmdb()))
+    subscription = await service.create(kind, tmdb_id, **kw)
+    assert subscription.id is not None
+    rows = (
+        (
+            await session.execute(
+                select(WantedItem).where(WantedItem.subscription_id == subscription.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows
+    aged = utcnow() - timedelta(minutes=25)
+    for row in rows:
+        row.status = WantedStatus.GRABBED
+        row.info_hash = _HASH
+        row.grabbed_at = aged
+        session.add(row)
+    await session.commit()
+    return subscription.id
+
+
+def _completed_status(
+    tmp_path, file_paths: list[str], name: str = "Test.Show.Pack"
+) -> TorrentStatus:
+    """已完成种子：落点指向真实临时目录（内容根实际建出，落点核验通过）。"""
+    root = file_paths[0].split("/")[0] if file_paths else name
+    (tmp_path / root).mkdir(parents=True, exist_ok=True)
+    return TorrentStatus(
+        info_hash=_HASH,
+        name=name,
+        progress=1.0,
+        completed=True,
+        save_path=str(tmp_path),
+        files=[TorrentFile(path=p, size_bytes=1) for p in file_paths],
+        state="completed",
+    )
+
+
+def _stub_query(monkeypatch, status: TorrentStatus) -> None:
+    async def fake_query(info_hash, downloaders, *, include_files=True):
+        return _FakeDownloaderRow(), status
+
+    monkeypatch.setattr(download_progress, "_query_torrent", fake_query)
+
+
+async def _wanted_map(session, sub_id: int) -> dict[tuple[int, int], WantedItem]:
+    rows = (
+        (await session.execute(select(WantedItem).where(WantedItem.subscription_id == sub_id)))
+        .scalars()
+        .all()
+    )
+    return {(w.season_number, w.episode_number): w for w in rows}
+
+
+async def _dispatch_failed(session, sub_id: int) -> list[SubscriptionActivity]:
+    rows = (
+        (
+            await session.execute(
+                select(SubscriptionActivity).where(
+                    SubscriptionActivity.subscription_id == sub_id,
+                    SubscriptionActivity.type == ActivityType.DISPATCH_FAILED,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows)
+
+
+# ---------------------------------------------------------------------------
+# _observed_units：场景命名解析
+# ---------------------------------------------------------------------------
+
+
+def _files(*paths: str) -> list[TorrentFile]:
+    return [TorrentFile(path=p, size_bytes=1) for p in paths]
+
+
+def test_observed_units_scene_naming() -> None:
+    """常规 SxxEyy（大小写皆可）逐文件解析。"""
+    observed = _observed_units(
+        _files(
+            "Show/Show.S01E01.1080p.WEB-DL.mkv",
+            "Show/show.s01e02.1080p.web-dl.mkv",
+            "Show/Show.S02E01.mkv",
+        )
+    )
+    assert observed == {(1, 1), (1, 2), (2, 1)}
+
+
+def test_observed_units_multi_episode_and_range() -> None:
+    """连写按列举，恰好两个递增集号按区间展开。"""
+    assert _observed_units(_files("Show.S01E05E06.mkv")) == {(1, 5), (1, 6)}
+    assert _observed_units(_files("Show.S01E05-E08.mkv")) == {(1, 5), (1, 6), (1, 7), (1, 8)}
+
+
+def test_observed_units_unrecognized_is_empty() -> None:
+    """认不出集数（原盘结构/裸名）返回空集——调用方据此保守不动。"""
+    assert _observed_units(_files("BDMV/STREAM/00001.m2ts", "Movie.2020.1080p.mkv")) == set()
+
+
+# ---------------------------------------------------------------------------
+# covered_units：全集包不承诺特别篇
+# ---------------------------------------------------------------------------
+
+
+def _wanted(season: int, episode: int) -> WantedItem:
+    return WantedItem(
+        subscription_id=1,
+        media_item_id=1,
+        season_number=season,
+        episode_number=episode,
+        air_date=date(2020, 1, 1),
+    )
+
+
+def test_complete_series_skips_specials() -> None:
+    """全集包展开覆盖正剧与电影正片，但不覆盖特别篇的具体集。"""
+    open_units = {
+        (0, 1): _wanted(0, 1),  # 特别篇：不该被承诺
+        (1, 1): _wanted(1, 1),  # 正剧：照常覆盖
+    }
+    covered = covered_units(IdentityMatch(is_complete_series=True), open_units, published=_TODAY)
+    assert [(w.season_number, w.episode_number) for w in covered] == [(1, 1)]
+
+
+def test_complete_series_still_covers_movie_unit() -> None:
+    """电影单元 (0, 0) 不是特别篇，全集包语义保持原状。"""
+    open_units = {(0, 0): _wanted(0, 0)}
+    covered = covered_units(IdentityMatch(is_complete_series=True), open_units, published=_TODAY)
+    assert len(covered) == 1
+
+
+def test_explicit_special_episode_still_covered() -> None:
+    """标题显式声明的特别篇集号（episodes 通道）不受全集包口径影响。"""
+    open_units = {(0, 1): _wanted(0, 1)}
+    covered = covered_units(
+        IdentityMatch(episodes=frozenset({(0, 1)})), open_units, published=_TODAY
+    )
+    assert len(covered) == 1
+
+
+# ---------------------------------------------------------------------------
+# _rescue_group 完成分支：内容核验端到端
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_episodes_requeued(db, tmp_path, monkeypatch) -> None:
+    """真实教训回归：全集包声明覆盖特别篇但内容里没有——缺失集退回 wanted
+    （info_hash 清空、冷却后重找），清单里存在的集保持在途等对账。"""
+    async with db.session() as session:
+        sub_id = await _grabbed_subscription(session, MediaKind.TV, 300, selected_seasons=[0, 1])
+    _stub_query(
+        monkeypatch,
+        _completed_status(tmp_path, ["Show/Show.S01E01.mkv", "Show/Show.S01E02.mkv"]),
+    )
+    await _rescue_group(sub_id, _HASH, [(object(), object())])
+
+    async with db.session() as session:
+        wanted = await _wanted_map(session, sub_id)
+        assert wanted[(0, 1)].status == WantedStatus.WANTED
+        assert wanted[(0, 2)].status == WantedStatus.WANTED
+        assert wanted[(0, 1)].info_hash is None
+        assert wanted[(0, 1)].next_search_at is not None
+        assert wanted[(1, 1)].status == WantedStatus.GRABBED
+        assert wanted[(1, 2)].status == WantedStatus.GRABBED
+        activities = await _dispatch_failed(session, sub_id)
+        assert len(activities) == 1
+        assert activities[0].payload["reason"] == "content_missing"
+        assert "S00E01" in activities[0].message
+
+
+@pytest.mark.asyncio
+async def test_all_episodes_present_untouched(db, tmp_path, monkeypatch) -> None:
+    """承诺的集数都在清单里：不退回，继续等库存对账正常关单。"""
+    async with db.session() as session:
+        sub_id = await _grabbed_subscription(session, MediaKind.TV, 300, selected_seasons=[0, 1])
+    _stub_query(
+        monkeypatch,
+        _completed_status(
+            tmp_path,
+            [
+                "Show/Show.S00E01.mkv",
+                "Show/Show.S00E02.mkv",
+                "Show/Show.S01E01.mkv",
+                "Show/Show.S01E02.mkv",
+            ],
+        ),
+    )
+    await _rescue_group(sub_id, _HASH, [(object(), object())])
+
+    async with db.session() as session:
+        wanted = await _wanted_map(session, sub_id)
+        assert all(w.status == WantedStatus.GRABBED for w in wanted.values())
+        assert await _dispatch_failed(session, sub_id) == []
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_filenames_untouched(db, tmp_path, monkeypatch) -> None:
+    """清单一个集数都认不出（原盘目录）：证据不足，保守不动。"""
+    async with db.session() as session:
+        sub_id = await _grabbed_subscription(session, MediaKind.TV, 300, selected_seasons=[0, 1])
+    _stub_query(
+        monkeypatch,
+        _completed_status(tmp_path, ["Show/BDMV/STREAM/00001.m2ts"], name="Show"),
+    )
+    await _rescue_group(sub_id, _HASH, [(object(), object())])
+
+    async with db.session() as session:
+        wanted = await _wanted_map(session, sub_id)
+        assert all(w.status == WantedStatus.GRABBED for w in wanted.values())
+
+
+@pytest.mark.asyncio
+async def test_movie_units_never_judged(db, tmp_path, monkeypatch) -> None:
+    """电影单元没有集号语义：即便清单里认得出别的集数也不判。"""
+    async with db.session() as session:
+        sub_id = await _grabbed_subscription(session, MediaKind.MOVIE, 100)
+    _stub_query(
+        monkeypatch,
+        _completed_status(tmp_path, ["Bonus/Some.Show.S01E01.mkv"]),
+    )
+    await _rescue_group(sub_id, _HASH, [(object(), object())])
+
+    async with db.session() as session:
+        wanted = await _wanted_map(session, sub_id)
+        assert all(w.status == WantedStatus.GRABBED for w in wanted.values())
+
+
+@pytest.mark.asyncio
+async def test_grace_period_defers_judgement(db, tmp_path, monkeypatch) -> None:
+    """宽限期内（刚完成）不判：种子可能还在归位，下一轮再看。"""
+    async with db.session() as session:
+        sub_id = await _grabbed_subscription(session, MediaKind.TV, 300, selected_seasons=[0, 1])
+        rows = (
+            (await session.execute(select(WantedItem).where(WantedItem.subscription_id == sub_id)))
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            row.grabbed_at = utcnow()
+            session.add(row)
+        await session.commit()
+    _stub_query(
+        monkeypatch,
+        _completed_status(tmp_path, ["Show/Show.S01E01.mkv"]),
+    )
+    await _rescue_group(sub_id, _HASH, [(object(), object())])
+
+    async with db.session() as session:
+        wanted = await _wanted_map(session, sub_id)
+        assert all(w.status == WantedStatus.GRABBED for w in wanted.values())
+
+
+@pytest.mark.asyncio
+async def test_empty_file_list_untouched(db, tmp_path, monkeypatch) -> None:
+    """旧适配器不上报文件清单：无证据，保守不动。"""
+    async with db.session() as session:
+        sub_id = await _grabbed_subscription(session, MediaKind.TV, 300, selected_seasons=[0, 1])
+    _stub_query(monkeypatch, _completed_status(tmp_path, [], name="Show"))
+    await _rescue_group(sub_id, _HASH, [(object(), object())])
+
+    async with db.session() as session:
+        wanted = await _wanted_map(session, sub_id)
+        assert all(w.status == WantedStatus.GRABBED for w in wanted.values())


### PR DESCRIPTION
## 问题

生产实测踩到的卡死场景（绝命毒师订阅）：

1. 特别篇 7 个缺口（S00E01-05/08/09）搜索时，唯一命中是 pthome 的「Breaking.Bad.Complete.Series.1080p.NF.WEB-DL」全集包，`covered_units` 的 `is_complete_series` 分支把它们全部划入覆盖范围并投递；
2. 种子下载完成，62 个文件全是 S01–S05 正剧，**一个 SP 文件都没有**；正剧照常入库，但 7 张特别篇工单等的文件物理上不存在；
3. 库存对账只认领真实存在的文件——这些工单以 `grabbed` 永久挂起，任务中心那条「等待入库」永不消失；
4. 救援巡检现有三种兜底（种子丢失/下载卡死/落点不可见）都覆盖不到"种子完成但内容与声明不符"，没有任何机制能把它救回来。

## 修复（两层）

**匹配侧修根 —— `covered_units`**：全集包展开不再覆盖特别篇（season 0 的具体集）。市面上的"全集/合集"几乎从不收录 SP/短剧集，赌它包含的代价是工单挂上一个永远等不来的种子。特别篇只信显式声明（标题写明 S00/SP 时 `episodes` / `pack_seasons` 通道照常覆盖），电影单元 `(0, 0)` 行为不变。这一层同时消除了兜底退回后再次匹配同一种子的循环。

**救援侧兜底 —— `check_download_progress`**：种子已完成且落点可见时新增**内容核验**：工单承诺的集数不在种子文件清单里（而清单明确认得出其他集数）→ 缺失部分退回 `wanted` 冷却后重新找资源，清单里存在的集数不受影响、照常等对账关单；时间线记 `content_missing` 中文活动。

判定刻意保守，证据不足一律不动：

- 电影不判（单元没有集号语义）；
- 文件清单为空（旧适配器不上报）不判；
- 清单里一个集数都认不出（原盘目录/非常规命名）不判——只有"明确认得出集数、且明确没有这一集"才断言缺失；
- 落点核验的 10 分钟宽限期同样约束内容核验（`_verify_landing` 改为返回落点是否可见，可见才进入内容核验）。

集数解析用轻量正则（SxxEyy，含 E05E06 连写与 E05-E08 区间展开），**不依赖 NER 模型**——库扫描侧的完整口径需要模型，救援巡检要在无模型环境同样工作，而正则漏认只会让判定更保守（认不出 → 不动），不会造成误退。

## 测试

新增 `tests/api/test_download_rescue.py`（12 例）：

- `_observed_units` 纯函数：常规命名/连写/区间/认不出返回空；
- `covered_units` 口径：全集包跳过特别篇、电影正片不受影响、显式 S00 声明照常覆盖；
- `_rescue_group` 完成分支端到端（真库 + 打桩下载器 + 真实临时目录落点）：缺失退回（状态/info_hash/冷却/活动全断言）、全在不动、认不出不动、电影不判、宽限期内不判、无清单不动。

相关既有测试（pipeline / downloads / fulfillment / manual / matcher / downloader，144 例）全部通过。