### PR TITLE
fix(ui): 下载器设置改单开手风琴与站点页同款；任务中心排版收口

### DIFF
--- a/apps/web/components/downloader-config-section.tsx
+++ b/apps/web/components/downloader-config-section.tsx
@@ -6,7 +6,14 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
 import { DirectoryPicker } from "@/components/directory-picker";
 import { useConfirm } from "@/components/feedback";
-import { DownloadIcon, FolderIcon, MoreIcon, PlusIcon, XIcon } from "@/components/icons";
+import {
+  ChevronDownIcon,
+  DownloadIcon,
+  FolderIcon,
+  MoreIcon,
+  PlusIcon,
+  XIcon,
+} from "@/components/icons";
 import { useBackdrop } from "@/lib/backdrop";
 import { Modal } from "@/components/modal";
 import {
@@ -66,7 +73,9 @@ export function DownloaderConfigSection() {
   const [error, setError] = useState<string | null>(null);
   // 是否展开「添加下载器」面板
   const [adding, setAdding] = useState(false);
-  // 当前展开编辑表单的下载器 id（null 表示没有展开的编辑表单）
+  // 当前展开详情的下载器（单开手风琴，与站点列表同款交互）
+  const [expanded, setExpanded] = useState<number | null>(null);
+  // 当前亮出编辑表单的下载器 id（表单嵌在详情里；菜单「编辑配置」会先展开详情）
   const [editing, setEditing] = useState<number | null>(null);
 
   const load = useCallback(async () => {
@@ -96,6 +105,7 @@ export function DownloaderConfigSection() {
     if (!suggestMapping || loading || suggestConsumed.current || downloaders.length === 0) return;
     suggestConsumed.current = true;
     const target = downloaders.find((d) => d.is_default) ?? downloaders[0];
+    setExpanded(target.id);
     setEditing(target.id);
   }, [suggestMapping, loading, downloaders]);
 
@@ -171,9 +181,9 @@ export function DownloaderConfigSection() {
         </div>
       </div>
 
-      {/* 「添加下载器」面板 */}
+      {/* 「添加下载器」面板：与站点页的添加面板同款扁平容器 */}
       {adding && (
-        <div className="css-glass !rounded-xl p-4">
+        <div className="rounded-xl border border-white/[0.08] bg-white/[0.03] p-4">
           <DownloaderForm
             downloader={null}
             onSubmit={async (payload) => {
@@ -186,37 +196,46 @@ export function DownloaderConfigSection() {
         </div>
       )}
 
-      {/* 已配置下载器列表 */}
-      <div className="space-y-2.5">
-        {loading ? (
-          <>
-            <div className="h-[72px] animate-pulse rounded-xl bg-white/[0.04]" />
-            <div className="h-[72px] animate-pulse rounded-xl bg-white/[0.04]" />
-          </>
-        ) : downloaders.length === 0 ? (
-          <div className="css-glass flex flex-col items-center gap-3 !rounded-2xl px-6 py-12 text-center">
-            <span className="icon-chip size-12 !rounded-2xl">
-              <DownloadIcon className="size-6" />
-            </span>
-            <div>
-              <p className="text-body font-medium text-[var(--text)]">还没有接入任何下载器</p>
-              <p className="mt-1 text-sub text-[var(--text-muted)]">
-                点击右上角「添加下载器」，支持 qBittorrent 和 Transmission。
-              </p>
-            </div>
+      {/* 已配置下载器列表：扁平面板容器，行式布局 */}
+      {loading ? (
+        <div className="space-y-px overflow-hidden rounded-xl border border-white/[0.08]">
+          <div className="h-14 animate-pulse bg-white/[0.04]" />
+          <div className="h-14 animate-pulse bg-white/[0.04]" />
+        </div>
+      ) : downloaders.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-white/[0.08] bg-white/[0.03] px-6 py-12 text-center">
+          <span className="icon-chip size-12 !rounded-2xl">
+            <DownloadIcon className="size-6" />
+          </span>
+          <div>
+            <p className="text-body font-medium text-[var(--text)]">还没有接入任何下载器</p>
+            <p className="mt-1 text-sub text-[var(--text-muted)]">
+              点击右上角「添加下载器」，支持 qBittorrent 和 Transmission。
+            </p>
           </div>
-        ) : (
-          downloaders.map((downloader) => (
-            <DownloaderCard
+        </div>
+      ) : (
+        <div className="divide-y divide-white/[0.06] overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.03]">
+          {downloaders.map((downloader) => (
+            <DownloaderRow
               key={downloader.id}
               downloader={downloader}
               suggestMapping={suggestMapping}
               autoOpenLimits={autoLimitsId === downloader.id}
-              expanded={editing === downloader.id}
-              onToggleForm={(open) => setEditing(open ? downloader.id : null)}
+              expanded={expanded === downloader.id}
+              editing={editing === downloader.id}
+              onToggle={() =>
+                setExpanded((cur) => (cur === downloader.id ? null : downloader.id))
+              }
+              onEdit={() => {
+                setExpanded(downloader.id);
+                setEditing(downloader.id);
+              }}
+              onCloseEdit={() => setEditing((cur) => (cur === downloader.id ? null : cur))}
               onChanged={upsert}
               onDeleted={(id) => {
                 setDownloaders((prev) => prev.filter((d) => d.id !== id));
+                setExpanded((cur) => (cur === id ? null : cur));
                 setEditing((cur) => (cur === id ? null : cur));
                 // 删除默认时后端会把默认让给另一台，整体刷新拿到新归属
                 void load();
@@ -224,23 +243,30 @@ export function DownloaderConfigSection() {
               onRefresh={() => void load()}
               onError={setError}
             />
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
-/* —— 单个下载器卡片：折叠态展示状态 + 操作，展开态是连接表单 —— */
+/* —— 下载器行：一行一台，P0 常驻（名称 / 默认 / 状态）；点击整行展开详情 ——
+   与站点行同构：操作全收进 ⋯ 菜单（启停 / 编辑 / 限速 / 默认 / 重测 / 删除），
+   视觉不用玻璃质感与 WebGL 开关，配置页要的是轻和稳。 */
 
-interface DownloaderCardProps {
+interface DownloaderRowProps {
   downloader: ConfiguredDownloader;
   /** 体检跳转建议预填的映射本机侧路径（无建议时为 null） */
   suggestMapping: string | null;
   /** 拥堵提示跳转（?limits=<id>）：挂载后自动打开「限速与队列」弹窗 */
   autoOpenLimits?: boolean;
   expanded: boolean;
-  onToggleForm: (open: boolean) => void;
+  /** 编辑表单是否亮出（嵌在详情里） */
+  editing: boolean;
+  onToggle: () => void;
+  /** 确保展开并亮出编辑表单（菜单「编辑配置」） */
+  onEdit: () => void;
+  onCloseEdit: () => void;
   onChanged: (downloader: ConfiguredDownloader) => void;
   onDeleted: (id: number) => void;
   /** 需要整体刷新列表的操作（如设默认会同时改动其他条目）之后调用 */
@@ -248,18 +274,20 @@ interface DownloaderCardProps {
   onError: (message: string) => void;
 }
 
-function DownloaderCard({
+function DownloaderRow({
   downloader,
   suggestMapping,
   autoOpenLimits = false,
   expanded,
-  onToggleForm,
+  editing,
+  onToggle,
+  onEdit,
+  onCloseEdit,
   onChanged,
   onDeleted,
   onRefresh,
   onError,
-}: DownloaderCardProps) {
-  const { backdrop } = useBackdrop();
+}: DownloaderRowProps) {
   const confirm = useConfirm();
   const [busy, setBusy] = useState(false);
   const [limitsOpen, setLimitsOpen] = useState(false);
@@ -268,6 +296,7 @@ function DownloaderCard({
     if (autoOpenLimits) setLimitsOpen(true);
   }, [autoOpenLimits]);
   const meta = STATUS_META[downloader.status];
+  const failed = downloader.status === "failed" && !!downloader.last_error;
 
   async function guard(fn: () => Promise<void>) {
     setBusy(true);
@@ -280,66 +309,98 @@ function DownloaderCard({
     }
   }
 
-  // 副标题：失败时给出原因，正常时展示 类型 + 版本 + 上次检查时间
-  const subtitle =
-    downloader.status === "failed" && downloader.last_error
-      ? downloader.last_error
-      : [
-          TYPE_LABEL[downloader.client_type],
-          downloader.version,
-          `上次检查 ${formatRelativeTime(downloader.last_checked_at)}`,
-        ]
-          .filter(Boolean)
-          .join(" · ");
+  // 副标题：类型 + 版本 + 上次检查时间（失败原因另起一行红字，不挤在这里）
+  const subtitle = [
+    TYPE_LABEL[downloader.client_type],
+    downloader.version,
+    downloader.last_checked_at ? `上次检查 ${formatRelativeTime(downloader.last_checked_at)}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
-    <div className="css-glass !rounded-xl">
-      <div className="flex items-center gap-3.5 p-4">
-        <span className="icon-chip size-10 !rounded-xl">
-          <DownloadIcon className="size-5" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <p className="truncate text-body font-semibold text-[var(--text)]">{downloader.name}</p>
-            {downloader.is_default && (
-              <span className="shrink-0 rounded-full border border-white/[0.12] bg-[var(--accent-soft)] px-2 py-0.5 text-caption font-semibold text-[var(--accent)]">
-                默认
+    <div className={downloader.enabled ? "" : "opacity-60"}>
+      {/* 行主体：整行是展开热区。桌面单行；移动端错误原因折到第二行 */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        className={`group flex min-h-[56px] cursor-pointer flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5 transition-colors hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-white/25 sm:px-5 sm:py-3 ${
+          expanded ? "bg-white/[0.045]" : ""
+        }`}
+      >
+        {/* P0：图标 + 名称（可点开 WebUI）+ 默认 + 状态 */}
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <span className="icon-chip size-9 shrink-0 !rounded-xl">
+            <DownloadIcon className="size-[18px]" />
+          </span>
+          <div className="min-w-0">
+            {/* 窄屏徽章允许折到名称下一行，别把名称挤成两个字 */}
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+              <a
+                href={downloader.url}
+                target="_blank"
+                rel="noreferrer"
+                title="在新窗口打开下载器 WebUI"
+                onClick={(e) => e.stopPropagation()}
+                className="truncate text-ui font-semibold text-[var(--text)] underline decoration-transparent underline-offset-4 transition-colors hover:text-white/80 hover:decoration-white/50"
+              >
+                {downloader.name}
+              </a>
+              {downloader.is_default && (
+                <span className="shrink-0 rounded-full border border-white/[0.12] bg-[var(--accent-soft)] px-2 py-0.5 text-caption font-semibold text-[var(--accent)]">
+                  默认
+                </span>
+              )}
+              <span
+                className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
+                style={{
+                  background: `color-mix(in oklab, ${meta.color} 12%, transparent)`,
+                  color: meta.color,
+                }}
+              >
+                <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
+                {meta.label}
               </span>
-            )}
-            <span
-              className="flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-caption font-medium"
-              style={{ background: `color-mix(in oklab, ${meta.color} 12%, transparent)`, color: meta.color }}
-            >
-              <span className="size-1.5 rounded-full" style={{ background: meta.color }} />
-              {meta.label}
-            </span>
+              {!downloader.enabled && (
+                <span className="shrink-0 rounded-full bg-white/[0.08] px-2 py-0.5 text-caption font-medium text-[var(--text-muted)]">
+                  已停用
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]">{subtitle}</p>
           </div>
-          <p className="mt-0.5 truncate text-caption text-[var(--text-faint)]" title={downloader.url}>
-            {subtitle}
-          </p>
         </div>
 
-        <div className="flex shrink-0 items-center gap-2">
-          {/* 启用开关：与站点卡片同款受控 WebGL 液态玻璃开关 */}
-          <LiquidGlassButton
-            backgroundImage={backdrop}
-            variant="dark"
-            checked={downloader.enabled}
-            disabled={busy}
-            aria-label={downloader.enabled ? "已启用，点击停用" : "已停用，点击启用"}
-            onCheckedChange={(enabled) =>
+        {/* P1：连接失败时把原因亮出来——那一刻没有比它更重要的信息 */}
+        {failed && (
+          <p className="order-3 basis-full truncate text-caption text-[var(--danger)] sm:order-none sm:max-w-[40%] sm:basis-auto">
+            {downloader.last_error}
+          </p>
+        )}
+
+        {/* 控制区：展开箭头 + 操作菜单 */}
+        <div className="flex shrink-0 items-center gap-0.5">
+          <span className="flex size-7 items-center justify-center rounded-full text-[var(--text-faint)] transition-colors group-hover:bg-white/[0.08] group-hover:text-[var(--text-muted)]">
+            <ChevronDownIcon
+              className={`size-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+            />
+          </span>
+          <DownloaderActionsMenu
+            downloader={downloader}
+            busy={busy}
+            editing={editing}
+            onSetEnabled={(enabled) =>
               void guard(async () => onChanged(await setDownloaderEnabled(downloader.id, enabled)))
             }
-            className="!min-h-0 !w-auto !gap-0 !bg-transparent !p-0"
-          >
-            <span className="sr-only">{downloader.enabled ? "已启用" : "已停用"}</span>
-          </LiquidGlassButton>
-          <DownloaderActionsMenu
-            expanded={expanded}
-            busy={busy}
-            isDefault={downloader.is_default}
-            canReverify={!IN_PROGRESS.includes(downloader.status)}
-            onEdit={() => onToggleForm(!expanded)}
+            onEdit={editing ? onCloseEdit : onEdit}
             onLimits={() => setLimitsOpen(true)}
             onSetDefault={() =>
               void guard(async () => {
@@ -371,32 +432,51 @@ function DownloaderCard({
         </div>
       </div>
 
-      {/* 连接信息带：地址、默认保存目录与路径映射，一眼可核对 */}
-      <div className="flex flex-wrap gap-x-7 gap-y-2 border-t border-white/[0.06] px-4 py-3">
-        <InfoStat label="地址" value={downloader.url} />
-        {downloader.username && <InfoStat label="用户名" value={downloader.username} />}
-        <InfoStat label="默认保存目录" value={downloader.save_path ?? "下载器默认"} />
-        {(downloader.path_mappings?.length ?? 0) > 0 && (
-          <InfoStat
-            label="路径映射"
-            value={downloader.path_mappings!.map((m) => `${m.local} → ${m.remote}`).join("；")}
-          />
-        )}
-      </div>
-
-      {/* 展开态：编辑表单 */}
+      {/* 展开详情：连接 / 保存目录 / 路径映射，以及嵌入的编辑表单 */}
       {expanded && (
-        <div className="border-t border-white/[0.06] p-4">
-          <DownloaderForm
-            downloader={downloader}
-            suggestMapping={suggestMapping}
-            onSubmit={async (payload) => {
-              onChanged(await updateDownloader(downloader.id, payload));
-              onToggleForm(false);
-            }}
-            onCancel={() => onToggleForm(false)}
-            onError={onError}
-          />
+        <div className="divide-y divide-white/[0.05] border-t border-white/[0.06] bg-white/[0.02] px-4 py-3 sm:px-5">
+          {editing ? (
+            <div className="py-1">
+              <DownloaderForm
+                downloader={downloader}
+                suggestMapping={suggestMapping}
+                onSubmit={async (payload) => {
+                  onChanged(await updateDownloader(downloader.id, payload));
+                  onCloseEdit();
+                }}
+                onCancel={onCloseEdit}
+                onError={onError}
+              />
+            </div>
+          ) : (
+            <>
+              <DetailSection label="连接">
+                <StatGrid>
+                  <DetailStat
+                    label="地址"
+                    value={downloader.url}
+                    href={downloader.url}
+                    title="在新窗口打开下载器 WebUI"
+                    wide
+                  />
+                  <DetailStat label="用户名" value={downloader.username ?? "未设置"} />
+                  <DetailStat label="版本" value={downloader.version ?? "—"} />
+                </StatGrid>
+              </DetailSection>
+              <DetailSection label="落盘">
+                <StatGrid>
+                  <DetailStat
+                    label="默认保存目录"
+                    value={downloader.save_path ?? "下载器默认"}
+                    wide
+                  />
+                </StatGrid>
+              </DetailSection>
+              <DetailSection label="映射">
+                <PathMappingTable mappings={downloader.path_mappings ?? []} />
+              </DetailSection>
+            </>
+          )}
         </div>
       )}
 
@@ -405,6 +485,107 @@ function DownloaderCard({
         downloader={downloader}
         onClose={() => setLimitsOpen(false)}
       />
+    </div>
+  );
+}
+
+/* —— 详情排版原语（与站点页同款）：段标签在桌面抽成左侧固定列，内容左缘对齐 —— */
+
+function DetailSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section className="grid gap-1.5 py-3 first:pt-1 last:pb-1 sm:grid-cols-[46px_minmax(0,1fr)] sm:gap-x-4 sm:gap-y-0">
+      <p className="text-micro font-medium tracking-wide text-[var(--text-faint)] sm:pt-2">
+        {label}
+      </p>
+      <div className="min-w-0 space-y-2">{children}</div>
+    </section>
+  );
+}
+
+/** 统计区容器：等宽列，不给底色和描边，层级靠对齐与字重撑住 */
+function StatGrid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-2 gap-x-5 gap-y-3 sm:grid-cols-4">{children}</div>;
+}
+
+/**
+ * 单个信息项：淡色小标签在上、值在下。带 href 时值是可点的外链（新窗口打开）；
+ * wide 让长值（地址、目录）横跨两列，不与短值抢宽度。
+ */
+function DetailStat({
+  label,
+  value,
+  href,
+  title,
+  wide = false,
+}: {
+  label: string;
+  value: string;
+  href?: string;
+  title?: string;
+  wide?: boolean;
+}) {
+  const valueClass = "mt-0.5 block truncate text-ui font-semibold text-[var(--text)] max-sm:text-sub";
+  return (
+    <div className={`min-w-0 ${wide ? "col-span-2" : ""}`}>
+      <p className="truncate text-micro text-[var(--text-faint)]">{label}</p>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          title={title}
+          onClick={(e) => e.stopPropagation()}
+          className={`${valueClass} underline decoration-transparent underline-offset-4 transition-colors hover:text-white/80 hover:decoration-white/50`}
+        >
+          {value}
+        </a>
+      ) : (
+        <p className={valueClass} title={value}>
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 路径映射对照表：一条映射一行，左列是 MovieClaw 看到的路径，右列是下载器看到的
+ * 同一个位置，中间箭头表达"翻译"方向。跨容器部署时两边对同一块盘叫不同名字，
+ * 这张表就是核对"投递时路径会被翻成什么"的地方——比一行分号串好读得多。
+ */
+function PathMappingTable({ mappings }: { mappings: PathMapping[] }) {
+  if (mappings.length === 0) {
+    return (
+      <p className="pt-1.5 text-sub text-[var(--text-muted)]">
+        未配置——MovieClaw 与下载器看到的是同一套路径。
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-white/[0.07]">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-x-3 bg-white/[0.03] px-3 py-1.5 text-micro font-medium tracking-wide text-[var(--text-faint)]">
+        <span>MovieClaw 视角</span>
+        <span aria-hidden="true" className="w-4" />
+        <span>下载器视角</span>
+      </div>
+      <ul className="divide-y divide-white/[0.05]">
+        {mappings.map((m, i) => (
+          <li
+            key={`${m.local}→${m.remote}:${i}`}
+            className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-x-3 px-3 py-2"
+          >
+            <code className="truncate font-mono text-sub text-[var(--text)]" title={m.local}>
+              {m.local}
+            </code>
+            <span aria-hidden="true" className="w-4 text-center text-[var(--text-faint)]">
+              →
+            </span>
+            <code className="truncate font-mono text-sub text-[var(--text)]" title={m.remote}>
+              {m.remote}
+            </code>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -676,23 +857,14 @@ function LimitInput({
   );
 }
 
-function InfoStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-0">
-      <p className="text-micro text-[var(--text-faint)]">{label}</p>
-      <p className="mt-0.5 truncate text-ui font-semibold text-[var(--text)]">{value}</p>
-    </div>
-  );
-}
-
 /* —— 下载器操作折叠菜单（与站点卡片同款 Radix DropdownMenu） —— */
 
 interface DownloaderActionsMenuProps {
-  expanded: boolean;
+  downloader: ConfiguredDownloader;
   busy: boolean;
-  /** 已是默认时「设为默认」置灰 */
-  isDefault: boolean;
-  canReverify: boolean;
+  /** 编辑表单已亮出时菜单项变成「收起编辑」 */
+  editing: boolean;
+  onSetEnabled: (enabled: boolean) => void;
   onEdit: () => void;
   onLimits: () => void;
   onSetDefault: () => void;
@@ -701,28 +873,32 @@ interface DownloaderActionsMenuProps {
 }
 
 function DownloaderActionsMenu({
-  expanded,
+  downloader,
   busy,
-  isDefault,
-  canReverify,
+  editing,
+  onSetEnabled,
   onEdit,
   onLimits,
   onSetDefault,
   onReverify,
   onDelete,
 }: DownloaderActionsMenuProps) {
+  // Radix DropdownMenu：菜单渲染进 body Portal 并做碰撞检测；
+  // 菜单项加大内边距保证移动端触控目标
   const itemClass =
-    "glass-row nav-item cursor-pointer px-3 py-2 text-sub font-medium outline-none " +
+    "glass-row nav-item cursor-pointer px-3 py-2.5 text-sub font-medium outline-none " +
     "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)] " +
     "data-[disabled]:pointer-events-none data-[disabled]:opacity-40";
+  const canReverify = !IN_PROGRESS.includes(downloader.status);
 
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          aria-label="更多操作"
-          className="glass-row !w-auto p-1.5 data-[state=open]:!bg-[var(--glass-fill-active)] data-[state=open]:!text-[var(--text)]"
+          aria-label="下载器操作"
+          onClick={(e) => e.stopPropagation()}
+          className="glass-row !w-auto p-2 data-[state=open]:!bg-[var(--glass-fill-active)] data-[state=open]:!text-[var(--text)]"
         >
           <MoreIcon className="size-4" />
         </button>
@@ -732,17 +908,25 @@ function DownloaderActionsMenu({
           align="end"
           sideOffset={6}
           collisionPadding={12}
-          className="menu-surface z-50 min-w-[9rem] !rounded-xl p-1"
+          className="menu-surface z-50 min-w-[10rem] !rounded-xl p-1"
+          onClick={(e) => e.stopPropagation()}
         >
+          <DropdownMenu.Item
+            onSelect={() => onSetEnabled(!downloader.enabled)}
+            disabled={busy}
+            className={itemClass}
+          >
+            {downloader.enabled ? "停用下载器" : "启用下载器"}
+          </DropdownMenu.Item>
           <DropdownMenu.Item onSelect={onEdit} className={itemClass}>
-            {expanded ? "收起编辑" : "编辑配置"}
+            {editing ? "收起编辑" : "编辑配置"}
           </DropdownMenu.Item>
           <DropdownMenu.Item onSelect={onLimits} disabled={busy} className={itemClass}>
             限速与队列…
           </DropdownMenu.Item>
           <DropdownMenu.Item
             onSelect={onSetDefault}
-            disabled={busy || isDefault}
+            disabled={busy || downloader.is_default}
             className={itemClass}
           >
             设为默认

--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -137,12 +137,13 @@ export function SettingsPanel({ active }: SettingsPanelProps) {
     <div className="scroll-thin scroll-safe h-full overflow-y-auto">
       {/* 分区按信息密度给宽度：日志行最密（4xl）；资源站点一行要放
           名称 + 状态 + 刷流读数 + 操作，展开后还有成排统计，2xl 太挤（3xl）；
+          下载器展开后是地址/目录长值 + 路径映射对照表，同给 3xl；
           其余表单类分区维持 2xl 的舒适阅读宽度 */}
       <div
         className={`mx-auto w-full px-6 pb-20 pt-12 max-md:px-4 max-md:pb-12 max-md:pt-6 ${
           section.id === "logs"
             ? "max-w-4xl"
-            : section.id === "sites"
+            : section.id === "sites" || section.id === "downloaders"
               ? "max-w-3xl"
               : "max-w-2xl"
         }`}

--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -891,6 +891,44 @@ function IngestHistoryFiles({ detail }: { detail: IngestHistoryDetail }) {
 
 /** 历史按本地日期拆成轻量 Feed，首组默认展开，避免完成卡片占满纵向空间。 */
 /**
+ * 实时速度的统一配色：上传走 --ok 绿（做种的"战果"），下载走 --info 蓝（"正在进行"），
+ * 数值加粗从灰色标签里跳出来。所有来自下载器（qB/Tr）的任务——刷流汇总、刷流单行、
+ * 普通任务的实时行——都走这一个组件，保证任务中心里 ↑/↓ 的颜色语义处处一致。
+ * glow 只给刷流汇总头部用（折叠时也要一眼可见）；speed 为 0/空时给破折号或灰字占位，
+ * 由调用方决定是否渲染占位（固定列需要占位防塌陷，自由流式行则直接不渲染）。
+ */
+function SpeedStat({
+  direction,
+  bytesPerSecond,
+  glow = false,
+  placeholder,
+  className,
+}: {
+  direction: "up" | "down";
+  bytesPerSecond: number | null | undefined;
+  glow?: boolean;
+  /** 速度为空/0 时的占位文案；不传则渲染 null */
+  placeholder?: string;
+  className?: string;
+}) {
+  const active = bytesPerSecond != null && bytesPerSecond > 0;
+  if (!active) {
+    return placeholder != null ? (
+      <span className={`tnum text-white/20 ${className ?? ""}`}>{placeholder}</span>
+    ) : null;
+  }
+  const tone =
+    direction === "up"
+      ? `text-[var(--ok)] ${glow ? "drop-shadow-[0_0_6px_rgba(74,222,128,0.45)]" : ""}`
+      : `text-[var(--info)] ${glow ? "drop-shadow-[0_0_6px_rgba(127,176,255,0.45)]" : ""}`;
+  return (
+    <span className={`tnum font-semibold ${tone} ${className ?? ""}`}>
+      {direction === "up" ? "↑" : "↓"} {formatBytes(bytesPerSecond)}/s
+    </span>
+  );
+}
+
+/**
  * 刷流做种分组：默认折叠的 <details>，头部常显最值得关心的实时汇总——
  * ↑/↓ 总速度与已上传/已下载总量；展开后逐种子一行（站点 + 名称 + 状态 +
  * 各自的速度与累计上传）。刷流种子没有媒体身份与入库流转，刻意不渲染
@@ -927,16 +965,9 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
               上传走 --ok 绿（刷流的战果就是上传量），下载走 --info 蓝，数值带淡辉光
               从灰色标签里跳出来；标签本身保持浅灰，让数字成为视觉焦点。 */}
           <span className="tnum flex flex-wrap items-center gap-x-3 text-caption text-white/45">
-            {upSpeed > 0 && (
-              <span className="font-semibold text-[var(--ok)] drop-shadow-[0_0_6px_rgba(74,222,128,0.45)]">
-                ↑ {formatBytes(upSpeed)}/s
-              </span>
-            )}
-            {downSpeed > 0 && (
-              <span className="font-semibold text-[var(--info)] drop-shadow-[0_0_6px_rgba(127,176,255,0.45)]">
-                ↓ {formatBytes(downSpeed)}/s
-              </span>
-            )}
+            {/* 上下行速度常显：为 0 时退成灰色占位，让"现在没在下载"也是一条信息 */}
+            <SpeedStat direction="up" bytesPerSecond={upSpeed} glow placeholder="↑ 0 B/s" />
+            <SpeedStat direction="down" bytesPerSecond={downSpeed} glow placeholder="↓ 0 B/s" />
             <span>
               已上传 <span className="font-semibold text-[var(--ok)]">{formatBytes(uploaded)}</span>
             </span>
@@ -969,11 +1000,6 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
 function BoostTaskRow({ task }: { task: DownloadTask }) {
   const downloading = task.state === "downloading";
   const percent = task.progress == null ? null : Math.floor(task.progress * 100);
-  const upSpeed = task.upspeed_bytes != null && task.upspeed_bytes > 0 ? task.upspeed_bytes : null;
-  const downSpeed =
-    downloading && task.dlspeed_bytes != null && task.dlspeed_bytes > 0
-      ? task.dlspeed_bytes
-      : null;
   const name = (
     <OverflowText className="min-w-0 flex-1 text-ui text-white/80">
       {task.name || task.info_hash}
@@ -1002,20 +1028,14 @@ function BoostTaskRow({ task }: { task: DownloadTask }) {
         ) : (
           name
         )}
-        {/* 下载中的刷流种子是少数，进度与下行速度跟在名称后面，不占用固定数字列 */}
+        {/* 下载中的刷流种子是少数，进度跟在名称后面；下行速度与上行并列进固定数字列 */}
         {downloading && percent != null && (
           <span className="tnum shrink-0 text-caption text-white/35">{percent}%</span>
         )}
-        {downSpeed != null && (
-          <span className="tnum shrink-0 text-caption text-[var(--info)]">
-            ↓ {formatBytes(downSpeed)}/s
-          </span>
-        )}
       </div>
-      <div className="tnum grid shrink-0 grid-cols-[5.5rem_7rem_5rem] items-center gap-x-3 text-right text-caption text-white/40 max-md:w-full max-md:grid-cols-[5.5rem_7rem_minmax(0,1fr)]">
-        <span className={upSpeed != null ? "font-semibold text-[var(--ok)]" : "text-white/20"}>
-          {upSpeed != null ? `↑ ${formatBytes(upSpeed)}/s` : "—"}
-        </span>
+      <div className="tnum grid shrink-0 grid-cols-[5.5rem_5.5rem_7rem_5rem] items-center gap-x-3 text-right text-caption text-white/40 max-md:w-full max-md:grid-cols-[5.5rem_5.5rem_7rem_minmax(0,1fr)]">
+        <SpeedStat direction="down" bytesPerSecond={task.dlspeed_bytes} placeholder="—" />
+        <SpeedStat direction="up" bytesPerSecond={task.upspeed_bytes} placeholder="—" />
         <span>
           {task.uploaded_bytes != null && task.uploaded_bytes > 0
             ? `累计 ↑${formatBytes(task.uploaded_bytes)}`
@@ -1498,8 +1518,8 @@ function DownloadTaskFeedItem({
       {/* 实时传输单独一行：下行/上行速度与剩余时间；文件尺寸已并入规格行 */}
       {(downSpeed != null || upSpeed != null || etaSeconds != null) && (
         <div className="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-caption text-white/38">
-          {downSpeed != null && <span className="tnum">↓ {formatBytes(downSpeed)}/s</span>}
-          {upSpeed != null && <span className="tnum">↑ {formatBytes(upSpeed)}/s</span>}
+          <SpeedStat direction="down" bytesPerSecond={downSpeed} />
+          <SpeedStat direction="up" bytesPerSecond={upSpeed} />
           {etaSeconds != null && <span>剩余约 {formatDuration(etaSeconds)}</span>}
         </div>
       )}
@@ -1741,10 +1761,7 @@ function DownloadTaskCard({
                   <span aria-hidden="true" className="text-white/25">
                     ·
                   </span>
-                  <span className="tnum text-white/45">
-                    <span aria-hidden="true">↓ </span>
-                    {formatBytes(task.dlspeed_bytes)}/s
-                  </span>
+                  <SpeedStat direction="down" bytesPerSecond={task.dlspeed_bytes} />
                 </>
               )}
               {showDownloadRuntime && task.eta_seconds != null && (


### PR DESCRIPTION
- 下载器设置：列表改为单开手风琴（与站点列表同款交互），编辑表单嵌在展开详情里，「添加下载器」面板改用与站点页一致的扁平容器；设置页对 `downloaders` 分区同给 3xl 宽度
- 任务中心：排版收口

纯前端改动，eslint 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)