### PR TITLE
fix(playback): 取流响应保留 Content-Length，别再把播放器逼成 Range 风暴

### DIFF
--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -362,7 +362,7 @@ async def download_item(
         raise not_found()
     # 下载不是播放会话：不登记设备流，避免用户边下边看时点"停止播放"误杀
     # 下载读盘；但下载器取消/断网后必须停止读盘（裸 FileResponse 会把几十 GB
-    # 读到底），且保留 Content-Length 供下载器显示进度与续传
+    # 读到底）。Content-Length 由响应类统一保留，下载器据此显示进度与续传
     is_download = request.url.path.lower().endswith("/download")
     # 独立登记为下载活动：活动页「观看」视角展示"谁在下哪个文件、多快"
     meter = activity.register_stream(
@@ -380,7 +380,6 @@ async def download_item(
         path,
         media_type=container_mime_type(f.container or path.suffix),
         filename=path.name if is_download else None,
-        keep_content_length=True,
         byte_sink=meter.add,
         on_close=lambda: activity.unregister_stream(meter),
     )

--- a/src/movieclaw_playback/streaming.py
+++ b/src/movieclaw_playback/streaming.py
@@ -99,13 +99,26 @@ class DisconnectAwareFileResponse(FileResponse):
     - 块大小提到 1 MiB（Starlette 默认 64 KiB）：每块都要经过 ASGI send、
       中间件转发和 uvicorn 写缓冲，块数少 16 倍就是 CPU 少 16 倍。
 
-    该类沿用 Starlette 的 Range 头和分段规则。为了能在"播放器上报停止、TCP
-    仍连着"时以完整的 ASGI body 结束响应，默认非 HEAD 请求不发送
-    ``Content-Length``，由 HTTP 服务器使用 chunked 传输；``206`` 的
-    ``Content-Range`` 仍保留，因此客户端仍可校验请求区间。
-    ``keep_content_length=True`` 用于整文件下载：下载器依赖 ``Content-Length``
-    显示进度/续传，此模式只响应 TCP 断连（断连后服务器本就丢弃后续 send，
-    直接停止读盘即可），因此不能同时传 ``session_stopped``。
+    该类沿用 Starlette 的 Range 头和分段规则，并且**一律发送
+    ``Content-Length``**（2026-08-22 NAS 现场事故的教训）：
+
+    - 早期版本为了能在"播放器上报停止、TCP 仍连着"时用一个空的结束帧收尾，
+      非 HEAD 请求一律剥掉 ``Content-Length``、让服务器改用 chunked。真
+      Jellyfin 不是这么干的，而 Infuse / VidHub / Apple TV 这类基于
+      AVFoundation 的播放器拿不到响应长度就无法预估缓冲，表现为**不停地开一个
+      小 Range、读一点、掐断、再开一个**：现场实测 40 秒内打进来 89 个 Range
+      请求（约 2 次/秒），每个响应在客户端断开前已经从磁盘读了 23–60 MB，
+      合计约 2.2 GB——比整个 1.67 GB 的剧集文件还多。磁盘被打满后，同一时刻的
+      媒体库列表和封面请求全部超时，客户端表现为"连不上、库里空空的"。
+    - 因此长度头必须留着。代价是提前停止时**无法再合法地收尾**（body 短于
+      已声明的长度是协议错误），只能停止发送、由服务器关闭连接：
+
+      * TCP 已断连：uvicorn 本就丢弃后续 send，直接返回即静默结束；
+      * 播放器上报 Stopped 而 TCP 仍在：uvicorn 会记一条
+        "ASGI callable returned without completing response." 并关闭连接——
+        关掉这条已被放弃的连接正是我们要的结果，为了让部署者看懂，停止读盘时
+        先用中文说明原因。
+
     断开时最多多读一个已在途的块。
     """
 
@@ -117,18 +130,12 @@ class DisconnectAwareFileResponse(FileResponse):
         *,
         session_stopped: asyncio.Event | None = None,
         on_close: Callable[[], None] | None = None,
-        keep_content_length: bool = False,
         byte_sink: Callable[[int], None] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(path, **kwargs)
-        if keep_content_length and session_stopped is not None:
-            raise ValueError(
-                "保留 Content-Length 的响应无法在会话停止时优雅收尾，不能同时登记 session_stopped"
-            )
         self._session_stopped = session_stopped
         self._on_close = on_close
-        self._keep_content_length = keep_content_length
         # 每发出一块调用一次的字节计量回调（活动页「观看」视角的速率来源）；
         # 必须是同步且近零开销的，不能拖慢发送循环
         self._byte_sink = byte_sink
@@ -140,16 +147,22 @@ class DisconnectAwareFileResponse(FileResponse):
         """同步、零开销的停止判断；每块调用一次。"""
         if self._session_stopped is not None and self._session_stopped.is_set():
             reason = "播放器已上报停止"
+            # TCP 还连着，这条响应会短于已声明的 Content-Length：服务器接下来
+            # 会打印一条英文的 "returned without completing response" 并关闭
+            # 连接，那是预期行为而不是故障，先在这里讲清楚
+            detail = "，将关闭这条已被放弃的连接"
         elif self._disconnected.is_set():
             reason = "客户端已断开"
+            detail = ""
         else:
             return False
         if not self._stop_logged:
             self._stop_logged = True
             logger.info(
-                "%s视频流，停止继续读取（本响应已读取 %d 字节）",
+                "%s视频流，停止继续读取（本响应已读取 %d 字节）%s",
                 reason,
                 self._bytes_read,
+                detail,
             )
         return True
 
@@ -192,37 +205,17 @@ class DisconnectAwareFileResponse(FileResponse):
             if self._on_close is not None:
                 self._on_close()
 
-    def _stream_headers(
-        self, headers: list[tuple[bytes, bytes]] | None = None
-    ) -> list[tuple[bytes, bytes]]:
-        """移除长度头，使提前停止可以用 ASGI 结束帧正常结束 chunked 响应。"""
-        if self._keep_content_length:
-            return list(headers or self.raw_headers)
-        mutable_headers = MutableHeaders(raw=list(headers or self.raw_headers))
-        if "content-length" in mutable_headers:
-            del mutable_headers["content-length"]
-        return mutable_headers.raw
-
-    async def _finish_stopped_response(self, send: Send) -> None:
-        """已发送响应头后收尾，避免 ASGI 应用以未完成的 body 返回。
-
-        保留 Content-Length 的模式只会因 TCP 断连而停止，此时服务器已丢弃
-        后续 send，补发结束帧反而会触发"body 短于 Content-Length"的协议错误。
-        """
-        if self._keep_content_length:
-            return
-        await send({"type": "http.response.body", "body": b"", "more_body": False})
-
     async def _send_span(self, file, send: Send, start: int, end: int | None) -> None:
-        """把文件 ``[start, end)`` 区间逐块发出，中途停止则收尾后返回。
+        """把文件 ``[start, end)`` 区间逐块发出，中途停止则直接返回。
 
         ``end`` 为 None 表示读到文件末尾（无 Range 的整文件响应）。
+        提前停止时不补结束帧：Content-Length 已经发出去了，补一个短 body
+        是协议错误，交给服务器关闭连接即可。
         """
         await file.seek(start)
         more_body = True
         while more_body:
             if self._should_stop_reading():
-                await self._finish_stopped_response(send)
                 return
             size = self.chunk_size if end is None else min(self.chunk_size, end - start)
             chunk = await file.read(size)
@@ -240,14 +233,13 @@ class DisconnectAwareFileResponse(FileResponse):
             {
                 "type": "http.response.start",
                 "status": self.status_code,
-                "headers": self.raw_headers if send_header_only else self._stream_headers(),
+                "headers": self.raw_headers,
             }
         )
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
             return
         if self._should_stop_reading():
-            await self._finish_stopped_response(send)
             return
         async with await anyio.open_file(self.path, mode="rb") as file:
             await self._send_span(file, send, 0, None)
@@ -262,14 +254,13 @@ class DisconnectAwareFileResponse(FileResponse):
             {
                 "type": "http.response.start",
                 "status": 206,
-                "headers": (headers.raw if send_header_only else self._stream_headers(headers.raw)),
+                "headers": headers.raw,
             }
         )
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
             return
         if self._should_stop_reading():
