### PR TITLE
feat(tasks): 任务中心种子行布局优化——补站点/规格信息，去重复状态

### DIFF
--- a/alembic/versions/20260816_1600_e9a2b5c7d013_add_manual_intent_torrent_id.py
+++ b/alembic/versions/20260816_1600_e9a2b5c7d013_add_manual_intent_torrent_id.py
@@ -1,0 +1,35 @@
+"""add manual_download_intent.torrent_id（站点内种子 ID）
+
+任务中心的「打开种子页」需要用 site_id + torrent_id 反查 site_torrent 的
+详情页 URL。订阅投递台账早已记录这两个字段，手动下载的身份锚此前只存了
+site_id，无法定位到站内种子——补上 torrent_id 后手动任务同样能回链种子页。
+
+可空列、无默认值约束：旧代码忽略该列即回到"手动任务没有种子页入口"的
+旧行为，符合应用内一键回退的向前兼容契约。
+
+Revision ID: e9a2b5c7d013
+Revises: d8f1a4b6c902
+Create Date: 2026-08-16 16:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e9a2b5c7d013"
+down_revision: str | None = "d8f1a4b6c902"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("manual_download_intent", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("torrent_id", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("manual_download_intent", schema=None) as batch_op:
+        batch_op.drop_column("torrent_id")

--- a/apps/web/components/download-target-dialog.tsx
+++ b/apps/web/components/download-target-dialog.tsx
@@ -33,6 +33,8 @@ import {
 export interface DownloadTargetRequest {
   site_id: string;
   download_url: string;
+  /** 站点内种子 ID：随提交锚定，任务中心据此提供「打开种子页」 */
+  torrent_id: string;
   /** 解析出的条目身份；三件套不全时为 null（智能入库选项不出现） */
   identity: { kind: "movie" | "tv"; title: string; year: number } | null;
   subtitle: string | null;
@@ -114,6 +116,7 @@ export async function submitRememberedTarget(
   return submitTorrentDownload({
     site_id: request.site_id,
     download_url: request.download_url,
+    torrent_id: request.torrent_id,
     ...libraryPart,
     ...(target.kind === "dir" ? { save_path: target.savePath } : {}),
     ...(target.downloaderId != null ? { downloader_id: target.downloaderId } : {}),
@@ -433,6 +436,7 @@ function DialogContent({
     void submitTorrentDownload({
       site_id: request.site_id,
       download_url: request.download_url,
+      torrent_id: request.torrent_id,
       ...(option.kind === "smart" && identity && manualTarget?.tmdb_id != null
         ? {
             auto_route: true,

--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -2417,6 +2417,7 @@ function DownloadButton({ hit, className }: { hit: TorrentHit; className: string
     const req: DownloadTargetRequest = {
       site_id: hit.site_id,
       download_url: hit.download_url,
+      torrent_id: hit.torrent_id,
       identity:
         mediaType && title && attrs?.year != null
           ? { kind: mediaType, title, year: attrs.year }

--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from "react";
 
 import type { Route } from "next";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 import {
   JOB_STATUS_LABELS,
@@ -1164,15 +1163,14 @@ function DownloadTaskFeedItem({
   const title = grouped
     ? task.name || task.media_title || task.info_hash
     : task.media_title || task.name || task.info_hash;
-  const sourceLabel =
-    task.source === "subscription"
-      ? "订阅投递"
-      : task.source === "manual"
-        ? "手动下载"
-        : "下载器任务";
   const note = downloadTaskNote(task, ingestJob);
   const showReplace = shouldOfferInlineReplacement(task);
   const firstSubscription = task.subscriptions[0];
+  // 种子名前用站点徽标回答"这个资源从哪来"；画面规格与片源紧随其后，
+  // 弥补高度同质化的 release 名。状态与进度由底部生命周期承担，不再重复。
+  const specs = [task.resolution, task.media_source].filter(
+    (item): item is string => item != null,
+  );
 
   return (
     <div className={grouped ? "py-2.5 first:pt-1 last:pb-1" : ""}>
@@ -1188,27 +1186,27 @@ function DownloadTaskFeedItem({
                 实时
               </span>
             )}
+            {task.site_name && (
+              <span className="shrink-0 rounded-full border border-white/[0.14] bg-white/[0.06] px-1.5 py-0.5 text-[11px] font-medium leading-none text-white/55">
+                {task.site_name}
+              </span>
+            )}
             <OverflowText className="flex-1">{title}</OverflowText>
           </h3>
-          <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-caption">
-            <span className="font-medium" style={{ color: meta.color }}>
-              {meta.label}
-            </span>
-            {percent != null && (
-              <>
-                <span aria-hidden="true" className="text-white/25">·</span>
-                <span className="tnum text-white/55">{Math.min(100, Math.max(0, percent))}%</span>
-              </>
-            )}
-            {!ingestOwnsState && task.state === "downloading" && task.dlspeed_bytes != null && task.dlspeed_bytes > 0 && (
-              <>
-                <span aria-hidden="true" className="text-white/25">·</span>
-                <span className="tnum text-white/42">↓ {formatBytes(task.dlspeed_bytes)}/s</span>
-              </>
-            )}
-          </p>
+          {specs.length > 0 && (
+            <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-caption text-white/45">
+              {specs.map((spec, index) => (
+                <span key={spec} className="flex items-center gap-x-1.5">
+                  {index > 0 && (
+                    <span aria-hidden="true" className="text-white/25">·</span>
+                  )}
+                  {spec}
+                </span>
+              ))}
+            </p>
+          )}
         </div>
-        {(firstSubscription || task.downloader_id != null) && (
+        {(task.page_url != null || task.downloader_id != null) && (
           <DownloadTaskActionsMenu
             task={task}
             deleting={deleting}
@@ -1233,14 +1231,24 @@ function DownloadTaskFeedItem({
           />
         </div>
       )}
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-caption text-white/32">
-        <span>{sourceLabel}</span>
-        <span>{task.downloader_name || "下载器未找到"}</span>
-        {task.size_bytes != null && <span>{formatBytes(task.size_bytes)}</span>}
-        {!ingestOwnsState && task.eta_seconds != null && (
-          <span>剩余约 {formatDuration(task.eta_seconds)}</span>
-        )}
-      </div>
+      {/* 大小/速度/剩余时间合并成一行；投递来源与下载器名由生命周期"已投递"承担 */}
+      {(task.size_bytes != null ||
+        (!ingestOwnsState &&
+          ((task.state === "downloading" && task.dlspeed_bytes != null && task.dlspeed_bytes > 0) ||
+            task.eta_seconds != null))) && (
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-caption text-white/38">
+          {task.size_bytes != null && <span className="tnum">{formatBytes(task.size_bytes)}</span>}
+          {!ingestOwnsState &&
+            task.state === "downloading" &&
+            task.dlspeed_bytes != null &&
+            task.dlspeed_bytes > 0 && (
+              <span className="tnum">↓ {formatBytes(task.dlspeed_bytes)}/s</span>
+            )}
+          {!ingestOwnsState && task.eta_seconds != null && (
+            <span>剩余约 {formatDuration(task.eta_seconds)}</span>
+          )}
+        </div>
+      )}
       {firstSubscription && (
         <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-caption">
           <span className="text-white/30">
@@ -1414,7 +1422,7 @@ function DownloadTaskCard({
               <OverflowText>{title}</OverflowText>
             </h3>
           </div>
-          {(firstSubscription || task.downloader_id != null) && (
+          {(task.page_url != null || task.downloader_id != null) && (
             <DownloadTaskActionsMenu
               task={task}
               deleting={deleting}
@@ -1697,7 +1705,7 @@ function DownloadLifecycle({
   );
 }
 
-/** 查看订阅与删除仍收进右上角菜单；需要处理的换种动作跟随提示就近展示。 */
+/** 打开种子页与删除收进右上角菜单；查看订阅由分组标题承担，不在此重复。 */
 function DownloadTaskActionsMenu({
   task,
   deleting,
@@ -1709,20 +1717,19 @@ function DownloadTaskActionsMenu({
   replacing: boolean;
   onDelete: (task: DownloadTask) => void;
 }) {
-  const router = useRouter();
-  const firstSubscription = task.subscriptions[0];
   return (
     <TaskActionsMenu
       ariaLabel={`${task.name || task.info_hash}的更多操作`}
       disabled={deleting || replacing}
       items={[
-        ...(firstSubscription
+        ...(task.page_url
           ? [
               {
-                id: "subscription",
-                label: "查看订阅",
-                onSelect: () =>
-                  router.push(`/subscriptions/${firstSubscription.id}` as Route),
+                id: "torrent-page",
+                label: "打开种子页",
+                onSelect: () => {
+                  window.open(task.page_url!, "_blank", "noopener,noreferrer");
+                },
               },
             ]
           : []),

--- a/apps/web/lib/api/downloaders.ts
+++ b/apps/web/lib/api/downloaders.ts
@@ -252,6 +252,8 @@ export interface DownloadSubmitPayload {
   site_id: string;
   /** 种子下载入口（TorrentHit.download_url） */
   download_url: string;
+  /** 站点内种子 ID（TorrentHit.torrent_id）：任务中心据此提供「打开种子页」 */
+  torrent_id?: string | null;
   /** 入库目标库（可选）：带上后保存目录由库推导（主根/标题 (年份)） */
   library_id?: number | null;
   /** 条目标题（推导条目子目录用；身份未确认时不要带） */

--- a/apps/web/lib/api/downloaders.ts
+++ b/apps/web/lib/api/downloaders.ts
@@ -87,6 +87,14 @@ export interface DownloadTask {
   eta_seconds: number | null;
   state: DownloadTaskState;
   source: "subscription" | "manual" | "external";
+  /** 来源站点 ID / 显示名；movieclaw 投递的任务才有，外部任务为 null */
+  site_id: string | null;
+  site_name: string | null;
+  /** 站点种子详情页 URL；能定位到站内种子时提供，供浏览器新窗口打开 */
+  page_url: string | null;
+  /** 投递时快照的画面规格与片源（如 2160p / WEB-DL）；未知为 null */
+  resolution: string | null;
+  media_source: string | null;
   media_item_id: number | null;
   media_title: string | null;
   media_kind: string | null;

--- a/src/movieclaw_api/api/routes/downloaders.py
+++ b/src/movieclaw_api/api/routes/downloaders.py
@@ -219,6 +219,7 @@ async def submit_download(
             media_item_id=manual_item.id,
             library_id=library.id,
             site_id=payload.site_id,
+            torrent_id=payload.torrent_id,
         )
     view = DownloadSubmitView(
         info_hash=result.info_hash,

--- a/src/movieclaw_api/schemas/downloader.py
+++ b/src/movieclaw_api/schemas/downloader.py
@@ -133,6 +133,15 @@ class DownloadTaskView(BaseModel):
         "unknown",
     ]
     source: Literal["subscription", "manual", "external"]
+    # -- 种子来源与规格（movieclaw 投递的任务才有）：站点身份、详情页入口
+    # 与投递时的质量快照，供任务中心展示"这个种子从哪来、什么规格"。
+    site_id: str | None = None
+    site_name: str | None = Field(default=None, description="来源站点显示名；未知站点回落 site_id")
+    page_url: str | None = Field(
+        default=None, description="站点种子详情页 URL；能定位到站内种子时提供"
+    )
+    resolution: str | None = Field(default=None, description="投递时快照的分辨率，如 2160p")
+    media_source: str | None = Field(default=None, description="投递时快照的片源，如 WEB-DL")
     media_item_id: int | None = None
     media_title: str | None = None
     media_kind: str | None = None

--- a/src/movieclaw_api/schemas/downloader.py
+++ b/src/movieclaw_api/schemas/downloader.py
@@ -263,6 +263,10 @@ class DownloadSubmitPayload(BaseModel):
 
     site_id: str = Field(min_length=1, description="种子所属站点 ID（TorrentHit.site_id）")
     download_url: str = Field(min_length=1, description="种子下载入口（TorrentHit.download_url）")
+    # 站点内种子 ID：随身份锚落库，任务中心据此反查详情页提供「打开种子页」
+    torrent_id: str | None = Field(
+        default=None, description="站点内种子 ID（TorrentHit.torrent_id）"
+    )
     # 入库目标（可选）：带 library_id 时保存目录改为由库推导（主根/标题 (年份)）。
     # title/year 来自搜索结果的解析实体；无法确定条目身份时只带 library_id，
     # 落到库主根目录。三者都缺省 = 维持原行为（下载器默认目录）。

--- a/src/movieclaw_api/services/download_tasks.py
+++ b/src/movieclaw_api/services/download_tasks.py
@@ -211,34 +211,6 @@ async def _relations(
             ),
         }
 
-    # 反查站点种子详情页：投递台账记了 site_id + torrent_id，站点快照索引里
-    # 存有面向浏览器的 detail_url。查不到（快照被淘汰/旧数据）就不给链接。
-    site_pairs = {
-        (meta["_site_id"], meta["_torrent_id"])
-        for meta in subscription_meta.values()
-        if meta.get("_site_id") and meta.get("_torrent_id")
-    }
-    page_urls: dict[tuple[str, str], str] = {}
-    if site_pairs:
-        rows = await session.execute(
-            select(SiteTorrent.site_id, SiteTorrent.torrent_id, SiteTorrent.detail_url).where(
-                or_(
-                    *(
-                        and_(SiteTorrent.site_id == site_id, SiteTorrent.torrent_id == torrent_id)
-                        for site_id, torrent_id in site_pairs
-                    )
-                )
-            )
-        )
-        page_urls = {
-            (site_id, torrent_id): detail_url
-            for site_id, torrent_id, detail_url in rows
-            if detail_url
-        }
-    for meta in subscription_meta.values():
-        if meta.get("_site_id") and meta.get("_torrent_id"):
-            meta["_page_url"] = page_urls.get((meta["_site_id"], meta["_torrent_id"]))
-
     subscriptions: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for key, meta in subscription_meta.items():
         info_hash, _subscription_id = key
@@ -265,6 +237,7 @@ async def _relations(
             "intent_created_at": intent.created_at,
             "library_id": intent.library_id,
             "site_id": intent.site_id,
+            "torrent_id": intent.torrent_id,
             "media_item_id": media.id,
             "media_title": media.title,
             "media_kind": media.kind,
@@ -272,6 +245,42 @@ async def _relations(
         }
         for intent, media in manual_rows
     }
+
+    # 反查站点种子详情页：订阅投递台账与手动身份锚都记了 site_id + torrent_id，
+    # 站点快照索引里存有面向浏览器的 detail_url。查不到（快照未覆盖的老种子
+    # /旧数据）就不给链接，仅少一个跳转入口。
+    subscription_entries = [entry for group in subscriptions.values() for entry in group]
+    site_pairs = {
+        (entry["_site_id"], entry["_torrent_id"])
+        for entry in subscription_entries
+        if entry.get("_site_id") and entry.get("_torrent_id")
+    } | {
+        (entry["site_id"], entry["torrent_id"])
+        for entry in manual.values()
+        if entry.get("site_id") and entry.get("torrent_id")
+    }
+    if site_pairs:
+        rows = await session.execute(
+            select(SiteTorrent.site_id, SiteTorrent.torrent_id, SiteTorrent.detail_url).where(
+                or_(
+                    *(
+                        and_(SiteTorrent.site_id == site_id, SiteTorrent.torrent_id == torrent_id)
+                        for site_id, torrent_id in site_pairs
+                    )
+                )
+            )
+        )
+        page_urls = {
+            (site_id, torrent_id): detail_url
+            for site_id, torrent_id, detail_url in rows
+            if detail_url
+        }
+        for entry in subscription_entries:
+            if entry.get("_site_id") and entry.get("_torrent_id"):
+                entry["_page_url"] = page_urls.get((entry["_site_id"], entry["_torrent_id"]))
+        for entry in manual.values():
+            if entry.get("site_id") and entry.get("torrent_id"):
+                entry["_page_url"] = page_urls.get((entry["site_id"], entry["torrent_id"]))
     return dict(subscriptions), manual
 
 
@@ -483,7 +492,8 @@ def _task_dict(
         "site_name": _site_display_name(site_id),
         "page_url": next(
             (entry["_page_url"] for entry in subscriptions if entry.get("_page_url")), None
-        ),
+        )
+        or (manual or {}).get("_page_url"),
         "resolution": quality.get("resolution"),
         "media_source": quality.get("media_source"),
         "media_item_id": (media or {}).get("media_item_id"),

--- a/src/movieclaw_api/services/download_tasks.py
+++ b/src/movieclaw_api/services/download_tasks.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from pathlib import PurePosixPath
 from typing import Any
 
+from sqlalchemy import and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -29,6 +30,7 @@ from movieclaw_db.models import (
     LibraryFile,
     ManualDownloadIntent,
     MediaItem,
+    SiteTorrent,
     Subscription,
     SubscriptionDownloadAttempt,
     WantedItem,
@@ -47,6 +49,19 @@ from movieclaw_downloader import (
 logger = logging.getLogger("movieclaw_api.download_tasks")
 
 _IN_FLIGHT = (WantedStatus.GRABBED, WantedStatus.DOWNLOADED)
+
+
+def _site_display_name(site_id: str | None) -> str | None:
+    """把站点 ID 换成用户可读的站点名；站点配置已被移除时回落原 ID。"""
+    if not site_id:
+        return None
+    from movieclaw_tracker.exceptions import SiteNotFoundError
+    from movieclaw_tracker.registry import get_site_config
+
+    try:
+        return get_site_config(site_id).display_name
+    except SiteNotFoundError:
+        return site_id
 
 
 def _poster_url(item: MediaItem) -> str | None:
@@ -178,6 +193,9 @@ async def _relations(
         }
         subscription_meta[key] = {
             **base_meta,
+            "_site_id": attempt.site_id,
+            "_torrent_id": attempt.torrent_id,
+            "_quality": attempt.quality,
             "_attempt_status": attempt.status,
             "_attempt_downloader_id": attempt.downloader_id,
             "_last_progress_at": attempt.last_progress_at,
@@ -192,6 +210,34 @@ async def _relations(
                 DownloadAttemptStatus.COMPLETED,
             ),
         }
+
+    # 反查站点种子详情页：投递台账记了 site_id + torrent_id，站点快照索引里
+    # 存有面向浏览器的 detail_url。查不到（快照被淘汰/旧数据）就不给链接。
+    site_pairs = {
+        (meta["_site_id"], meta["_torrent_id"])
+        for meta in subscription_meta.values()
+        if meta.get("_site_id") and meta.get("_torrent_id")
+    }
+    page_urls: dict[tuple[str, str], str] = {}
+    if site_pairs:
+        rows = await session.execute(
+            select(SiteTorrent.site_id, SiteTorrent.torrent_id, SiteTorrent.detail_url).where(
+                or_(
+                    *(
+                        and_(SiteTorrent.site_id == site_id, SiteTorrent.torrent_id == torrent_id)
+                        for site_id, torrent_id in site_pairs
+                    )
+                )
+            )
+        )
+        page_urls = {
+            (site_id, torrent_id): detail_url
+            for site_id, torrent_id, detail_url in rows
+            if detail_url
+        }
+    for meta in subscription_meta.values():
+        if meta.get("_site_id") and meta.get("_torrent_id"):
+            meta["_page_url"] = page_urls.get((meta["_site_id"], meta["_torrent_id"]))
 
     subscriptions: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for key, meta in subscription_meta.items():
@@ -218,6 +264,7 @@ async def _relations(
             "intent_id": intent.id,
             "intent_created_at": intent.created_at,
             "library_id": intent.library_id,
+            "site_id": intent.site_id,
             "media_item_id": media.id,
             "media_title": media.title,
             "media_kind": media.kind,
@@ -385,6 +432,13 @@ def _task_dict(
     )
     completed = bool(torrent and torrent.completed)
     state = absent_state if torrent is None else "completed" if completed else torrent.state
+    # 站点/质量信息取自投递台账（订阅任务）或手动身份锚；外部任务两者皆无
+    site_id = next(
+        (entry["_site_id"] for entry in subscriptions if entry.get("_site_id")), None
+    ) or (manual or {}).get("site_id")
+    quality = next(
+        (entry["_quality"] for entry in subscriptions if entry.get("_quality")), None
+    ) or {}
     no_progress_seconds = None
     if rescue is not None and rescue.get("_last_progress_at") is not None:
         last_progress = rescue["_last_progress_at"]
@@ -425,6 +479,13 @@ def _task_dict(
         "eta_seconds": torrent.eta_seconds if torrent is not None else None,
         "state": state,
         "source": source,
+        "site_id": site_id,
+        "site_name": _site_display_name(site_id),
+        "page_url": next(
+            (entry["_page_url"] for entry in subscriptions if entry.get("_page_url")), None
+        ),
+        "resolution": quality.get("resolution"),
+        "media_source": quality.get("media_source"),
         "media_item_id": (media or {}).get("media_item_id"),
         "media_title": (media or {}).get("media_title"),
         "media_kind": (media or {}).get("media_kind"),

--- a/src/movieclaw_api/services/torrent_submit.py
+++ b/src/movieclaw_api/services/torrent_submit.py
@@ -274,6 +274,7 @@ async def anchor_manual_download(
     media_item_id: int,
     library_id: int,
     site_id: str,
+    torrent_id: str | None = None,
 ) -> None:
     """按 infohash 保存手动下载的已确认身份，供监听导入完成后直接认领。
 
