### PR TITLE
fix(jellyfin): 补 /Persons 与 /Search/Hints，搜索口径对齐 Jellyfin

### DIFF
--- a/docs/design/jellyfin-compat.md
+++ b/docs/design/jellyfin-compat.md
@@ -117,6 +117,7 @@ P2 兜底兼容。**凡列出 legacy 别名的都必须与新路由一起实现*
 | `GET /Users/Me`、`GET /Users/{userId}`、`GET /Users/Public` | 用户信息/续验 token（Public 匿名） |
 | `GET /UserViews` + legacy `GET /Users/{userId}/Views` | 库视图列表（**不补 legacy 则老客户端库列表直接空**） |
 | `GET /Items`（含 `?searchTerm`）+ legacy `GET /Users/{userId}/Items` | 核心查询 |
+| `GET /Persons`、`GET /Persons/{name}` | 人物查询。**Infuse 的搜索页是 `/Items` + `/Persons` 两路并发**，缺这一路会让它把整次搜索判为失败、结果页全空（2026-08-22 抓包实证，见 11 节考古） |
 | `GET /Items/{itemId}` + legacy `GET /Users/{userId}/Items/{itemId}` | 单条目详情（**全字段语义，无 fields 参数**，见 5.3） |
 | `GET /Shows/{seriesId}/Seasons`、`GET /Shows/{seriesId}/Episodes` | 剧集结构 |
 | `GET\|HEAD /Items/{itemId}/Images/{type}[/{index}]` | 海报/背景/缩略图 |
@@ -138,6 +139,7 @@ P2 兜底兼容。**凡列出 legacy 别名的都必须与新路由一起实现*
 | `GET /Branding/Configuration`、`GET /QuickConnect/Enabled` | 匿名轻量 JSON（固定值） |
 | `GET /Branding/Css` + `/Branding/Css.css` | 匿名，**`text/css` 裸文本**（空串即可），非 JSON |
 | `GET /Sessions` → `[]`、`DELETE /Videos/ActiveEncodings` → 204、`GET /System/Endpoint` → `{"IsLocal":true,"IsInNetwork":true}` | 敷衍实现防客户端卡启动/退出（Fileball/VidHub 退出时会无条件发 ActiveEncodings 清理） |
+| `GET /Search/Hints` | 搜索建议（Jellyfin 官方 Web/Android 的搜索框走它；Infuse 不用）。输出是扁平的 `{SearchHints, TotalRecordCount}`，不是 QueryResult |
 | `GET\|HEAD /Items/{itemId}/Download` 与 `/Items/{itemId}/File` | 整文件下载。Policy 宣告了 `EnableContentDownloading:true`，VidHub 等客户端的下载按钮打 Download，缺失则下载 404 无法开始。本地文件回 FileResponse（Download 带 attachment 文件名，File 不带，均支持 Range 断点续传）；strm 偏离真 Jellyfin（后者回 .strm 文本）：302 到云端直链 |
 
 **P2 兜底**：legacy `POST /PlayingItems/{itemId}`、`POST /PlayingItems/{itemId}/Progress`、
@@ -145,7 +147,7 @@ P2 兜底兼容。**凡列出 legacy 别名的都必须与新路由一起实现*
 变体（参数走 query，均 204）；`GET /Items/Filters2`（部分客户端进库时无条件请求，
 返回空结构 `{"Genres":[],"Tags":[]}` 兜底）与 `/Items/Filters`；`GET /Items/Root` +
 legacy；`GET /Items/{itemId}/Similar`（返回空 QueryResult 比 404 干净）；
-`GET /Search/Hints`（内部转调 /Items 再映射扁平结构）；`GET /System/Info`（复用
+`GET /System/Info`（复用
 Public 字段）；`/emby/*` 路径前缀别名（**非 Jellyfin 行为**——12.0 源码不存在
 该前缀，纯为个别客户端探测兜底）。
 
