### PR TITLE
perf(playback): 取流/下载断连即停读盘，中间件改纯 ASGI

### DIFF
--- a/src/movieclaw_api/middleware.py
+++ b/src/movieclaw_api/middleware.py
@@ -1,7 +1,24 @@
+"""全局 HTTP 中间件：spec 指纹头与访问日志。
+
+两者都以**纯 ASGI 中间件**实现，而不是 ``@app.middleware("http")``
+（``BaseHTTPMiddleware``）。原因是 2026-08 NAS 现场事故：
+
+- ``BaseHTTPMiddleware`` 会把响应体的每一块经 anyio 内存流再转发一跳，
+  视频取流/整文件下载按块计费的 CPU 开销直接翻倍；
+- 更要命的是它的 ``receive`` 包装会让 Starlette 1.x 的
+  ``Request.is_disconnected()`` 永远返回 False（预取消的 CancelScope 在到达
+  服务器 receive 前就被中间件内部的检查点取消），任何依赖它停读盘的响应都会
+  在客户端断开后把文件读到底。
+
+纯 ASGI 中间件只包一层 ``send``，不碰 ``receive``、不复制 body，对流式响应
+零开销。
+"""
+
 import logging
 import time
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from movieclaw_api.core.config import Settings
 from movieclaw_api.spec_state import SPEC_HASH_HEADER, get_spec_hash
@@ -9,50 +26,85 @@ from movieclaw_api.spec_state import SPEC_HASH_HEADER, get_spec_hash
 logger = logging.getLogger("movieclaw_api.access")
 
 
-def register_middlewares(app: FastAPI, settings: Settings) -> None:
-    @app.middleware("http")
-    async def spec_hash_header_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
-        """所有 API 响应携带 spec 指纹头，CLI 借此零成本发现版本偏斜。"""
-        response = await call_next(request)
-        if request.url.path.startswith(settings.api_v1_prefix):
-            response.headers[SPEC_HASH_HEADER] = get_spec_hash(request.app)
-        return response
+class SpecHashHeaderMiddleware:
+    """所有 API 响应携带 spec 指纹头，CLI 借此零成本发现版本偏斜。"""
 
-    @app.middleware("http")
-    async def access_log_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+    def __init__(self, app: ASGIApp, *, api_prefix: str) -> None:
+        self.app = app
+        self.api_prefix = api_prefix
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not scope.get("path", "").startswith(self.api_prefix):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_header(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                spec_hash = get_spec_hash(scope["app"])
+                headers.append(
+                    (SPEC_HASH_HEADER.lower().encode("latin-1"), spec_hash.encode("latin-1"))
+                )
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)
+
+
+class AccessLogMiddleware:
+    """访问日志：响应头发出时记一条（含耗时），异常记 500。
+
+    对流式响应（取流/SSE）与 BaseHTTPMiddleware 时代语义一致：在响应头就绪时
+    记录，不等 body 传完。
+    """
+
+    def __init__(self, app: ASGIApp, *, enabled: bool) -> None:
+        self.app = app
+        self.enabled = enabled
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not self.enabled:
+            await self.app(scope, receive, send)
+            return
+        method = scope.get("method", "")
+        path = scope.get("path", "")
         started_at = time.perf_counter()
 
