### PR TITLE
fix(web): 媒体库「最近添加」在触摸端可展开信息层

### DIFF
--- a/apps/web/components/library-view.tsx
+++ b/apps/web/components/library-view.tsx
@@ -526,6 +526,7 @@ export function LibraryView() {
               moreLabel="查看全部"
               cardAction="none"
               cardHref={hrefOf}
+              cardRevealInfoOnTouch
             />
           ))}
         </div>

--- a/apps/web/components/media-row.tsx
+++ b/apps/web/components/media-row.tsx
@@ -17,6 +17,7 @@ export function MediaRow({
   moreLabel = "查看完整榜单",
   cardAction,
   cardHref,
+  cardRevealInfoOnTouch = false,
 }: {
   row: MediaRowData;
   moreHref?: Route;
@@ -31,6 +32,12 @@ export function MediaRow({
    * 返回 undefined 的条目回落到默认的发现页详情。
    */
   cardHref?: (item: MediaItem) => Route | undefined;
+  /**
+   * 触摸端首次点按先展开卡片信息层。媒体库「最近添加」行没有悬浮操作键，
+   * 默认规则不会给它「首点展开」，手机上季集范围与入库时间就完全读不到——
+   * 这类纯信息层的行需要显式打开。
+   */
+  cardRevealInfoOnTouch?: boolean;
 }) {
   return (
     // content-visibility：视口外的整行（标题 + 几十张海报卡）跳过布局与绘制，
@@ -61,6 +68,7 @@ export function MediaRow({
               item={item}
               action={typeof cardAction === "function" ? cardAction(item) : cardAction}
               href={cardHref?.(item)}
+              revealInfoOnTouch={cardRevealInfoOnTouch}
             />
           </div>
         ))}

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -37,6 +37,8 @@ export interface PosterCardProps {
   /** 点击目标覆盖：传入即直接链接到该地址（媒体库「最近添加」行跳
    *  库内条目详情），缺省走发现页详情（useMediaDetail.open） */
   href?: Route;
+  /** 触摸端首次点按是否先展开纯信息层；默认仍单击直达详情。 */
+  revealInfoOnTouch?: boolean;
 }
 
 /**
@@ -96,13 +98,27 @@ export interface PosterVisualItem {
   libraryStatus?: MediaLibraryStatus | null;
 }
 
-export function PosterCard({ item, action, href }: PosterCardProps) {
+export function PosterCard({ item, action, href, revealInfoOnTouch }: PosterCardProps) {
   // 点击整卡（含 hover 信息层）进入该影片的详情页
   const { open } = useMediaDetail();
   if (href) {
-    return <PosterCardVisual item={item} action={action} href={href} />;
+    return (
+      <PosterCardVisual
+        item={item}
+        action={action}
+        href={href}
+        revealInfoOnTouch={revealInfoOnTouch}
+      />
+    );
   }
-  return <PosterCardVisual item={item} action={action} onClick={() => open(item)} />;
+  return (
+    <PosterCardVisual
+      item={item}
+      action={action}
+      onClick={() => open(item)}
+      revealInfoOnTouch={revealInfoOnTouch}
+    />
+  );
 }
 
 /** 统一海报视觉组件；传入 onClick 时才渲染为可点击按钮。 */


### PR DESCRIPTION
## 问题

v0.13.0 把「本批新增的季集范围」与「入库时间」从海报常显文案移进了 hover 信息层
（`libraryItemToMediaItem` 不再写 `extent`，改写 `overlayDetails`）。但媒体库首页
「最近添加」行传的是 `cardAction="none"`，而 `PosterCardVisual` 的 `revealOnTouch`
只在「有悬浮操作键」时才为真：

```ts
const revealOnTouch =
  (hasSubscribeAction && canSubscribe) || (revealInfoOnTouch && showOverlay);
```

手机/平板既没有 CSS `:hover`，这一行又拿不到「首次点按先展开」，结果是季集范围和
入库时间在触摸端**完全读不到**——而改动前它们是常显在海报下方的，等于净丢信息。

## 改动

把 `revealInfoOnTouch` 从 `PosterCardVisual` 透出到 `PosterCard` 与 `MediaRow`，
由「最近添加」行显式打开：

- `apps/web/components/poster-card.tsx` — `PosterCardProps` 新增 `revealInfoOnTouch`，两个分支（Link / button）都往下传
- `apps/web/components/media-row.tsx` — 新增 `cardRevealInfoOnTouch`，默认 `false`，其它调用方行为不变
- `apps/web/components/library-view.tsx` — 「最近添加」行传 `cardRevealInfoOnTouch`

触摸端首次点按升起信息层（等价于鼠标悬停），看清后再点才进条目详情，点卡片外任意处收起。
桌面端行为完全不变；发现页、单库页、订阅页的海报墙也不受影响——它们要么本来就有悬浮
操作键触发展开，要么已经自己显式传了这个开关。

信息层为空时不拦截跳转：`revealOnTouch` 带 `&& showOverlay` 这道闸门，没有可展示内容的
卡片仍是单击直达详情，不会出现「点一下什么都没发生」。

## 验证

- `tsc --noEmit` 无错
- 改动文件 `eslint` 干净
- `TZ=Asia/Shanghai node --test` 73/73 通过（默认 UTC 下 `time.test.mjs` 有 1 个既有的时区相关失败，与本改动无关）

## 未覆盖

升级前就在库里的剧集，展开后仍只有「X 前入库」一行，季集范围出不来：`added_batch_id`
是 v0.13.0 迁移新加的可空列，历史行全为 NULL，且 `upsert_by_path` 刻意不回写它
（语义是「首次入账批次」），重新扫描也补不上。只有升级之后新入库的集才带批次号。
存量数据的补法本次按讨论未处理。