### PR TITLE
fix(activity): 播放会话「已传输」按整场累计，不再随换连接归零

### DIFF
--- a/src/movieclaw_api/services/playback_activity.py
+++ b/src/movieclaw_api/services/playback_activity.py
@@ -310,8 +310,14 @@ async def media_activity_overview(
                     if device_meters
                     else None
                 ),
+                # 已传输 = 本会话内已结束连接的累计 + 当前在服务连接的实时增量。
+                # 播放器每次 seek / 续拉缓冲都换一条 Range 连接，只看在服务的
+                # 连接会让读数反复归零，和观看进度对不上。全程无字节（网盘直链）
+                # 才是 None——展示层据此隐藏该项，而不是显示一个 0。
                 bytes_sent=(
-                    sum(m.bytes_sent for m in device_meters) if device_meters else None
+                    play.bytes_transferred
+                    + sum(m.bytes_sent for m in device_meters)
+                    or None
                 ),
                 connections=len(device_meters),
                 file=_file_spec(ctx.file),

--- a/src/movieclaw_playback/activity.py
+++ b/src/movieclaw_playback/activity.py
@@ -101,6 +101,12 @@ class PlaySession:
     #: 本会话是否走过本地取流。False = 网盘直链（302）或播放器只上报不取流，
     #: 展示层据此把速率标注为"不经过服务器"，而不是显示 0。
     local_streamed: bool = False
+    #: 本会话内**已结束**连接累计传出的字节。播放器一场播放里会换很多条
+    #: Range 连接（每次 seek、每次缓冲区续拉都是新连接，旧连接随即关闭），
+    #: 只统计当下还在服务的连接会让"已传输"在整场播放里反复归零，
+    #: 与观看进度完全对不上。仍在服务的连接由各自计量器实时累加，
+    #: 展示口径 = 本字段 + 活跃计量器的 bytes_sent 之和。
+    bytes_transferred: int = 0
     #: 保鲜时钟（monotonic），进度上报与本地取流字节都会续期。
     last_activity_mono: float = field(default_factory=time.monotonic)
 
