### PR TITLE
feat(web): 站点管理页交互打磨——刷流菜单化确认、favicon 代理、动态副标题

### DIFF
--- a/apps/web/components/extension-settings.tsx
+++ b/apps/web/components/extension-settings.tsx
@@ -17,16 +17,17 @@ import { formatDateTime } from "@/lib/time";
 /**
  * 浏览器插件卡片：嵌在「资源站点」分区底部（插件是站点 Cookie 同步的配套工具，
  * 不单设分区）。
- * - 安装引导：自动检测是否已安装（见 lib/extension-install.ts），未安装时提供 zip
- *   下载与加载步骤（Chrome 政策不允许商店外插件一键静默安装，下载后需在
- *   chrome://extensions 手动加载，卡片把步骤讲清楚）；
- * - 同步令牌：设完即用、极少回访的配置，不占第一屏——收进「同步令牌」按钮的
- *   弹窗里管理（生成 / 查看 / 复制 / 重新生成 / 关闭）。
+ * 卡面保持极简（一段说明 + 状态点 + 两个按钮）：
+ * - 安装引导收进「安装插件」按钮的弹窗——Chrome 政策不允许商店外插件一键
+ *   静默安装，必须手动加载，四步指引在弹窗里讲清楚，不平铺占版面；
+ * - 同步令牌：设完即用、极少回访的配置，收进「同步令牌」按钮的弹窗里管理。
  * 各站点的同步与验证状态直接看上方站点列表，不在这里重复展示。
+ * 视觉与站点列表同款扁平面板（配置页不用玻璃质感）。
  */
 export function ExtensionCard() {
   const { installed } = useExtensionInstalled();
   const [tokenOpen, setTokenOpen] = useState(false);
+  const [installOpen, setInstallOpen] = useState(false);
 
   const badge =
     installed === null
@@ -36,7 +37,7 @@ export function ExtensionCard() {
         : { label: "未检测到", color: "#c0c4cc" };
 
   return (
-    <section className="css-glass !rounded-2xl p-6">
+    <section className="rounded-xl border border-white/[0.08] bg-white/[0.03] p-5">
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-3.5">
           <span className="icon-chip size-10 shrink-0 !rounded-xl">
@@ -59,40 +60,16 @@ export function ExtensionCard() {
         </span>
       </div>
 
-      {installed ? (
-        <p className="mt-4 rounded-xl bg-white/[0.03] px-4 py-3 text-body text-[var(--text-muted)]">
-          <CheckIcon className="mr-1.5 inline size-4 text-[var(--ok)]" />
-          插件已就绪。打开支持的站点页面，点击浏览器工具栏的 MovieClaw
-          图标即可同步该站 Cookie；首次使用请先点下方「同步令牌」生成并填入插件。
-        </p>
-      ) : (
-        <ol className="mt-4 space-y-2 rounded-xl bg-white/[0.03] px-4 py-3.5 text-ui leading-6 text-[var(--text-muted)]">
-          <li>
-            <b className="text-[var(--text)]">1.</b> 点击下方按钮下载插件包，解压得到{" "}
-            <code className="rounded bg-white/[0.06] px-1 font-mono text-sub">chrome-mv3</code> 文件夹。
-          </li>
-          <li>
-            <b className="text-[var(--text)]">2.</b> 浏览器打开{" "}
-            <code className="rounded bg-white/[0.06] px-1 font-mono text-sub">chrome://extensions</code>
-            ，右上角开启「开发者模式」。
-          </li>
-          <li>
-            <b className="text-[var(--text)]">3.</b>{" "}
-            点「加载已解压的扩展程序」选择该文件夹，切回本页即自动识别为「已安装」。
-          </li>
-        </ol>
-      )}
-
       <div className="mt-4 flex flex-wrap items-center gap-3">
         {!installed && (
-          <a
-            href={EXTENSION_ZIP_URL}
-            download
+          <button
+            type="button"
+            onClick={() => setInstallOpen(true)}
             className="btn-accent flex items-center gap-1.5 rounded-full px-4 py-2 text-sub font-semibold"
           >
             <DownloadIcon className="size-4" />
-            下载插件包
-          </a>
+            安装插件
+          </button>
         )}
         <button
           type="button"
@@ -102,15 +79,129 @@ export function ExtensionCard() {
           <ShieldIcon className="size-4" />
           同步令牌
         </button>
-        {!installed && (
+        {installed && (
           <p className="text-caption text-[var(--text-faint)]">
-            支持 Chrome / Edge 等 Chromium 内核浏览器；安装检测同样仅对 Chromium 生效。
+            <CheckIcon className="mr-1 inline size-3.5 text-[var(--ok)]" />
+            打开站点页面，点浏览器工具栏的 MovieClaw 图标即可同步；首次使用先生成同步令牌填入插件。
           </p>
         )}
       </div>
 
+      <InstallModal
+        open={installOpen}
+        onClose={() => setInstallOpen(false)}
+        onOpenToken={() => {
+          setInstallOpen(false);
+          setTokenOpen(true);
+        }}
+      />
       <TokenModal open={tokenOpen} onClose={() => setTokenOpen(false)} />
     </section>
+  );
+}
+
+/**
+ * 安装指引弹窗：四步明确操作。Chrome 政策不允许商店外插件静默安装，
+ * 下载后须在 chrome://extensions 手动加载——步骤只在用户点「安装插件」
+ * 时才展开，不在卡面平铺。
+ */
+function InstallModal({
+  open,
+  onClose,
+  onOpenToken,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onOpenToken: () => void;
+}) {
+  const steps: { text: React.ReactNode; action?: React.ReactNode }[] = [
+    {
+      text: (
+        <>
+          下载插件包并解压，得到{" "}
+          <code className="rounded bg-white/[0.06] px-1 font-mono text-sub">chrome-mv3</code>{" "}
+          文件夹。
+        </>
+      ),
+      action: (
+        <a
+          href={EXTENSION_ZIP_URL}
+          download
+          className="btn-accent flex w-fit items-center gap-1.5 rounded-full px-3.5 py-1.5 text-sub font-semibold"
+        >
+          <DownloadIcon className="size-4" />
+          下载插件包
+        </a>
+      ),
+    },
+    {
+      text: (
+        <>
+          浏览器地址栏打开{" "}
+          <code className="rounded bg-white/[0.06] px-1 font-mono text-sub">
+            chrome://extensions
+          </code>
+          ，右上角开启「开发者模式」。
+        </>
+      ),
+    },
+    {
+      text: <>点「加载已解压的扩展程序」，选择第 1 步解压出的文件夹。</>,
+    },
+    {
+      text: <>生成同步令牌并填入插件设置，之后切回本页会自动识别为「已安装」。</>,
+      action: (
+        <button
+          type="button"
+          onClick={onOpenToken}
+          className="btn-glass flex w-fit items-center gap-1.5 px-3.5 py-1.5 text-sub font-medium"
+        >
+          <ShieldIcon className="size-4" />
+          去生成令牌
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <Modal open={open} onClose={onClose} label="安装浏览器插件" width="lg">
+      <div className="space-y-4 p-6">
+        <div>
+          <h2 className="text-title font-bold text-[var(--text)]">安装浏览器插件</h2>
+          <p className="mt-1 text-sub leading-5 text-[var(--text-muted)]">
+            按下面四步操作，全程约一分钟。Chrome 应用商店政策不允许商店外插件一键安装，
+            所以需要手动加载一次，之后升级会自动提示。
+          </p>
+        </div>
+
+        <ol className="space-y-3">
+          {steps.map((step, i) => (
+            <li key={i} className="flex gap-3 rounded-xl bg-white/[0.03] px-4 py-3">
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-white/[0.08] text-sub font-semibold text-[var(--text)]">
+                {i + 1}
+              </span>
+              <div className="min-w-0 space-y-2 pt-0.5 text-ui leading-6 text-[var(--text-muted)]">
+                <p>{step.text}</p>
+                {step.action}
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <p className="text-caption text-[var(--text-faint)]">
+            支持 Chrome / Edge 等 Chromium 内核浏览器；安装检测同样仅对 Chromium 生效。
+          </p>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn-glass shrink-0 px-4 py-2 text-sub font-medium"
+          >
+            完成
+          </button>
+        </div>
+      </div>
+    </Modal>
   );
 }
 

--- a/apps/web/components/search-settings.tsx
+++ b/apps/web/components/search-settings.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { LiquidGlassButton } from "@/vendor/liquid-glass";
 
 import { useConfirm } from "@/components/feedback";
-import { GripIcon, PlusIcon } from "@/components/icons";
+import { GripIcon } from "@/components/icons";
 import { listConfiguredSites, listSiteCatalog } from "@/lib/api/sites";
 import { useBackdrop } from "@/lib/backdrop";
 import {
@@ -83,8 +83,9 @@ interface SiteOption {
  * 一个统一混排的标签列表：内置分类（不可删只可隐藏）与自定义分类（可增删改）
  * 同列拖拽排序、同款显隐开关；「全部」固定在搜索面板首位，不在此列表中。
  *
- * 自定义分类 = 命名的「分类组合 × 站点组合」预设：底部「新建自定义分类」
- * 打开编辑器（名称 + 分类勾选 + 站点勾选），分类/站点都不勾选表示「不限」。
+ * 自定义分类 = 命名的「分类组合 × 站点组合」预设：新建入口在父分区的工具栏
+ * （与「添加站点」同位同款主按钮），经 ``createRequest`` 信号触发本组件打开
+ * 编辑器（名称 + 分类勾选 + 站点勾选），分类/站点都不勾选表示「不限」。
  * 站点勾选器只列**已配置**站点；暂时不可用（禁用/验证未通过）的照样可勾选，
  * 搜索时会自动跳过。
  *
@@ -94,7 +95,7 @@ interface SiteOption {
  * 拖拽用原生 Pointer Events 手写（约 60 行），不为此引入 dnd 库：
  * 场景是单列定长小列表，库的能力（多容器、虚拟滚动、传感器抽象）全用不上。
  */
-export function SearchSection() {
+export function SearchSection({ createRequest = 0 }: { createRequest?: number }) {
   const { backdrop } = useBackdrop();
   const confirm = useConfirm();
   const { tabs, loading, saveTabs } = useSearchPrefs();
@@ -103,6 +104,12 @@ export function SearchSection() {
   const [drag, setDrag] = useState<DragState | null>(null);
   const [editor, setEditor] = useState<EditorState | null>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  // 父分区工具栏的「新建自定义分类」按钮：每点一次计数 +1，这里响应信号
+  // 打开空白编辑器（初始 0 不触发，避免挂载即弹编辑器）
+  useEffect(() => {
+    if (createRequest > 0) openEditor(null);
+  }, [createRequest]);
 
   /** 统一的保存包装：清错误 + busy 防抖 + 中文错误回显；返回是否成功。 */
   const apply = async (next: SearchTab[]): Promise<boolean> => {
@@ -366,18 +373,6 @@ export function SearchSection() {
           ))}
         </div>
 
-        {/* 新建入口：编辑器打开时收起，避免两个入口打架 */}
-        {!editor && (
-          <button
-            type="button"
-            onClick={() => openEditor(null)}
-            disabled={busy || loading}
-            className="btn-glass mt-3 px-3.5 py-2 text-sub font-medium disabled:opacity-40"
-          >
-            <PlusIcon className="size-4" />
-            <span>新建自定义分类</span>
-          </button>
-        )}
       </section>
 
       {editor && (

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -15,7 +15,7 @@ import { MembersSection } from "@/components/members-section";
 import { LlmConfigSection } from "@/components/llm-config-section";
 import { ImPushSection } from "@/components/im-push-section";
 import { NetworkConfigSection } from "@/components/network-config-section";
-import { SiteConfigSection } from "@/components/site-config-section";
+import { SiteConfigSection, SitesSectionSubtitle } from "@/components/site-config-section";
 import { SubscriptionSettingsSection } from "@/components/subscription-settings-section";
 import { SystemLogsSection } from "@/components/system-logs-section";
 import { WebhookSection } from "@/components/webhook-section";
@@ -152,7 +152,12 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
               {section.label}
             </h1>
             <p className="text-on-image mt-0.5 text-ui text-[var(--text-muted)]">
-              {section.description}
+              {/* 资源站点分区的副标题是活的：有站点时显示健康统计，无站点回落介绍 */}
+              {section.id === "sites" ? (
+                <SitesSectionSubtitle fallback={section.description} />
+              ) : (
+                section.description
+              )}
             </p>
           </div>
         </header>

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -224,33 +224,40 @@ export function SiteConfigSection() {
     [configured],
   );
 
-  // 顶部健康摘要：站点总数 / 异常数 / 保护数 / 刷流近 24h 总产出
-  const failedCount = configured.filter((s) => s.status === "failed").length;
-  const protectedCount = configured.filter((s) => s.protected).length;
-  const boost24h = Object.values(boostStats).reduce(
-    (sum, s) => sum + (s.uploaded_bytes_24h || 0),
-    0,
-  );
-
   return (
     <div className="space-y-5">
-      {/* 胶囊标签切换：与「外观」分区同一交互语言 */}
-      <div className="flex gap-1.5">
-        {TABS.map((t) => (
+      {/* 工具栏行：左侧胶囊标签切换视图，右侧主操作——描述（分区副标题）之下
+          的第一行。接入统计已上移到分区副标题，这里不再重复；刷新按钮省去
+          （验证轮询 + 操作后回写已覆盖刷新诉求）。 */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex gap-1.5">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              aria-pressed={t.id === tab}
+              onClick={() => setTab(t.id)}
+              className={`rounded-full px-3.5 py-1.5 text-sub font-medium transition-colors ${
+                t.id === tab
+                  ? "bg-white/[0.14] text-white"
+                  : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        {tab === "sites" && (
           <button
-            key={t.id}
             type="button"
-            aria-pressed={t.id === tab}
-            onClick={() => setTab(t.id)}
-            className={`rounded-full px-3.5 py-1.5 text-sub font-medium transition-colors ${
-              t.id === tab
-                ? "bg-white/[0.14] text-white"
-                : "text-[var(--text-muted)] hover:bg-white/[0.07] hover:text-[var(--text)]"
-            }`}
+            onClick={() => setAdding((v) => !v)}
+            disabled={loading}
+            className="btn-accent flex shrink-0 items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-sub font-semibold disabled:opacity-60"
           >
-            {t.label}
+            <PlusIcon className="size-4" />
+            添加站点
           </button>
-        ))}
+        )}
       </div>
 
       {tab === "search" ? (
@@ -262,47 +269,6 @@ export function SiteConfigSection() {
               {error}
             </div>
           )}
-
-          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-            <p className="text-sub text-[var(--text-muted)]">
-              {loading ? (
-                "加载中…"
-              ) : (
-                <>
-                  已接入 {configured.length} 个站点
-                  {failedCount > 0 && (
-                    <>
-                      {" · "}
-                      <span className="font-medium text-[var(--danger)]">
-                        {failedCount} 个异常
-                      </span>
-                    </>
-                  )}
-                  {protectedCount > 0 && ` · ${protectedCount} 个保护中`}
-                  {boost24h > 0 && ` · 刷流近24h ↑${formatBytes(boost24h)}`}
-                </>
-              )}
-            </p>
-            <div className="flex shrink-0 items-center gap-2.5">
-              <button
-                type="button"
-                onClick={() => void load()}
-                disabled={loading}
-                className="btn-glass px-3.5 py-1.5 text-sub font-medium"
-              >
-                刷新
-              </button>
-              <button
-                type="button"
-                onClick={() => setAdding((v) => !v)}
-                disabled={loading}
-                className="btn-accent flex items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-sub font-semibold disabled:opacity-60"
-              >
-                <PlusIcon className="size-4" />
-                添加站点
-              </button>
-            </div>
-          </div>
 
           {/* 「添加站点」面板：从目录里挑选未配置的站点 */}
           {adding && (

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -581,9 +581,7 @@ function SiteRow({
       >
         {/* P0：徽标 + 名称 + 状态 */}
         <div className="flex min-w-0 flex-1 items-center gap-2.5">
-          <span className="icon-chip size-8 shrink-0 !rounded-lg text-sub font-semibold">
-            {item.display_name.charAt(0).toUpperCase()}
-          </span>
+          <SiteBadge item={item} />
           {site.protected && (
             <span
               className="flex shrink-0 items-center"
@@ -772,24 +770,28 @@ function SiteDetail({
         </DetailSection>
       )}
 
-      {/* ─ 账号 ─ */}
+      {/* ─ 账号 ─ 两行分组：身份与持有（用户名/等级/做种/魔力）、流量指标（上传/下载/分享率） */}
       {site.profile && (
         <DetailSection label="账号">
           <div
-            className="grid grid-cols-2 gap-x-5 gap-y-2 sm:flex sm:flex-wrap sm:gap-x-7"
+            className="space-y-2.5"
             title={`资料更新于 ${formatRelativeTime(site.profile.fetched_at)}`}
           >
-            <DetailStat label="用户名" value={site.profile.username} />
-            {site.profile.user_class && (
-              <DetailStat label="等级" value={site.profile.user_class} />
-            )}
-            <DetailStat label="上传量" value={formatBytes(site.profile.uploaded_bytes)} />
-            <DetailStat label="下载量" value={formatBytes(site.profile.downloaded_bytes)} />
-            <DetailStat label="分享率" value={formatRatio(site.profile.ratio)} />
-            {site.profile.bonus != null && (
-              <DetailStat label="魔力" value={formatCompact(site.profile.bonus)} />
-            )}
-            <DetailStat label="做种" value={String(site.profile.seeding_count)} />
+            <div className="grid grid-cols-2 gap-x-5 gap-y-2 sm:flex sm:flex-wrap sm:gap-x-7">
+              <DetailStat label="用户名" value={site.profile.username} />
+              {site.profile.user_class && (
+                <DetailStat label="等级" value={site.profile.user_class} />
+              )}
+              <DetailStat label="做种" value={String(site.profile.seeding_count)} />
+              {site.profile.bonus != null && (
+                <DetailStat label="魔力" value={formatCompact(site.profile.bonus)} />
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-x-5 gap-y-2 sm:flex sm:flex-wrap sm:gap-x-7">
+              <DetailStat label="上传量" value={formatBytes(site.profile.uploaded_bytes)} />
+              <DetailStat label="下载量" value={formatBytes(site.profile.downloaded_bytes)} />
+              <DetailStat label="分享率" value={formatRatio(site.profile.ratio)} />
+            </div>
           </div>
         </DetailSection>
       )}
@@ -836,6 +838,43 @@ function SiteDetail({
         )}
       </DetailSection>
     </div>
+  );
+}
+
+/* —— 站点徽标：优先取站点真实 favicon（域名 + /favicon.ico），失败回落首字母 ——
+   刻意不走 Google/DuckDuckGo 的 favicon 聚合服务：目标用户网络环境里那些
+   域名普遍不可达；而用户既然配置了这个 PT 站，浏览器就一定能直连它本身。 */
+
+function SiteBadge({ item }: { item: CatalogItem }) {
+  const [failed, setFailed] = useState(false);
+  const origin = useMemo(() => {
+    if (!item.base_url) return null;
+    try {
+      return new URL(item.base_url).origin;
+    } catch {
+      return null;
+    }
+  }, [item.base_url]);
+
+  if (!origin || failed) {
+    return (
+      <span className="icon-chip size-8 shrink-0 !rounded-lg text-sub font-semibold">
+        {item.display_name.charAt(0).toUpperCase()}
+      </span>
+    );
+  }
+  return (
+    <span className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/[0.08] bg-white/[0.04]">
+      {/* 外站 favicon，不经 next/image 优化管道 */}
+      <img
+        src={`${origin}/favicon.ico`}
+        alt=""
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        className="size-5"
+        onError={() => setFailed(true)}
+      />
+    </span>
   );
 }
 

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -5,7 +5,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
 import { useConfirm, usePrompt } from "@/components/feedback";
-import { ChevronDownIcon, MoreIcon, PlusIcon, ServerIcon } from "@/components/icons";
+import {
+  ChevronDownIcon,
+  MoreIcon,
+  PlusIcon,
+  ServerIcon,
+  ShieldIcon,
+} from "@/components/icons";
 import { ExtensionCard } from "@/components/extension-settings";
 import { SearchSection } from "@/components/search-settings";
 import type { ConfiguredSite, SiteAuthType, SiteStatus } from "@/lib/api/extension";
@@ -578,6 +584,15 @@ function SiteRow({
           <span className="icon-chip size-8 shrink-0 !rounded-lg text-sub font-semibold">
             {item.display_name.charAt(0).toUpperCase()}
           </span>
+          {site.protected && (
+            <span
+              className="flex shrink-0 items-center"
+              title="站点保护中：订阅不会自动从该站拉种（下载量归零），手动搜索和下载不受影响"
+              aria-label="站点保护中"
+            >
+              <ShieldIcon className="size-4 text-[var(--info)]" />
+            </span>
+          )}
           {item.base_url ? (
             <a
               href={item.base_url}
@@ -611,42 +626,29 @@ function SiteRow({
           )}
         </div>
 
-        {/* P1：条件徽章（异常时错误原因吃掉徽章位——那一刻没有比它更重要的信息） */}
+        {/* P1：条件徽章（异常时错误原因吃掉徽章位——那一刻没有比它更重要的信息）。
+            保护状态不占徽章位——站点名前的护盾图标已承担（更紧凑，移动端友好） */}
         {failed ? (
           <p className="order-3 basis-full truncate text-caption text-[var(--danger)] sm:order-none sm:basis-auto sm:max-w-[45%]">
             {site.last_error}
           </p>
         ) : (
-          (site.protected || site.boost_enabled) && (
+          site.boost_enabled && (
             <div className="order-3 flex basis-full flex-wrap items-center gap-1.5 sm:order-none sm:basis-auto">
-              {site.protected && (
-                <span
-                  className="rounded-full px-2 py-0.5 text-caption font-medium"
-                  style={{
-                    background: "color-mix(in oklab, var(--info) 12%, transparent)",
-                    color: "var(--info)",
-                  }}
-                  title="订阅不会自动从该站拉种，手动搜索下载不受影响"
-                >
-                  保护中
-                </span>
-              )}
-              {site.boost_enabled && (
-                <span
-                  className="rounded-full px-2 py-0.5 text-caption font-medium"
-                  style={{
-                    background: "color-mix(in oklab, var(--ok) 12%, transparent)",
-                    color: "var(--ok)",
-                  }}
-                  title="自动刷分享率运行中：已用/预算 · 近 24 小时上传"
-                >
-                  刷流 {boost ? formatBytes(boost.used_bytes) : "0"}/
-                  {formatBytes(site.boost_budget_bytes)}
-                  {boost && boost.uploaded_bytes_24h > 0 && (
-                    <> · 24h ↑{formatBytes(boost.uploaded_bytes_24h)}</>
-                  )}
-                </span>
-              )}
+              <span
+                className="rounded-full px-2 py-0.5 text-caption font-medium"
+                style={{
+                  background: "color-mix(in oklab, var(--ok) 12%, transparent)",
+                  color: "var(--ok)",
+                }}
+                title="自动刷分享率运行中：已用/预算 · 近 24 小时上传"
+              >
+                刷流 {boost ? formatBytes(boost.used_bytes) : "0"}/
+                {formatBytes(site.boost_budget_bytes)}
+                {boost && boost.uploaded_bytes_24h > 0 && (
+                  <> · 24h ↑{formatBytes(boost.uploaded_bytes_24h)}</>
+                )}
+              </span>
             </div>
           )
         )}
@@ -777,7 +779,7 @@ function SiteDetail({
             className="grid grid-cols-2 gap-x-5 gap-y-2 sm:flex sm:flex-wrap sm:gap-x-7"
             title={`资料更新于 ${formatRelativeTime(site.profile.fetched_at)}`}
           >
-            <DetailStat label="账号" value={site.profile.username} />
+            <DetailStat label="用户名" value={site.profile.username} />
             {site.profile.user_class && (
               <DetailStat label="等级" value={site.profile.user_class} />
             )}

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -91,6 +91,40 @@ function fallbackItem(siteId: string): CatalogItem {
   return { site_id: siteId, display_name: siteId, base_url: "", supported_auth_types: [] };
 }
 
+/**
+ * 「资源站点」分区的动态副标题（设置头部用）：有站点时显示健康统计——
+ * 「已接入 X 个站点，全部正常 / Y 个异常需要关注」；还没接入任何站点时
+ * 回落功能介绍文案（fallback），此时统计没有意义、介绍才有引导价值。
+ */
+export function SitesSectionSubtitle({ fallback }: { fallback: string }) {
+  const [sites, setSites] = useState<ConfiguredSite[] | null>(null);
+  useEffect(() => {
+    let alive = true;
+    listConfiguredSites()
+      .then((rows) => {
+        if (alive) setSites(rows);
+      })
+      .catch(() => {
+        /* 拉取失败保持介绍文案，分区主体会展示具体错误 */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (!sites || sites.length === 0) return <>{fallback}</>;
+  const failed = sites.filter((s) => s.status === "failed").length;
+  if (failed > 0) {
+    return (
+      <>
+        已接入 {sites.length} 个站点，
+        <span className="font-medium text-[var(--danger)]">{failed} 个异常需要关注</span>
+      </>
+    );
+  }
+  return <>已接入 {sites.length} 个站点，全部正常</>;
+}
+
 export function SiteConfigSection() {
   const [tab, setTab] = useState<SiteTab>("sites");
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -34,6 +34,7 @@ import {
   updateSite,
 } from "@/lib/api/sites";
 import { formatBytes, formatCompact, formatDuration, formatRatio } from "@/lib/format";
+import { cachedImageUrl } from "@/lib/image-proxy";
 import { formatRelativeTime } from "@/lib/time";
 import { useVisiblePolling } from "@/lib/use-visible-polling";
 
@@ -842,8 +843,10 @@ function SiteDetail({
 }
 
 /* —— 站点徽标：优先取站点真实 favicon（域名 + /favicon.ico），失败回落首字母 ——
-   刻意不走 Google/DuckDuckGo 的 favicon 聚合服务：目标用户网络环境里那些
-   域名普遍不可达；而用户既然配置了这个 PT 站，浏览器就一定能直连它本身。 */
+   经后端 /images/proxy 统一图片代理回源（cachedImageUrl 收口）：favicon 也是
+   站点流量，必须走 movieclaw_net 统一出口受代理路由与网络策略管控，且服务端
+   落盘缓存后浏览器不再反复触达站点。刻意不走 Google/DuckDuckGo 的 favicon
+   聚合服务：目标用户网络环境里那些域名普遍不可达。 */
 
 function SiteBadge({ item }: { item: CatalogItem }) {
   const [failed, setFailed] = useState(false);
@@ -865,12 +868,11 @@ function SiteBadge({ item }: { item: CatalogItem }) {
   }
   return (
     <span className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/[0.08] bg-white/[0.04]">
-      {/* 外站 favicon，不经 next/image 优化管道 */}
+      {/* 经统一图片代理的外站 favicon，不经 next/image 优化管道 */}
       <img
-        src={`${origin}/favicon.ico`}
+        src={cachedImageUrl(`${origin}/favicon.ico`)}
         alt=""
         loading="lazy"
-        referrerPolicy="no-referrer"
         className="size-5"
         onError={() => setFailed(true)}
       />

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -139,6 +139,8 @@ export function SiteConfigSection() {
   const [adding, setAdding] = useState(false);
   // 当前展开详情的站点（单开手风琴）
   const [expandedSite, setExpandedSite] = useState<string | null>(null);
+  // 「新建自定义分类」的触发信号：工具栏按钮每点一次 +1，SearchSection 响应打开编辑器
+  const [createPresetNonce, setCreatePresetNonce] = useState(0);
 
   const catalogMap = useMemo(() => new Map(catalog.map((c) => [c.site_id, c])), [catalog]);
 
@@ -247,7 +249,7 @@ export function SiteConfigSection() {
             </button>
           ))}
         </div>
-        {tab === "sites" && (
+        {tab === "sites" ? (
           <button
             type="button"
             onClick={() => setAdding((v) => !v)}
@@ -257,11 +259,20 @@ export function SiteConfigSection() {
             <PlusIcon className="size-4" />
             添加站点
           </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreatePresetNonce((n) => n + 1)}
+            className="btn-accent flex shrink-0 items-center gap-1 rounded-full py-1.5 pl-2.5 pr-3.5 text-sub font-semibold"
+          >
+            <PlusIcon className="size-4" />
+            新建自定义分类
+          </button>
         )}
       </div>
 
       {tab === "search" ? (
-        <SearchSection />
+        <SearchSection createRequest={createPresetNonce} />
       ) : (
         <>
           {error && (

--- a/apps/web/components/site-config-section.tsx
+++ b/apps/web/components/site-config-section.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
-import { useConfirm } from "@/components/feedback";
+import { useConfirm, usePrompt } from "@/components/feedback";
 import { ChevronDownIcon, MoreIcon, PlusIcon, ServerIcon } from "@/components/icons";
 import { ExtensionCard } from "@/components/extension-settings";
 import { SearchSection } from "@/components/search-settings";
@@ -307,6 +307,7 @@ export function SiteConfigSection() {
                   onToggle={() =>
                     setExpandedSite((cur) => (cur === site.site_id ? null : site.site_id))
                   }
+                  onOpen={() => setExpandedSite(site.site_id)}
                   onChanged={upsertConfigured}
                   onDeleted={(siteId) => {
                     setConfigured((prev) => prev.filter((s) => s.site_id !== siteId));
@@ -455,6 +456,8 @@ interface SiteRowProps {
   boost?: SiteBoostStats;
   expanded: boolean;
   onToggle: () => void;
+  /** 确保展开（不切换）：菜单里的「编辑授权」需要先展开详情再亮出表单 */
+  onOpen: () => void;
   onChanged: (site: ConfiguredSite) => void;
   onDeleted: (siteId: string) => void;
   onError: (message: string) => void;
@@ -467,12 +470,16 @@ function SiteRow({
   boost,
   expanded,
   onToggle,
+  onOpen,
   onChanged,
   onDeleted,
   onError,
 }: SiteRowProps) {
   const confirm = useConfirm();
+  const prompt = usePrompt();
   const [busy, setBusy] = useState(false);
+  // 授权表单的展开态由行持有：菜单点「编辑授权」时行可能还没展开，需要先展开再亮表单
+  const [editingAuth, setEditingAuth] = useState(false);
   const meta = STATUS_META[site.status];
   const failed = site.status === "failed" && !!site.last_error;
 
@@ -485,6 +492,69 @@ function SiteRow({
     } finally {
       setBusy(false);
     }
+  }
+
+  /** 弹预算输入框并解析；返回字节数，取消返回 null，非法输入报错后返回 null。 */
+  async function askBudget(options: {
+    title: string;
+    description: string;
+    confirmLabel: string;
+  }): Promise<number | null> {
+    const raw = await prompt({
+      ...options,
+      initialValue: String(Math.round(site.boost_budget_bytes / GIB)),
+      placeholder: "存储预算（GiB）",
+    });
+    if (raw == null) return null; // 用户取消
+    const gib = Math.round(Number(raw.trim()));
+    if (!Number.isFinite(gib) || gib < 1) {
+      onError("刷流预算必须是不小于 1 的整数（单位 GiB）");
+      return null;
+    }
+    return gib * GIB;
+  }
+
+  /** 开启刷流（含再次开启）：二次确认讲清将发生什么 + 同窗设置预算。 */
+  async function enableBoost() {
+    const budget = await askBudget({
+      title: `开启「${item.display_name}」的自动刷分享率？`,
+      description:
+        "开启后将自动抢该站新发布的免费种子做种以提升分享率；占用空间在下方预算内" +
+        "自动汰换（只有下载完成、入池满 72 小时且上传效率过低的任务才会被连数据删除）；" +
+        "该站的索引同步会提速到约 5 分钟一次。请确认本次刷流的存储预算：",
+      confirmLabel: "开启刷流",
+    });
+    if (budget == null) return;
+    await guard(async () => onChanged(await setSiteRatioBoost(site.site_id, true, budget)));
+  }
+
+  /** 关闭刷流：二次确认讲清后果（不删数据，只停新增）。 */
+  async function disableBoost() {
+    const ok = await confirm({
+      title: `关闭「${item.display_name}」的自动刷分享率？`,
+      bullets: [
+        "停止抢该站新发布的免费种子",
+        "已在做种的刷流任务全部保留，不删除任何数据",
+        "站点索引同步回到正常自适应节奏",
+        "重新开启时会再次确认预算",
+      ],
+      confirmLabel: "关闭刷流",
+    });
+    if (!ok) return;
+    await guard(async () => onChanged(await setSiteRatioBoost(site.site_id, false)));
+  }
+
+  /** 调整刷流预算（仅开启时可见）。 */
+  async function adjustBudget() {
+    const budget = await askBudget({
+      title: `调整「${item.display_name}」的刷流预算`,
+      description:
+        `当前预算 ${formatBytes(site.boost_budget_bytes)}。调小预算不会立刻删种——` +
+        "引擎按汰换规则逐步收敛到新预算，72 小时保留期内的任务绝不会被删除。",
+      confirmLabel: "保存",
+    });
+    if (budget == null || budget === site.boost_budget_bytes) return;
+    await guard(async () => onChanged(await setSiteRatioBoost(site.site_id, true, budget)));
   }
 
   return (
@@ -595,6 +665,13 @@ function SiteRow({
             onSetProtected={(next) =>
               void guard(async () => onChanged(await setSiteProtection(site.site_id, next)))
             }
+            onEnableBoost={() => void enableBoost()}
+            onDisableBoost={() => void disableBoost()}
+            onAdjustBudget={() => void adjustBudget()}
+            onEditAuth={() => {
+              onOpen();
+              setEditingAuth(true);
+            }}
             onReverify={() =>
               void guard(async () => onChanged(await reverifySite(site.site_id)))
             }
@@ -629,6 +706,8 @@ function SiteRow({
           busy={busy}
           guard={guard}
           onChanged={onChanged}
+          editingAuth={editingAuth}
+          onCloseEditAuth={() => setEditingAuth(false)}
         />
       )}
     </div>
@@ -645,92 +724,51 @@ interface SiteDetailProps {
   busy: boolean;
   guard: (fn: () => Promise<void>) => Promise<void>;
   onChanged: (site: ConfiguredSite) => void;
+  /** 授权表单展开态由行持有（菜单「编辑授权」可在未展开时触发） */
+  editingAuth: boolean;
+  onCloseEditAuth: () => void;
 }
 
-function SiteDetail({ item, site, stats, boost, busy, guard, onChanged }: SiteDetailProps) {
-  const [editingAuth, setEditingAuth] = useState(false);
-  // 预算输入（GiB 为单位）：失焦即存；site 变化（别处保存成功）时回同步
-  const [budgetGib, setBudgetGib] = useState(() =>
-    String(Math.round(site.boost_budget_bytes / GIB)),
-  );
-  useEffect(() => {
-    setBudgetGib(String(Math.round(site.boost_budget_bytes / GIB)));
-  }, [site.boost_budget_bytes]);
-
-  function commitBudget() {
-    const gib = Math.round(Number(budgetGib));
-    if (!Number.isFinite(gib) || gib < 1) {
-      setBudgetGib(String(Math.round(site.boost_budget_bytes / GIB)));
-      return;
-    }
-    const bytes = gib * GIB;
-    if (bytes === site.boost_budget_bytes) return;
-    void guard(async () =>
-      onChanged(await setSiteRatioBoost(site.site_id, site.boost_enabled, bytes)),
-    );
-  }
-
+function SiteDetail({
+  item,
+  site,
+  stats,
+  boost,
+  busy,
+  guard,
+  onChanged,
+  editingAuth,
+  onCloseEditAuth,
+}: SiteDetailProps) {
   return (
     <div className="space-y-4 border-t border-white/[0.06] bg-white/[0.02] px-4 py-4">
-      {/* ─ 刷流 ─ */}
-      <DetailSection label="刷流">
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-          <div className="flex items-center gap-2.5">
-            <FlatSwitch
-              checked={site.boost_enabled}
-              disabled={busy}
-              label={site.boost_enabled ? "关闭自动刷分享率" : "开启自动刷分享率"}
-              onChange={(next) =>
-                void guard(async () => onChanged(await setSiteRatioBoost(site.site_id, next)))
-              }
+      {/* ─ 刷流 ─ 只读运行统计；启停与预算在 ⋯ 菜单（带二次确认与预算弹窗） */}
+      {site.boost_enabled && (
+        <DetailSection label="刷流">
+          <div className="grid grid-cols-2 gap-x-5 gap-y-2 sm:flex sm:flex-wrap sm:gap-x-7">
+            <DetailStat
+              label="已用 / 预算"
+              value={`${formatBytes(boost?.used_bytes ?? 0)} / ${formatBytes(site.boost_budget_bytes)}`}
             />
-            <span className="text-sub text-[var(--text-muted)]">
-              自动抢免费新种做种，预算内汰换低效任务（72 小时保留期内绝不删）
-            </span>
-          </div>
-          {site.boost_enabled && (
-            <div className="flex items-center gap-2">
-              <span className="text-micro text-[var(--text-faint)]">预算</span>
-              <input
-                type="number"
-                min={1}
-                value={budgetGib}
-                disabled={busy}
-                onChange={(e) => setBudgetGib(e.target.value)}
-                onBlur={commitBudget}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-                }}
-                className="w-20 rounded-lg border border-white/[0.08] bg-white/[0.04] px-2 py-1 text-right text-ui text-[var(--text)] outline-none focus:border-[var(--accent)]/60"
-              />
-              <span className="text-caption text-[var(--text-muted)]">GiB</span>
-            </div>
-          )}
-        </div>
-        {site.boost_enabled && boost && (
-          <>
-            <div className="grid grid-cols-2 gap-x-5 gap-y-2 sm:flex sm:flex-wrap sm:gap-x-7">
-              <DetailStat
-                label="已用 / 预算"
-                value={`${formatBytes(boost.used_bytes)} / ${formatBytes(boost.budget_bytes)}`}
-              />
-              <DetailStat label="在池做种" value={String(boost.active_count)} />
-              <DetailStat label="累计上传" value={formatBytes(boost.uploaded_bytes_total)} />
-              {boost.evicted_count > 0 && (
-                <DetailStat label="已汰换" value={String(boost.evicted_count)} />
-              )}
-            </div>
-            {boost.avg_used_bytes_24h > 0 && (
-              <p className="text-caption text-[var(--text-muted)]">
-                近 24 小时：{formatBytes(boost.avg_used_bytes_24h)} 在池种子贡献了{" "}
-                {formatBytes(boost.uploaded_bytes_24h)} 上传
-                {boost.avg_used_bytes_7d > 0 &&
-                  ` · 近 7 天：${formatBytes(boost.avg_used_bytes_7d)} 贡献 ${formatBytes(boost.uploaded_bytes_7d)}`}
-              </p>
+            <DetailStat label="在池做种" value={String(boost?.active_count ?? 0)} />
+            <DetailStat
+              label="累计上传"
+              value={formatBytes(boost?.uploaded_bytes_total ?? 0)}
+            />
+            {boost && boost.evicted_count > 0 && (
+              <DetailStat label="已汰换" value={String(boost.evicted_count)} />
             )}
-          </>
-        )}
-      </DetailSection>
+          </div>
+          {boost && boost.avg_used_bytes_24h > 0 && (
+            <p className="text-caption text-[var(--text-muted)]">
+              近 24 小时：{formatBytes(boost.avg_used_bytes_24h)} 在池种子贡献了{" "}
+              {formatBytes(boost.uploaded_bytes_24h)} 上传
+              {boost.avg_used_bytes_7d > 0 &&
+                ` · 近 7 天：${formatBytes(boost.avg_used_bytes_7d)} 贡献 ${formatBytes(boost.uploaded_bytes_7d)}`}
+            </p>
+          )}
+        </DetailSection>
+      )}
 
       {/* ─ 账号 ─ */}
       {site.profile && (
@@ -774,7 +812,7 @@ function SiteDetail({ item, site, stats, boost, busy, guard, onChanged }: SiteDe
         </DetailSection>
       )}
 
-      {/* ─ 授权 ─ */}
+      {/* ─ 授权 ─ 编辑入口在 ⋯ 菜单（编辑授权），这里默认只读展示 */}
       <DetailSection label="授权">
         {editingAuth ? (
           <SiteForm
@@ -784,25 +822,15 @@ function SiteDetail({ item, site, stats, boost, busy, guard, onChanged }: SiteDe
             onSubmit={(payload) =>
               guard(async () => {
                 onChanged(await updateSite(item.site_id, payload));
-                setEditingAuth(false);
+                onCloseEditAuth();
               })
             }
           />
         ) : (
-          <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-            <span className="text-sub text-[var(--text-muted)]">
-              {AUTH_TYPE_LABEL[site.auth_type]} · 上次检查{" "}
-              {formatRelativeTime(site.last_checked_at)}
-            </span>
-            <button
-              type="button"
-              onClick={() => setEditingAuth(true)}
-              disabled={busy}
-              className="btn-glass px-3 py-1 text-sub font-medium"
-            >
-              编辑授权
-            </button>
-          </div>
+          <span className="text-sub text-[var(--text-muted)]">
+            {AUTH_TYPE_LABEL[site.auth_type]} · 上次检查{" "}
+            {formatRelativeTime(site.last_checked_at)}
+          </span>
         )}
       </DetailSection>
     </div>
@@ -835,47 +863,17 @@ function nextSyncLabel(iso: string | null): string {
   return formatRelativeTime(iso);
 }
 
-/* —— 轻量 CSS 开关：配置页刻意不用 WebGL 玻璃开关（移动端性能与稳定优先） —— */
-
-interface FlatSwitchProps {
-  checked: boolean;
-  disabled?: boolean;
-  label: string;
-  onChange: (next: boolean) => void;
-}
-
-function FlatSwitch({ checked, disabled, label, onChange }: FlatSwitchProps) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      disabled={disabled}
-      onClick={(e) => {
-        e.stopPropagation();
-        onChange(!checked);
-      }}
-      className={`relative h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-50 ${
-        checked ? "bg-[var(--ok)]/70" : "bg-white/[0.14]"
-      }`}
-    >
-      <span
-        className={`absolute left-0.5 top-0.5 size-5 rounded-full bg-white shadow transition-transform ${
-          checked ? "translate-x-5" : ""
-        }`}
-      />
-    </button>
-  );
-}
-
-/* —— 站点操作折叠菜单：启停 / 保护 / 重验 / 删除 全部收口于此 —— */
+/* —— 站点操作折叠菜单：启停 / 保护 / 刷流 / 编辑授权 / 重验 / 删除 全部收口于此 —— */
 
 interface SiteActionsMenuProps {
   site: ConfiguredSite;
   busy: boolean;
   onSetEnabled: (enabled: boolean) => void;
   onSetProtected: (next: boolean) => void;
+  onEnableBoost: () => void;
+  onDisableBoost: () => void;
+  onAdjustBudget: () => void;
+  onEditAuth: () => void;
   onReverify: () => void;
   onDelete: () => void;
 }
@@ -885,6 +883,10 @@ function SiteActionsMenu({
   busy,
   onSetEnabled,
   onSetProtected,
+  onEnableBoost,
+  onDisableBoost,
+  onAdjustBudget,
+  onEditAuth,
   onReverify,
   onDelete,
 }: SiteActionsMenuProps) {
@@ -929,6 +931,23 @@ function SiteActionsMenu({
             className={itemClass}
           >
             {site.protected ? "取消保护" : "开启保护"}
+          </DropdownMenu.Item>
+          {/* 刷流启停都带二次确认（开启含预算设置）——onSelect 后弹的是
+              feedback 层的对话框，菜单自身正常关闭即可 */}
+          <DropdownMenu.Item
+            onSelect={site.boost_enabled ? onDisableBoost : onEnableBoost}
+            disabled={busy}
+            className={itemClass}
+          >
+            {site.boost_enabled ? "关闭刷流…" : "开启刷流…"}
+          </DropdownMenu.Item>
+          {site.boost_enabled && (
+            <DropdownMenu.Item onSelect={onAdjustBudget} disabled={busy} className={itemClass}>
+              调整刷流预算…
+            </DropdownMenu.Item>
+          )}
+          <DropdownMenu.Item onSelect={onEditAuth} disabled={busy} className={itemClass}>
+            编辑授权
           </DropdownMenu.Item>
           <DropdownMenu.Item
             onSelect={onReverify}


### PR DESCRIPTION
## 背景

站点保护 / 自动刷分享率的核心机制与站点管理页行式重构已随 #158 合并；本 PR 是其后的 8 个 UI 交互与视觉打磨提交（纯前端，无后端与数据库变更）。

## 改动

**操作收口与二次确认**
- 刷流启停、编辑授权全部收进 ⋯ 菜单：「开启刷流…」弹窗讲清将发生什么（抢免费种、预算内汰换、72h 保留期、同步提速）并**同窗确认预算**，再次开启同样走此流程；「关闭刷流…」以动作清单讲清后果（在池任务与数据全保留）；开启后菜单出现「调整刷流预算…」弹窗编辑；
- 「编辑授权」经菜单触发时自动展开详情并亮出表单，详情区授权段回归只读；
- 弹窗复用全站 feedback 层的 confirm（bullets）与 prompt 原语，未新造模态组件。

**视觉与信息层级**
- 保护状态从「保护中」文字徽章改为站点名前的护盾图标 + tooltip 完整释义；
- 站点徽标换真实 favicon：经既有 `/images/proxy` 统一图片代理回源（movieclaw_net 统一出口 + SSRF 防护 + 双层缓存，浏览器零直连站点），失败回落首字母；
- 账号统计两行分组：身份与持有（用户名/等级/做种/魔力）、流量指标（上传/下载/分享率），统计项「账号」改「用户名」消除与段标题重复。

**分区结构**
- 分区副标题改为健康统计：「已接入 X 个站点，全部正常 / Y 个异常需要关注」（异常标红），无站点时回落功能介绍；
- 分区内的重复统计行与刷新按钮移除（验证轮询 + 操作回写已覆盖）；主操作统一进工具栏——胶囊标签右侧按档展示「添加站点」/「新建自定义分类」，同位同款 accent 主按钮（后者经 createRequest 信号触发 SearchSection 打开编辑器，编辑器状态仍归其内部）；
- 浏览器插件卡面极简化（说明 + 状态点 + 两按钮），安装指引收进 1/2/3/4 步骤弹窗，第 4 步「去生成令牌」无缝衔接令牌弹窗。

## 测试

前端 tsc / ESLint / 生产构建全绿；无后端改动，无迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYF2hcbh8HMRWvJTFN3Z1i