@@ -303,6 +304,7 @@ async def anchor_manual_download(
                 media_item_id=media_item_id,
                 library_id=library_id,
                 site_id=site_id,
+                torrent_id=torrent_id,
             )
         )
         try:
@@ -326,6 +328,17 @@ async def anchor_manual_download(
                 library_id,
             )
             return
+    # 同一 hash 即同一份内容：旧锚缺站点种子 ID 时用本次提交补全（只补
+    # 同站信息，跨站同种不能把别站的种子 ID 配到旧站点上）；身份归属不变。
+    if (
+        torrent_id
+        and not existing.torrent_id
+        and (existing.site_id is None or existing.site_id == site_id)
+    ):
+        existing.site_id = site_id
+        existing.torrent_id = torrent_id
+        existing.updated_at = utcnow()
+        await session.commit()
     if existing.media_item_id != media_item_id or existing.library_id != library_id:
         logger.warning(
             "手动下载 hash=%s 已锚定到 media_item=%s/library=%s；"

--- a/src/movieclaw_db/models/manual_download_intent.py
+++ b/src/movieclaw_db/models/manual_download_intent.py
@@ -44,3 +44,6 @@ class ManualDownloadIntent(TimestampMixin, table=True):
         description="按收藏范围路由后确认的目标媒体库",
     )
     site_id: str | None = Field(default=None, description="来源站点（追溯用）")