@@ -204,13 +210,20 @@ def register_stream(
 
 
 def unregister_stream(meter: StreamMeter) -> None:
-    """回收已结束的字节流；同设备会话的保鲜时钟顺带续期。"""
+    """回收已结束的字节流；字节数结转进会话累计，保鲜时钟顺带续期。
+
+    先 ``remove`` 再结转：重复回收（同一条连接的 on_close 被调用两次）在
+    第一次之后就直接返回，不会把同一批字节计两遍。只结转给单元相同的会话——
+    换集时新会话可能先建立，上一集的收尾连接不该把字节记到新一集头上。
+    """
     try:
         _meters.remove(meter)
     except ValueError:
         return
     session = _sessions.get(meter.device_id)
     if session is not None and meter.kind == STREAM_KIND_PLAY and meter.bytes_sent > 0:
+        if session.unit == meter.unit:
+            session.bytes_transferred += meter.bytes_sent
         session.local_streamed = True
         session.last_activity_mono = time.monotonic()
 

--- a/tests/api/test_playback_activity.py
+++ b/tests/api/test_playback_activity.py
@@ -214,6 +214,65 @@ async def test_download_connections_aggregate_per_file(client: TestClient) -> No
     assert download["progress_percent"] == 5
 
 
+async def test_session_bytes_sent_spans_reconnects(client: TestClient) -> None:
+    """已传输 = 已结束连接的累计 + 在服务连接的实时增量，换连接不归零。"""
+    async with get_database().session() as session:
+        movie = MediaItem(
+            kind="movie",
+            tmdb_id=27205,
+            title="盗梦空间",
+            original_title="Inception",
+            year=2010,
+            aliases=[],
+        )
+        library = Library(name="电影", kind="movie", root_paths=["/media/movies"])
+        session.add_all([movie, library])
+        await session.commit()
+        session.add(
+            LibraryFile(
+                library_id=library.id,
+                media_item_id=movie.id,
+                file_path="/media/movies/inception.mkv",
+                source="scanned",
+                size_bytes=100_000,
+            )
+        )
+        await session.commit()
+        movie_id = movie.id
+
+    unit = (movie_id, 0, 0)
+    info = ClientInfo(
+        name="Infuse", device_name="客厅 Apple TV", device_id="dev-3", version="8.0"
+    )
+    activity.report_start("dev-3", member_id=0, client=info, unit=unit)
+
+    def _open() -> activity.StreamMeter:
+        return activity.register_stream(
+            device_id="dev-3",
+            kind=activity.STREAM_KIND_PLAY,
+            member_id=0,
+            unit=unit,
+            file_id=None,
+            file_name="inception.mkv",
+            size_bytes=100_000,
+            client=info,
+        )
+
+    # 前两条 Range 连接已经结束（播放器 seek / 续拉缓冲换的连接）
+    for sent in (30_000, 20_000):
+        finished = _open()
+        finished.add(sent)
+        activity.unregister_stream(finished)
+    live = _open()
+    live.add(5_000)
+
+    data = client.get("/api/v1/playback/activity").json()["data"]
+    view = data["sessions"][0]
+    assert view["bytes_sent"] == 55_000
+    # 连接数仍是"当下在服务的条数"，与累计字节是两个读数
+    assert view["connections"] == 1
+
+
 async def test_strm_session_reports_remote_play_method(client: TestClient) -> None:
     """strm 网盘条目走 302 直链、流量不经过服务器：标注 remote 而非伪造速率。"""
     async with get_database().session() as session:

--- a/tests/playback/test_activity.py
+++ b/tests/playback/test_activity.py
@@ -158,3 +158,64 @@ def test_repeat_start_keeps_session_identity() -> None:
     assert sessions[0].started_at == started_at
     # 已看位置不因重复开始而闪回
     assert sessions[0].position_ms == 60_000
+
+
+def test_session_accumulates_bytes_across_connections() -> None:
+    """换连接不清零：一场播放里已结束连接的字节结转进会话累计。"""
+    activity.report_start("dev-1", member_id=0, client=CLIENT, unit=UNIT)
+
+    def _open() -> activity.StreamMeter:
+        return activity.register_stream(
+            device_id="dev-1",
+            kind=activity.STREAM_KIND_PLAY,
+            member_id=0,
+            unit=UNIT,
+            file_id=11,
+            file_name="movie.mkv",
+            size_bytes=100_000,
+            client=CLIENT,
+        )
+
+    first = _open()
+    first.add(30_000)
+    activity.unregister_stream(first)
+    sessions, meters = activity.snapshot()
+    assert meters == []
+    assert sessions[0].bytes_transferred == 30_000
+
+    # 重复回收（on_close 被调两次）不能把同一批字节记两遍
+    activity.unregister_stream(first)
+    sessions, _ = activity.snapshot()
+    assert sessions[0].bytes_transferred == 30_000
+
+    second = _open()
+    second.add(20_000)
+    activity.unregister_stream(second)
+    sessions, _ = activity.snapshot()
+    assert sessions[0].bytes_transferred == 50_000
+
+
+def test_finished_connection_bytes_do_not_leak_to_next_unit() -> None:
+    """换集时上一集的收尾连接不把字节记到新一集头上。"""
+    activity.report_start("dev-1", member_id=0, client=CLIENT, unit=UNIT)
+    meter = activity.register_stream(
+        device_id="dev-1",
+        kind=activity.STREAM_KIND_PLAY,
+        member_id=0,
+        unit=UNIT,
+        file_id=11,
+        file_name="s01e01.mkv",
+        size_bytes=100_000,
+        client=CLIENT,
+    )
+    meter.add(30_000)
+
+    next_unit = (1, 1, 2)
+    activity.report_progress(
+        "dev-1", member_id=0, client=CLIENT, unit=next_unit, position_ms=0, paused=False
+    )
+    activity.unregister_stream(meter)
+
+    sessions, _ = activity.snapshot()
+    assert sessions[0].unit == next_unit
+    assert sessions[0].bytes_transferred == 0


### PR DESCRIPTION
活动页「正在播放」的已传输字节此前只统计当下还在服务的 Range 连接：
播放器每次 seek、每次续拉缓冲都会开新连接并关掉旧连接，旧连接的字节
随计量器一起被丢弃，读数于是在整场播放里反复归零——观看进度都快跑完了，
已传输却只有几百 MB，与文件尺寸怎么算都对不上。

会话上增加 bytes_transferred，连接回收时把该条已传字节结转进去，展示口径
= 已结束连接的累计 + 在服务连接的实时增量。结转只认单元相同的会话，换集时
上一集的收尾连接不会记到新一集头上；先 remove 再结转，重复回收不会双计。