### PR TITLE
fix(docker): 看门狗变量名被中文标点吞掉 + 占位页被反向 DNS 拖住

### DIFF
--- a/apps/web/test/subscription-ui.test.mjs
+++ b/apps/web/test/subscription-ui.test.mjs
@@ -15,6 +15,7 @@ function subscription({
   grabbed = 0,
   downloaded = 0,
   imported = 0,
+  upgrading = 0,
   status = "active",
   mediaStatus = "Returning Series",
   selectedSeasons = [],
@@ -32,6 +33,7 @@ function subscription({
       grabbed,
       downloaded,
       imported,
+      upgrading,
     },
   };
 }
@@ -70,7 +72,7 @@ test("在播剧只展示最新一季的低密度收录进度", () => {
       seasons: [season(1, 10, 10, 10), season(2, 7, 5, 5)],
     }),
   );
-  assert.deepEqual(result, { label: "第 2 季", value: "5 / 7", tracking: true });
+  assert.deepEqual(result, { label: "第 2 季", value: "5 / 7", tracking: true, upgrading: false });
 });
 
 test("完结多季已收齐时聚合为季数和总集数", () => {
@@ -86,7 +88,7 @@ test("完结多季已收齐时聚合为季数和总集数", () => {
       seasons,
     }),
   );
-  assert.deepEqual(result, { label: "共 8 季", value: "73 集全", tracking: false });
+  assert.deepEqual(result, { label: "共 8 季", value: "73 集全", tracking: false, upgrading: false });
 });
 
 test("完结剧补旧时聚合显示已收录和总集数", () => {
@@ -102,7 +104,7 @@ test("完结剧补旧时聚合显示已收录和总集数", () => {
       ],
     }),
   );