+    # 站点内种子 ID：与 site_id 一起反查 site_torrent 的详情页，供任务中心
+    # 提供「打开种子页」。旧数据/前端未传时为 NULL，仅少一个跳转入口
+    torrent_id: str | None = Field(default=None, description="站点内种子 ID；NULL=未知")

--- a/tests/api/test_download_submit.py
+++ b/tests/api/test_download_submit.py
@@ -546,6 +546,7 @@ def test_auto_route_submits_to_watch_and_anchors_info_hash(client, monkeypatch) 
         "/api/v1/downloaders/submit",
         json={
             **_SUBMIT,
+            "torrent_id": "8866",
             "auto_route": True,
             "media_kind": "movie",
             "tmdb_id": 9527,
@@ -565,6 +566,8 @@ def test_auto_route_submits_to_watch_and_anchors_info_hash(client, monkeypatch) 
     intent = asyncio.run(load_intent())
     assert intent.info_hash == "a" * 40
     assert intent.library_id == library["id"]
+    # 站点种子 ID 随身份锚落库，任务中心据此反查详情页提供「打开种子页」
+    assert intent.torrent_id == "8866"
 
 
 def test_anchor_sweeps_stale_orphan_intents(client) -> None:

--- a/tests/api/test_downloaders.py
+++ b/tests/api/test_downloaders.py
@@ -368,6 +368,73 @@ def test_task_center_aggregates_live_downloads_and_subscription_context(client) 
     ]
 
 
