### PR TITLE
fix(web): 活动页「最近观看」改用历史图标

### DIFF
--- a/apps/web/components/icons.tsx
+++ b/apps/web/components/icons.tsx
@@ -88,6 +88,19 @@ export const ClockIcon = (p: IconProps) => (
   </Base>
 );
 
+/**
+ * 历史：时钟 + 逆时针回拨箭头。
+ * 用于「最近观看」这类"已经发生过"的记录，与表达"此刻正在发生"的
+ * PlayIcon 区分开——两者都用播放三角时，用户无法一眼分辨实时与回顾。
+ */
+export const HistoryIcon = (p: IconProps) => (
+  <Base {...p}>
+    <path d="M3.5 12a8.5 8.5 0 1 0 2.6-6.1L3.5 8.3" />
+    <path d="M3.5 3.6v4.7h4.7" />
+    <path d="M12 7.5V12l3 1.8" />
+  </Base>
+);
+
 /** 活动：脉冲折线。时钟表达的是"排队与历史"，活动要表达"此刻正在发生"。 */
 export const ActivityIcon = (p: IconProps) => (
   <Base {...p}>

--- a/apps/web/components/media-activity-section.tsx
+++ b/apps/web/components/media-activity-section.tsx
@@ -9,6 +9,7 @@ import {
   CheckIcon,
   ChevronRightIcon,
   DownloadIcon,
+  HistoryIcon,
   PlayIcon,
 } from "@/components/icons";
 import { useToast } from "@/components/feedback";
@@ -643,7 +644,7 @@ export function MediaActivityPanel({
       {snapshot.recent.length > 0 && (
         <section className="mt-7" aria-label="最近观看">
           <SectionHeading
-            icon={<PlayIcon className="size-4 text-white/40" />}
+            icon={<HistoryIcon className="size-4 text-white/40" />}
             title="最近观看"
             count={snapshot.recent.length}
           />


### PR DESCRIPTION
## 问题

活动页「观看」视角里，「正在播放」和「最近观看」两个分区共用同一个 `PlayIcon`。两者在同屏纵向并列，图标完全一样时无法一眼分辨哪个是"此刻正在发生"、哪个是"已经发生过"。

## 改动

- `apps/web/components/icons.tsx`：新增 `HistoryIcon` —— 时钟表盘 + 左上角逆时针回拨箭头，通用的「历史记录」符号。表针路径与既有的 `ClockIcon` 保持一致，视觉上属于同一族。
- `apps/web/components/media-activity-section.tsx`：「最近观看」分区标题图标由 `PlayIcon` 换为 `HistoryIcon`。

改完后语义分工明确：播放三角 = 实时，回拨时钟 = 回顾。

## 验证

`npx tsc --noEmit` 通过。纯展示层改动，无接口与数据变更。

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)