@@ -392,7 +394,7 @@ allFields），我们没有的字段靠 null 省略天然合法。响应 `QueryR
 | `sortBy` / `sortOrder` | 至少支持 `SortName` `Name` `DateCreated` `PremiereDate` `ProductionYear` `CommunityRating` `Runtime` `Random` `DatePlayed` `AiredEpisodeOrder` `ParentIndexNumber,IndexNumber`；`Ascending`/`Descending` 按位配对 |
 | `fields` | 字段门控，见 5.3 |
 | `filters` | `IsPlayed` `IsUnplayed` `IsResumable` `IsFavorite` |
-| `searchTerm` | 标题/别名模糊匹配（走 media_item.title/aliases） |
+| `searchTerm` | 逐字对齐 `BaseItemRepository.TranslateQuery.cs:178`：`CleanName.Contains(cleanedTerm) \|\| OriginalTitle LIKE %term%`，其中 `cleanedTerm`/`CleanName` 都过 `GetCleanValue()`（去变音符 → 小写 → 标点转空格 → 折叠空白）。实现见 `movieclaw_jellyfin/search.py`，口径单测在 `tests/jellyfin/test_search_matching.py` |
 | `genres` `years` `officialRatings` | 筛选；genres/officialRatings 用 `\|` 分隔，years 逗号 |
 | `ids` | 批量取条目（逗号分隔，非法项静默丢弃） |
 | `isPlayed` / `isFavorite` | 与 filters 等价的另一入口 |
@@ -943,13 +945,28 @@ Next 侧的 rewrite 保留给裸机开发。
 （并修正其 GetMD5 误用 UTF-8 的编码差异），另补齐了它没覆盖的 /Plugins。
 
 **已知差距**（有意留下的小缺口，不影响 Infuse 主链路）：
-- `GET /Search/Hints` 未实现（P2 兜底项，主流播放器搜索走 /Items?searchTerm）；
 - `imageTypeLimit`/`enableImageTypes`/`enableTotalRecordCount` 接受但忽略
   （超集输出，协议宽容）；
 - `PrimaryImageAspectRatio` 不输出（本地未存图片尺寸，纯排版观感）；
-- `/Persons/*` 独立命名空间未实现（人物条目走 `/Items/{personGuid}` +
-  `personIds` 过滤已覆盖主流客户端的演员页链路）；
+- `/Search/Hints` 的 `isNews`/`isKids`/`isSports` 接受但忽略（无直播电视、
+  无分级标签数据），`includeGenres`/`includeStudios`/`includeArtists` 同理
+  （没有 Genre/Studio/MusicArtist 实体，能给的按名类型只有 Person）；
+- `/Persons` 的 `IsFavorite` 筛成空（本层不落人物收藏台账）；
+- `/Items` 里 Person 与媒体条目混排时不参与 `sortBy` 比较，恒排在媒体之后；
 - 图片两种 404 body 未细分（均给 text 文案；客户端不解析 body）。
+
+**2026-08-23 补齐**（起因：Infuse 搜索页整体不可用，抓包定位）：
+- `GET /Persons`、`GET /Persons/{name}` 实现（`routes/persons.py`）。此前
+  `persons` 不在 `NAMESPACE_PREFIXES` 里，请求连兼容层都进不去，掉到前端
+  catch-all 返回 21KB 的 Next.js HTML 404；
+- `GET /Search/Hints` 实现（`routes/search.py`）；
+- 搜索匹配从「标题/原名/**别名**的裸子串」改为 Jellyfin 口径（见 5.2）。
+  副作用是别名不再参与匹配——搜 "Nirvana in Fire" 不再命中《琅琊榜》，
+  与真 Jellyfin 一致；相应地分集标题变得可搜（Episode 有自己的 Name），
+  剧名命中也不再把整季集数一并带出；
+- 带 `searchTerm` 的查询改为「先按名字列粗筛、只水合命中条目」。此前是全库
+  水合后再在内存过滤，千级条目库单次 1.4 秒，Infuse 逐字符发请求且不取消，
+  4 个并发就把单次拖到 5~8 秒。
 
 **与产品侧读策略的对齐记录**（2026-08-04，Infuse 联调后重构）：
 - 单条目详情与图片接口已复用 Web 的共享读策略（`library/items.py` 的
@@ -959,8 +976,9 @@ Next 侧的 rewrite 保留给裸机开发。
   TMDB 路径兜底出 tag——否则客户端不发图片请求，兜底层永远走不到。
 - 自愈刮削两条触发：档案缺失/从未刮过（分层读内部，与 Web 同源）；
   档案有 cast 但影人关系为空（存量补齐，收敛条件）。仅挂单条目详情。
-- **仍独立实现**：/Items 的搜索与排序口径（`_search_match` 只匹配
-  标题/原名/别名，与 Web 搜索服务的拼音等能力不同源）；People 不做
+- **仍独立实现**：/Items 的搜索与排序口径（2026-08-23 起改为逐字对齐
+  Jellyfin，见 `movieclaw_jellyfin/search.py`；与 Web 搜索服务的拼音、简繁等
+  能力**有意不同源**——协议层要的是"和真 Jellyfin 一样"，不是"更好用"）；People 不做
   NFO 叠加（人物页需要关系表影人 id，NFO 给不出，靠自愈收敛）；
   季/集图片未接目录美术图层（`season{NN}-poster.jpg` 目前只在镜像写出，
   读取仍走资产）。

--- a/src/movieclaw_jellyfin/catalog.py
+++ b/src/movieclaw_jellyfin/catalog.py
@@ -45,6 +45,7 @@ from movieclaw_jellyfin.ids import (
     root_guid,
     season_guid,
 )
+from movieclaw_jellyfin.search import SearchTerm, person_name_matches
 from movieclaw_playback.streaming import container_mime_type, is_strm  # noqa: F401
 
 TICKS_PER_SECOND = 10_000_000
@@ -590,6 +591,160 @@ async def item_ids_with_files(
         )
     ).scalars()
     return list(kind_ids)
+
+
+async def search_candidate_item_ids(
+    session: AsyncSession, term: SearchTerm, candidate_ids: list[int]
+) -> set[int]:
+    """搜索粗筛：候选条目里，自身**或其任一季/集**能命中搜索词的条目 id。
+
+    为什么要先粗筛
+    --------------
+    带 searchTerm 的查询原先要把候选条目全部水合成 bundle（条目 ⋈ 文件 ⋈ 季 ⋈
+    集 ⋈ 元数据 ⋈ 播放状态）之后才在内存里做子串过滤——命中 1 条也得先装完
+    整库。Infuse 是逐字符发请求且不取消上一个，几个并发就把单次拖到 5~8 秒
+    （实测千级条目的库 1.4 秒/次）。这里改成先用「只取名字列」的轻量投影选出
+    命中的条目 id，水合只覆盖真正要输出的那几条。
+
+    只查三张表的名字列（不 join、不反序列化 JSON 大列），因此代价与库规模
+    线性但常数极小。季/集也纳入判定是因为 Jellyfin 里 Season/Episode 是各自
+    独立的 BaseItem，有自己的 Name——搜集名在真 Jellyfin 是能搜到的。
+    最终每条候选是否真的进结果，仍由调用方按条目类型逐条判定（见
+    ``routes/library.py`` 的 ``_entry_search_match``），这里只负责收窄水合面。
+    """
+    if not candidate_ids or term.empty:
+        return set()
+    matched: set[int] = set()
+
+    rows = await session.execute(
+        select(MediaItem.id, MediaItem.title, MediaItem.original_title).where(
+            MediaItem.id.in_(candidate_ids)
+        )
+    )
+    for item_id, title, original_title in rows:
+        if term.matches(title, original_title):
+            matched.add(item_id)
+
+    season_rows = await session.execute(
+        select(MediaSeason.media_item_id, MediaSeason.name).where(
+            MediaSeason.media_item_id.in_(candidate_ids)
+        )
+    )
+    for item_id, name in season_rows:
+        if item_id not in matched and term.matches(name):
+            matched.add(item_id)
+
+    episode_rows = await session.execute(
+        select(MediaEpisode.media_item_id, MediaEpisode.name).where(
+            MediaEpisode.media_item_id.in_(candidate_ids)
+        )
+    )
+    for item_id, name in episode_rows:
+        if item_id not in matched and term.matches(name):
+            matched.add(item_id)
+
+    return matched
+
+
+async def query_persons(
+    session: AsyncSession,
+    *,
+    name_contains: str | None = None,
+    name_starts_with: str | None = None,
+    name_less_than: str | None = None,
+    name_starts_with_or_greater: str | None = None,
+    appears_in_item_id: int | None = None,
+    person_types: set[str] | None = None,
+    exclude_person_types: set[str] | None = None,
+    visible_item_ids: list[int] | None = None,
+    start_index: int = 0,
+    limit: int = 0,
+) -> tuple[int, list[Person]]:
+    """人物查询（PeopleRepository.cs:270-360 的等价筛选），返回 (总数, 该页)。
+
+    ``visible_item_ids`` 是可见性收口：人物不属于任何库，真 Jellyfin 靠
+    「至少在一部该用户能看到的片里有署名」来判定（PersonsController.cs:128
+    的 BuildAccessFilter），这里同构——传入的是该观看者可见的条目 id。
+
+    两段式：先只取 (id, name) 做结构筛选与姓名匹配，分页切完才水合整行。
+    人物表是万级的，全量水合 ORM 行只为返回一页 24 条不值当；而
+    ``NameContains`` 的口径（Unicode 大写子串）SQLite 的 LIKE 表达不出来
+    （LIKE 只对 ASCII 大小写不敏感，重音字母会漏），必须在 Python 侧判定。
+    """
+    projection = select(Person.id, Person.name)
+    linked = select(MediaItemPerson.person_id)
+    needs_link = False
+    if visible_item_ids is not None:
+        linked = linked.where(MediaItemPerson.media_item_id.in_(visible_item_ids))
+        needs_link = True
+    if appears_in_item_id is not None:
+        linked = linked.where(MediaItemPerson.media_item_id == appears_in_item_id)
+        needs_link = True
+    if person_types:
+        linked = linked.where(MediaItemPerson.department.in_(person_types))
+        needs_link = True
+    if exclude_person_types:
+        linked = linked.where(MediaItemPerson.department.not_in(exclude_person_types))
+        needs_link = True
+    if needs_link:
+        projection = projection.where(Person.id.in_(linked))
+
+    # StartsWith/LessThan/StartsWithOrGreater 照抄 PeopleRepository.cs:344-357：
+    # 过滤值先转小写再比，比对列不转——SQLite 的 LIKE/序比对与之同解
+    if name_starts_with:
+        projection = projection.where(
+            Person.name.like(f"{_escape_like(name_starts_with.lower())}%", escape="\\")
+        )
+    if name_less_than:
+        projection = projection.where(Person.name < name_less_than.lower())
+    if name_starts_with_or_greater:
+        projection = projection.where(Person.name >= name_starts_with_or_greater.lower())
+
+    rows = list(await session.execute(projection.order_by(Person.name.asc())))
+    if name_contains:
+        rows = [r for r in rows if person_name_matches(r[1], name_contains)]
+
+    total = len(rows)
+    page_rows = rows[start_index : start_index + limit] if limit > 0 else rows[start_index:]
+    page_ids = [r[0] for r in page_rows]
+    if not page_ids:
+        return total, []
+    loaded = {
+        p.id: p
+        for p in (await session.execute(select(Person).where(Person.id.in_(page_ids))))
+        .scalars()
+    }
+    return total, [loaded[i] for i in page_ids if i in loaded]
+
+
+def _escape_like(value: str) -> str:
+    """转义 LIKE 元字符——过滤值里的 % 和 _ 是字面量，不是通配符。"""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def person_dto(ctx: DtoContext, person: Person) -> dict[str, Any]:
+    """人物条目的 BaseItemDto（Type=Person 的 ItemsByName 形态）。
+
+    人物不是媒体，没有 MediaSources/UserData/库归属；Jellyfin 侧由
+    `DtoService.GetItemByNameDto` 产出，字段集就是这么窄。
+    """
+    dto: dict[str, Any] = {
+        "Name": person.name,
+        "ServerId": ctx.server_id,
+        "Id": person_guid(person.id or 0),
+        "Type": "Person",
+        "MediaType": "Unknown",
+        "IsFolder": False,
+        "ImageTags": (
+            {"Primary": hashlib.md5(person.profile_path.encode()).hexdigest()}  # noqa: S324
+            if person.profile_path
+            else {}
+        ),
+        "BackdropImageTags": [],
+    }
+    if person.original_name and person.original_name != person.name:
+        dto["OriginalTitle"] = person.original_name
+    return dto
 
 
 async def list_libraries(

--- a/src/movieclaw_jellyfin/router.py
+++ b/src/movieclaw_jellyfin/router.py
@@ -17,8 +17,10 @@ from movieclaw_jellyfin.routes.common import require_enabled
 from movieclaw_jellyfin.routes.images import router as images_router
 from movieclaw_jellyfin.routes.library import router as library_router
 from movieclaw_jellyfin.routes.misc import router as misc_router
+from movieclaw_jellyfin.routes.persons import router as persons_router
 from movieclaw_jellyfin.routes.playback import router as playback_router
 from movieclaw_jellyfin.routes.playstate import router as playstate_router
+from movieclaw_jellyfin.routes.search import router as search_router
 from movieclaw_jellyfin.routes.system import router as system_router
 from movieclaw_jellyfin.routes.users import router as users_router
 
@@ -31,6 +33,8 @@ NAMESPACE_PREFIXES = {
     "userplayeditems",
     "userfavoriteitems",
     "items",
+    "persons",
+    "search",
     "videos",
     "shows",
     "sessions",
@@ -96,6 +100,23 @@ _KNOWN_QUERY_KEYS = [
     "format",
     # DisplayPreferences 的客户端标识参数（issue #124）
     "client",
+    # /Persons 与 /Search/Hints 的参数（PersonsController.cs / SearchController.cs）
+    "nameStartsWith",
+    "nameLessThan",
+    "nameStartsWithOrGreater",
+    "personTypes",
+    "excludePersonTypes",
+    "appearsInItemId",
+    "includePeople",
+    "includeMedia",
+    "includeGenres",
+    "includeStudios",
+    "includeArtists",
+    "isMovie",
+    "isSeries",
+    "isNews",
+    "isKids",
+    "isSports",
 ]
 
 # 注册顺序即匹配顺序：字面路径的模块在参数路径之前
@@ -106,6 +127,8 @@ _SUB_ROUTERS = [
     playstate_router,
     playback_router,
     images_router,
+    search_router,
+    persons_router,
     library_router,
 ]
 

--- a/src/movieclaw_jellyfin/routes/library.py
+++ b/src/movieclaw_jellyfin/routes/library.py
@@ -33,7 +33,10 @@ from movieclaw_jellyfin.catalog import (
     movie_dto,
     movie_library_page,
     next_up_item_ids,
+    person_dto,
+    query_persons,
     resume_unit_candidates,
+    search_candidate_item_ids,
     season_dto,
     series_dto,
 )
@@ -53,6 +56,7 @@ from movieclaw_jellyfin.routes.common import (
     parse_pipe,
     query_result,
 )
+from movieclaw_jellyfin.search import SearchTerm, parse_term
 from movieclaw_jellyfin.security import RequestIdentity, require_device
 
 router = APIRouter(dependencies=[Depends(require_device)])
@@ -110,8 +114,10 @@ async def viewer_scope(
         visible = await member_visible_ids(session, member_id)
     return ViewerScope(member_id, visible)
 
-# (type, bundle, season, episode)：查询管线里的一条候选
-Entry = tuple[str, ItemBundle, int, int]
+# (type, payload, season, episode)：查询管线里的一条候选。
+# payload 通常是 ItemBundle；type == "Person" 时是 Person 行——人物是
+# ItemsByName，没有文件/季集/播放状态，凑不出 bundle，也不参与媒体侧筛选与排序。
+Entry = tuple[str, Any, int, int]
 
 
 async def _items_with_persons(
@@ -302,11 +308,20 @@ def _entry_favorite(entry: Entry) -> bool:
     return bool(st and st.is_favorite)
 
 
-def _search_match(bundle: ItemBundle, term: str) -> bool:
-    lowered = term.lower()
-    candidates = [bundle.item.title, bundle.item.original_title]
-    candidates.extend(bundle.item.aliases or [])
-    return any(lowered in (c or "").lower() for c in candidates)
+def _entry_search_match(entry: Entry, term: SearchTerm) -> bool:
+    """逐条目判定 searchTerm 是否命中——口径见 ``movieclaw_jellyfin.search``。
+
+    按 Jellyfin 的语义，Season / Episode 是各自独立的 BaseItem，只比对**自己的
+    Name**：剧名命中不会把它下面几十集一并带出来，反过来集名命中也能单独出现。
+    """
+    kind, bundle, season, episode = entry
+    if kind == "Episode":
+        row = bundle.episodes.get((season, episode))
+        return term.matches(row.name if row else None)
+    if kind == "Season":
+        row = bundle.seasons.get(season)
+        return term.matches(row.name if row else None)
+    return term.matches(bundle.item.title, bundle.item.original_title)
 
 
 def _build_entries(
@@ -426,6 +441,8 @@ def _sort_entries(entries: list[Entry], sort_by: list[str], sort_orders: list[st
 
 def _entry_dto(ctx: DtoContext, entry: Entry, options: DtoOptions) -> dict[str, Any]:
     kind, bundle, season, episode = entry
+    if kind == "Person":
+        return person_dto(ctx, bundle)
     if kind == "Movie":
         return movie_dto(ctx, bundle, options)
     if kind == "Series":
@@ -448,7 +465,7 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
     recursive = parse_bool(q.get("recursive"))
     parent_raw = q.get("parentId")
     ids_raw = parse_comma(q.get("ids"))
-    search_term = q.get("searchTerm")
+    search_term = parse_term(q.get("searchTerm"))
     person_ids_raw = parse_comma(q.get("personIds"))
     start_index = _parse_int(q.get("startIndex"))
     limit = _parse_int(q.get("limit"), default=-1)
@@ -521,7 +538,7 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
                 scope,
                 include_types=include_types,
                 recursive=recursive,
-                has_search=bool(search_term),
+                search=search_term,
                 options=options,
             )
             if entries is None:
@@ -536,6 +553,14 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
         if not simple_movie_page and person_ids_raw:
             member_ids = await _items_with_persons(session, person_ids_raw)
             entries = [e for e in entries if e[1].item.id in member_ids]
+        # 人物条目（ItemsByName）：Person 行不属于任何库、没有 TopParentId，
+        # 真 Jellyfin 用 GetExemptedItemByNameTypes 把它豁免出库过滤
+        # （BaseItemRepository.QueryBuilding.cs:504-513）——只有 includeItemTypes
+        # 显式点名 Person 才产出，且不参与年份/类型/播放状态这些媒体侧筛选。
+        # 这里在会话内查出来，拼接放到全部媒体筛选与排序之后。
+        person_entries: list[Entry] = []
+        if "Person" in include_types and not ids_raw and not simple_movie_page:
+            person_entries = await _person_entries(session, scope, search_term)
     if simple_movie_page:
         entries = page_entries or []
         total = simple_total
@@ -546,7 +571,7 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
 
         # ---- 过滤 ---------------------------------------------------------
         if search_term:
-            entries = [e for e in entries if _search_match(e[1], search_term)]
+            entries = [e for e in entries if _entry_search_match(e, search_term)]
         years = {int(y) for y in parse_comma(q.get("years")) if y.isdigit()}
         if years:
             entries = [e for e in entries if e[1].item.year in years]
@@ -576,13 +601,82 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
         if "IsFavorite" in filters or parse_bool(q.get("isFavorite")) is True:
             entries = [e for e in entries if _entry_favorite(e)]
 
-        # ---- 排序 / 分页 / DTO -------------------------------------------
-        entries = _sort_entries(entries, sort_by, sort_order)
+        # ---- 排序 / 分页 -----------------------------------------------------
+        entries = _sort_entries(entries, sort_by, sort_order) + person_entries
         total = len(entries)
         page = entries[start_index : start_index + limit] if limit >= 0 else entries[start_index:]
 
     dtos = [_entry_dto(ctx, e, options) for e in page]
     return JSONResponse(query_result(dtos, total, start_index))
+
+
+async def collect_search_entries(
+    session: AsyncSession,
+    scope: ViewerScope,
+    search: SearchTerm,
+    *,
+    media_types: set[str],
+    include_persons: bool,
+    library_id: int | None = None,
+) -> list[Entry]:
+    """按搜索词装配候选条目——`/Search/Hints` 与 `/Items?searchTerm=` 共用同一口径。
+
+    独立成公开函数是为了让两个接口的"什么算命中"只有一份实现：/Search/Hints
+    在真 Jellyfin 里也是先拿候选再换一套输出结构（SearchManager.cs:176），
+    不是另一套匹配规则。
+    """
+    entries: list[Entry] = []
+    if media_types:
+        ids = await item_ids_with_files(
+            session,
+            library_id=library_id,
+            visible_library_ids=scope.visible,
+        )
+        ids = await _narrow_by_search(session, ids, search)
+        bundles = await load_bundles(
+            session,
+            ids,
+            member_id=scope.member_id,
+            library_id=library_id,
+            visible_library_ids=scope.visible,
+            dto_options=DtoOptions(),
+        )
+        entries = [
+            e
+            for e in _build_entries(bundles, media_types)
+            if _entry_search_match(e, search)
+        ]
+    if include_persons:
+        entries += await _person_entries(session, scope, search, library_id=library_id)
+    return entries
+
+
+async def _person_entries(
+    session: AsyncSession,
+    scope: ViewerScope,
+    search: SearchTerm | None,
+    *,
+    library_id: int | None = None,
+) -> list[Entry]:
+    """/Items 里的 Person 候选。可见性 = 至少在一部可见条目里有署名。
+
+    这里的姓名比对走 ``SearchTerm``（CleanName 口径），与 `/Persons` 的
+    NameContains 不同——两条路径在真 Jellyfin 里分别落在 BaseItemRepository 与
+    PeopleRepository，口径本就不一致，照抄。
+    """
+    visible_ids: list[int] | None = None
+    if library_id is not None:
+        visible_ids = await item_ids_with_files(
+            session, library_id=library_id, visible_library_ids=scope.visible
+        )
+    elif scope.visible is not None:
+        visible_ids = await item_ids_with_files(
+            session, visible_library_ids=scope.visible
+        )
+    _, persons = await query_persons(session, visible_item_ids=visible_ids)
+    if search is not None:
+        persons = [p for p in persons if search.matches(p.name, p.original_name)]
+    return [("Person", p, 0, 0) for p in persons]
 
 
 async def _entries_for_ids(
@@ -615,6 +709,20 @@ async def _entries_for_ids(
     return entries
 
 
+async def _narrow_by_search(
+    session: AsyncSession, ids: list[int], search: SearchTerm | None
+) -> list[int]:
+    """带 searchTerm 时，把待水合的条目收窄到搜索粗筛命中的那些。
+
+    粗筛只读名字列，水合才是重头——顺序反过来就是「命中 1 条也要装完整库」，
+    也就是 Infuse 逐字搜索被拖到 5~8 秒的原因。
+    """
+    if search is None:
+        return ids
+    matched = await search_candidate_item_ids(session, search, ids)
+    return [i for i in ids if i in matched]
+
+
 async def _entries_for_parent(
     session: AsyncSession,
     parent_raw: str | None,
@@ -622,15 +730,16 @@ async def _entries_for_parent(
     *,
     include_types: set[str],
     recursive: bool | None,
-    has_search: bool,
+    search: SearchTerm | None,
     options: DtoOptions,
 ) -> list[Entry] | None:
     """按 parentId 语义展开候选。返回 None 表示"根级 → 视图列表"。"""
     if not parent_raw or is_empty_guid(parent_raw):
-        if has_search or include_types:
+        if search is not None or include_types:
             # 无 parent 的全局搜索/类型查询：跨**可见**库递归
             types = include_types or {"Movie", "Series"}
             ids = await item_ids_with_files(session, visible_library_ids=scope.visible)
+            ids = await _narrow_by_search(session, ids, search)
             bundles = await load_bundles(
                 session,
                 ids,
@@ -667,6 +776,7 @@ async def _entries_for_parent(
             # 非递归 = 只看直接子级，includeItemTypes 在其上做过滤（可为空集）
             types = (include_types & default_types) if include_types else default_types
         ids = await item_ids_with_files(session, library_id=ref.entity_id)
+        ids = await _narrow_by_search(session, ids, search)
         bundles = await load_bundles(
             session,
             ids,
@@ -1091,25 +1201,7 @@ async def get_item(
             person = await session.get(Person, ref.entity_id)
             if person is None:
                 raise not_found()
-            import hashlib
-
-            dto: dict[str, Any] = {
-                "Name": person.name,
-                "ServerId": ctx.server_id,
-                "Id": item_id.lower().replace("-", ""),
-                "Type": "Person",
-                "MediaType": "Unknown",
-                "IsFolder": False,
-                "ImageTags": (
-                    {"Primary": hashlib.md5(person.profile_path.encode()).hexdigest()}
-                    if person.profile_path
-                    else {}
-                ),
-                "BackdropImageTags": [],
-            }
-            if person.original_name and person.original_name != person.name:
-                dto["OriginalTitle"] = person.original_name
-            return JSONResponse(dto)
+            return JSONResponse(person_dto(ctx, person))
         if ref.kind == EntityKind.LIBRARY:
             if scope.library_hidden(ref.entity_id):
                 raise not_found()

--- a/src/movieclaw_jellyfin/routes/persons.py
+++ b/src/movieclaw_jellyfin/routes/persons.py
@@ -1,0 +1,149 @@
+"""人物接口（`Jellyfin.Api/Controllers/PersonsController.cs`）。
+
+Infuse 的搜索页是两路并发：`/Items?searchTerm=` 取媒体、`/Persons?searchTerm=`
+取演职员，两者结果合并渲染。本层此前没有这个命名空间，请求会掉到前端的
+catch-all 返回一整页 HTML 404——搜索页因此表现为不可用（2026-08-22 抓包实证）。
+
+人物是 ItemsByName：不属于任何库、没有文件、没有 UserData。可见性由
+「至少在一部该观看者可见的条目里有署名」推导，对齐 PersonsController.cs:128
+的 BuildAccessFilter。
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from movieclaw_db.engine import get_database
+from movieclaw_db.models import Library
+from movieclaw_jellyfin.catalog import (
+    item_ids_with_files,
+    person_dto,
+    query_persons,
+)
+from movieclaw_jellyfin.errors import not_found
+from movieclaw_jellyfin.ids import EntityKind, decode_guid
+from movieclaw_jellyfin.routes.common import (
+    dto_context,
+    parse_bool,
+    parse_comma,
+    query_result,
+)
+from movieclaw_jellyfin.routes.library import ViewerScope, viewer_scope
+from movieclaw_jellyfin.security import require_device
+
+router = APIRouter(dependencies=[Depends(require_device)])
+
+# Jellyfin PersonKind ↔ movieclaw 的 media_item_person.department。
+# movieclaw 只收 cast/director 两类署名（见 MediaItemPerson 的类注释），
+# 其余 PersonKind（Writer/Producer/Composer…）在本库里恒无匹配。
+_PERSON_KIND_TO_DEPARTMENT = {"actor": "cast", "director": "director"}
+
+
+def _departments(raw: str | None) -> set[str]:
+    """personTypes/excludePersonTypes → department 集合（未知种类静默丢弃）。"""
+    return {
+        dept
+        for kind in parse_comma(raw)
+        if (dept := _PERSON_KIND_TO_DEPARTMENT.get(kind.lower()))
+    }
+
+
+def _int_or_none(raw: str | None) -> int | None:
+    try:
+        return int(raw) if raw is not None else None
+    except ValueError:
+        return None
+
+
+async def _library_item_ids(session, parent_raw: str | None) -> list[int] | None:
+    """parentId 收窄：把人物限定在该库有署名的条目上。
+
+    非库 GUID / 未知 GUID 一律当作"没有这样的库"，返回空列表（结果为空），
+    不抛 404——PersonsController 对 parentId 不做存在性校验。
+    """
+    if not parent_raw:
+        return None
+    ref = decode_guid(parent_raw)
+    if ref is None or ref.kind != EntityKind.LIBRARY:
+        return []
+    library = await session.get(Library, ref.entity_id)
+    if library is None:
+        return []
+    return await item_ids_with_files(session, library_id=ref.entity_id)
+
+
+@router.get("/Persons")
+async def get_persons(
+    request: Request, scope: ViewerScope = Depends(viewer_scope)
+) -> JSONResponse:
+    q = request.query_params
+    ctx = await dto_context()
+    start_index = _int_or_none(q.get("startIndex")) or 0
+    limit = _int_or_none(q.get("limit")) or 0
+    search_term = q.get("searchTerm")
+    filters = set(parse_comma(q.get("filters")))
+    is_favorite = parse_bool(q.get("isFavorite"))
+
+    # 人物没有 UserData 台账（本层不落人物收藏），IsFavorite 恒无匹配。
+    # 对齐真 Jellyfin 的「筛选后为空」而不是「忽略该筛选」——忽略会把整个
+    # 人物列表当成收藏夹返回，比空列表离谱得多。
+    if is_favorite is True or "IsFavorite" in filters:
+        return JSONResponse(query_result([], 0, start_index))
+
+    async with get_database().session() as session:
+        parent_ids = await _library_item_ids(session, q.get("parentId"))
+        visible_ids: list[int] | None = None
+        if scope.visible is not None:
+            visible_ids = await item_ids_with_files(
+                session, visible_library_ids=scope.visible
+            )
+        if parent_ids is not None:
+            visible_ids = (
+                parent_ids
+                if visible_ids is None
+                else [i for i in parent_ids if i in set(visible_ids)]
+            )
+
+        appears_in = decode_guid(q.get("appearsInItemId") or "")
+        total, page = await query_persons(
+            session,
+            name_contains=search_term,
+            name_starts_with=q.get("nameStartsWith"),
+            name_less_than=q.get("nameLessThan"),
+            name_starts_with_or_greater=q.get("nameStartsWithOrGreater"),
+            appears_in_item_id=(
+                appears_in.entity_id
+                if appears_in is not None and appears_in.kind == EntityKind.ITEM
+                else None
+            ),
+            person_types=_departments(q.get("personTypes")),
+            exclude_person_types=_departments(q.get("excludePersonTypes")),
+            visible_item_ids=visible_ids,
+            start_index=start_index,
+            limit=limit,
+        )
+
+    return JSONResponse(query_result([person_dto(ctx, p) for p in page], total, start_index))
+
+
+@router.get("/Persons/{name}")
+async def get_person_by_name(
+    name: str, scope: ViewerScope = Depends(viewer_scope)
+) -> JSONResponse:
+    """按**姓名**取单个人物（PersonsController.cs:151，路由段是名字不是 GUID）。"""
+    ctx = await dto_context()
+    async with get_database().session() as session:
+        visible_ids: list[int] | None = None
+        if scope.visible is not None:
+            visible_ids = await item_ids_with_files(
+                session, visible_library_ids=scope.visible
+            )
+        _, candidates = await query_persons(
+            session, name_contains=name, visible_item_ids=visible_ids
+        )
+    # NameContains 是子串匹配，这里要的是精确同名；大小写不敏感对齐 GetPerson
+    exact = [p for p in candidates if p.name.upper() == name.upper()]
+    if not exact:
+        raise not_found()
+    return JSONResponse(person_dto(ctx, exact[0]))

--- a/src/movieclaw_jellyfin/routes/search.py
+++ b/src/movieclaw_jellyfin/routes/search.py
@@ -1,0 +1,185 @@
+"""搜索建议接口（`Jellyfin.Api/Controllers/SearchController.cs`）。
+
+Infuse 不用这个接口（它直接打 /Items + /Persons），但 Jellyfin 官方 Web /
+Android 客户端的搜索框走的就是它。此前未实现，请求会掉到前端 catch-all 返回
+一整页 HTML 404。
+
+与 /Items 的关系：真 Jellyfin 的 SearchManager 先由搜索提供方给出候选 id，再
+回 `GetItemList` 取条目，最后映射成扁平的 SearchHint（SearchManager.cs:176）。
+这里同构——复用 /Items 的候选装配与匹配口径，只在最后换一套更窄的输出结构。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from movieclaw_db.engine import get_database
+from movieclaw_db.models import Library
+from movieclaw_jellyfin.catalog import (
+    TICKS_PER_MS,
+    DtoContext,
+    ItemBundle,
+    person_dto,
+)
+from movieclaw_jellyfin.errors import bad_request_text
+from movieclaw_jellyfin.ids import (
+    EntityKind,
+    decode_guid,
+    episode_guid,
+    is_empty_guid,
+    item_guid,
+    season_guid,
+)
+from movieclaw_jellyfin.routes.common import dto_context, parse_bool, parse_comma
+from movieclaw_jellyfin.routes.library import (
+    Entry,
+    ViewerScope,
+    collect_search_entries,
+    viewer_scope,
+)
+from movieclaw_jellyfin.search import parse_term
+from movieclaw_jellyfin.security import require_device
+
+router = APIRouter(dependencies=[Depends(require_device)])
+
+# includeMedia=false 时，只有这些"按名"类型还留在结果里（SearchManager.cs:417）。
+# movieclaw 没有 Genre/Studio/MusicArtist 实体，能给的按名类型只有 Person。
+_MEDIA_KINDS = {"Movie", "Series", "Season", "Episode"}
+
+
+def _hint(ctx: DtoContext, entry: Entry) -> dict[str, Any]:
+    """Entry → SearchHint（MediaBrowser.Model/Search/SearchHint.cs）。
+
+    只输出本层拿得到的字段：SearchHint 里 Album/Artists/ChannelName 等音乐与
+    直播电视字段在 movieclaw 没有对应数据，按"可空字段值为 null 时省略"的
+    全局约定不输出（设计文档 5.3）。
+    """
+    kind, payload, season, episode = entry
+    if kind == "Person":
+        dto = person_dto(ctx, payload)
+        return {
+            "ItemId": dto["Id"],
+            "Id": dto["Id"],
+            "Name": dto["Name"],
+            "MatchedTerm": dto["Name"],
+            "Type": "Person",
+            "MediaType": "Unknown",
+            **({"PrimaryImageTag": dto["ImageTags"]["Primary"]} if dto["ImageTags"] else {}),
+        }
+
+    bundle: ItemBundle = payload
+    item = bundle.item
+    if kind == "Episode":
+        guid = episode_guid(item.id or 0, season, episode)
+        row = bundle.episodes.get((season, episode))
+        name = (row.name if row else None) or f"第 {episode} 集"
+    elif kind == "Season":
+        guid = season_guid(item.id or 0, season)
+        row = bundle.seasons.get(season)
+        name = (row.name if row else None) or f"第 {season} 季"
+    else:
+        guid = item_guid(item.id or 0)
+        name = item.title
+
+    hint: dict[str, Any] = {
+        "ItemId": guid,  # 老客户端仍读这个键（SearchController.cs:156）
+        "Id": guid,
+        "Name": name,
+        "MatchedTerm": name,
+        "Type": kind,
+        "MediaType": "Unknown" if kind in ("Series", "Season") else "Video",
+    }
+    if kind in ("Series", "Season"):
+        hint["IsFolder"] = True
+    if kind == "Episode":
+        hint["IndexNumber"] = episode
+        hint["ParentIndexNumber"] = season
+        hint["Series"] = item.title
+    if item.year:
+        hint["ProductionYear"] = item.year
+    runtime_ms = bundle.unit_runtime_ms(season, episode)
+    if runtime_ms:
+        hint["RunTimeTicks"] = runtime_ms * TICKS_PER_MS
+    if kind == "Series" and item.status:
+        hint["Status"] = item.status
+    return hint
+
+
+@router.get("/Search/Hints")
+async def get_search_hints(
+    request: Request, scope: ViewerScope = Depends(viewer_scope)
+) -> JSONResponse:
+    q = request.query_params
+    search = parse_term(q.get("searchTerm"))
+    # searchTerm 是 [Required]，且 SearchManager 入口还有
+    # ArgumentException.ThrowIfNullOrWhiteSpace（SearchManager.cs:179）——
+    # 缺失和纯空白都是 400。注意 /Items 那边用的是 IsNullOrEmpty，纯空白会被
+    # 当成正常搜索词照走（结果自然为空），两处不一致是 Jellyfin 自身如此。
+    if search is None or not search.raw.strip():
+        raise bad_request_text()
+
+    include_types = set(parse_comma(q.get("includeItemTypes")))
+    exclude_types = set(parse_comma(q.get("excludeItemTypes")))
+    include_media = parse_bool(q.get("includeMedia")) is not False
+    include_people = parse_bool(q.get("includePeople")) is not False
+    start_index = _int_or_zero(q.get("startIndex"))
+    limit = _int_or_zero(q.get("limit"))
+
+    # 类型收敛照抄 SearchManager.BuildIncludeItemTypes / BuildExcludeItemTypes：
+    # includeMedia=false 时媒体类型整体退出，只留按名类型（本层只有 Person）
+    media_types = (
+        ((include_types & _MEDIA_KINDS) if include_types else set(_MEDIA_KINDS))
+        if include_media
+        else set()
+    ) - exclude_types
+    # isMovie/isSeries 是媒体类型的另一个入口；isNews/isKids/isSports 本层无
+    # 对应数据（无直播电视、无分级标签），接受但忽略
+    if parse_bool(q.get("isMovie")) is True:
+        media_types &= {"Movie"}
+    if parse_bool(q.get("isSeries")) is True:
+        media_types &= {"Series", "Season", "Episode"}
+    want_person = (
+        include_people
+        and "Person" not in exclude_types
+        and (not include_types or "Person" in include_types)
+    )
+
+    ctx = await dto_context()
+    async with get_database().session() as session:
+        library_id = await _parent_library_id(session, q.get("parentId"))
+        if library_id is False:  # parentId 给了但不是本层认识的库 → 空结果
+            return JSONResponse({"SearchHints": [], "TotalRecordCount": 0})
+        entries = await collect_search_entries(
+            session,
+            scope,
+            search,
+            media_types=media_types,
+            include_persons=want_person,
+            library_id=library_id,
+        )
+
+    total = len(entries)
+    page = entries[start_index : start_index + limit] if limit > 0 else entries[start_index:]
+    return JSONResponse(
+        {"SearchHints": [_hint(ctx, e) for e in page], "TotalRecordCount": total}
+    )
+
+
+def _int_or_zero(raw: str | None) -> int:
+    try:
+        return int(raw) if raw is not None else 0
+    except ValueError:
+        return 0
+
+
+async def _parent_library_id(session, parent_raw: str | None) -> int | None | bool:
+    """parentId → 库 id；未传返回 None（不收窄）；不是已知库返回 False（空结果）。"""
+    if not parent_raw or is_empty_guid(parent_raw):
+        return None
+    ref = decode_guid(parent_raw)
+    if ref is None or ref.kind != EntityKind.LIBRARY:
+        return False
+    return ref.entity_id if await session.get(Library, ref.entity_id) else False

--- a/src/movieclaw_jellyfin/search.py
+++ b/src/movieclaw_jellyfin/search.py
@@ -1,0 +1,101 @@
+"""搜索匹配口径：逐字对齐 Jellyfin 服务端，不做任何本地增强。
+
+协议依据（`jellyfin/jellyfin` @ `929834c`）：
+
+- `src/Jellyfin.Extensions/StringExtensions.cs:158` `GetCleanValue()`
+  —— 去变音符 → 转小写 → 标点/符号替换成空格 → 折叠连续空格并去首尾；
+- `Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs:178`
+  —— 命中条件是 `CleanName.Contains(cleanedTerm) || OriginalTitle LIKE %term%`，
+  其中 `CleanName` 是入库时对 `Name` 预算的 `GetCleanValue()`；
+- `Jellyfin.Server.Implementations/Item/PeopleRepository.cs:338`
+  —— `/Persons` 的 `NameContains` **不走** GetCleanValue，是裸的
+  `Name.ToUpper().Contains(term.ToUpper())`。两条路径口径不同是 Jellyfin
+  自身的历史差异，这里照抄，不做统一。
+
+有意不做的事（真 Jellyfin 也不做，做了就是偏离）：简繁折叠、拼音、别名匹配。
+搜「三體」命不中「三体」、搜「santi」命不中「三体」都是对齐后的预期行为。
+
+顺带说明一处 Jellyfin 的死代码：`TranslateQuery.cs:182` 会检查 cleaned term
+里有没有 `% _ [ ] ^` 来决定走 LIKE 通配分支，但 `GetCleanValue()` 已经把这五个
+字符全替换成空格了，该分支恒不成立。这里因此不实现通配语义。
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from functools import lru_cache
+
+_SPACES = re.compile(r"\s+")
+
+
+def _remove_diacritics(value: str) -> str:
+    """去变音符：NFD 拆分后丢弃所有非间距记号（Unicode 类别 Mn）。
+
+    等价于 .NET 侧 `Diacritics.Extensions.RemoveDiacritics`。Jellyfin 在这之前
+    还剥了落单的代理项字符（`NonConformingUnicodeRegex`），Python 的 str 拿不到
+    落单代理项，无需对应处理。
+    """
+    decomposed = unicodedata.normalize("NFD", value)
+    stripped = "".join(c for c in decomposed if unicodedata.category(c) != "Mn")
+    return unicodedata.normalize("NFC", stripped)
+
+
+# 库里的标题会被反复归一化（每次搜索一遍全部候选），而标题本身极少变动，
+# 缓存住省掉重复的 NFD 拆分。上限按「万级条目 + 万级分集名」留量。
+@lru_cache(maxsize=32768)
+def clean_value(value: str | None) -> str:
+    """`GetCleanValue()` 的等价实现。空/纯空白原样返回（对齐 C# 的提前返回）。"""
+    if not value or not value.strip():
+        return value or ""
+    cleaned = _remove_diacritics(value).lower()
+    # C# 是 [^\p{L}\p{N}\s] → " "。Python 的 re 没有 \p{...}，逐字符按 Unicode
+    # 类别判定才能等价：\w 含下划线、又不含 Nl/No（如 ½、Ⅷ），用不得。
+    cleaned = "".join(
+        c if (c.isspace() or unicodedata.category(c)[0] in ("L", "N")) else " "
+        for c in cleaned
+    )
+    return _SPACES.sub(" ", cleaned).strip()
+
+
+@dataclass(frozen=True)
+class SearchTerm:
+    """预处理好的搜索词。一次请求算一次，避免在每条候选上重复归一化。"""
+
+    raw: str
+    cleaned: str
+    lowered: str
+
+    @property
+    def empty(self) -> bool:
+        return not self.cleaned and not self.lowered
+
+    def matches(self, name: str | None, original_title: str | None = None) -> bool:
+        """条目级命中判定（BaseItemRepository.TranslateQuery.cs:178-193）。
+
+        ``name`` 比对的是它的 CleanName（这里现算，movieclaw 没有预存列）；
+        ``original_title`` 走 LIKE，即大小写不敏感的裸子串。
+        """
+        if self.cleaned and name and self.cleaned in clean_value(name):
+            return True
+        return bool(
+            self.lowered and original_title and self.lowered in original_title.lower()
+        )
+
+
+def parse_term(raw: str | None) -> SearchTerm | None:
+    """把 query 里的 searchTerm 转成预处理形态；未传/空串返回 None。"""
+    if not raw:
+        return None
+    return SearchTerm(raw=raw, cleaned=clean_value(raw), lowered=raw.lower())
+
+
+def person_name_matches(name: str | None, term_raw: str) -> bool:
+    """`/Persons` 的 NameContains 口径（PeopleRepository.cs:338-342）。
+
+    注意这里**不过** GetCleanValue：真 Jellyfin 对人物就是裸的大写子串比对。
+    """
+    if not name or not term_raw:
+        return False
+    return term_raw.upper() in name.upper()

--- a/tests/jellyfin/test_persons_and_search.py
+++ b/tests/jellyfin/test_persons_and_search.py
@@ -1,0 +1,314 @@
+"""`/Persons` 与 `/Search/Hints` 的协议形态，以及搜索口径对齐后的 /Items 行为。
+
+背景：2026-08-22 抓包发现 Infuse 的搜索页并发打 `/Items?searchTerm=` 和
+`/Persons?searchTerm=`，后者当时没有实现，请求掉到前端 catch-all 返回一整页
+HTML 404，搜索页整体不可用。这里的断言既锁形态，也锁"不要再退回 HTML"。
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from jellyfin.helpers import jf_login
+from movieclaw_jellyfin.ids import item_guid, library_guid
+
+
+class TestPersons:
+    def test_returns_query_result_not_html(self, client: TestClient) -> None:
+        token = jf_login(client)
+        resp = client.get("/Persons", params={"ApiKey": token})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        body = resp.json()
+        assert set(body) == {"Items", "TotalRecordCount", "StartIndex"}
+        # 播种了 3 位影人，全部挂在电影上
+        assert body["TotalRecordCount"] == 3
+        assert {i["Type"] for i in body["Items"]} == {"Person"}
+
+    def test_person_dto_shape(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Persons", params={"ApiKey": token, "searchTerm": "迪卡普里奥"}
+        ).json()
+        assert body["TotalRecordCount"] == 1
+        dto = body["Items"][0]
+        assert dto["Name"] == "莱昂纳多·迪卡普里奥"
+        assert dto["Type"] == "Person"
+        assert dto["MediaType"] == "Unknown"
+        assert dto["IsFolder"] is False
+        assert dto["OriginalTitle"] == "Leonardo DiCaprio"
+        assert dto["ImageTags"]["Primary"]
+        assert len(dto["Id"]) == 32
+
+    def test_search_term_matches_name_only(self, client: TestClient) -> None:
+        """NameContains 只看 name 列，不看 original_name（PeopleRepository.cs:341）。"""
+        token = jf_login(client)
+        by_name = client.get(
+            "/Persons", params={"ApiKey": token, "searchTerm": "诺兰"}
+        ).json()
+        assert [i["Name"] for i in by_name["Items"]] == ["克里斯托弗·诺兰"]
+        by_original = client.get(
+            "/Persons", params={"ApiKey": token, "searchTerm": "Nolan"}
+        ).json()
+        assert by_original["TotalRecordCount"] == 0
+
+    def test_person_types_filter(self, client: TestClient) -> None:
+        token = jf_login(client)
+        directors = client.get(
+            "/Persons", params={"ApiKey": token, "personTypes": "Director"}
+        ).json()
+        assert [i["Name"] for i in directors["Items"]] == ["克里斯托弗·诺兰"]
+        actors = client.get(
+            "/Persons", params={"ApiKey": token, "personTypes": "Actor"}
+        ).json()
+        assert actors["TotalRecordCount"] == 2
+        # 未知 PersonKind 静默丢弃 → 不产生过滤条件
+        unknown = client.get(
+            "/Persons", params={"ApiKey": token, "personTypes": "Composer"}
+        ).json()
+        assert unknown["TotalRecordCount"] == 3
+
+    def test_exclude_person_types(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Persons", params={"ApiKey": token, "excludePersonTypes": "Director"}
+        ).json()
+        assert body["TotalRecordCount"] == 2
+
+    def test_appears_in_item_id(self, client: TestClient, seeded: dict) -> None:
+        token = jf_login(client)
+        on_movie = client.get(
+            "/Persons",
+            params={"ApiKey": token, "appearsInItemId": item_guid(seeded["movie"])},
+        ).json()
+        assert on_movie["TotalRecordCount"] == 3
+        on_show = client.get(
+            "/Persons",
+            params={"ApiKey": token, "appearsInItemId": item_guid(seeded["show"])},
+        ).json()
+        assert on_show["TotalRecordCount"] == 0
+
+    def test_parent_id_scopes_to_library(self, client: TestClient, seeded: dict) -> None:
+        token = jf_login(client)
+        movie_lib = client.get(
+            "/Persons",
+            params={"ApiKey": token, "parentId": library_guid(seeded["movie_lib"])},
+        ).json()
+        assert movie_lib["TotalRecordCount"] == 3
+        tv_lib = client.get(
+            "/Persons",
+            params={"ApiKey": token, "parentId": library_guid(seeded["tv_lib"])},
+        ).json()
+        assert tv_lib["TotalRecordCount"] == 0
+
+    def test_paging(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Persons", params={"ApiKey": token, "startIndex": 1, "limit": 1}
+        ).json()
+        assert body["TotalRecordCount"] == 3
+        assert body["StartIndex"] == 1
+        assert len(body["Items"]) == 1
+
+    def test_name_starts_with(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Persons", params={"ApiKey": token, "nameStartsWith": "克"}
+        ).json()
+        assert [i["Name"] for i in body["Items"]] == ["克里斯托弗·诺兰"]
+
+    def test_is_favorite_yields_empty(self, client: TestClient) -> None:
+        """本层不落人物收藏，IsFavorite 应筛成空而不是被忽略。"""
+        token = jf_login(client)
+        body = client.get(
+            "/Persons", params={"ApiKey": token, "isFavorite": "true"}
+        ).json()
+        assert body["TotalRecordCount"] == 0
+        assert body["Items"] == []
+
+    def test_get_by_name(self, client: TestClient) -> None:
+        token = jf_login(client)
+        resp = client.get("/Persons/克里斯托弗·诺兰", params={"ApiKey": token})
+        assert resp.status_code == 200
+        assert resp.json()["Name"] == "克里斯托弗·诺兰"
+
+    def test_get_by_name_unknown_is_404(self, client: TestClient) -> None:
+        token = jf_login(client)
+        resp = client.get("/Persons/查无此人", params={"ApiKey": token})
+        assert resp.status_code == 404
+        assert resp.text == ""
+
+    def test_get_by_name_requires_exact_match(self, client: TestClient) -> None:
+        """子串命中不算——路由段是姓名，语义是精确取人。"""
+        token = jf_login(client)
+        assert client.get("/Persons/诺兰", params={"ApiKey": token}).status_code == 404
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        assert client.get("/Persons").status_code == 401
+
+    def test_pascal_case_query_keys(self, client: TestClient) -> None:
+        """PascalCase 客户端（Infuse 就是）发的键要能被归一化中间件认出来。"""
+        token = jf_login(client)
+        body = client.get(
+            "/Persons", params={"ApiKey": token, "SearchTerm": "诺兰", "Limit": 5}
+        ).json()
+        assert body["TotalRecordCount"] == 1
+
+
+class TestSearchHints:
+    def test_shape(self, client: TestClient) -> None:
+        token = jf_login(client)
+        resp = client.get(
+            "/Search/Hints", params={"ApiKey": token, "searchTerm": "breaking"}
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        body = resp.json()
+        assert set(body) == {"SearchHints", "TotalRecordCount"}
+        assert body["TotalRecordCount"] == 1
+        hint = body["SearchHints"][0]
+        assert hint["Name"] == "绝命毒师"
+        assert hint["Type"] == "Series"
+        assert hint["IsFolder"] is True
+        assert hint["ProductionYear"] == 2008
+        assert hint["Status"] == "Ended"
+        # 老客户端读 ItemId，新客户端读 Id，两个都要给且相等
+        assert hint["ItemId"] == hint["Id"]
+
+    def test_missing_term_is_400(self, client: TestClient) -> None:
+        token = jf_login(client)
+        assert client.get("/Search/Hints", params={"ApiKey": token}).status_code == 400
+        assert (
+            client.get(
+                "/Search/Hints", params={"ApiKey": token, "searchTerm": "   "}
+            ).status_code
+            == 400
+        )
+
+    def test_episode_hint_carries_index_numbers(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Search/Hints", params={"ApiKey": token, "searchTerm": "Pilot"}
+        ).json()
+        assert body["TotalRecordCount"] == 1
+        hint = body["SearchHints"][0]
+        assert hint["Type"] == "Episode"
+        assert (hint["ParentIndexNumber"], hint["IndexNumber"]) == (1, 1)
+        assert hint["Series"] == "绝命毒师"
+
+    def test_includes_people_by_default(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Search/Hints", params={"ApiKey": token, "searchTerm": "诺兰"}
+        ).json()
+        assert [h["Type"] for h in body["SearchHints"]] == ["Person"]
+
+    def test_include_people_false(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Search/Hints",
+            params={"ApiKey": token, "searchTerm": "诺兰", "includePeople": "false"},
+        ).json()
+        assert body["TotalRecordCount"] == 0
+
+    def test_include_media_false_keeps_only_by_name_types(
+        self, client: TestClient
+    ) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Search/Hints",
+            params={"ApiKey": token, "searchTerm": "盗梦", "includeMedia": "false"},
+        ).json()
+        assert body["TotalRecordCount"] == 0
+
+    def test_include_item_types_narrows(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Search/Hints",
+            params={
+                "ApiKey": token,
+                "searchTerm": "绝命",
+                "includeItemTypes": "Episode",
+            },
+        ).json()
+        assert body["TotalRecordCount"] == 0
+
+    def test_parent_id_scopes(self, client: TestClient, seeded: dict) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Search/Hints",
+            params={
+                "ApiKey": token,
+                "searchTerm": "breaking",
+                "parentId": library_guid(seeded["movie_lib"]),
+            },
+        ).json()
+        assert body["TotalRecordCount"] == 0
+
+    def test_requires_auth(self, client: TestClient) -> None:
+        assert client.get("/Search/Hints", params={"searchTerm": "x"}).status_code == 401
+
+
+class TestItemsSearchAlignment:
+    """/Items?searchTerm= 的口径对齐（BaseItemRepository.TranslateQuery.cs:178）。"""
+
+    def test_episode_title_is_searchable(self, client: TestClient) -> None:
+        """分集有自己的 Name，搜集名能单独命中——这是对齐后新增的能力。"""
+        token = jf_login(client)
+        body = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "searchTerm": "Pilot",
+                "recursive": "true",
+                "includeItemTypes": "Episode",
+            },
+        ).json()
+        assert body["TotalRecordCount"] == 1
+        assert body["Items"][0]["Name"] == "Pilot"
+
+    def test_series_hit_does_not_drag_in_its_episodes(self, client: TestClient) -> None:
+        """剧名命中不会把整季集数一并带出：Season/Episode 只比对自己的 Name。"""
+        token = jf_login(client)
+        body = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "searchTerm": "breaking",
+                "recursive": "true",
+                "includeItemTypes": "Movie,Series,Episode",
+            },
+        ).json()
+        assert [i["Type"] for i in body["Items"]] == ["Series"]
+
+    def test_original_title_match(self, client: TestClient) -> None:
+        token = jf_login(client)
+        body = client.get(
+            "/Items",
+            params={"ApiKey": token, "searchTerm": "INCEPTION", "recursive": "true"},
+        ).json()
+        assert [i["Name"] for i in body["Items"]] == ["盗梦空间"]
+
+    def test_person_type_included_on_demand(self, client: TestClient) -> None:
+        """includeItemTypes 点名 Person 时才产出人物（ItemsByName 语义）。"""
+        token = jf_login(client)
+        without = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "searchTerm": "诺兰",
+                "recursive": "true",
+                "includeItemTypes": "Movie,Series",
+            },
+        ).json()
+        assert without["TotalRecordCount"] == 0
+        with_person = client.get(
+            "/Items",
+            params={
+                "ApiKey": token,
+                "searchTerm": "诺兰",
+                "recursive": "true",
+                "includeItemTypes": "Movie,Series,Person",
+            },
+        ).json()
+        assert [i["Type"] for i in with_person["Items"]] == ["Person"]

--- a/tests/jellyfin/test_search_matching.py
+++ b/tests/jellyfin/test_search_matching.py
@@ -1,0 +1,126 @@
+"""搜索匹配口径单测：逐条锚定 Jellyfin 源码的行为，防止"顺手加个中文友好"。
+
+对照物是 `jellyfin/jellyfin` @ `929834c`：
+- `src/Jellyfin.Extensions/StringExtensions.cs:158` GetCleanValue
+- `Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs:178`
+- `Jellyfin.Server.Implementations/Item/PeopleRepository.cs:338`
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from movieclaw_jellyfin.search import (
+    clean_value,
+    parse_term,
+    person_name_matches,
+)
+
+
+class TestCleanValue:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # 去变音符（RemoveDiacritics）
+            ("Aquí huele a muerto", "aqui huele a muerto"),
+            ("Amélie", "amelie"),
+            # 标点/符号 → 空格，再折叠空白并去首尾
+            ("Spider-Man: No Way Home", "spider man no way home"),
+            ("  Mission:   Impossible  ", "mission impossible"),
+            ("WALL·E", "wall e"),
+            # 下划线在 C# 的 [^\p{L}\p{N}\s] 里算标点，Python 的 \w 里不算，
+            # 逐字符按 Unicode 类别判定才对得上
+            ("foo_bar", "foo bar"),
+            # 数字类保留（\p{N} 含 Nl/No，不只是 Nd）
+            ("Iron Man 3", "iron man 3"),
+            ("½", "½"),
+            # CJK 不受影响，也不做任何简繁折叠
+            ("三体", "三体"),
+            ("三體", "三體"),
+        ],
+    )
+    def test_clean_value(self, raw: str, expected: str) -> None:
+        assert clean_value(raw) == expected
+
+    def test_blank_returns_input(self) -> None:
+        """空/纯空白原样返回，对齐 C# 的 IsNullOrWhiteSpace 提前返回。"""
+        assert clean_value("") == ""
+        assert clean_value("   ") == "   "
+        assert clean_value(None) == ""
+
+
+class TestSearchTermMatch:
+    def test_matches_clean_name(self) -> None:
+        term = parse_term("spider man")
+        assert term is not None
+        assert term.matches("Spider-Man: No Way Home")
+
+    def test_term_punctuation_is_normalized_too(self) -> None:
+        """搜索词自身也过 GetCleanValue，所以带不带连字符都命中。"""
+        assert parse_term("spider-man").matches("Spider Man")
+        assert parse_term("spider man").matches("Spider-Man")
+
+    def test_matches_original_title_case_insensitively(self) -> None:
+        """OriginalTitle 走 LIKE：裸子串、大小写不敏感、不过 GetCleanValue。"""
+        assert parse_term("INCEPTION").matches("盗梦空间", "Inception")
+        assert parse_term("cept").matches("盗梦空间", "Inception")
+
+    def test_diacritics_folded_on_both_sides(self) -> None:
+        assert parse_term("aqui").matches("Aquí huele a muerto")
+        assert parse_term("aquí").matches("Aqui huele a muerto")
+
+    def test_no_simplified_traditional_folding(self) -> None:
+        """有意不做简繁折叠——真 Jellyfin 也不做，做了就是偏离。"""
+        assert not parse_term("三體").matches("三体")
+        assert not parse_term("三体").matches("三體")
+
+    def test_no_pinyin(self) -> None:
+        """有意不做拼音匹配。"""
+        assert not parse_term("santi").matches("三体")
+
+    def test_aliases_are_not_searched(self) -> None:
+        """别名不参与匹配：Jellyfin 只看 Name(CleanName) 与 OriginalTitle。
+
+        movieclaw 早期实现会连 media_item.aliases 一起比对，命中集因此是
+        TMDB 别名表的函数（搜 The 能命中三百多条「The Proud General」之类）。
+        这里锁死为「别名不参与」——匹配面由 matches() 的两个入参决定。
+        """
+        term = parse_term("Nirvana in Fire")
+        assert term is not None
+        assert not term.matches("琅琊榜", "琅琊榜")
+
+    def test_percent_and_underscore_are_literal(self) -> None:
+        """搜索词里的 LIKE 元字符不是通配符。
+
+        Jellyfin 里那段 SearchWildcardTerms 分支是死代码：GetCleanValue 已把
+        % _ [ ] ^ 全替换成空格，检查恒不成立。这里同样不实现通配语义。
+        """
+        assert not parse_term("a%c").matches("abc")
+        assert not parse_term("a_c").matches("abc")
+
+    def test_empty_term_parses_to_none(self) -> None:
+        assert parse_term(None) is None
+        assert parse_term("") is None
+
+
+class TestPersonNameMatch:
+    def test_plain_case_insensitive_substring(self) -> None:
+        assert person_name_matches("Leonardo DiCaprio", "leonardo")
+        assert person_name_matches("Leonardo DiCaprio", "DICAPRIO")
+        assert person_name_matches("克里斯托弗·诺兰", "诺兰")
+
+    def test_does_not_use_clean_value(self) -> None:
+        """`/Persons` 的 NameContains 是裸的大写子串比对，不去变音符、不去标点。
+
+        与条目搜索口径不同是 Jellyfin 自身的历史差异（两条路径分别落在
+        PeopleRepository 与 BaseItemRepository），照抄不统一。
+        """
+        assert not person_name_matches("Amélie Nothomb", "amelie")
+        assert person_name_matches("Amélie Nothomb", "amélie")
+        # 标点保留：连字符不会被当成空格
+        assert not person_name_matches("Jean-Luc Godard", "jean luc")
+        assert person_name_matches("Jean-Luc Godard", "jean-luc")
+
+    def test_empty_inputs(self) -> None:
+        assert not person_name_matches(None, "x")
+        assert not person_name_matches("x", "")


### PR DESCRIPTION
## 起因

Infuse 上搜索**完全不可用**——任何关键字都出不来结果。

2026-08-22 在 NAS 上抓包定位到：Infuse 的搜索页是两路并发，

```
GET /Items?userId=…&searchTerm=三體&recursive=true&limit=24&fields=…  → 200  Total=1
GET /Persons?userId=…&searchTerm=三體&recursive=true&limit=24         → 404  21KB HTML
```

`persons` 不在 `NAMESPACE_PREFIXES` 里，请求连兼容层都进不去，掉到前端
catch-all 返回一整页 Next.js 的 "This page could not be found"。**服务端其实
一直有正确返回**（`/Items` 那一路是对的），但并发的另一路硬失败，Infuse 就把
整个结果页判为空——这解释了「任何关键字都不可用」而不只是「某些词搜不到」。

## 改了什么

### 1. 补齐两个缺失的命名空间

- `GET /Persons`、`GET /Persons/{name}`（`routes/persons.py`），参数与
  `QueryResult` 形态照 `PersonsController.cs`
- `GET /Search/Hints`（`routes/search.py`），扁平的 `{SearchHints,
  TotalRecordCount}` 结构照 `SearchController.cs`
- `persons` / `search` 一并登记进 `NAMESPACE_PREFIXES`，这两个命名空间下
  未实现的兄弟路径也不会再吐前端 HTML，而是退化成协议形态的空 body 404

### 2. 搜索匹配口径对齐 Jellyfin

匹配逻辑独立成 `movieclaw_jellyfin/search.py`，逐字对齐
`BaseItemRepository.TranslateQuery.cs:178`：

```
GetCleanValue(term) ⊂ GetCleanValue(Name)  ||  OriginalTitle LIKE %term%
```

`GetCleanValue()` = 去变音符 → 小写 → 标点转空格 → 折叠空白
（`src/Jellyfin.Extensions/StringExtensions.cs:158`）。

原实现是 `title`/`original_title`/**`aliases`** 的裸子串，命中集实际上变成了
TMDB 别名表的函数——搜 `The` 命中 331 条，多半是「The Proud General」这类
别名在凑数。

**有意的行为变更**（都与真 Jellyfin 一致）：

| | 改前 | 改后 |
|---|---|---|
| `Nirvana in Fire` → 琅琊榜 | 命中（走别名） | 不命中 |
| 分集标题（如「冉方旭要求更换搭档」） | 0 命中 | 1 命中 |
| 剧名命中时的分集 | 整季集数一并带出 | 只出剧本身 |
| `The` | 331 条 | 121 条 |
| `三體` → 三体 / `santi` → 三体 | 不命中 | 不命中（不做简繁/拼音，真 Jellyfin 也不做） |

### 3. 搜索性能：先粗筛，再水合

带 `searchTerm` 的查询原先要把候选条目**全部**水合成 bundle（条目 ⋈ 文件 ⋈
季 ⋈ 集 ⋈ 元数据 ⋈ 播放状态）之后才在内存里做子串过滤——命中 1 条也得先装
完整库。改成先用「只取名字列」的轻量投影选出命中的条目 id，水合只覆盖真正
要输出的那几条。

NAS 日志里那 8 个 `/Items` 就是这么来的：

```
22:24:23  /Items  2872ms      22:24:33  /Items  6418ms
22:24:24  /Items  2824ms      22:24:34  /Items  7864ms
22:24:25  /Items  2431ms      22:24:35  /Items  7272ms
22:24:27  /Items  2263ms      22:24:35  /Items  7252ms
```

复现：串行单次 1.4s，4 个并发（Infuse 逐字符发且不取消上一个）→ 5~6.6s。

## 验证

用 NAS 真实库的在线备份（853 条目 / 9308 分集名 / 554 季名 / 15919 影人）复核：

```
                       粗筛耗时    命中
三体                     1.4ms     1  ['三体']
琅琊榜                    1.4ms     1  ['琅琊榜']
inception               1.4ms     1  ['盗梦空间']
冉方旭要求更换搭档            1.3ms     1  ['黑夜告白']   ← 改前 0
The                     1.4ms   121                  ← 改前 331

/Persons?searchTerm=胡歌      → 1 人   ← 改前 21KB HTML 404
/Persons?searchTerm=诺兰      → 5 人
/Persons?searchTerm=leonardo → 4 人
```

过滤阶段 1400ms → 1.4ms，且只水合命中的 1 条而非 853 条。

新增 41 个测试（`test_search_matching.py` 锁匹配口径、`test_persons_and_search.py`
锁 HTTP 形态），`tests/jellyfin` 共 160 个全绿；`ruff check` 通过。

## 不含

不涉及运行时依赖变更，**不需要 bump `docker/runtime-version`**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