+def test_task_center_manual_task_links_site_torrent_page(client) -> None:
+    """手动下载锚定了站点种子 ID 时，任务中心带回站点身份与种子详情页。"""
+    from movieclaw_db.engine import get_database
+    from movieclaw_db.models import (
+        Library,
+        ManualDownloadIntent,
+        MediaItem,
+        SiteTorrent,
+        TorrentSource,
+    )
+
+    c, _ = client
+    c.post("/api/v1/downloaders", json=_PAYLOAD)
+    info_hash = "f" * 40
+    _fake_torrents.append(
+        TorrentBrief(
+            name="Manual.Movie.2160p",
+            content_name="Manual.Movie.2160p",
+            completed=False,
+            info_hash=info_hash,
+            progress=0.2,
+            state="downloading",
+        )
+    )
+
+    async def seed() -> None:
+        async with get_database().session() as session:
+            media = MediaItem(
+                kind="movie",
+                tmdb_id=54321,
+                title="手动种子页测试",
+                original_title="Manual Page Test",
+            )
+            library = Library(name="手动种子页测试库", kind="movie", root_paths=["/media"])
+            session.add_all([media, library])
+            await session.flush()
+            assert media.id is not None and library.id is not None
+            session.add(
+                ManualDownloadIntent(
+                    info_hash=info_hash,
+                    media_item_id=media.id,
+                    library_id=library.id,
+                    site_id="pt-demo",
+                    torrent_id="777",
+                )
+            )
+            session.add(
+                SiteTorrent(
+                    site_id="pt-demo",
+                    torrent_id="777",
+                    title="Manual.Movie.2160p",
+                    detail_url="https://pt.example.com/details.php?id=777",
+                    source=TorrentSource.LIST,
+                )
+            )
+            await session.commit()
+
+    asyncio.run(seed())
+
+    items = c.get("/api/v1/downloaders/tasks").json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["source"] == "manual"
+    assert items[0]["site_id"] == "pt-demo"
+    assert items[0]["site_name"] == "pt-demo"
+    assert items[0]["page_url"] == "https://pt.example.com/details.php?id=777"
+
+
 def test_task_center_degrades_single_downloader_failure(client) -> None:
     """一台下载器读取失败只标记来源异常，不能拖垮其余下载器任务。"""
     c, _ = client

