### PR TITLE
fix(web): 修复任务中心移动端刷流做种的排版

### DIFF
--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -936,8 +936,10 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
               上传走 --ok 绿（刷流的战果就是上传量），下载走 --info 蓝，数值带淡辉光
               从灰色标签里跳出来；标签本身保持浅灰，让数字成为视觉焦点。
               窄屏这四项塞不进标题行，整块换到第二行（order-2 + w-full）独占一行，
-              避免和"展开"挤在一起互相把对方顶出去。 */}
-          <span className="tnum flex flex-wrap items-center gap-x-3 text-caption text-white/45 max-md:order-2 max-md:w-full">
+              避免和"展开"挤在一起互相把对方顶出去。第二行再排成 2×2 网格：速度一行、
+              总量一行——四项自由换行时"已下载"会随速度值的宽窄时而落单成第三行，
+              网格让分组头部的高度和对齐不随数字长短抖动。 */}
+          <span className="tnum flex flex-wrap items-center gap-x-3 text-caption text-white/45 max-md:order-2 max-md:grid max-md:w-full max-md:grid-cols-2 max-md:gap-y-1">
             {/* 上下行速度常显：为 0 时退成灰色占位，让"现在没在下载"也是一条信息 */}
             <SpeedStat direction="up" bytesPerSecond={upSpeed} glow placeholder="↑ 0 B/s" />
             <SpeedStat direction="down" bytesPerSecond={downSpeed} glow placeholder="↓ 0 B/s" />

