### PR TITLE
fix(web): 修复移动端刷流做种头部"展开"按钮换行

### DIFF
--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -238,7 +238,6 @@ export function TaskCenterView({
     (showActive && boostTasks.length > 0 ? 1 : 0) +
     (showHistory ? standaloneHistoricalJobs.length : 0);
   const failedSources = sources.filter((source) => source.status !== "active");
-  const healthySourceCount = sources.length - failedSources.length;
   const viewCounts: Partial<Record<TaskCenterViewName, number>> = {
     attention: attentionTotal,
     active: activeTotal,
@@ -262,37 +261,9 @@ export function TaskCenterView({
           </div>
         </header>
 
-        <div className="mt-4 flex min-h-10 flex-wrap items-center gap-x-3 gap-y-2 border-y border-white/[0.06] py-2.5 text-caption text-[var(--text-muted)]">
-          <span
-            className={`flex items-center gap-2 ${
-              failedSources.length > 0 || error ? "text-amber-200/80" : "text-white/50"
-            }`}
-          >
-            <span
-              className={`size-1.5 rounded-full ${
-                failedSources.length > 0 || error
-                  ? "bg-[var(--warn)]"
-                  : loading && refreshedAt == null
-                    ? "animate-pulse bg-[var(--info)]"
-                    : "bg-[var(--ok)]"
-              }`}
-            />
-            {failedSources.length > 0 || error
-              ? "自动更新部分异常"
-              : loading && refreshedAt == null
-                ? "正在同步任务"
-                : "自动更新正常"}
-          </span>
-          {sources.length > 0 && (
-            <>
-              <span aria-hidden="true" className="h-3 w-px bg-white/10" />
-              <span className={failedSources.length > 0 ? "text-amber-200/80" : "text-white/45"}>
-                下载器 {healthySourceCount}/{sources.length} 可用
-              </span>
-            </>
-          )}
-        </div>
-
+        {/* 一切正常时的"自动更新正常 / 下载器 N/N 可用"是纯噪音，占掉首屏一整条；
+            出问题时下面的 SourceWarning 会指名道姓说清哪个下载器怎么了并给出设置入口，
+            比一句"0/1 可用"信息量更大，所以这条状态条整体去掉，只保留告警 */}
         {(failedSources.length > 0 || error) && (
           <SourceWarning sources={failedSources} error={error} />
         )}

--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -1003,6 +1003,10 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
  * 现在的分工：站点与名称占左半区（名称吃掉全部剩余宽度），上行速度 / 累计上传 /
  * 体积三列右对齐且逐行等宽；缺值补破折号，保证列不塌陷。窄屏时数字整块换到第二行，
  * 让名称在小屏也有完整宽度。
+ *
+ * 下行速度刻意不占固定列：刷流种子绝大多数只做种不下载，给它留一列的结果是整张列表
+ * 挂着一排毫无信息量的破折号，还把上行速度挤到要换行。它改成和进度百分比一起跟在
+ * 名称后面，只在真的在下载时出现。
  */
 function BoostTaskRow({ task }: { task: DownloadTask }) {
   const downloading = task.state === "downloading";
@@ -1035,13 +1039,21 @@ function BoostTaskRow({ task }: { task: DownloadTask }) {
         ) : (
           name
         )}
-        {/* 下载中的刷流种子是少数，进度跟在名称后面；下行速度与上行并列进固定数字列 */}
+        {/* 下载中的刷流种子是少数：进度与下行速度都跟在名称后面按需出现，不占固定列 */}
         {downloading && percent != null && (
           <span className="tnum shrink-0 text-caption text-white/35">{percent}%</span>
         )}
+        <SpeedStat
+          direction="down"
+          bytesPerSecond={task.dlspeed_bytes}
+          className="shrink-0 text-caption"
+        />
       </div>
-      <div className="tnum grid shrink-0 grid-cols-[5.5rem_5.5rem_7rem_5rem] items-center gap-x-3 text-right text-caption text-white/40 max-md:w-full max-md:grid-cols-[5.5rem_5.5rem_7rem_minmax(0,1fr)]">
-        <SpeedStat direction="down" bytesPerSecond={task.dlspeed_bytes} placeholder="—" />
+      {/* 窄屏字号比桌面大一档（--text-caption 11px → 13px），5.5rem 装不下
+          "↑ 63.95 KB/s"，速度会被折成两行。窄屏改用按内容需求配比的弹性列
+          （速度 : 累计 : 体积 ≈ 9 : 10 : 7），列宽随屏宽缩放而比例不变——既保住逐行
+          对齐，也让 360px 的小屏和 430px 的大屏都留有余量；nowrap 再兜一道底 */}
+      <div className="tnum grid shrink-0 grid-cols-[5.5rem_7rem_5rem] items-center gap-x-3 whitespace-nowrap text-right text-caption text-white/40 max-md:w-full max-md:grid-cols-[9fr_10fr_7fr] max-md:gap-x-2">
         <SpeedStat direction="up" bytesPerSecond={task.upspeed_bytes} placeholder="—" />
         <span>
           {task.uploaded_bytes != null && task.uploaded_bytes > 0

--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -963,8 +963,10 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
           <span className="tnum text-caption text-white/60">{tasks.length} 个种子</span>
           {/* 实时汇总：速度是"现在"，总量是"战果"——都放头部，折叠时也一眼可见。
               上传走 --ok 绿（刷流的战果就是上传量），下载走 --info 蓝，数值带淡辉光
-              从灰色标签里跳出来；标签本身保持浅灰，让数字成为视觉焦点。 */}
-          <span className="tnum flex flex-wrap items-center gap-x-3 text-caption text-white/45">
+              从灰色标签里跳出来；标签本身保持浅灰，让数字成为视觉焦点。
+              窄屏这四项塞不进标题行，整块换到第二行（order-2 + w-full）独占一行，
+              避免和"展开"挤在一起互相把对方顶出去。 */}
+          <span className="tnum flex flex-wrap items-center gap-x-3 text-caption text-white/45 max-md:order-2 max-md:w-full">
             {/* 上下行速度常显：为 0 时退成灰色占位，让"现在没在下载"也是一条信息 */}
             <SpeedStat direction="up" bytesPerSecond={upSpeed} glow placeholder="↑ 0 B/s" />
             <SpeedStat direction="down" bytesPerSecond={downSpeed} glow placeholder="↓ 0 B/s" />
@@ -975,9 +977,14 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
               已下载 <span className="font-semibold text-[var(--info)]">{formatBytes(downloaded)}</span>
             </span>
           </span>
-          <span className="ml-auto text-caption text-white/30 group-open:hidden">展开</span>
-          <span className="ml-auto hidden text-caption text-white/30 group-open:inline">收起</span>
-          <ChevronRightIcon className="size-4 text-white/30 transition-transform group-open:rotate-90" />
+          {/* 展开态文案和箭头必须同进同退，所以包在一个不可换行的组里：上一版两者是
+              summary 的兄弟节点，窄屏换行时箭头会被单独甩到下一行成为孤儿。
+              窄屏 order-1 让它跟在"N 个种子"后面停在标题行右端。 */}
+          <span className="ml-auto flex shrink-0 items-center gap-1 whitespace-nowrap text-caption text-white/30 max-md:order-1">
+            <span className="group-open:hidden">展开</span>
+            <span className="hidden group-open:inline">收起</span>
+            <ChevronRightIcon className="size-4 transition-transform group-open:rotate-90" />
+          </span>
         </summary>
         <div className="mt-2 divide-y divide-white/[0.05]">
           {sorted.map((task) => (


### PR DESCRIPTION
窄屏字号档位比桌面大一档（--text-caption 11px → 13px），刷流做种的 summary
一行放不下「标题 + 种子数 + 四项汇总 + 展开 + 箭头」，flex-wrap 把箭头单独
甩到第三行，"展开"和箭头被拆散。

改为窄屏两行布局：汇总块 order-2 + w-full 独占第二行，"展开/收起"文案与箭头
合并成一个 whitespace-nowrap 的组（order-1）贴在标题行右端，永不拆散。桌面端
不加 order/w-full，仍是原来的单行布局。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MYL69i4ph6a6N8fNuNaqTK