--- a/tests/api/test_downloaders.py
+++ b/tests/api/test_downloaders.py
@@ -200,8 +200,10 @@ def test_task_center_aggregates_live_downloads_and_subscription_context(client) 
         DownloadAttemptStatus,
         MediaItem,
         RuleSet,
+        SiteTorrent,
         Subscription,
         SubscriptionDownloadAttempt,
+        TorrentSource,
         WantedItem,
         WantedStatus,
         utcnow,
@@ -295,6 +297,8 @@ def test_task_center_aggregates_live_downloads_and_subscription_context(client) 
                     subscription_id=subscription.id,
                     downloader_id=downloader_id,
                     info_hash=missing_hash,
+                    site_id="pt-demo",
+                    torrent_id="4321",
                     torrent_title="Missing.Show.S01E02",
                     units=[[1, 2]],
                     quality={"resolution": "1080p", "media_source": "WEB-DL"},
@@ -302,6 +306,16 @@ def test_task_center_aggregates_live_downloads_and_subscription_context(client) 
                     hit_and_run=False,
                     status=DownloadAttemptStatus.ACTIVE,
                     last_progress_at=utcnow() - timedelta(minutes=16),
+                )
+            )
+            # 站点快照索引里存有该种子的详情页，任务中心据此提供"打开种子页"
+            session.add(
+                SiteTorrent(
+                    site_id="pt-demo",
+                    torrent_id="4321",
+                    title="Missing.Show.S01E02",
+                    detail_url="https://pt.example.com/details.php?id=4321",
+                    source=TorrentSource.LIST,
                 )
             )
             await session.commit()
