### PR TITLE
fix(ui): 影片详情页背景回到全局沉浸，不再只铺局部

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -419,6 +419,47 @@ body::before {
 }
 
 /*
+ * 影片详情页（媒体库条目 / 发现页条目）的「剧照 → 纯黑」渐变板。
+ *
+ * 剧照本身是全站背景（BackdropProvider 的沉浸覆盖层，随页面进入淡入、
+ * 离开淡出），详情页自己不再画任何 Hero 图层；这层渐变挂在页面的滚动容器上，
+ * 顶部一段完全透明让剧照直出，从标题上方开始逐级压暗，到基础信息之后落成
+ * 纯黑并一直铺到内容底部。
+ *
+ * 为什么挂在滚动容器的 background 上、而不是内容层的 div：
+ *   - .scroll-thin 在 WebKit 下是占位的经典滚动条（9px），绝对定位 / 普通流
+ *     的子元素都盖不到滚动条轨道那一条，轨道透明就会漏出一条原图；元素自身
+ *     的 background 覆盖的是 border-box，连轨道一起盖住；
+ *   - background-attachment: local 让渐变随内容一起滚动、并以整个可滚动
+ *     高度为 100%，短内容时也至少铺满容器，底部不会露出剧照。
+ * 渐变起点 --detail-ambient-top = 氛围留白高度 − 内容层上提量（-mt-28 = 112px），
+ * 色阶与原先内容层上的渐变完全一致。
+ */
+.detail-ambient {
+  --detail-ambient-top: calc(max(30vh, 180px) - 112px);
+  background-image: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0) 0,
+    rgba(0, 0, 0, 0) var(--detail-ambient-top),
+    rgba(0, 0, 0, 0.16) calc(var(--detail-ambient-top) + 42px),
+    rgba(0, 0, 0, 0.34) calc(var(--detail-ambient-top) + 78px),
+    rgba(0, 0, 0, 0.55) calc(var(--detail-ambient-top) + 120px),
+    rgba(0, 0, 0, 0.73) calc(var(--detail-ambient-top) + 165px),
+    rgba(0, 0, 0, 0.87) calc(var(--detail-ambient-top) + 210px),
+    rgba(0, 0, 0, 0.96) calc(var(--detail-ambient-top) + 255px),
+    #000 calc(var(--detail-ambient-top) + 315px),
+    #000 100%
+  );
+  background-attachment: local;
+  background-repeat: no-repeat;
+}
+@media (max-width: 767px) {
+  .detail-ambient {
+    --detail-ambient-top: calc(max(22vh, 120px) - 112px);
+  }
+}
+
+/*
  * 氛围页的加载/错误兜底底板。
  *
  * 「氛围页」（首页与两个影片详情页，见 app-shell 的 isHome）刻意不铺全局蒙版，

--- a/apps/web/components/library-item-detail-view.tsx
+++ b/apps/web/components/library-item-detail-view.tsx
@@ -55,6 +55,7 @@ import { getDiscoveryReturnPath } from "@/lib/discovery-return-path";
 import { formatBytes, formatRuntimeMinutes, formatVideoResolution } from "@/lib/format";
 import { USER_LOWEST_SOURCE, mediaSourceDisplayLabel } from "@/lib/media-source-annotation";
 import { useDoubanAppHref } from "@/lib/douban-app-link";
+import { useBackdrop } from "@/lib/backdrop";
 import { resolveRequestUrl } from "@/lib/http";
 import { cachedImageUrl } from "@/lib/image-proxy";
 import { invalidateLibraryDetailSnapshot } from "@/lib/library-detail-snapshot";
@@ -76,7 +77,7 @@ interface SelectedEpisodeContext {
  * （MediaDetailView，纯 TMDB 实时数据）职责不同：这里回答的是
  * 「**我拥有的这份拷贝**是什么」，全部信息来自本地刮削成果与文件本体：
  *
- *   1. Hero 背景优先条目目录里的 fanart（本地美术图接口），其次 TMDB 剧照；
+ *   1. 沉浸背景（全站背景临时换成本片剧照）优先条目目录里的 fanart（本地美术图接口），其次 TMDB 剧照；
  *   2. 简介 / 风格 / 片长 / 演职员来自条目目录的 NFO（TMM/Emby 刮削产物）；
  *   3. 片源规格来自 ffprobe 对文件本体的探测；基础信息展示当前文件的音轨 / 字幕，
  *      底部文件区按物理文件折叠尺寸 / 视频 / 码率，剧集只展示当前选中集；
@@ -168,6 +169,17 @@ export function LibraryItemDetailView({
     setSelectedTrackFileId(null);
     reload();
   }, [reload]);
+
+  // 沉浸背景：进入本页把全站背景临时换成该片剧照（侧栏、外壳留白一起透出，
+  // 不再只铺详情卡片的局部），离开即恢复用户配置的背景——见 lib/backdrop.tsx
+  // 的 setOverrideBackdrop。没有横幅剧照时退回海报，覆盖层自己会铺满作氛围色。
+  const { setOverrideBackdrop } = useBackdrop();
+  const immersiveUrl = detail ? imageUrl(detail.backdrop_url ?? detail.poster_url) : "";
+  useEffect(() => {
+    if (!immersiveUrl) return;
+    setOverrideBackdrop(immersiveUrl);
+    return () => setOverrideBackdrop(null);
+  }, [immersiveUrl, setOverrideBackdrop]);
 
   // 待回收行的恢复 / 立即清理（library-file-recycle.md §7）。
   // 恢复是可逆动作直接执行；清理真删磁盘，做种保护形态额外讲清断种风险
@@ -271,7 +283,6 @@ export function LibraryItemDetailView({
 
   const isMovie = detail.kind === "movie";
   const meta = detail.local_meta;
-  const itemBackdropUrl = imageUrl(detail.backdrop_url ?? detail.poster_url);
   // 片长：NFO 的 runtime 优先，其次任意文件的实测时长
   const runtimeMinutes =
     meta?.runtime_minutes ??
@@ -363,25 +374,11 @@ export function LibraryItemDetailView({
     // 满屏布局，没有留白，圆角直接压在屏幕边上：顶栏的吸顶雾层被这层
     // overflow 一裁，就成了贴在屏幕顶上的一块圆角色块（手机上肉眼可见的
     // 两个缺角），底边同理被 Home 指示条切掉。手机上一律方角、真通栏。
-    <div className="scroll-thin scroll-safe relative isolate h-full overflow-y-auto rounded-2xl bg-black max-md:rounded-none">
-      {/* 背景只属于顶部 Hero：有限高度、随页面滚走；cover 始终等比例缩放，
-          只裁切超出的边缘，不改变图片宽高比。图片自身先在较长区间内淡出到
-          完全透明，真正的容器底边因此只剩下同色黑底，不会形成一条切边。 */}
-      {itemBackdropUrl && (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[calc(30vh+360px)] min-h-[540px] bg-cover bg-center bg-no-repeat max-md:h-[calc(22vh+340px)] max-md:min-h-[460px]"
-          style={{
-            backgroundImage: `url(${JSON.stringify(itemBackdropUrl)})`,
-            WebkitMaskImage:
-              "linear-gradient(to bottom,#000 0%,#000 50%,rgba(0,0,0,.92) 60%,rgba(0,0,0,.65) 72%,rgba(0,0,0,.3) 84%,rgba(0,0,0,.08) 93%,transparent 98%,transparent 100%)",
-            maskImage:
-              "linear-gradient(to bottom,#000 0%,#000 50%,rgba(0,0,0,.92) 60%,rgba(0,0,0,.65) 72%,rgba(0,0,0,.3) 84%,rgba(0,0,0,.08) 93%,transparent 98%,transparent 100%)",
-          }}
-        />
-      )}
-
-      {/* 顶栏首屏只有返回键与操作入口浮在局部剧照上。 */}
+    <div className="detail-ambient scroll-thin scroll-safe relative isolate h-full overflow-y-auto rounded-2xl max-md:rounded-none">
+      {/* 没有任何 Hero 图层：全站背景此刻就是本片剧照（沉浸覆盖 + 本页豁免
+          全局蒙版，见 app-shell 的 isHome），大图直出、零边界；.detail-ambient
+          在滚动容器上铺「透明 → 纯黑」的渐变板托住下方内容（见 globals.css）。
+          顶栏首屏只有返回键与操作入口浮在剧照上。 */}
       <PageNav
         title={detail.title}
         fallback={navFallback}