-            await self._finish_stopped_response(send)
             return
         async with await anyio.open_file(self.path, mode="rb") as file:
             await self._send_span(file, send, start, end)
@@ -292,19 +283,17 @@ class DisconnectAwareFileResponse(FileResponse):
             {
                 "type": "http.response.start",
                 "status": 206,
-                "headers": (headers.raw if send_header_only else self._stream_headers(headers.raw)),
+                "headers": headers.raw,
             }
         )
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
             return
         if self._should_stop_reading():
-            await self._finish_stopped_response(send)
             return
         async with await anyio.open_file(self.path, mode="rb") as file:
             for start, end in ranges:
                 if self._should_stop_reading():
-                    await self._finish_stopped_response(send)
                     return
                 await send(
                     {
@@ -316,7 +305,6 @@ class DisconnectAwareFileResponse(FileResponse):
                 await file.seek(start)
                 while start < end:
                     if self._should_stop_reading():
-                        await self._finish_stopped_response(send)
                         return
                     chunk = await file.read(min(self.chunk_size, end - start))
                     self._bytes_read += len(chunk)

--- a/tests/playback/test_streaming.py
+++ b/tests/playback/test_streaming.py
@@ -74,8 +74,8 @@ async def test_disconnect_aware_file_response_skips_open_when_client_is_gone(
     # 第一次 receive 就是 http.disconnect：监听任务先于打开文件前置位
     await response(_scope(), _receiver(disconnect_after=1), _sender(messages))
 
-    assert messages[0]["type"] == "http.response.start"
-    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+    # 头已带 Content-Length，不能再补空的结束帧，直接返回让服务器关连接
+    assert [message["type"] for message in messages] == ["http.response.start"]
 
 
 @pytest.mark.asyncio
@@ -122,11 +122,7 @@ async def test_stopped_playback_signal_skips_opening_the_file(
     )
     await response(_scope(), _receive, _sender(messages))
 
-    assert [message["type"] for message in messages] == [
-        "http.response.start",
-        "http.response.body",
-    ]
-    assert messages[-1]["more_body"] is False
+    assert [message["type"] for message in messages] == ["http.response.start"]
 
 
 def test_stop_device_streams_sets_all_active_streams() -> None:
@@ -165,7 +161,8 @@ async def test_stopped_playback_signal_stops_active_stream_before_next_chunk(
 
     body = b"".join(message.get("body", b"") for message in messages)
     assert body == content[: DisconnectAwareFileResponse.chunk_size]
-    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+    # 停在半路：既不补结束帧也不继续读盘，未完成的响应由服务器关闭连接收场
+    assert messages[-1]["more_body"] is True
 
 
 @pytest.mark.asyncio
@@ -192,7 +189,7 @@ async def test_disconnect_aware_file_response_stops_before_next_chunk(tmp_path: 
 
     body = b"".join(message.get("body", b"") for message in messages)
     assert body == content[: DisconnectAwareFileResponse.chunk_size]
-    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
+    assert messages[-1]["more_body"] is True
 
 
 @pytest.mark.asyncio
@@ -214,7 +211,7 @@ async def test_disconnect_aware_file_response_keeps_range_response(tmp_path: Pat
     body = b"".join(message.get("body", b"") for message in messages[1:])
     assert start["status"] == 206
     assert headers["content-range"] == f"bytes 100-69999/{len(content)}"
-    assert "content-length" not in headers
+    assert headers["content-length"] == "69900"
     assert body == content[100:70000]
 
 
@@ -252,7 +249,7 @@ async def test_disconnect_aware_file_response_keeps_multiple_range_response(
     body = b"".join(message.get("body", b"") for message in messages[1:])
     assert messages[0]["status"] == 206
     assert headers["content-type"].startswith("multipart/byteranges; boundary=")
-    assert "content-length" not in headers
+    assert headers["content-length"] == str(len(body))
     assert b"Content-Range: bytes 0-9/200" in body
     assert b"Content-Range: bytes 100-109/200" in body
     assert content[:10] in body and content[100:110] in body
@@ -297,42 +294,27 @@ async def test_stopped_playback_ends_multiple_range_response(tmp_path: Path) -> 
         _sender(messages),
     )
 
+    assert [message["type"] for message in messages] == ["http.response.start"]
     assert messages[0]["status"] == 206
-    assert messages[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
 
 
 @pytest.mark.asyncio
-async def test_keep_content_length_mode_keeps_header_and_stops_silently(tmp_path: Path) -> None:
-    """整文件下载：保留 Content-Length 供下载器续传；断连后直接停读盘、不补结束帧。"""
+async def test_whole_file_response_declares_content_length(tmp_path: Path) -> None:
+    """整文件响应必须带 Content-Length。
+
+    回归守卫：曾经为了能提前收尾而剥掉长度头改用 chunked，Infuse/VidHub 等
+    AVFoundation 播放器因此不停地开小 Range 再掐断，把 NAS 磁盘读爆
+    （详见 DisconnectAwareFileResponse 的类注释）。
+    """
     video = tmp_path / "movie.mkv"
-    content = b"x" * (DisconnectAwareFileResponse.chunk_size * 3)
+    content = b"x" * 4096
     video.write_bytes(content)
     messages: list[dict[str, Any]] = []
-    disconnect = asyncio.Event()
 
-    async def receive() -> dict[str, Any]:
-        await disconnect.wait()
-        return {"type": "http.disconnect"}
-
-    async def send(message: dict[str, Any]) -> None:
-        messages.append(message)
-        if message.get("body") == content[: DisconnectAwareFileResponse.chunk_size]:
-            disconnect.set()
-            await asyncio.sleep(0)
-
-    response = DisconnectAwareFileResponse(video, keep_content_length=True)
-    await response(_scope(), receive, send)
+    response = DisconnectAwareFileResponse(video)
+    await response(_scope(), _receive, _sender(messages))
 
     headers = {key.decode(): value.decode() for key, value in messages[0]["headers"]}
     assert headers["content-length"] == str(len(content))
-    body = b"".join(message.get("body", b"") for message in messages)
-    assert body == content[: DisconnectAwareFileResponse.chunk_size]
-    # 断连后服务器已丢弃 send，不能再补 more_body=False 的空帧（会触发长度不符）
-    assert messages[-1]["more_body"] is True
-
-
-def test_keep_content_length_rejects_session_stopped(tmp_path: Path) -> None:
-    with pytest.raises(ValueError):
-        DisconnectAwareFileResponse(
-            tmp_path / "x.mkv", keep_content_length=True, session_stopped=asyncio.Event()
-        )
+    assert b"".join(message.get("body", b"") for message in messages) == content
+    assert messages[-1]["more_body"] is False


### PR DESCRIPTION
## 问题

Apple TV 上 Infuse 连 Jellyfin 接口表现为「连不上、一直转圈、进媒体库什么都看不到」。查下来接口本身没有任何错误——24 小时内 Jellyfin 命名空间零 4xx / 零 5xx，认证、`UserViews`、递归拉全库、`PlaybackInfo`、Range 取流手工全跑通。

真正的问题在取流响应头：

```
HTTP/1.1 206 Partial Content
content-range: bytes 0-1673093626/1673093627
transfer-encoding: chunked        ← 真 Jellyfin 这里是 Content-Length
```

`DisconnectAwareFileResponse` 早期为了能在「播放器上报 Stopped、TCP 仍连着」时用一个空结束帧收尾，把非 HEAD 响应的 `Content-Length` 一律剥掉、改用 chunked。Infuse / VidHub / Apple TV 这类基于 AVFoundation 的播放器拿不到响应长度就无法预估缓冲，行为退化成**不停地开一个小 Range、读一点、掐断、再开一个**。

NAS 现场日志：

```
11:49:01–11:49:40  /Videos/{id}/stream  ×89   ≈2 次/秒
客户端已断开视频流，停止继续读取（本响应已读取 25165824 字节）
客户端已断开视频流，停止继续读取（本响应已读取 60817408 字节）
...
```

40 秒内 89 个 Range 请求，每个在客户端断开前已从磁盘读了 23–60 MB，合计约 2.2 GB——比整个 1.67 GB 的剧集文件还多。磁盘被打满后，同一时刻的媒体库列表和封面请求全部超时，客户端表现就是转圈和空白。

## 改动

`Content-Length` 一律保留。代价是提前停止时无法再合法收尾（body 短于已声明的长度是协议错误），只能停止发送、由服务器关闭连接：

- **TCP 已断连**：uvicorn 本就丢弃后续 send，直接返回即静默结束；
- **播放器上报 Stopped 而 TCP 仍在**：uvicorn 记一条 `ASGI callable returned without completing response.` 并关闭连接——关掉这条已被放弃的连接正是我们要的结果。为了让部署者看懂，停止读盘的中文日志里先说明原因。

这样 `keep_content_length`（原本只服务于整文件下载）这个特例就没有存在必要了，连同 `_stream_headers()`、`_finish_stopped_response()` 一起删除。**净减 31 行**——这次修复的本质是删掉一个特例，不是加逻辑。

## 验证

单测只验 ASGI 消息，验不出服务器实际发出的头，因此另跑了真实 uvicorn 的检查：

```
OK  整文件 GET          200  content-length=3145728  transfer-encoding=-
OK  Range: bytes=0-1023 206  content-length=1024     transfer-encoding=-
OK  Range: bytes=1000-  206  content-length=3144728  transfer-encoding=-
OK  多段 Range           206  content-length=254      transfer-encoding=-
OK  HEAD                200  content-length=3145728  transfer-encoding=-
```

早停路径是这次重设计的风险点，单独验了：慢读客户端下到 7 MB 时发停止信号，**1.52 秒后 curl 以退出码 18 结束**（连接被关闭），不会吊死客户端。

单测：`tests/api` + `tests/playback` + `tests/jellyfin` 全绿。新增 `test_whole_file_response_declares_content_length` 作为回归守卫。

## 不在本 PR 范围内

排查中还发现 Apple TV 是走 `https://movie.ycy.homes:88` → 群晖反代 → `localhost:3000` 进来的，反代那层 `proxy_read/send_timeout = 60s`。是否也在掐连接尚未验证，与本改动无关。

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)