+        async def send_logged(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                duration_ms = (time.perf_counter() - started_at) * 1000
+                log = logger.info
+                if status_code >= 500:
+                    log = logger.error
+                elif status_code >= 400:
+                    log = logger.warning
+                log(
+                    "method=%s path=%s status_code=%s duration_ms=%.2f message=%s",
+                    method,
+                    path,
+                    status_code,
+                    duration_ms,
+                    "request completed",
+                )
+            await send(message)
+
         try:
-            response = await call_next(request)
+            await self.app(scope, receive, send_logged)
         except Exception:
             duration_ms = (time.perf_counter() - started_at) * 1000
-            if settings.access_log_enabled:
-                logger.error(
-                    "method=%s path=%s status_code=%s duration_ms=%.2f message=%s",
-                    request.method,
-                    request.url.path,
-                    500,
-                    duration_ms,
-                    "request failed",
-                )
+            logger.error(
+                "method=%s path=%s status_code=%s duration_ms=%.2f message=%s",
+                method,
+                path,
+                500,
+                duration_ms,
+                "request failed",
+            )
             raise
 
-        duration_ms = (time.perf_counter() - started_at) * 1000
 
-        if settings.access_log_enabled:
-            log = logger.info
-            if response.status_code >= 500:
-                log = logger.error
-            elif response.status_code >= 400:
-                log = logger.warning
-
-            log(
-                "method=%s path=%s status_code=%s duration_ms=%.2f message=%s",
-                request.method,
-                request.url.path,
-                response.status_code,
-                duration_ms,
-                "request completed",
-            )
-
-        return response
+def register_middlewares(app: FastAPI, settings: Settings) -> None:
+    # add_middleware 后注册者在外层：访问日志最外层，与原 @app.middleware 顺序一致
+    app.add_middleware(SpecHashHeaderMiddleware, api_prefix=settings.api_v1_prefix)
+    app.add_middleware(AccessLogMiddleware, enabled=settings.access_log_enabled)

--- a/src/movieclaw_jellyfin/router.py
+++ b/src/movieclaw_jellyfin/router.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.responses import Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from movieclaw_jellyfin.errors import JellyfinError, render_error
 from movieclaw_jellyfin.routes.common import require_enabled
@@ -171,25 +172,52 @@ def register(app: FastAPI) -> None:
         rewritten = [(query_key_map.get(k.lower(), k), v) for k, v in pairs]
         return urlencode(rewritten).encode("latin-1")
 
-    @app.middleware("http")
-    async def jellyfin_case_normalizer(request: Request, call_next):  # type: ignore[no-untyped-def]
-        path = request.scope.get("path", "")
-        parts = path.split("/")
-        in_namespace = len(parts) > 1 and parts[1].lower() in NAMESPACE_PREFIXES
-        if in_namespace:
-            request.scope["path"] = "/".join(_normalize_segment(p) for p in parts)
-            raw_query = request.scope.get("query_string", b"")
+    class JellyfinCaseNormalizer:
+        """纯 ASGI 中间件（不要改回 BaseHTTPMiddleware：它会让取流的断连检测
+        失效并给每个 body 块加一跳转发，见 movieclaw_api/middleware.py）。"""
+
+        def __init__(self, inner: ASGIApp) -> None:
+            self.inner = inner
+
+        async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+            if scope["type"] != "http":
+                await self.inner(scope, receive, send)
+                return
+            path = scope.get("path", "")
+            parts = path.split("/")
+            in_namespace = len(parts) > 1 and parts[1].lower() in NAMESPACE_PREFIXES
+            if not in_namespace:
+                await self.inner(scope, receive, send)
+                return
+            scope["path"] = "/".join(_normalize_segment(p) for p in parts)
+            raw_query = scope.get("query_string", b"")
             if raw_query:
-                request.scope["query_string"] = _normalize_query(raw_query)
-        response = await call_next(request)
-        # 命名空间内未实现的路径/方法（/LiveStreams/Open、master.m3u8 等）会
-        # 落到业务统一处理器，返回 RESOURCE_NOT_FOUND 业务信封——这是最容易
-        # 暴露"不是真 Jellyfin"的地方。路由未匹配（scope 无 route）时改按
-        # 协议形态应答：404/405 空 body，对齐 ASP.NET 终结点兜底
-        if (
-            in_namespace
-            and response.status_code in (404, 405)
-            and "route" not in request.scope
-        ):
-            return Response(status_code=response.status_code)
-        return response
+                scope["query_string"] = _normalize_query(raw_query)
+
+            # 命名空间内未实现的路径/方法（/LiveStreams/Open、master.m3u8 等）会
+            # 落到业务统一处理器，返回 RESOURCE_NOT_FOUND 业务信封——这是最容易
+            # 暴露"不是真 Jellyfin"的地方。路由未匹配（scope 无 route）时改按
+            # 协议形态应答：404/405 空 body，对齐 ASP.NET 终结点兜底
+            swallow_body = False
+
+            async def send_normalized(message: Message) -> None:
+                nonlocal swallow_body
+                if message["type"] == "http.response.start":
+                    if message["status"] in (404, 405) and "route" not in scope:
+                        swallow_body = True
+                        await send(
+                            {
+                                "type": "http.response.start",
+                                "status": message["status"],
+                                "headers": [],
+                            }
+                        )
+                        await send({"type": "http.response.body", "body": b"", "more_body": False})
+                        return
+                elif swallow_body and message["type"] == "http.response.body":
+                    return
+                await send(message)
+
+            await self.inner(scope, receive, send_normalized)
+
+    app.add_middleware(JellyfinCaseNormalizer)

--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -19,7 +19,7 @@ import secrets
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from sqlalchemy import select
 
 from movieclaw_api.services.library.access import member_visible_ids
@@ -133,14 +133,10 @@ async def playback_info(
     files = await _files_for_ref(ref, identity.device.member_id)
     selected = _select_source(files, media_source_id, item_id)
     if not selected:
-        return JSONResponse(
-            {"MediaSources": [], "ErrorCode": "NoCompatibleStream"}
-        )
+        return JSONResponse({"MediaSources": [], "ErrorCode": "NoCompatibleStream"})
     # 播放协商是唯一现读 strm 的场景：直链多带时效签名，须现读现用；
     # 解析失败的版本剔除，全部失败按"无可播源"应答
-    pairs = [
-        (f, s) for f in selected if (s := media_source_dto(f, resolve_strm=True))
-    ]
+    pairs = [(f, s) for f in selected if (s := media_source_dto(f, resolve_strm=True))]
     if not pairs:
         return JSONResponse({"MediaSources": [], "ErrorCode": "NoCompatibleStream"})
 
@@ -172,9 +168,7 @@ def _unit_item_guid(ref: EntityRef) -> str:
     return item_guid(ref.entity_id)
 
 
-def _apply_subtitle_delivery(
-    source: dict, f: LibraryFile, ref: EntityRef, token: str
-) -> None:
+def _apply_subtitle_delivery(source: dict, f: LibraryFile, ref: EntityRef, token: str) -> None:
     """给外挂字幕流补投递字段（仅 PlaybackInfo 场景，jellyfin-subtitle.md §4.3）。
 
     无条件输出是既定偏离：真 Jellyfin 无 DeviceProfile 时不输出，我们不
@@ -193,8 +187,7 @@ def _apply_subtitle_delivery(
         stream["DeliveryMethod"] = "External"
         stream["IsExternalUrl"] = False
         stream["DeliveryUrl"] = (
-            f"/Videos/{item_g}/{ms_g}/Subtitles/{stream['Index']}/0/Stream.{fmt}"
-            f"?ApiKey={token}"
+            f"/Videos/{item_g}/{ms_g}/Subtitles/{stream['Index']}/0/Stream.{fmt}?ApiKey={token}"
         )
 
 
@@ -267,7 +260,6 @@ async def video_stream(
     return DisconnectAwareFileResponse(
         path,
         media_type=media_type,
-        is_disconnected=request.is_disconnected,
         session_stopped=session_stopped,
         on_close=lambda: unregister_device_stream(device_id, session_stopped),
     )
@@ -314,13 +306,15 @@ async def download_item(
     path = Path(f.file_path)
     if not path.is_file():
         raise not_found()
-    # 下载不是播放会话：用普通 FileResponse，不登记设备流，避免用户边下边看
-    # 时点"停止播放"误杀下载读盘（TCP 断连兜底对下载器依然生效）
+    # 下载不是播放会话：不登记设备流，避免用户边下边看时点"停止播放"误杀
+    # 下载读盘；但下载器取消/断网后必须停止读盘（裸 FileResponse 会把几十 GB
+    # 读到底），且保留 Content-Length 供下载器显示进度与续传
     is_download = request.url.path.lower().endswith("/download")
-    return FileResponse(
+    return DisconnectAwareFileResponse(
         path,
         media_type=container_mime_type(f.container or path.suffix),
         filename=path.name if is_download else None,
+        keep_content_length=True,
     )
 
 

--- a/src/movieclaw_playback/streaming.py
+++ b/src/movieclaw_playback/streaming.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from pathlib import Path
 from secrets import token_hex
 from urllib.parse import urlsplit
@@ -79,45 +79,69 @@ def stop_device_streams(device_id: str) -> int:
 
 
 class DisconnectAwareFileResponse(FileResponse):
-    """客户端断开后立即停止读取本地媒体文件的 ``FileResponse``。
+    """客户端断开或播放器上报停止后立即停止读盘的 ``FileResponse``。
 
     Uvicorn 检测到 TCP 连接断开后会静默丢弃后续 ASGI ``send`` 消息；而
     Starlette 原生 ``FileResponse`` 不读取 ``receive``，仍会把整个 Range
     循环从磁盘读完。对数十 GB 的机械盘媒体文件，这会表现为客户端已经退出、
-    服务端却持续高 CPU 和读盘。
+    服务端却持续高 CPU 和读盘（播放器每次 seek 留下的旧 Range 连接都会把
+    文件读到底）。
 
-    该类沿用 Starlette 的 Range 头和分段规则，只在每次读取前后检查连接状态。
-    为了能在停止时以完整的 ASGI body 结束响应，非 HEAD 请求不发送
+    断连检测的实现要点（2026-08 NAS 现场事故的教训）：
+
+    - **不要每块调用** ``Request.is_disconnected()``：Starlette 1.x 的实现是
+      "预取消的 CancelScope + await receive()"，在 ``BaseHTTPMiddleware``
+      包裹下永远在中间件内部的检查点处被取消、**恒返回 False**，而且每块两次
+      取消舞的 CPU 开销比读盘发包本身还高。
+    - 改为响应开始时起**一个**后台任务 ``await receive()``，收到
+      ``http.disconnect`` 就置位 ``_disconnected``；发送循环里只做
+      ``Event.is_set()`` 的同步检查，每块开销趋近于零。
+    - 块大小提到 1 MiB（Starlette 默认 64 KiB）：每块都要经过 ASGI send、
+      中间件转发和 uvicorn 写缓冲，块数少 16 倍就是 CPU 少 16 倍。
+
+    该类沿用 Starlette 的 Range 头和分段规则。为了能在"播放器上报停止、TCP
+    仍连着"时以完整的 ASGI body 结束响应，默认非 HEAD 请求不发送
     ``Content-Length``，由 HTTP 服务器使用 chunked 传输；``206`` 的
-    ``Content-Range`` 仍保留，因此客户端仍可校验请求区间。断开时最多多读
-    一个已在途的 64 KiB 块。
+    ``Content-Range`` 仍保留，因此客户端仍可校验请求区间。
+    ``keep_content_length=True`` 用于整文件下载：下载器依赖 ``Content-Length``
+    显示进度/续传，此模式只响应 TCP 断连（断连后服务器本就丢弃后续 send，
+    直接停止读盘即可），因此不能同时传 ``session_stopped``。
+    断开时最多多读一个已在途的块。
     """
+
+    chunk_size = 1024 * 1024
 
     def __init__(
         self,
         path: str | Path,
         *,
-        is_disconnected: Callable[[], Awaitable[bool]],
         session_stopped: asyncio.Event | None = None,
         on_close: Callable[[], None] | None = None,
+        keep_content_length: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(path, **kwargs)
-        self._is_disconnected = is_disconnected
+        if keep_content_length and session_stopped is not None:
+            raise ValueError(
+                "保留 Content-Length 的响应无法在会话停止时优雅收尾，不能同时登记 session_stopped"
+            )
         self._session_stopped = session_stopped
         self._on_close = on_close
+        self._keep_content_length = keep_content_length
+        self._disconnected = asyncio.Event()
         self._bytes_read = 0
-        self._disconnect_logged = False
+        self._stop_logged = False
 
-    async def _should_stop_reading(self) -> bool:
+    def _should_stop_reading(self) -> bool:
+        """同步、零开销的停止判断；每块调用一次。"""
         if self._session_stopped is not None and self._session_stopped.is_set():
             reason = "播放器已上报停止"
-        elif await self._is_disconnected():
+        elif self._disconnected.is_set():
             reason = "客户端已断开"
         else:
             return False
-        if not self._disconnect_logged:
-            self._disconnect_logged = True
+        if not self._stop_logged:
+            self._stop_logged = True
             logger.info(
                 "%s视频流，停止继续读取（本响应已读取 %d 字节）",
                 reason,
@@ -125,8 +149,25 @@ class DisconnectAwareFileResponse(FileResponse):
             )
         return True
 
+    async def _watch_disconnect(self, receive: Receive) -> None:
+        """后台等待客户端断开。
+
+        请求体（GET/HEAD 为空）消费完后，ASGI 服务器的 ``receive`` 会一直挂起
+        直到连接断开才返回 ``http.disconnect``；BaseHTTPMiddleware 的包装同样
+        会把这条消息透传下来（Starlette 自己的 StreamingResponse 也靠这条路径
+        监听断连）。
+        """
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                self._disconnected.set()
+                return
+            # 防御：某些测试桩/服务器会重复返回空的 http.request，让出事件循环
+            # 避免空转
+            await asyncio.sleep(0)
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        """无论正常结束、客户端断开还是会话取消，都回收设备流登记。"""
+        """无论正常结束、客户端断开还是会话取消，都回收设备流登记与监听任务。"""
         # pathsend 会把文件路径交给 ASGI 服务器，之后应用层既不能观察 Stopped，
         # 也无法中止服务器的持续读盘。视频流必须由本响应逐块读取和检查。
         extensions = scope.get("extensions")
@@ -139,9 +180,11 @@ class DisconnectAwareFileResponse(FileResponse):
                     if key != "http.response.pathsend"
                 },
             }
+        watcher = asyncio.ensure_future(self._watch_disconnect(receive))
         try:
             await super().__call__(scope, receive, send)
         finally:
+            watcher.cancel()
             if self._on_close is not None:
                 self._on_close()
 
@@ -149,14 +192,40 @@ class DisconnectAwareFileResponse(FileResponse):
         self, headers: list[tuple[bytes, bytes]] | None = None
     ) -> list[tuple[bytes, bytes]]:
         """移除长度头，使提前停止可以用 ASGI 结束帧正常结束 chunked 响应。"""