@@ -433,9 +430,9 @@ export function LibraryItemDetailView({
       {/* 氛围留白：这一段什么都不放，让剧照完整呼吸 */}
       <div className="h-[30vh] min-h-[180px] max-md:h-[22vh] max-md:min-h-[120px]" />
 
-      {/* 内容遮罩与图片透明衰减交叠：用更多低跨度色阶缓慢落黑，避免在某个
-          固定高度突然结束渐变；音轨附近已经接近纯黑，下面则保持全黑。 */}
-      <div className="relative z-10 -mt-28 bg-[linear-gradient(180deg,rgba(0,0,0,0)_0,rgba(0,0,0,0.16)_42px,rgba(0,0,0,0.34)_78px,rgba(0,0,0,0.55)_120px,rgba(0,0,0,0.73)_165px,rgba(0,0,0,0.87)_210px,rgba(0,0,0,0.96)_255px,#000_315px,#000_100%)] pb-12 pt-28">
+      {/* 内容层：-mt-28/pt-28 与 .detail-ambient 的渐变起点对齐——渐变从标题
+          上方开始压暗，音轨附近已接近纯黑，下面保持全黑。 */}
+      <div className="relative z-10 -mt-28 pb-12 pt-28">
       {/* —— 头部信息区 —— */}
       <div className="relative z-10 px-12 pt-6 max-md:px-4 max-md:pt-3">
         <div className="min-w-0 max-w-5xl pb-1">

--- a/apps/web/components/media-detail-view.tsx
+++ b/apps/web/components/media-detail-view.tsx
@@ -56,7 +56,8 @@ import {
  * 片源规格与文件区。
  *
  * 页面纵向结构：
- *   1. 局部 Hero —— 剧照只铺顶部有限高度，cover 等比裁切，不再用全站背景拉满页面；
+ *   1. 沉浸背景 —— 进入本页把全站背景临时换成该片剧照（setOverrideBackdrop），
+ *      页面本身不画 Hero 图层：大图直出、零边界，侧栏与外壳留白一起透出。
  *      顶栏首屏只有一颗返回键浮在剧照上，没有横幅剧照时退回海报作氛围图。
  *   2. 氛围留白 + 渐变内容层 —— 渐变从标题上方开始压暗，并在基础信息之后落成纯黑。
  *   3. 头部信息区 —— 标题 / 核心元信息 / 地区、语言与类型 / 上映日期 / 订阅操作，
@@ -131,6 +132,22 @@ export function MediaDetailView({
   const item = detail?.item ?? listItem;
   usePageTitle(item?.title);
 
+  // 沉浸背景：进入本页把全站背景临时换成该片剧照（侧栏、外壳留白一起透出，
+  // 不再只铺详情卡片的局部），离开即恢复用户配置的背景——与媒体库条目详情页
+  // 同一条链路（见 lib/backdrop.tsx 的 setOverrideBackdrop）。没有横幅剧照时
+  // 退回海报，覆盖层自己会铺满作氛围色。
+  //
+  // 豆瓣来源不换背景：豆瓣只有小尺寸海报、没有高清横幅剧照，铺成全屏背景是
+  // 一片糊图，比用户自己配置的背景差得多。宁可保持原背景，也不要为了沉浸降质。
+  const { setOverrideBackdrop } = useBackdrop();
+  const immersiveUrl =
+    source === "douban" ? "" : item?.backdropUrl || item?.posterUrl || "";
+  useEffect(() => {
+    if (!immersiveUrl) return;
+    setOverrideBackdrop(immersiveUrl);
+    return () => setOverrideBackdrop(null);
+  }, [immersiveUrl, setOverrideBackdrop]);
+
   // 豆瓣外链的移动端 App 直跳：无悬停设备把「豆瓣」外链换成官方分发地址，
   // 装了豆瓣 App 直接拉起进词条页（桌面/未命中时为 null，回落网页地址）
   const doubanAppHref = useDoubanAppHref(source === "douban" ? id : null);
@@ -150,7 +167,6 @@ export function MediaDetailView({
   }
 
   const info = detail?.info;
-  const itemBackdropUrl = item.backdropUrl || item.posterUrl;
   const collection = detail?.collection;
   const related = detail?.related ?? [];
   const libraryLinks = detail?.libraryLinks ?? [];
@@ -194,33 +210,19 @@ export function MediaDetailView({
     // max-md:rounded-none：圆角只在桌面成立（外壳 p-3.5 的留白托着卡片）；
     // 窄屏通栏满屏，圆角会直接压在屏幕边上，把吸顶顶栏裁成一块贴在屏幕顶上的
     // 圆角色块——与 library-item-detail-view 同一处理。
-    <div className="scroll-thin scroll-safe relative isolate h-full overflow-y-auto rounded-2xl bg-black max-md:rounded-none">
-      {/* 背景只属于顶部 Hero：有限高度、随页面滚走；cover 始终等比例缩放，
-          只裁切超出的边缘，不改变图片宽高比。图片自身先在较长区间内淡出到
-          完全透明，真正的容器底边因此只剩下同色黑底，不会形成一条切边。 */}
-      {itemBackdropUrl && (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[calc(30vh+360px)] min-h-[540px] bg-cover bg-center bg-no-repeat max-md:h-[calc(22vh+340px)] max-md:min-h-[460px]"
-          style={{
-            backgroundImage: `url(${JSON.stringify(itemBackdropUrl)})`,
-            WebkitMaskImage:
-              "linear-gradient(to bottom,#000 0%,#000 50%,rgba(0,0,0,.92) 60%,rgba(0,0,0,.65) 72%,rgba(0,0,0,.3) 84%,rgba(0,0,0,.08) 93%,transparent 98%,transparent 100%)",
-            maskImage:
-              "linear-gradient(to bottom,#000 0%,#000 50%,rgba(0,0,0,.92) 60%,rgba(0,0,0,.65) 72%,rgba(0,0,0,.3) 84%,rgba(0,0,0,.08) 93%,transparent 98%,transparent 100%)",
-          }}
-        />
-      )}
-
-      {/* 顶栏首屏只有返回键浮在局部剧照上。 */}
+    <div className="detail-ambient scroll-thin scroll-safe relative isolate h-full overflow-y-auto rounded-2xl max-md:rounded-none">
+      {/* 没有任何 Hero 图层：全站背景此刻就是本片剧照（沉浸覆盖 + 本页豁免
+          全局蒙版，见 app-shell 的 isHome），大图直出、零边界；.detail-ambient
+          在滚动容器上铺「透明 → 纯黑」的渐变板托住下方内容（见 globals.css）。
+          顶栏首屏只有一颗返回键浮在剧照上。 */}
       <PageNav title={item.title} fallback={navFallback} />
 
       {/* 氛围留白：这一段什么都不放，让剧照完整呼吸。 */}
       <div className="h-[30vh] min-h-[180px] max-md:h-[22vh] max-md:min-h-[120px]" />
 
-      {/* 内容遮罩与图片透明衰减交叠：用更多低跨度色阶缓慢落黑，避免在某个
-          固定高度突然结束渐变；基础信息附近已经接近纯黑，下面保持全黑。 */}
-      <div className="relative z-10 -mt-28 bg-[linear-gradient(180deg,rgba(0,0,0,0)_0,rgba(0,0,0,0.16)_42px,rgba(0,0,0,0.34)_78px,rgba(0,0,0,0.55)_120px,rgba(0,0,0,0.73)_165px,rgba(0,0,0,0.87)_210px,rgba(0,0,0,0.96)_255px,#000_315px,#000_100%)] pb-12 pt-28">
+      {/* 内容层：-mt-28/pt-28 与 .detail-ambient 的渐变起点对齐——渐变从标题
+          上方开始压暗，基础信息附近已接近纯黑，下面保持全黑。 */}
+      <div className="relative z-10 -mt-28 pb-12 pt-28">
       {/* —— 3. 头部信息区 —— */}
       <div className="relative z-10 px-12 pt-6 max-md:px-4 max-md:pt-3">
         <div className="min-w-0 max-w-5xl pb-1">


### PR DESCRIPTION
## 问题

两个影片详情页（媒体库条目 `/library/[id]/item/[mediaItemId]`、发现页条目 `/media/...`）的剧照只铺在页面卡片顶部的有限高度里，侧栏和外壳留白仍是用户自己配置的壁纸——一张图被切成一块贴在页面上，与这两页「氛围页、大图直出、零边界」的定位不符。

## 改动

背景改回**全局沉浸**：进页面把全站背景临时换成该片剧照（`BackdropProvider` 的 `setOverrideBackdrop`，图完整加载后才淡入、离开页面淡出恢复用户壁纸），页面自身不再画任何 Hero 图层。

**渐变策略完全不变**，只是承载它的元素从内容层的 `div` 挪到滚动容器上的 `.detail-ambient`：

- **为什么挂在滚动容器的 `background` 上**：`.scroll-thin` 在 WebKit 下是占位式经典滚动条（9px），绝对定位/普通流的子元素都盖不到滚动条轨道那一条，轨道透明就会漏出一条原图；元素自身的 `background` 覆盖 border-box，连轨道一起盖住。
- **`background-attachment: local`**：让渐变随内容一起滚动、并以整个可滚动高度为 100%，短内容（简介/演职员/剧照都缺的小众条目）时也至少铺满容器，底部不会露出剧照。
- **渐变起点**用 `--detail-ambient-top` 对齐氛围留白高度减去内容层上提量（`-mt-28` = 112px），色阶与原先内容层上的逐档一致；窄屏跟随 22vh 断点。

豆瓣来源仍不换背景（只有小尺寸海报，铺满是糊图，不如保持用户配置的壁纸）——与改动前的口径一致。

## 影响面

- `apps/web/app/globals.css`：新增 `.detail-ambient`
- `apps/web/components/library-item-detail-view.tsx`、`apps/web/components/media-detail-view.tsx`：去掉局部 Hero 图层，接回 `setOverrideBackdrop`

`app-shell` 的 `isHome` 豁免规则（这两条路由不铺全局蒙版）本来就在，无需改动。不涉及后端、数据库迁移与运行时依赖。

## 验证

本地起 stub 后端 + Next dev 逐页看过：两个详情页的剧照都铺满整个视口（侧栏、外壳留白一起透出），渐变落黑位置与改动前一致，滚到底部是纯黑无切边、滚动条轨道不漏图；离开页面背景恢复用户壁纸。`tsc --noEmit` 与 `eslint` 对这三个文件均无新增报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)