### PR TITLE
feat(web): PWA 装成 App 后禁用界面文案选中，贴近原生手感

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -237,9 +237,21 @@ textarea,
    导航项、按钮、列表行，只会拖出一片蓝色选区和系统菜单，手感立刻「掉回
    网页」。原生 App 里这些控件文案本来就是选不中的。
 
-   做法是把外壳整体设为不可选，再把**真正值得复制的内容**逐类放开：输入
-   控件、Markdown 正文、代码块，以及显式挂了 .selectable 的文本（对话气泡、
-   系统日志、错误详情、剧情简介、字幕预览等）。
+   做法是把外壳整体设为不可选，再把**真正值得复制的内容**放开。放行清单按
+   「语义类别」写而不是逐个组件枚举——枚举永远漏，漏掉的那处就是用户复制
+   不出来的死角：
+   - 表单控件：输入框、文本域、可编辑区；
+   - 机器数据：code / pre / samp，以及全站 .font-mono——本项目里等宽字体
+     就是「路径 / 种子 ID / 文件哈希 / 代理地址」这类要粘到别处去的数据，
+     几十处散落在媒体库详情、下载器配置、导入规则、网络设置里；
+   - 正文容器：.markdown 与 .code-highlight；
+   - 显式标注：.selectable，给不带上述特征的正文用（对话气泡、系统日志、
+     剧情简介、字幕台词、加载失败页的报错等）。
+
+   为什么要这么宽：这是自部署的开源软件，大量用户在局域网 HTTP 下访问，
+   而 Clipboard API 只在安全上下文可用（见 components/copy-button.tsx 的
+   execCommand 回退），全站带复制按钮的地方也只有三处——「长按选中手动
+   复制」往往是用户最后的兜底手段，禁错一处就是真的拿不出来。
 
    两个限定条件缺一不可：
    - display-mode: standalone —— 只管「已安装成 App」的形态，浏览器里访问
@@ -266,7 +278,11 @@ textarea,
   :where(
     input,
     textarea,
-    [contenteditable="true"],
+    [contenteditable]:not([contenteditable="false"]),
+    code,
+    pre,
+    samp,
+    .font-mono,
     .markdown,
     .code-highlight,
     .selectable

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -231,6 +231,52 @@ textarea,
   touch-action: manipulation;
 }
 
+/* —— 装成 App 之后的「不可选中」触感 ——
+   浏览器标签页里长按能选中文字、弹出「拷贝 / 查询」系统菜单，这是网页的
+   正常预期；但加到主屏独立打开后，用户会按原生 App 的直觉去操作——长按
+   导航项、按钮、列表行，只会拖出一片蓝色选区和系统菜单，手感立刻「掉回
+   网页」。原生 App 里这些控件文案本来就是选不中的。
+
+   做法是把外壳整体设为不可选，再把**真正值得复制的内容**逐类放开：输入
+   控件、Markdown 正文、代码块，以及显式挂了 .selectable 的文本（对话气泡、
+   系统日志、错误详情、剧情简介、字幕预览等）。
+
+   两个限定条件缺一不可：
+   - display-mode: standalone —— 只管「已安装成 App」的形态，浏览器里访问
+     照旧是网页行为，不剥夺用户随手复制的能力；
+   - pointer: coarse —— 只管手指操作的设备，桌面端安装的 PWA 是鼠标 + 键盘，
+     禁选会直接毁掉拖选复制。
+   两者相与即「手机 / 平板上的 PWA」，iOS 与 Android 一并覆盖。
+
+   放开时 user-select 与 -webkit-touch-callout 必须同时重申：前者是继承属性，
+   后者在 iOS 上同样逐级继承，只改一个会剩下另一个继续拦着（典型症状是
+   文字能选中了、长按却还是不弹拷贝菜单）。 */
+@media (display-mode: standalone) and (pointer: coarse) {
+  body {
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+
+  /* :where() 把优先级压到 0，不去和组件自己的选择器抢。注意本段是无层 CSS，
+     整体优先于 Tailwind 的 @layer utilities——同一个元素上再挂 select-none 是
+     盖不住的，要局部剔除就挂到子元素上（user-select 是继承属性，子元素自身
+     的声明必赢）：系统日志整行放开可选、行内时间戳与级别徽标各自挂
+     select-none 把自己排除在选区外，正是这个用法。 */
+  :where(
+    input,
+    textarea,
+    [contenteditable="true"],
+    .markdown,
+    .code-highlight,
+    .selectable
+  ) {
+    -webkit-user-select: text;
+    user-select: text;
+    -webkit-touch-callout: default;
+  }
+}
+
 /* —— 原生 <select> 下拉弹层的 Windows 修复 ——
    弹层由系统/浏览器绘制，Windows 上部分 Chromium（含 WebView）不跟随页面的
    color-scheme: dark，弹层是系统白底；而选项文字继承页面近白色 --text，

--- a/apps/web/components/agent-conversation-view.tsx
+++ b/apps/web/components/agent-conversation-view.tsx
@@ -326,7 +326,7 @@ function UserBubble({ text, onEdit }: { text: string; onEdit?: () => void }) {
           onClick 挂在气泡而非整行上：右对齐留出的空白不该也是热区。 */}
       <div
         onClick={toggle}
-        className="max-w-[80%] whitespace-pre-wrap break-words rounded-2xl bg-[var(--glass-fill-active)] px-4 py-3 text-body leading-6 text-[var(--text)]"
+        className="selectable max-w-[80%] whitespace-pre-wrap break-words rounded-2xl bg-[var(--glass-fill-active)] px-4 py-3 text-body leading-6 text-[var(--text)]"
       >
         {text}
       </div>