@@ -329,6 +343,14 @@ def test_task_center_aggregates_live_downloads_and_subscription_context(client) 
     assert by_hash[external_hash]["progress"] == 0.42
     assert by_hash[missing_hash]["state"] == "missing"
     assert by_hash[missing_hash]["downloader_id"] == downloader_id
+    # 投递台账带回站点身份、详情页与质量快照；外部任务没有这些信息
+    assert by_hash[missing_hash]["site_id"] == "pt-demo"
+    assert by_hash[missing_hash]["site_name"] == "pt-demo"
+    assert by_hash[missing_hash]["page_url"] == "https://pt.example.com/details.php?id=4321"
+    assert by_hash[missing_hash]["resolution"] == "1080p"
+    assert by_hash[missing_hash]["media_source"] == "WEB-DL"
+    assert by_hash[external_hash]["site_id"] is None
+    assert by_hash[external_hash]["page_url"] is None
     assert by_hash[missing_hash]["can_replace"] is True
     assert by_hash[missing_hash]["no_progress_seconds"] >= 15 * 60
     assert "立即换种" in by_hash[missing_hash]["rescue_message"]


### PR DESCRIPTION
- 种子名前新增来源站点徽标，名下补画面规格与片源（投递质量快照）
- 右上角菜单去掉与分组标题重复的「查看订阅」，新增「打开种子页」
  （movieclaw 投递且站点快照有详情页时，新窗口打开）
- 去掉与底部生命周期重复的「下载中·百分比」行和「订阅投递·下载器名」，
  大小/速度/剩余时间合并为一行
- 后端任务快照新增 site_id/site_name/page_url/resolution/media_source：
  订阅任务取自投递台账并反查 site_torrent 详情页，手动任务带回站点身份

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RMtTxMLbeR2dJULqRS6EBq