-  assert.deepEqual(result, { label: "共 3 季", value: "24 / 30", tracking: false });
+  assert.deepEqual(result, { label: "共 3 季", value: "24 / 30", tracking: false, upgrading: false });
 });
 
 test("最新一季尚未播出时不展示零进度", () => {
@@ -112,7 +114,20 @@ test("最新一季尚未播出时不展示零进度", () => {
       seasons: [season(3, 10, 0, 0)],
     }),
   );
-  assert.deepEqual(result, { label: "第 3 季", value: "待播出", tracking: true });
+  assert.deepEqual(result, { label: "第 3 季", value: "待播出", tracking: true, upgrading: false });
+});
+
+test("洗版中的订阅亮青点，暂停后不亮", () => {
+  const seasons = [season(1, 10, 10, 10)];
+  const upgrading = subscriptionCollectionMeta(
+    subscription({ selectedSeasons: [1], seasons, upgrading: 1 }),
+  );
+  assert.equal(upgrading.upgrading, true);
+
+  const paused = subscriptionCollectionMeta(
+    subscription({ selectedSeasons: [1], seasons, upgrading: 1, status: "paused" }),
+  );
+  assert.equal(paused.upgrading, false);
 });
 
 test("追更绿点只由未完结订阅的 active 状态控制", () => {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -108,7 +108,7 @@ overlay_version_if_valid() {
     for f in "$manifest" "$dir/backend/src/movieclaw_api/main.py" \
              "$dir/backend/alembic.ini" "$dir/web/apps/web/server.js"; do
         if [ ! -f "$f" ]; then
-            echo "[entrypoint] overlay $dir 缺少 $f，忽略该版本" >&2
+            echo "[entrypoint] overlay $dir 缺少 ${f}，忽略该版本" >&2
             return 0
         fi
     done
@@ -120,7 +120,7 @@ overlay_version_if_valid() {
         return 0
     fi
     if [ "$requires" != "$RUNTIME_VERSION" ]; then
-        echo "[entrypoint] overlay v$version 需要 runtime=$requires，镜像为 runtime=$RUNTIME_VERSION，忽略（需升级 Docker 镜像）" >&2
+        echo "[entrypoint] overlay v$version 需要 runtime=${requires}，镜像为 runtime=${RUNTIME_VERSION}，忽略（需升级 Docker 镜像）" >&2
         return 0
     fi
     if [ -f "$STATE_DIR/bad-$(sanitize "$version")" ]; then
@@ -242,6 +242,7 @@ except Exception:
 start_placeholder() {
     "$PYTHON_BIN" -c '
 import json
+import socketserver
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 PAGE = """<!doctype html>
@@ -308,7 +309,20 @@ class Handler(BaseHTTPRequestHandler):
         pass
 
 
-ThreadingHTTPServer(("0.0.0.0", 3000), Handler).serve_forever()
+class PlaceholderServer(ThreadingHTTPServer):
+    """跳过 HTTPServer.server_bind 里的 socket.getfqdn() 反向解析。
+
+    占位页的全部价值在于「启动瞬间就顶住 3000」；而 getfqdn 在 DNS 不可达
+    的部署环境里会阻塞数十秒，反而让占位页错过它要覆盖的那段窗口，用户照
+    样看到连接被拒。server_name 只用于生成默认错误页，这里用不到。
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
+PlaceholderServer(("0.0.0.0", 3000), Handler).serve_forever()
 ' &
     PLACEHOLDER_PID=$!
 }
@@ -446,7 +460,7 @@ start_health_watchdog() {
             else
                 segment="后端直连亦失败，疑似后端故障"
             fi
-            echo "[entrypoint] 完整健康链路检查失败（$failures/${HEALTHCHECK_FAILURE_THRESHOLD}）：$WEB_HEALTH_URL（原因：$reason；$segment）" >&2
+            echo "[entrypoint] 完整健康链路检查失败（$failures/${HEALTHCHECK_FAILURE_THRESHOLD}）：${WEB_HEALTH_URL}（原因：${reason}；${segment}）" >&2
             if [ "$failures" -ge "$HEALTHCHECK_FAILURE_THRESHOLD" ]; then
                 echo "[entrypoint] 完整健康链路连续失败，停止容器以触发 Docker 重启。" >&2
                 exit "$HEALTH_WATCHDOG_EXIT_CODE"

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -1102,7 +1102,7 @@ async def test_upgrade_retries_legacy_partial_import_through_job(db, tmp_path, m
 
     async with db.session() as session:
         job = (await session.execute(select(Job))).scalar_one()
-    assert job.handler_revision == ingest_mod._INGEST_HANDLER_REVISION
+    assert job.handler_revision == ingest_mod._ingest_handler_revision()
     await jobs.init_job_dispatcher(max_parallel=1)
     await _wait_job_status(job.id, JobStatus.SUCCEEDED)
 
@@ -1516,7 +1516,7 @@ async def test_upgrade_unblocks_old_revision_parser_gap_job(db, tmp_path, monkey
         unchanged = await session.get(Job, job.id)
         assert unchanged is not None
         assert unchanged.status == JobStatus.BLOCKED
-        assert unchanged.handler_revision == ingest_mod._INGEST_HANDLER_REVISION
+        assert unchanged.handler_revision == ingest_mod._ingest_handler_revision()
 
     # 模拟解析能力升级：旧 revision 的 blocked Job 应原地恢复；同一 revision
     # 后续再扫只会短路，避免每次启动都重新跑一遍。

--- a/tests/api/test_library_stats_repair_migration.py
+++ b/tests/api/test_library_stats_repair_migration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 
 from alembic import command
+from alembic.script import ScriptDirectory
 
 from movieclaw_api.core.config import get_settings
 from movieclaw_db.migrations import _build_config
@@ -30,5 +31,6 @@ def test_repair_migration_restores_missing_episode_count(tmp_path, monkeypatch) 
         columns = {row[1] for row in connection.execute("PRAGMA table_info(library)")}
         revision = connection.execute("SELECT version_num FROM alembic_version").fetchone()[0]
     assert "stats_episode_count" in columns
-    assert revision == "a5c8d1e3f679"
+    # 断言"已走到 head"，而不是写死某个修订号——否则每加一条迁移这里都会失效。
+    assert revision == ScriptDirectory.from_config(config).get_current_head()
     get_settings.cache_clear()

--- a/tests/docker/test_entrypoint_supervision.py
+++ b/tests/docker/test_entrypoint_supervision.py
@@ -27,8 +27,22 @@ def _write_executable(path: Path, source: str) -> None:
     path.chmod(0o755)
 
 
+# http.server.HTTPServer.server_bind 会对绑定地址做一次 socket.getfqdn()
+# 反向解析。在部分网络环境下（DNS 不可达、VPN、有网络挂载的开发机）这一步
+# 会阻塞数十秒——实测某台开发机上 getfqdn("127.0.0.1") 要 35 秒，远超本组
+# 测试给进程替身的就绪窗口，于是「验证启动顺序」的用例全部退化成超时失败。
+# 替身只服务回环地址，server_name 没有任何实际用途，直接跳过这次解析。
+_NO_FQDN_SERVER = """
+class FakeServer(ThreadingHTTPServer):
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+"""
+
+
 _FAKE_API = """#!{python}
 import os
+import socketserver
 import sys
 import threading
 import time
@@ -90,12 +104,14 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
 
-ThreadingHTTPServer(("127.0.0.1", 8000), Handler).serve_forever()
+{no_fqdn_server}
+FakeServer(("127.0.0.1", 8000), Handler).serve_forever()
 """
 
 
 _FAKE_WEB = """#!{python}
 import os
+import socketserver
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -127,7 +143,8 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
 
-ThreadingHTTPServer(("127.0.0.1", 3000), Handler).serve_forever()
+{no_fqdn_server}
+FakeServer(("127.0.0.1", 3000), Handler).serve_forever()
 """
 
 
@@ -146,11 +163,11 @@ def entrypoint_env(tmp_path: Path) -> dict[str, str]:
     bin_dir.mkdir()
     _write_executable(
         bin_dir / "fake-api",
-        _FAKE_API.format(python=sys.executable),
+        _FAKE_API.format(python=sys.executable, no_fqdn_server=_NO_FQDN_SERVER),
     )
     _write_executable(
         bin_dir / "node",
-        _FAKE_WEB.format(python=sys.executable),
+        _FAKE_WEB.format(python=sys.executable, no_fqdn_server=_NO_FQDN_SERVER),
     )
 
     return {


### PR DESCRIPTION
部署时跑全量测试发现 13 个失败（后端 9 + 前端 4），逐个定性后修掉。其中两处是 `entrypoint.sh` 的真实缺陷，会在生产环境发作。

## 1. 看门狗因变量名被中文标点吞掉而崩溃（严重）

`entrypoint.sh:463`：

```bash
echo "...：$WEB_HEALTH_URL（原因：$reason；$segment）" >&2
```

`$VAR` 后紧跟全角标点时，bash 在非 UTF-8 locale 下会把多字节字符的首字节并进变量名 —— 变量名变成 `WEB_HEALTH_URL\xef`，`set -u` 立刻报 unbound variable：

```
entrypoint.sh: line 463: WEB_HEALTH_URL\xef: unbound variable
[entrypoint] 健康看门狗意外退出（exit=1），停止容器。
```

这一行正好在**健康链路失败**的分支上。本该「打印失败原因，按阈值决定是否重启」，实际变成看门狗自己崩溃、容器立即停止，而且真正的失败原因被这条误导性日志盖掉 —— 容器出问题时最需要日志的时刻，日志反而没了。

全文件共 6 处同类写法（111、123×2、463×3），一并加花括号界定。

## 2. 占位页被反向 DNS 拖住（中等）

占位页用 `ThreadingHTTPServer` 直接绑定，而 `HTTPServer.server_bind()` 会做一次 `socket.getfqdn()` 反向解析。DNS 不可达时这一步阻塞数十秒（本机实测 `getfqdn("127.0.0.1")` 耗时 **35 秒**）。

占位页的唯一价值就是「启动瞬间顶住 3000 端口，别让用户看到连接被拒」—— 它自己要等几十秒才开始监听，就完全失去了意义。改为跳过该解析（`server_name` 仅用于生成默认错误页，这里用不到）。

## 3. 测试的进程替身踩同一个坑

`tests/docker` 的假 API / 假前端同样用 `ThreadingHTTPServer`，于是 6 个「启动顺序」用例在 DNS 慢的机器上全部退化成超时失败 —— 也正是这层超时掩盖了上面第 1 条，改掉 DNS 问题后真 bug 才浮出来。

## 4. 三处断言写死了会随代码演进的值

| 文件 | 问题 |
|---|---|
| `test_library_stats_repair_migration.py` | 写死 `revision == "a5c8d1e3f679"`，本意是「已走到 head」，现已落后三个迁移。改为向 alembic 查询真实 head |
| `test_library_ingest.py` | 两处用裸常量 `_INGEST_HANDLER_REVISION`，而生产代码用的是 `_ingest_handler_revision()`（代码修订 + NER 模型 tag）。装了 NER 模型的机器上必失败，CI 无模型才恰好通过 |
| `subscription-ui.test.mjs` | 4 个 `deepEqual` 期望对象漏了新增的 `upgrading` 字段 |

顺带给 `upgrading` 补了一个正向用例（含暂停不亮的分支）—— 该字段此前零测试覆盖，正是期望值漏改的根源。

## runtime 契约

entrypoint 改的是内部实现，未动环境变量、`resolve` 输出格式与退出码语义，不构成 runtime 契约变更，因此**不 bump** `docker/runtime-version`。

需要注意：这两个修复位于镜像内的 `entrypoint.sh`，**overlay 更新不会带上**，要重建镜像才生效。

## 验证

- `pytest -m "not integration"`：**1924 passed**（此前 9 failed）
- 前端 `pnpm test`：**74/74**（此前 69/73）
- `ruff check .` 全绿；`bash -n docker/entrypoint.sh` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)