### PR TITLE
统一发现页「已入库」标识为海报左上角绿斜标

### DIFF
--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -158,6 +158,15 @@ export function MediaDetailView({
   const libraryReturnTo = buildDiscoveryReturnPath(source, type ?? item.type, id);
 
   const isMovie = item.type === "movie";
+  // 电影入库即完成：再摆「订阅追踪 / 搜索资源」等于邀请用户重下一遍已有的片子，
+  // 隐藏后由上方的「在库」信息条接手（点库名直达条目，想看就去看）。
+  // 剧集不适用同一条规则——在库不等于收齐，缺集与未来新季仍要靠订阅追更或
+  // 手动找资源，所以剧集在库时两个按钮照常显示；口径与海报卡的
+  // libraryInventoryAction（电影 none、剧集 follow/backfill）一致。
+  const ownedMovie = isMovie && libraryLinks.length > 0;
+  // 已订阅的在库电影仍保留状态键：它是「管理 / 取消订阅」入口，不是再订一次的号召。
+  const showSubscribeButton = canSubscribe && (Boolean(sub) || !ownedMovie);
+  const showSearchButton = canSearch && !ownedMovie;
   const directorCast =
     info?.directorCredits.length
       ? info.directorCredits.map((director) => ({
@@ -296,48 +305,51 @@ export function MediaDetailView({
             </div>
           )}
 
-          {/* 操作区：已订阅的影片主按钮变为状态展示（点击进入管理弹层可取消订阅） */}
-          <div className="mt-5 flex flex-wrap items-center gap-3 max-md:mt-3.5 max-md:gap-2">
-            {canSubscribe && (sub ? (
-              <button
-                type="button"
-                onClick={openSubscribe}
+          {/* 操作区：已订阅的影片主按钮变为状态展示（点击进入管理弹层可取消订阅）。
+              在库电影会把两个按钮都收掉，此时整行无内容就不渲染，免得留一段空白。 */}
+          {(showSubscribeButton || showSearchButton || sub) && (
+            <div className="mt-5 flex flex-wrap items-center gap-3 max-md:mt-3.5 max-md:gap-2">
+              {showSubscribeButton && (sub ? (
+                <button
+                  type="button"
+                  onClick={openSubscribe}
+                  className="btn-glass flex h-10 items-center gap-2 bg-white/10 px-5 text-ui font-medium backdrop-blur-md transition hover:bg-white/15"
+                >
+                  <CheckIcon
+                    className="size-4"
+                    style={{ color: subscriptionStatusMeta[sub.status].color }}
+                  />
+                  已订阅 · {subscriptionStatusMeta[sub.status].label}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={openSubscribe}
+                  className="btn-accent flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold"
+                >
+                  <BellIcon className="size-4" />
+                  订阅追踪
+                </button>
+              ))}
+              {/* 搜索资源：不订阅、只想手动找种子下一次的直达口（此前只能回 ⌘K 重打片名） */}
+              {showSearchButton && <Link
+                href={`/search?q=${encodeURIComponent(item.title)}` as Route}
                 className="btn-glass flex h-10 items-center gap-2 bg-white/10 px-5 text-ui font-medium backdrop-blur-md transition hover:bg-white/15"
               >
-                <CheckIcon
-                  className="size-4"
-                  style={{ color: subscriptionStatusMeta[sub.status].color }}
-                />
-                已订阅 · {subscriptionStatusMeta[sub.status].label}
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={openSubscribe}
-                className="btn-accent flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold"
-              >
-                <BellIcon className="size-4" />
-                订阅追踪
-              </button>
-            ))}
-            {/* 搜索资源：不订阅、只想手动找种子下一次的直达口（此前只能回 ⌘K 重打片名） */}
-            {canSearch && <Link
-              href={`/search?q=${encodeURIComponent(item.title)}` as Route}
-              className="btn-glass flex h-10 items-center gap-2 bg-white/10 px-5 text-ui font-medium backdrop-blur-md transition hover:bg-white/15"
-            >
-              <SearchIcon className="size-4" />
-              搜索资源
-            </Link>}
-            {sub && (
-              <span className="text-on-image flex items-center gap-1.5 text-sub text-[var(--text-muted)]">
-                <span
-                  className="size-1.5 rounded-full"
-                  style={{ backgroundColor: subscriptionStatusMeta[sub.status].color }}
-                />
-                {subscriptionProgressNote(sub)}
-              </span>
-            )}
-          </div>
+                <SearchIcon className="size-4" />
+                搜索资源
+              </Link>}
+              {sub && (
+                <span className="text-on-image flex items-center gap-1.5 text-sub text-[var(--text-muted)]">
+                  <span
+                    className="size-1.5 rounded-full"
+                    style={{ backgroundColor: subscriptionStatusMeta[sub.status].color }}
+                  />
+                  {subscriptionProgressNote(sub)}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## 背景

发现页此前有两套「已入库」表达：演职员详情页在海报左上角打绿色斜标，而其余发现页（首页海报行、片单/榜单、筛选结果）只在海报下方年份后面缀一枚绿点。绿点混在灰色元信息里，扫海报墙时几乎看不见，两套语言也不一致。

## 改动

### 1. 「已入库」统一为海报左上角绿斜标（`f1f3d87`）

核心逻辑收在 `poster-card.tsx` 一处：新增 `resolveRibbon()`，凡是带 `libraryStatus` 的海报都自动打「已入库」绿斜标，调用方不必逐处传参；海报下方的绿点随之去掉。调用方显式传 `ribbon` 时仍以调用方为准（订阅墙的「自动续订」、演职员页的「已订阅」不受影响）。

`libraryStatus` 只由 discover 接口填充（`lib/api/discover.ts`），因此这一处改动正好覆盖全部发现影片的页面，且不会误伤媒体库/订阅页（那些条目不带该字段）：

- 发现页首页海报行（`media-row`）
- 片单 / 榜单页（`collection-grid-view`）
- 筛选结果页（`filtered-discovery-view`）
- 演职员详情页（`discovered-person-detail-view`，顺带简化：不再自己拼斜标，只补订阅态）

### 2. 去掉榜单海报上的名次序号（`f6f472d`）

榜单海报本就按名次顺序排列，海报角上再压一枚序号牌没有额外信息量，还占着斜标的角位。整块移除，连带清掉只为它存在的 `isRanked` 展示态与排名查表。接口层的 `is_ranked` 保留未动。

### 3. 在库电影的详情页收起「订阅追踪 / 搜索资源」（`843e37c`）

电影入库即完成，「在库」信息条已经回答了「我有没有」，旁边再摆两个按钮等于邀请用户重下一遍已有的片子。在库电影隐藏这两个按钮，整行无内容时不渲染；已订阅的在库电影保留「已订阅 · 状态」键，它是管理/取消订阅入口。

剧集不套用同一规则——在库不等于收齐，缺集与未来新季仍要靠订阅追更或手动找资源。口径与海报卡的 `libraryInventoryAction`（电影 `none`、剧集 `follow`/`backfill`）保持一致。

## 未改动的地方

发现页顶部 Hero 大幅剧照的元信息行（`discover-view.tsx`）仍是绿点 +「在库」。它不是海报卡，斜标形态在 16:9 剧照上会很怪，且与影片详情页的「在库」标识属同一种语言。

## 验证

- `tsc --noEmit`、`eslint` 通过
- `apps/web` 单测 73 项全绿（需 `TZ=Asia/Shanghai`，`time.test.mjs` 有既有的时区断言，与本 PR 无关）
- 视觉上用等比复刻的静态卡片渲染截图核对了 150px 卡宽下的排版


---
_Generated by [Claude Code](https://claude.ai/code/session_014HWo7c84wuFhqbF3e3BwVg)_