### PR TITLE
feat(web): 发现页「已入库」统一为海报左上角绿斜标

### DIFF
--- a/apps/web/components/collection-grid-view.tsx
+++ b/apps/web/components/collection-grid-view.tsx
@@ -377,9 +377,15 @@ export function CollectionGridView({
               {filtered.map((item) => {
                 const rank = rankById.get(item.id) ?? 0;
                 return (
-                  <div key={item.id} className="relative min-w-0">
-                    {isRanked && <RankBadge rank={rank} />}
+                  <div key={item.id} className="group/rank relative min-w-0">
                     <PosterCard item={item} />
+                    {/* 名次牌覆盖层与海报同为 2:3，才能把名次钉在海报右下角
+                        （左上角已归「已入库」斜标）；不拦指针事件，整卡仍可点。 */}
+                    {isRanked && (
+                      <div className="pointer-events-none absolute inset-x-0 top-0 aspect-[2/3]">
+                        <RankBadge rank={rank} />
+                      </div>
+                    )}
                   </div>
                 );
               })}
@@ -415,6 +421,11 @@ export function CollectionGridView({
   );
 }
 
+/**
+ * 榜单名次牌。原本钉在海报左上角外沿，与全站统一的「已入库」左上角斜标撞位
+ * （名次盖住斜标文案，两个信号互相削弱），改钉海报右下角：那里只在 hover
+ * 信息层升起时才有内容，所以 hover 时淡出让位，静态时名次与斜标各占一角。
+ */
 function RankBadge({ rank }: { rank: number }) {
   const tone =
     rank === 1
@@ -426,7 +437,7 @@ function RankBadge({ rank }: { rank: number }) {
           : "bg-black/70 text-white";
   return (
     <span
-      className={`tnum absolute -left-1.5 -top-1.5 z-10 min-w-8 rounded-lg px-2 py-1 text-center text-sub font-black shadow-lg ring-1 ring-white/15 ${tone}`}
+      className={`tnum absolute bottom-2 right-2 z-10 min-w-8 rounded-lg px-2 py-1 text-center text-sub font-black shadow-lg ring-1 ring-white/15 transition-opacity duration-200 group-hover/rank:opacity-0 ${tone}`}
     >
       {rank}
     </span>

--- a/apps/web/components/collection-grid-view.tsx
+++ b/apps/web/components/collection-grid-view.tsx
@@ -25,7 +25,6 @@ const MAX_COLLECTION_SNAPSHOTS = 32;
 interface CollectionGridSnapshot {
   items: MediaItem[];
   title: string;
-  isRanked: boolean;
   nextPage: number;
   totalResults: number;
   hasMore: boolean;
@@ -65,7 +64,6 @@ export function CollectionGridView({
   const scrollRef = useScrollRestoration(`collection:${collectionRef}`);
   const [items, setItems] = useState<MediaItem[] | null>(() => initialSnapshot?.items ?? null);
   const [title, setTitle] = useState(() => initialSnapshot?.title ?? "影视片单");
-  const [isRanked, setIsRanked] = useState(() => initialSnapshot?.isRanked ?? false);
   const [query, setQuery] = useState("");
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
   const [nextPage, setNextPage] = useState(() => initialSnapshot?.nextPage ?? 2);
@@ -85,12 +83,11 @@ export function CollectionGridView({
     rememberCollectionGridSnapshot(collectionRef, {
       items,
       title,
-      isRanked,
       nextPage,
       totalResults,
       hasMore,
     });
-  }, [collectionRef, hasMore, isRanked, items, nextPage, title, totalResults]);
+  }, [collectionRef, hasMore, items, nextPage, title, totalResults]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -106,7 +103,6 @@ export function CollectionGridView({
     if (cached) {
       setItems(cached.items);
       setTitle(cached.title);
-      setIsRanked(cached.isRanked);
       setNextPage(cached.nextPage);
       setTotalResults(cached.totalResults);
       setHasMore(cached.hasMore);
@@ -121,7 +117,6 @@ export function CollectionGridView({
     // 避免新请求完成前短暂显示旧榜单，或失败后把旧数据误当成新结果。
     setItems(null);
     setTitle("影视片单");
-    setIsRanked(false);
     setLoadingMore(false);
     setNextPage(2);
     setTotalResults(0);
@@ -136,7 +131,6 @@ export function CollectionGridView({
         if (controller.signal.aborted) return;
         setItems(collection.items);
         setTitle(collection.name);
-        setIsRanked(collection.isRanked);
         setTotalResults(collection.totalResults);
         setHasMore(provider === "tmdb" && collection.hasMore);
         setNextPage(collection.page + 1);
@@ -202,13 +196,6 @@ export function CollectionGridView({
     }
     return [...counts].sort((a, b) => b[1] - a[1]);
   }, [items]);
-
-  // 排名查表：渲染时用 items.indexOf 是每格 O(n) 的线性扫描，数百格一轮渲染
-  // 就是数万次比较；榜单加载后排名固定，建一次 Map 终身使用
-  const rankById = useMemo(
-    () => new Map((items ?? []).map((item, index) => [item.id, index + 1])),
-    [items],
-  );
 
   // 搜索输入用延迟值参与过滤：连续敲字时先渲染输入框本身，网格的全量
   // 过滤与重渲染放到浏览器空闲时批量跟上，输入不再一字一卡
@@ -374,21 +361,11 @@ export function CollectionGridView({
             </div>
           ) : (
             <div className="grid grid-cols-2 gap-x-4 gap-y-7 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8">
-              {filtered.map((item) => {
-                const rank = rankById.get(item.id) ?? 0;
-                return (
-                  <div key={item.id} className="group/rank relative min-w-0">
-                    <PosterCard item={item} />
-                    {/* 名次牌覆盖层与海报同为 2:3，才能把名次钉在海报右下角
-                        （左上角已归「已入库」斜标）；不拦指针事件，整卡仍可点。 */}
-                    {isRanked && (
-                      <div className="pointer-events-none absolute inset-x-0 top-0 aspect-[2/3]">
-                        <RankBadge rank={rank} />
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+              {filtered.map((item) => (
+                <div key={item.id} className="min-w-0">
+                  <PosterCard item={item} />
+                </div>
+              ))}
             </div>
           )}
 
@@ -418,29 +395,6 @@ export function CollectionGridView({
         </main>
       )}
     </div>
-  );
-}
-
-/**
- * 榜单名次牌。原本钉在海报左上角外沿，与全站统一的「已入库」左上角斜标撞位
- * （名次盖住斜标文案，两个信号互相削弱），改钉海报右下角：那里只在 hover
- * 信息层升起时才有内容，所以 hover 时淡出让位，静态时名次与斜标各占一角。
- */
-function RankBadge({ rank }: { rank: number }) {
-  const tone =
-    rank === 1
-      ? "bg-[#d8ad50] text-[#211704]"
-      : rank === 2
-        ? "bg-[#b9c1cc] text-[#171a20]"
-        : rank === 3
-          ? "bg-[#b9794c] text-[#211108]"
-          : "bg-black/70 text-white";
-  return (
-    <span
-      className={`tnum absolute bottom-2 right-2 z-10 min-w-8 rounded-lg px-2 py-1 text-center text-sub font-black shadow-lg ring-1 ring-white/15 transition-opacity duration-200 group-hover/rank:opacity-0 ${tone}`}
-    >
-      {rank}
-    </span>
   );
 }
 

--- a/apps/web/components/discovered-person-detail-view.tsx
+++ b/apps/web/components/discovered-person-detail-view.tsx
@@ -166,18 +166,16 @@ function CreditCard({
   subscribed: boolean;
   onOpen: (item: MediaItem) => void;
 }) {
+  // 「已入库」的绿斜标由 PosterCardVisual 依 libraryStatus 全站统一渲染，这里只补订阅态；
   // 两种状态同时存在时优先“已入库”：它表达作品已经可用，比追踪关系更直接。
-  const ribbon = item.libraryStatus ? "已入库" : subscribed ? "已订阅" : undefined;
-  const ribbonTone = item.libraryStatus ? "owned" : subscribed ? "subscribed" : undefined;
+  const subscribedOnly = !item.libraryStatus && subscribed;
   return (
     <PosterCardVisual
-      item={{
-        ...item,
-        libraryStatus: null,
-        ribbon,
-        ribbonVariant: "compact-left",
-        ribbonTone,
-      }}
+      item={
+        subscribedOnly
+          ? { ...item, ribbon: "已订阅", ribbonVariant: "compact-left", ribbonTone: "subscribed" }
+          : item
+      }
       action="none"
       onClick={() => onOpen(item)}
     />

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -80,11 +80,12 @@ export interface PosterVisualItem {
   genres?: string[];
   extent?: string;
   badges?: string[];
-  /** 海报角上的斜向常显标签（如「自动续订」「已入库」「已订阅」）。 */
+  /** 海报角上的斜向常显标签（如「自动续订」「已订阅」）；
+   *  「已入库」不必显式传，由 libraryStatus 自动派生（见 resolveRibbon）。 */
   ribbon?: string;
   /** 人物作品页使用更小的左上角斜标；缺省保持订阅墙现有样式。 */
   ribbonVariant?: "compact-left";
-  /** 人物作品页斜标的语义色：已入库为绿色，已订阅为蓝色。 */
+  /** 斜标的语义色：已入库为绿色，已订阅为蓝色。 */
   ribbonTone?: "owned" | "subscribed";
   /** 海报底部常显的一行左右信息；订阅墙用来承载剧集范围与收录进度。 */
   posterFooter?: { label: string; value: string; tracking?: boolean };
@@ -94,6 +95,28 @@ export interface PosterVisualItem {
   overlayDetails?: MediaOverlayDetails;
   overview?: string;
   libraryStatus?: MediaLibraryStatus | null;
+}
+
+/**
+ * 海报角标的最终形态（无角标返回 null）。
+ *
+ * 「已入库」曾有两套表达：人物作品页在海报左上角打绿色斜标，其余发现页只在
+ * 海报下方的年份后面缀一枚绿点。绿点小且混在灰色元信息里，扫墙时几乎看不见，
+ * 现全站统一到斜标——凡是带 libraryStatus 的海报都自动打「已入库」绿斜标。
+ * 调用方显式传 ribbon（订阅墙的「自动续订」、人物作品页的「已订阅」）时以调用方为准。
+ */
+function resolveRibbon(
+  item: PosterVisualItem,
+): { label: string; compactLeft: boolean; tone: "owned" | "subscribed" } | null {
+  if (item.ribbon) {
+    return {
+      label: item.ribbon,
+      compactLeft: item.ribbonVariant === "compact-left",
+      tone: item.ribbonTone ?? "subscribed",
+    };
+  }
+  if (item.libraryStatus) return { label: "已入库", compactLeft: true, tone: "owned" };
+  return null;
 }
 
 export function PosterCard({ item, action, href }: PosterCardProps) {
@@ -192,7 +215,7 @@ export function PosterCardVisual({
     "group/card block w-full cursor-pointer rounded-2xl text-left outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]";
   if (href) {
     const accessibilityDetails = [
-      item.ribbon,
+      resolveRibbon(item)?.label,
       item.posterFooter ? `${item.posterFooter.label}，收录 ${item.posterFooter.value}` : undefined,
       item.overlayDetails?.primary,
       item.overlayDetails?.secondary,
@@ -245,9 +268,9 @@ function PosterCardContent({
   const overlaySecondary = item.overlayDetails?.secondary?.trim() ?? "";
   const overlayMeta = item.overlayMeta?.trim() ?? "";
   const overview = item.overview ?? "";
-  const compactLeftRibbon = item.ribbonVariant === "compact-left";
+  const ribbon = resolveRibbon(item);
   const compactRibbonTone =
-    item.ribbonTone === "owned"
+    ribbon?.tone === "owned"
       ? "from-emerald-500 via-green-500 to-teal-500 shadow-[0_2px_8px_rgba(16,185,129,0.38)]"
       : "from-sky-500 via-blue-500 to-indigo-500 shadow-[0_2px_8px_rgba(59,130,246,0.38)]";
   return (
@@ -270,22 +293,22 @@ function PosterCardContent({
         )}
         {/* 作品状态用紧凑左上斜标，宽度随海报缩放且不遮评分；其余调用方
             沿用右侧规格。无状态不渲染，避免海报墙过吵。 */}
-        {item.ribbon && (
+        {ribbon && (
           <span
-            aria-label={item.ribbon}
+            aria-label={ribbon.label}
             className={
-              compactLeftRibbon
+              ribbon.compactLeft
                 ? `pointer-events-none absolute -left-[18%] top-2 z-10 w-[62%] -rotate-45 border-y border-white/20 bg-gradient-to-r py-0.5 text-center text-[9px] font-bold leading-[11px] tracking-[0.08em] text-white ${compactRibbonTone}`
                 : "pointer-events-none absolute -right-8 top-4 z-10 w-28 rotate-45 border-y border-white/25 bg-gradient-to-r from-cyan-500 via-sky-500 to-violet-500 py-1 text-center text-[10px] font-bold tracking-[0.12em] text-white shadow-[0_3px_14px_rgba(14,165,233,0.45)]"
             }
           >
-            {item.ribbon}
+            {ribbon.label}
           </span>
         )}
         {/* 右上：评分徽章（暂无评分时不渲染，避免展示 0.0） */}
         {item.rating > 0 && (
           <span
-            className={`tnum absolute right-2 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-caption font-semibold text-white ${item.ribbon && !compactLeftRibbon ? "top-12" : "top-2"}`}
+            className={`tnum absolute right-2 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-caption font-semibold text-white ${ribbon && !ribbon.compactLeft ? "top-12" : "top-2"}`}
           >
             <StarIcon className="size-3 text-[var(--warn)]" />
             {item.rating.toFixed(1)}
@@ -364,17 +387,12 @@ function PosterCardContent({
         <p className="text-on-image truncate text-ui font-semibold text-[var(--text)]">
           {item.title}
         </p>
-        {/* 始终保留一行元信息，避免在库状态或缺失年份让同一海报墙的卡片高低跳动。 */}
+        {/* 始终保留一行元信息，避免缺失年份让同一海报墙的卡片高低跳动。
+            在库与否不在这里表达——它已由海报左上角的「已入库」斜标承担。 */}
         <p className="text-on-image tnum mt-0.5 flex min-h-4 items-center gap-1.5 truncate text-caption text-[var(--text-muted)]">
           {!!item.year && <span>{item.year}</span>}
           {!!item.year && item.extent && <span>·</span>}
           {item.extent && <span>{item.extent}</span>}
-          {item.libraryStatus && (
-            <span className="flex shrink-0 items-center gap-1.5 text-emerald-300/90">
-              <span className="size-1.5 rounded-full bg-[var(--ok)]" />
-              在库
-            </span>
-          )}
         </p>
       </div>
     </>
@@ -407,7 +425,7 @@ function PosterCardActionButton({
   const tapGuard = useTapGuard(trigger);
 
   if (!subscribeMeta) {
-    // 在库标识：非交互，与库存格下方的绿点语言一致。
+    // 在库标识：非交互，绿点沿用全站「在库」的语义色（var(--ok)）。
     return (
       <span className="flex h-7 items-center gap-1.5 rounded-full bg-white/[0.18] px-3 text-caption font-semibold text-white/90">
         <span className="size-1.5 rounded-full bg-[var(--ok)]" />


### PR DESCRIPTION
发现页海报此前有两套在库表达：人物作品页在海报左上角打绿色斜标，其余
发现页（首页海报行、片单/榜单、筛选结果）只在海报下方年份后面缀一枚绿点。
绿点混在灰色元信息里，扫海报墙时几乎看不见。

现由 PosterCardVisual 统一处理：凡是带 libraryStatus 的海报都自动打
「已入库」绿斜标，调用方不必逐处传参；海报下方的绿点随之去掉。调用方显式
传 ribbon（订阅墙「自动续订」、人物作品页「已订阅」）时仍以调用方为准。

榜单名次牌原本钉在海报左上角外沿，与斜标撞位，改钉海报右下角并在 hover
信息层升起时淡出，让名次与斜标各占一角。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014HWo7c84wuFhqbF3e3BwVg