### PR TITLE
fix(tasks): 筛选标签按任务生命周期排序，进行中前置

### DIFF
--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -68,8 +68,8 @@ const HISTORY_JOB_STATUSES = new Set<JobStatus>(["succeeded", "cancelled"]);
 
 const VIEW_LABELS: { id: TaskCenterViewName; label: string }[] = [
   { id: "all", label: "全部" },
-  { id: "attention", label: "需要处理" },
   { id: "active", label: "进行中" },
+  { id: "attention", label: "需要处理" },
   { id: "history", label: "已结束" },
 ];
 


### PR DESCRIPTION
## 改了什么

任务中心筛选标签顺序改为 **全部 / 进行中 / 需要处理 / 已结束**（原为 全部 / 需要处理 / 进行中 / 已结束），只动 `VIEW_LABELS` 一行。

「进行中」是打开任务中心最常看的一档，排在「需要处理」之前；整体也顺着任务的生命周期从左到右读。

## Reviewer 需要知道的

- 只改标签栏顺序，**页面正文的分区渲染顺序没变**——仍是「需要你处理」置顶，然后「现在」、刷流做种、历史。
- 这个 commit 原本属于 #167，推送时那个 PR 已经合并关闭，所以单独拆出来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)