--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -982,6 +982,7 @@ function BoostTaskSection({ tasks }: { tasks: DownloadTask[] }) {
 function BoostTaskRow({ task }: { task: DownloadTask }) {
   const downloading = task.state === "downloading";
   const percent = task.progress == null ? null : Math.floor(task.progress * 100);
+  const showDownloadNote = (downloading && percent != null) || (task.dlspeed_bytes ?? 0) > 0;
   const name = (
     <OverflowText className="min-w-0 flex-1 text-ui text-white/80">
       {task.name || task.info_hash}
@@ -996,30 +997,19 @@ function BoostTaskRow({ task }: { task: DownloadTask }) {
           </span>
         )}
       </div>
-      <div className="flex min-w-0 flex-1 items-center gap-x-2">
-        {task.page_url ? (
-          <a
-            href={task.page_url}
-            target="_blank"
-            rel="noreferrer"
-            className="flex min-w-0 flex-1 hover:text-white"
-            title="打开站点种子详情页"
-          >
-            {name}
-          </a>
-        ) : (
-          name
-        )}
-        {/* 下载中的刷流种子是少数：进度与下行速度都跟在名称后面按需出现，不占固定列 */}
-        {downloading && percent != null && (
-          <span className="tnum shrink-0 text-caption text-white/35">{percent}%</span>
-        )}
-        <SpeedStat
-          direction="down"
-          bytesPerSecond={task.dlspeed_bytes}
-          className="shrink-0 text-caption"
-        />
-      </div>
+      {task.page_url ? (
+        <a
+          href={task.page_url}
+          target="_blank"
+          rel="noreferrer"
+          className="flex min-w-0 flex-1 hover:text-white"
+          title="打开站点种子详情页"
+        >
+          {name}
+        </a>
+      ) : (
+        name
+      )}
       {/* 窄屏字号比桌面大一档（--text-caption 11px → 13px），5.5rem 装不下
           "↑ 63.95 KB/s"，速度会被折成两行。窄屏改用按内容需求配比的弹性列
           （速度 : 累计 : 体积 ≈ 9 : 10 : 7），列宽随屏宽缩放而比例不变——既保住逐行
@@ -1033,6 +1023,15 @@ function BoostTaskRow({ task }: { task: DownloadTask }) {
         </span>
         <span>{task.size_bytes != null ? formatBytes(task.size_bytes) : "—"}</span>
       </div>
+      {/* 下载中的刷流种子是少数，进度与下行速度不占固定列，另起一行挂在数字列下方：
+          既不因为多出两个值把逐行对齐搞乱，也保证 ↑ 永远排在 ↓ 前面，和分组汇总
+          头部（↑ 速度 → ↓ 速度 → 已上传 → 已下载）的"上传在前"口径一致 */}
+      {showDownloadNote && (
+        <div className="flex w-full items-center justify-end gap-x-2 text-caption text-white/35">
+          {downloading && percent != null && <span className="tnum">{percent}%</span>}
+          <SpeedStat direction="down" bytesPerSecond={task.dlspeed_bytes} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -5,7 +5,12 @@
  * 避免各站点原始文本（"1.5 TB" / "1536GB"）格式不一。
  */
 
-/** 字节数 → 可读体积，如「1.50 TB」「800 GB」。0 也是有效值（显示 0 B）。 */
+/**
+ * 字节数 → 可读体积，如「1.50 TB」「800 GB」。0 也是有效值（显示 0 B）。
+ * 百位起省掉小数，保证数字部分最多 5 个字符（"99.99"），调用方的定宽数字列
+ * 按这个上限留宽度。判断档位前先按 2 位四舍五入，否则 99.997 会被格成
+ * "100.00"——多出一个字符，正好把窄屏的定宽列撑破。
+ */
 export function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return "—";
   const units = ["B", "KB", "MB", "GB", "TB", "PB"];
@@ -15,7 +20,8 @@ export function formatBytes(bytes: number): string {
     value /= 1024;
     i += 1;
   }
-  return `${value.toFixed(value >= 100 || i === 0 ? 0 : 2)} ${units[i]}`;
+  const rounded = Number(value.toFixed(2));
+  return `${rounded.toFixed(rounded >= 100 || i === 0 ? 0 : 2)} ${units[i]}`;
 }
 
 /**

--- a/apps/web/test/format.test.mjs
+++ b/apps/web/test/format.test.mjs
@@ -2,9 +2,18 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  formatBytes,
   formatRuntimeMinutes,
   formatVideoResolution,
 } from "../lib/format.ts";
+
+test("体积数字部分最多 5 个字符，进位到百位就丢掉小数", () => {
+  assert.equal(formatBytes(1024 * 1024 * 99.99), "99.99 MB");
+  // 99.997 MB：先四舍五入再判断档位，否则会格成 "100.00 MB" 撑破窄屏定宽列
+  assert.equal(formatBytes(1024 * 1024 * 99.997), "100 MB");
+  assert.equal(formatBytes(1023), "1023 B");
+  assert.equal(formatBytes(0), "0 B");
+});
 
 test("电影片长按小时和剩余分钟展示", () => {
   assert.equal(formatRuntimeMinutes(45), "45 分钟");


### PR DESCRIPTION
## 背景

移动端任务中心的「刷流做种」分组在窄屏下排版散架：折叠头部的箭头被甩到单独一行，展开后每行都挂着一个恒为 `—` 的下行速度列，而上行速度被挤到折行。根因是窄屏字号整体比桌面大一档（`--text-caption` 11px → 13px），桌面按 11px 定的固定列宽在 13px 下全部不够用。

## 改动

**1. 折叠头部：「展开」和箭头不再被拆散**

`展开` / `收起` / 箭头原本是 summary 下三个平级兄弟节点，`flex-wrap` 换行时箭头会单独落到下一行。现在合并成一个 `whitespace-nowrap` 的组贴在标题行右端；汇总数字块窄屏 `order-2 + w-full` 下沉独占第二行。桌面端不加 order/w-full，仍是原来的单行布局。

**2. 单行：去掉常空的下行速度列，修复速度换行**

- 刷流种子绝大多数只做种不下载，下行速度列在整张列表里恒为破折号，零信息量却白占 5.5rem。改成不占固定列，数字区从四列收到三列。
- 窄屏数字区改用按内容需求配比的弹性列（速度 : 累计 : 体积 = 9 : 10 : 7），列宽随屏宽缩放而比例不变——逐行对齐照旧保住，`whitespace-nowrap` 再兜一道底。

**3. 单行的 ↑/↓ 顺序与分组汇总对齐**

汇总头部是「上传在前」（`↑ 速度` → `↓ 速度` → `已上传` → `已下载`），单行却把下行速度排在上行前面。现在下行速度与进度另起一行右对齐挂在数字列下方：`↑` 永远排在 `↓` 前面，且不会因为下载中的行多出两个值而打乱逐行对齐（下载中的刷流种子是少数，只有这些行会多一行）。

**4. 去掉顶部运行状态条**

「自动更新正常 / 下载器 N/N 可用」一切正常时是纯噪音却占掉首屏一整条；异常时下方 `SourceWarning` 会指名道姓说清哪个下载器出了什么问题并给出「检查设置」入口，信息量更大。首屏同步中的反馈由标签栏右侧的「正在读取下载器 / N 前更新」承担，去掉不丢信息。

**5. `formatBytes` 保证数字部分最多 5 个字符**

`99.997 MB` 先 `toFixed(2)` 再落地会得到 `"100.00 MB"`，比「百位起省掉小数」的规则多出一个字符，正好把定宽数字列撑破。改成判断档位前先按 2 位四舍五入，输出回到 `100 MB`；定宽列可以按「最宽 `99.99`」这个上限安全留宽度。

## 验证

- `tsc --noEmit`、`eslint` 干净。
- `npm test`：74 通过 / 5 失败，5 个失败在 `test/subscription-ui.test.mjs`（订阅季标签文案），stash 掉本 PR 改动后同样失败，属既有问题，未在本 PR 处理。
- 排版用项目自身的 Tailwind 配置（含同一套移动端字号档位）搭对照页逐格实测「列宽 ÷ 文字实宽」，按 iOS 系统字比无头浏览器回退字宽 1.25 倍的悲观系数折算：360 / 390 / 430px 下最宽用例（`99.99 MB/s`、`累计 ↑99.99 TB`、`1024 KB/s`）全部不换行、行高恒定；320px（SE 一代）偏紧，未为其扭曲布局。