+        if self._keep_content_length:
+            return list(headers or self.raw_headers)
         mutable_headers = MutableHeaders(raw=list(headers or self.raw_headers))
         if "content-length" in mutable_headers:
             del mutable_headers["content-length"]
         return mutable_headers.raw
 
     async def _finish_stopped_response(self, send: Send) -> None:
-        """已发送响应头后收尾，避免 ASGI 应用以未完成的 body 返回。"""
+        """已发送响应头后收尾，避免 ASGI 应用以未完成的 body 返回。
+
+        保留 Content-Length 的模式只会因 TCP 断连而停止，此时服务器已丢弃
+        后续 send，补发结束帧反而会触发"body 短于 Content-Length"的协议错误。
+        """
+        if self._keep_content_length:
+            return
         await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    async def _send_span(self, file, send: Send, start: int, end: int | None) -> None:
+        """把文件 ``[start, end)`` 区间逐块发出，中途停止则收尾后返回。
+
+        ``end`` 为 None 表示读到文件末尾（无 Range 的整文件响应）。
+        """
+        await file.seek(start)
+        more_body = True
+        while more_body:
+            if self._should_stop_reading():
+                await self._finish_stopped_response(send)
+                return
+            size = self.chunk_size if end is None else min(self.chunk_size, end - start)
+            chunk = await file.read(size)
+            self._bytes_read += len(chunk)
+            start += len(chunk)
+            more_body = len(chunk) == self.chunk_size and (end is None or start < end)
+            await send({"type": "http.response.body", "body": chunk, "more_body": more_body})
 
     async def _handle_simple(
         self, send: Send, send_header_only: bool, _send_pathsend: bool
@@ -171,24 +240,11 @@ class DisconnectAwareFileResponse(FileResponse):
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
             return
-        if await self._should_stop_reading():
+        if self._should_stop_reading():
             await self._finish_stopped_response(send)
             return
         async with await anyio.open_file(self.path, mode="rb") as file:
-            more_body = True
-            while more_body:
-                if await self._should_stop_reading():
-                    await self._finish_stopped_response(send)
-                    return
-                chunk = await file.read(self.chunk_size)
-                self._bytes_read += len(chunk)
-                more_body = len(chunk) == self.chunk_size
-                if await self._should_stop_reading():
-                    await self._finish_stopped_response(send)
-                    return
-                await send(
-                    {"type": "http.response.body", "body": chunk, "more_body": more_body}
-                )
+            await self._send_span(file, send, 0, None)
 
     async def _handle_single_range(
         self, send: Send, start: int, end: int, file_size: int, send_header_only: bool
@@ -200,34 +256,17 @@ class DisconnectAwareFileResponse(FileResponse):
             {
                 "type": "http.response.start",
                 "status": 206,
-                "headers": (
-                    headers.raw if send_header_only else self._stream_headers(headers.raw)
-                ),
+                "headers": (headers.raw if send_header_only else self._stream_headers(headers.raw)),
             }
         )
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
             return
-        if await self._should_stop_reading():
+        if self._should_stop_reading():
             await self._finish_stopped_response(send)
             return
         async with await anyio.open_file(self.path, mode="rb") as file:
-            await file.seek(start)
-            more_body = True
-            while more_body:
-                if await self._should_stop_reading():
-                    await self._finish_stopped_response(send)
-                    return
-                chunk = await file.read(min(self.chunk_size, end - start))
-                self._bytes_read += len(chunk)
-                start += len(chunk)
-                more_body = len(chunk) == self.chunk_size and start < end
-                if await self._should_stop_reading():
-                    await self._finish_stopped_response(send)
-                    return
-                await send(
-                    {"type": "http.response.body", "body": chunk, "more_body": more_body}
-                )
+            await self._send_span(file, send, start, end)
 
     async def _handle_multiple_ranges(
         self,
@@ -247,20 +286,18 @@ class DisconnectAwareFileResponse(FileResponse):
             {
                 "type": "http.response.start",
                 "status": 206,
-                "headers": (
-                    headers.raw if send_header_only else self._stream_headers(headers.raw)
-                ),
+                "headers": (headers.raw if send_header_only else self._stream_headers(headers.raw)),
             }
         )
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
             return
-        if await self._should_stop_reading():
+        if self._should_stop_reading():
             await self._finish_stopped_response(send)
             return
         async with await anyio.open_file(self.path, mode="rb") as file:
             for start, end in ranges:
-                if await self._should_stop_reading():
+                if self._should_stop_reading():
                     await self._finish_stopped_response(send)
                     return
                 await send(
@@ -272,15 +309,12 @@ class DisconnectAwareFileResponse(FileResponse):
                 )
                 await file.seek(start)
                 while start < end:
-                    if await self._should_stop_reading():
+                    if self._should_stop_reading():
                         await self._finish_stopped_response(send)
                         return
                     chunk = await file.read(min(self.chunk_size, end - start))
                     self._bytes_read += len(chunk)
                     start += len(chunk)
-                    if await self._should_stop_reading():
-                        await self._finish_stopped_response(send)
-                        return
                     await send({"type": "http.response.body", "body": chunk, "more_body": True})
                 await send({"type": "http.response.body", "body": b"\r\n", "more_body": True})
             await send(

--- a/tests/playback/test_streaming.py
+++ b/tests/playback/test_streaming.py
@@ -25,8 +25,30 @@ def _scope(
     }
 
 
+def _receiver(disconnect_after: int | None = None):
+    """模拟 ASGI 服务器的 receive：先给空请求体，之后挂起直到断连。
+
+    ``disconnect_after=N`` 表示第 N 次 receive 调用时返回 http.disconnect。
+    """
+    calls = 0
+
+    async def receive() -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if disconnect_after is not None and calls >= disconnect_after:
+            return {"type": "http.disconnect"}
+        if calls == 1:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    return receive
+
+
 async def _receive() -> dict[str, Any]:
-    return {"type": "http.request", "body": b"", "more_body": False}
+    """连接保持、永不断开的 receive（请求体为空，GET/HEAD 不会再读它）。"""
+    await asyncio.Event().wait()
+    raise AssertionError("unreachable")
 
 
 def _sender(messages: list[dict[str, Any]]):
@@ -44,15 +66,13 @@ async def test_disconnect_aware_file_response_skips_open_when_client_is_gone(
     video.write_bytes(b"x" * 128)
     messages: list[dict[str, Any]] = []
 
-    async def disconnected() -> bool:
-        return True
-
     async def should_not_open(*args: Any, **kwargs: Any) -> None:
         raise AssertionError("断开的客户端不应继续打开媒体文件")
 
     monkeypatch.setattr("movieclaw_playback.streaming.anyio.open_file", should_not_open)
-    response = DisconnectAwareFileResponse(video, is_disconnected=disconnected)
-    await response(_scope(), _receive, _sender(messages))
+    response = DisconnectAwareFileResponse(video)
+    # 第一次 receive 就是 http.disconnect：监听任务先于打开文件前置位
+    await response(_scope(), _receiver(disconnect_after=1), _sender(messages))
 
     assert messages[0]["type"] == "http.response.start"
     assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
@@ -66,10 +86,7 @@ async def test_disconnect_aware_file_response_disables_pathsend(
     video.write_bytes(b"x" * 128)
     messages: list[dict[str, Any]] = []
 
-    async def connected() -> bool:
-        return False
-
-    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    response = DisconnectAwareFileResponse(video)
     await response(
         {**_scope(), "extensions": {"http.response.pathsend": {}}},
         _receive,
@@ -95,16 +112,12 @@ async def test_stopped_playback_signal_skips_opening_the_file(
     stopped = asyncio.Event()
     stopped.set()
 
-    async def connected() -> bool:
-        return False
-
     async def should_not_open(*args: Any, **kwargs: Any) -> None:
         raise AssertionError("Stopped 后不应继续打开媒体文件")
 
     monkeypatch.setattr("movieclaw_playback.streaming.anyio.open_file", should_not_open)
     response = DisconnectAwareFileResponse(
         video,
-        is_disconnected=connected,
         session_stopped=stopped,
     )
     await response(_scope(), _receive, _sender(messages))
@@ -139,9 +152,6 @@ async def test_stopped_playback_signal_stops_active_stream_before_next_chunk(
     messages: list[dict[str, Any]] = []
     stopped = asyncio.Event()
 
-    async def connected() -> bool:
-        return False
-
     async def send(message: dict[str, Any]) -> None:
         messages.append(message)
         if message.get("body") == content[: DisconnectAwareFileResponse.chunk_size]:
@@ -149,7 +159,6 @@ async def test_stopped_playback_signal_stops_active_stream_before_next_chunk(
 
     response = DisconnectAwareFileResponse(
         video,
-        is_disconnected=connected,
         session_stopped=stopped,
     )
     await response(_scope(), _receive, send)
@@ -165,13 +174,21 @@ async def test_disconnect_aware_file_response_stops_before_next_chunk(tmp_path: 
     content = b"x" * (DisconnectAwareFileResponse.chunk_size * 2)
     video.write_bytes(content)
     messages: list[dict[str, Any]] = []
-    checks = iter((False, False, False, True))
+    disconnect = asyncio.Event()
 
-    async def disconnected() -> bool:
-        return next(checks)
+    async def receive() -> dict[str, Any]:
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
 
-    response = DisconnectAwareFileResponse(video, is_disconnected=disconnected)
-    await response(_scope(), _receive, _sender(messages))
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+        if message.get("body") == content[: DisconnectAwareFileResponse.chunk_size]:
+            # 第一块刚发出客户端就断开；监听任务在下一块读取前置位
+            disconnect.set()
+            await asyncio.sleep(0)
+
+    response = DisconnectAwareFileResponse(video)
+    await response(_scope(), receive, send)
 
     body = b"".join(message.get("body", b"") for message in messages)
     assert body == content[: DisconnectAwareFileResponse.chunk_size]
@@ -185,10 +202,7 @@ async def test_disconnect_aware_file_response_keeps_range_response(tmp_path: Pat
     video.write_bytes(content)
     messages: list[dict[str, Any]] = []
 
-    async def connected() -> bool:
-        return False
-
-    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    response = DisconnectAwareFileResponse(video)
     await response(
         _scope(headers=[(b"range", b"bytes=100-69999")]),
         _receive,
@@ -210,10 +224,7 @@ async def test_disconnect_aware_file_response_keeps_head_response(tmp_path: Path
     video.write_bytes(b"x" * 128)
     messages: list[dict[str, Any]] = []
 
-    async def connected() -> bool:
-        return False
-
-    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    response = DisconnectAwareFileResponse(video)
     await response(_scope(method="HEAD"), _receive, _sender(messages))
 
     headers = {key.decode(): value.decode() for key, value in messages[0]["headers"]}
@@ -230,10 +241,7 @@ async def test_disconnect_aware_file_response_keeps_multiple_range_response(
     video.write_bytes(content)
     messages: list[dict[str, Any]] = []
 
-    async def connected() -> bool:
-        return False
-
-    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    response = DisconnectAwareFileResponse(video)
     await response(
         _scope(headers=[(b"range", b"bytes=0-9,100-109")]),
         _receive,
@@ -257,10 +265,7 @@ async def test_disconnect_aware_file_response_keeps_head_range_response(tmp_path
     video.write_bytes(b"x" * 128)
     messages: list[dict[str, Any]] = []
 
-    async def connected() -> bool:
-        return False
-
-    response = DisconnectAwareFileResponse(video, is_disconnected=connected)
+    response = DisconnectAwareFileResponse(video)
     await response(
         _scope(method="HEAD", headers=[(b"range", b"bytes=10-29")]),
         _receive,
@@ -282,12 +287,8 @@ async def test_stopped_playback_ends_multiple_range_response(tmp_path: Path) -> 
     stopped = asyncio.Event()
     stopped.set()
 
-    async def connected() -> bool:
-        return False
-
     response = DisconnectAwareFileResponse(
         video,
-        is_disconnected=connected,
         session_stopped=stopped,
     )
     await response(
@@ -298,3 +299,40 @@ async def test_stopped_playback_ends_multiple_range_response(tmp_path: Path) -> 
 
     assert messages[0]["status"] == 206
     assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_keep_content_length_mode_keeps_header_and_stops_silently(tmp_path: Path) -> None:
+    """整文件下载：保留 Content-Length 供下载器续传；断连后直接停读盘、不补结束帧。"""
+    video = tmp_path / "movie.mkv"
+    content = b"x" * (DisconnectAwareFileResponse.chunk_size * 3)
+    video.write_bytes(content)
+    messages: list[dict[str, Any]] = []
+    disconnect = asyncio.Event()
+
+    async def receive() -> dict[str, Any]:
+        await disconnect.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, Any]) -> None:
+        messages.append(message)
+        if message.get("body") == content[: DisconnectAwareFileResponse.chunk_size]:
+            disconnect.set()
+            await asyncio.sleep(0)
+
+    response = DisconnectAwareFileResponse(video, keep_content_length=True)
+    await response(_scope(), receive, send)
+
+    headers = {key.decode(): value.decode() for key, value in messages[0]["headers"]}
+    assert headers["content-length"] == str(len(content))
+    body = b"".join(message.get("body", b"") for message in messages)
+    assert body == content[: DisconnectAwareFileResponse.chunk_size]
+    # 断连后服务器已丢弃 send，不能再补 more_body=False 的空帧（会触发长度不符）
+    assert messages[-1]["more_body"] is True
+
+
+def test_keep_content_length_rejects_session_stopped(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        DisconnectAwareFileResponse(
+            tmp_path / "x.mkv", keep_content_length=True, session_stopped=asyncio.Event()
+        )


### PR DESCRIPTION
## 背景

NAS 现场 movieclaw 容器常驻 ~106% CPU、7.6 GiB 内存（页缓存），并发下载跑不满带宽。
采样发现 Python 进程 10 秒读盘 203 MB、socket 只写 50 KB：**客户端断开后仍把整个文件读到底**。

## 根因

- Starlette 1.x `Request.is_disconnected()` 的实现是"预取消 CancelScope + await receive()"，
  在 `BaseHTTPMiddleware` 包裹下永远在中间件内部检查点被取消、**恒返回 False**（本地用真实 uvicorn 复现：
  无中间件 1 秒停读，有中间件读到 2 GB 末尾）。
- 且每个 64 KiB 块两次取消舞 + 3 层 BaseHTTPMiddleware 逐块转发，CPU 开销数倍于读盘发包本身。
- 播放器每次 seek 留下的旧 Range 连接都会这样把几十 GB 读完 → 常驻高 CPU + 页缓存吃光内存 + 挤占真实下载。

## 改动

- `DisconnectAwareFileResponse`：响应开始起一个后台任务 `await receive()`，收到 `http.disconnect` 置位 Event；发送循环只做同步 `is_set()`。块大小 64 KiB → 1 MiB。
- `/Items/{id}/Download` 也改用该响应（`keep_content_length=True` 模式：保留 Content-Length 供下载器续传，只响应 TCP 断连），裸 `FileResponse` 同样会幽灵读。
- 访问日志、spec 指纹头、Jellyfin 大小写归一化三处中间件改为纯 ASGI（不复制 body、不包 receive）。

## 验证

- `tests/playback tests/jellyfin tests/api` 全绿；新增 keep_content_length 两条测试。
- 本地真实 uvicorn + 中间件栈：限速 20 MB/s、2 秒断开，两种模式均在一块内停读。
- NAS dev overlay 实测：中止 64 MiB 下载后 10 秒仅再读 1.6 MB（修复前 203 MB）；容器 106%→0.85% CPU。

🤖 Generated with [Claude Code](https://claude.com/claude-code)