### PR TITLE
fix(ui): 详情页横滚行跟随正文栅格，相似推荐不再左戳出一截

### DIFF
--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -402,6 +402,7 @@ export function MediaDetailView({
               title: collection.name,
               items: collection.items,
             }}
+            insetClassName="px-12 max-md:px-4"
           />
         </div>
       )}
@@ -409,7 +410,10 @@ export function MediaDetailView({
       {/* —— 9. 相似推荐 —— */}
       {related.length > 0 && (
         <div className="mt-9">
-          <MediaRow row={{ id: `related-${item.id}`, title: "相似推荐", items: related }} />
+          <MediaRow
+            row={{ id: `related-${item.id}`, title: "相似推荐", items: related }}
+            insetClassName="px-12 max-md:px-4"
+          />
         </div>
       )}
 

--- a/apps/web/components/media-row.tsx
+++ b/apps/web/components/media-row.tsx
@@ -18,6 +18,7 @@ export function MediaRow({
   cardAction,
   cardHref,
   cardRevealInfoOnTouch = false,
+  insetClassName = "px-6 max-md:px-4",
 }: {
   row: MediaRowData;
   moreHref?: Route;
@@ -38,13 +39,20 @@ export function MediaRow({
    * 这类纯信息层的行需要显式打开。
    */
   cardRevealInfoOnTouch?: boolean;
+  /**
+   * 行的左右留白，缺省对齐发现页 / 媒体库首页的 px-6 栅格。影片详情页正文用
+   * px-12，行不跟着改的话标题与海报会比上方的简介、剧照墙往左戳出一截。
+   */
+  insetClassName?: string;
 }) {
   return (
     // content-visibility：视口外的整行（标题 + 几十张海报卡）跳过布局与绘制，
     // 发现页 16 行 / 库首页多行「最近添加」的首帧与滚动成本只与可见行相关；
     // intrinsic-size 先占住一行的近似高度（auto 记住实测值），滚动条不跳
     <section className="relative [contain-intrinsic-size:auto_330px] [content-visibility:auto]">
-      <div className="mb-3 flex items-center justify-between gap-4 px-6 max-md:mb-2 max-md:px-4">
+      <div
+        className={`mb-3 flex items-center justify-between gap-4 max-md:mb-2 ${insetClassName}`}
+      >
         <h3 className="text-on-image text-body-lg font-semibold tracking-[-0.01em] text-[var(--text)]">
           {row.title}
         </h3>
@@ -58,7 +66,7 @@ export function MediaRow({
         )}
       </div>
 
-      <HScroller className="gap-4 px-6 pb-1 pt-1 max-md:gap-3 max-md:px-4">
+      <HScroller className={`gap-4 pb-1 pt-1 max-md:gap-3 ${insetClassName}`}>
         {row.items.map((item) => (
           <div
             key={`${row.id}-${item.id}`}


### PR DESCRIPTION
## 问题

影片详情页（`/media/movie|tv/[id]`）的「相似推荐」和「系列电影」两行，标题与海报卡都比上方的简介、演职员、剧照墙往左多出 24px，看上去像掉出了内容列。

根因：`MediaRow` 把左右留白硬编码成 `px-6`（24px），那是发现页 / 媒体库首页的栅格；而影片详情页正文用的是 `px-12`（48px）。

## 改动

- `apps/web/components/media-row.tsx`：新增可选 prop `insetClassName`，缺省值仍是 `px-6 max-md:px-4`。标题栏与 `HScroller` 共用同一个值，保证标题和卡片永远落在同一条基线上。
- `apps/web/components/media-detail-view.tsx`：「系列电影」与「相似推荐」两处调用传 `px-12 max-md:px-4`。

## Reviewer 需要知道的

- 缺省值不变，发现页（`discover-view.tsx`）与媒体库首页（`library-view.tsx`）的 `MediaRow` 渲染结果零变化。
- 「系列电影」行有同样的错位，一并修了 —— 截图里只有相似推荐是因为那部片没有系列。
- `HScroller` 的左右翻页钮用 `left-2 / right-2` 定位，与行内边距无关，改留白不影响按钮位置。
- 未做浏览器视觉复核：预览面板打开详情页会被重定向到登录页，我不能代用户输入密码。改动是纯 class 替换，`px-12` 已在同一文件的其它区块用到，Tailwind 产物里必然存在。`tsc --noEmit` 在这两个文件上无报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)