@@ -506,7 +506,7 @@ const ProcessBlock = memo(function ProcessBlock({ segment, active }: { segment: 
               // token（点号不是换行机会点），不断词会把整个消息列撑出横向溢出
               <p
                 key={index}
-                className="whitespace-pre-wrap break-words text-sub leading-5 text-[var(--text-faint)]"
+                className="selectable whitespace-pre-wrap break-words text-sub leading-5 text-[var(--text-faint)]"
               >
                 {item.text}
               </p>
@@ -613,7 +613,7 @@ const ToolCallCard = memo(function ToolCallCard({ tool }: { tool: AgentTurnToolC
           ) : (
             <div
               // 行高用相对值：字号随语义 token 在移动端换档（11→13px），固定 16px 行高会挤死多行日志
-              className={`scroll-thin mt-1 max-h-44 overflow-y-auto whitespace-pre-wrap break-words font-mono text-caption leading-[1.45] ${
+              className={`selectable scroll-thin mt-1 max-h-44 overflow-y-auto whitespace-pre-wrap break-words font-mono text-caption leading-[1.45] ${
                 tool.isError ? "text-[#ff6b6b]" : "text-[var(--text-muted)]"
               }`}
             >
@@ -654,7 +654,7 @@ const CompactionCard = memo(function CompactionCard({
       </button>
       {open && (
         <div className="mt-1.5 space-y-1.5 border-l-2 border-white/[0.08] pl-3">
-          <p className="whitespace-pre-wrap break-words text-sub leading-5 text-[var(--text-faint)]">
+          <p className="selectable whitespace-pre-wrap break-words text-sub leading-5 text-[var(--text-faint)]">
             {segment.summary}
           </p>
           <p className="text-caption text-[var(--text-faint)]">

--- a/apps/web/components/auth-gate.tsx
+++ b/apps/web/components/auth-gate.tsx
@@ -113,7 +113,8 @@ function StartupStatus({
         {failure ? (
           <>
             <h1 className="mt-2 text-title font-semibold text-[var(--text)]">工作台加载失败</h1>
-            <p className="mt-2 text-ui leading-relaxed text-[var(--text-muted)]">
+            {/* 部署出问题时这段报错是用户唯一能拿去求助的线索，PWA 下也必须可选可复制 */}
+            <p className="selectable mt-2 text-ui leading-relaxed text-[var(--text-muted)]">
               {failure.message}
             </p>
             <p className="mt-3 break-all rounded-lg bg-black/25 px-3 py-2 font-mono text-caption text-[var(--text-faint)]">

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -472,7 +472,7 @@ function ExpandablePlot({ text }: { text: string }) {
     <div className="max-w-3xl">
       <p
         ref={paragraphRef}
-        className={`text-on-image text-body-lg leading-7 text-white/78 ${
+        className={`selectable text-on-image text-body-lg leading-7 text-white/78 ${
           expanded ? "" : "line-clamp-4"
         }`}
       >

--- a/apps/web/components/subtitle-preview-dialog.tsx
+++ b/apps/web/components/subtitle-preview-dialog.tsx
@@ -168,7 +168,7 @@ export function SubtitlePreviewDialog({
                   <span>{formatTimestamp(cue.start_ms)}</span>
                   <span className="text-white/30">→ {formatTimestamp(cue.end_ms)}</span>
                 </span>
-                <span className="whitespace-pre-wrap break-words text-ui leading-6 text-white/88">
+                <span className="selectable whitespace-pre-wrap break-words text-ui leading-6 text-white/88">
                   {cue.text}
                 </span>
               </li>

--- a/apps/web/components/system-logs-section.tsx
+++ b/apps/web/components/system-logs-section.tsx
@@ -598,7 +598,9 @@ export function SystemLogsSection() {
 function LogRow({ entry, query }: { entry: LogEntry; query: string }) {
   const style = LEVEL_STYLE[entry.level];
   return (
-    <div className={`flex items-start gap-2.5 px-4 py-[3px] transition-colors hover:bg-white/[0.04] ${style.row}`}>
+    <div
+      className={`selectable flex items-start gap-2.5 px-4 py-[3px] transition-colors hover:bg-white/[0.04] ${style.row}`}
+    >
       <span className="tnum shrink-0 select-none text-[var(--text-faint)]">{entry.time || "​"}</span>
       <span
         className={`mt-[2px] w-[46px] shrink-0 select-none rounded px-1 py-px text-center text-micro font-semibold tracking-wide ${style.badge}`}


### PR DESCRIPTION
移动端把站点加到主屏独立打开后，长按侧栏导航项、按钮、列表行会拖出蓝色
选区并弹出系统「拷贝 / 查询」菜单，手感立刻掉回网页——原生 App 里这些控件
文案本来就是选不中的。

在 (display-mode: standalone) and (pointer: coarse) 下把外壳整体设为
user-select: none + -webkit-touch-callout: none，再逐类放开真正值得复制的
内容：输入控件、Markdown 正文、代码块，以及新增的 .selectable 工具类；对话
气泡、思考过程、工具输出、压缩摘要、系统日志、剧情简介、字幕台词都挂上该类。

两个媒体条件缺一不可：standalone 保证浏览器标签页里访问仍是网页行为，
pointer: coarse 排除桌面端安装的 PWA（鼠标拖选不能禁）。

Chromium 实测（--app 独立窗口 + 触摸模拟）：界面文案三击选区为空、.selectable
正文与输入框照常可选可输入；浏览器形态与桌面 PWA 计算值均维持 auto 不受影响。
日志行整行放开、行内时间戳与级别徽标凭自身 select-none 仍被排除在选区外。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016whXkphBYqZexjX3VxGXXT