### PR TITLE
fix(web): 用首帧缓存消除侧栏导航顺序的刷新闪跳

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -7,6 +7,7 @@ import type { Route } from "next";
 import { AuthError, AuthField, AuthScreen } from "@/components/auth-screen";
 import { getBootstrapStatus, getSession, login } from "@/lib/api/auth";
 import { clearBackdropCache } from "@/lib/backdrop-cache";
+import { clearUiPrefsCache } from "@/lib/ui-prefs-cache";
 import { usePageTitle } from "@/lib/use-page-title";
 import { HttpError } from "@/lib/http";
 import { accessiblePathFor } from "@/lib/permissions";
@@ -74,6 +75,7 @@ export default function LoginPage() {
       // 整页跳转而非路由跳转：让 AppShell 及全部数据在已登录态下重新初始化。
       // 回到 next 指向的页面（会话过期前所在处），默认首页。
       clearBackdropCache();
+      clearUiPrefsCache();
       window.location.href = resolveNext(session);
     } catch (err) {
       setError(err instanceof HttpError ? err.message : "网络异常，请稍后重试");

--- a/apps/web/components/user-menu.tsx
+++ b/apps/web/components/user-menu.tsx
@@ -7,6 +7,7 @@ import { AvatarBadge } from "@/components/avatar-badge";
 import { GearIcon, LogoutIcon } from "@/components/icons";
 import { logout } from "@/lib/api/auth";
 import { clearBackdropCache } from "@/lib/backdrop-cache";
+import { clearUiPrefsCache } from "@/lib/ui-prefs-cache";
 import { roleLabel } from "@/lib/permissions";
 import { useSession } from "@/lib/session";
 
@@ -64,6 +65,7 @@ export function UserMenu({ onOpenSettings, collapsed = false }: UserMenuProps) {
       // 即使请求失败（如网络断开），也照常跳登录页；会话在后端仍会自然过期
     }
     clearBackdropCache();
+    clearUiPrefsCache();
     window.location.href = "/login";
   };
 

--- a/apps/web/lib/api/ui.ts
+++ b/apps/web/lib/api/ui.ts
@@ -59,9 +59,12 @@ export const DEFAULT_UI_PREFS: UiPreferences = {
   nav: { order: [] },
 };
 
-/** 把后端返回的偏好与内置默认逐分组合并：老版本后端（不认识新分组/新字段）
- *  返回的数据会缺项，缺什么补什么的默认值，保证消费者拿到的结构永远完整。 */
-function withDefaults(data: Partial<UiPreferences> | null | undefined): UiPreferences {
+/** 把偏好与内置默认逐分组合并：老版本后端（不认识新分组/新字段）返回的数据会
+ *  缺项，缺什么补什么的默认值，保证消费者拿到的结构永远完整。
+ *  首帧缓存（lib/ui-prefs-cache.ts）读出的旧版本数据同样走这里补齐。 */
+export function normalizeUiPreferences(
+  data: Partial<UiPreferences> | null | undefined,
+): UiPreferences {
   return {
     sidebar: { ...DEFAULT_UI_PREFS.sidebar, ...data?.sidebar },
     scrim: { ...DEFAULT_UI_PREFS.scrim, ...data?.scrim },
@@ -73,14 +76,14 @@ function withDefaults(data: Partial<UiPreferences> | null | undefined): UiPrefer
 
 /** 读取全站界面偏好（从未配置的页面返回默认值），存服务端、跨设备一致。 */
 export async function fetchUiPreferences(init?: RequestInit): Promise<UiPreferences> {
-  return withDefaults(
+  return normalizeUiPreferences(
     await unwrap(request<ApiEnvelope<Partial<UiPreferences>>>("/ui/preferences", init)),
   );
 }
 
 /** 整体覆盖式保存界面偏好，返回保存后的值。 */
 export async function updateUiPreferences(prefs: UiPreferences): Promise<UiPreferences> {
-  return withDefaults(
+  return normalizeUiPreferences(
     await unwrap(
       request<ApiEnvelope<Partial<UiPreferences>>>("/ui/preferences", {
         method: "PUT",

--- a/apps/web/lib/http.ts
+++ b/apps/web/lib/http.ts
@@ -1,5 +1,6 @@
 import { publicEnv } from "@/lib/env";
 import { clearBackdropCache } from "@/lib/backdrop-cache";
+import { clearUiPrefsCache } from "@/lib/ui-prefs-cache";
 
 export class HttpError extends Error {
   status: number;
@@ -62,6 +63,7 @@ export function redirectToLoginOn401(status: number): void {
     if (path !== "/login" && path !== "/setup") {
       const next = encodeURIComponent(path + window.location.search);
       clearBackdropCache();
+      clearUiPrefsCache();
       window.location.href = `/login?next=${next}`;
     }
   }

--- a/apps/web/lib/ui-prefs-cache.ts
+++ b/apps/web/lib/ui-prefs-cache.ts
@@ -1,0 +1,59 @@
+import type { UiPreferences } from "@/lib/api/ui";
+
+/**
+ * 界面偏好的首帧缓存（localStorage）。
+ *
+ * 为什么需要：`ui.preferences` 是启动后异步拉回来的（见 lib/ui-prefs.tsx），
+ * 在它返回之前全站只能按内置默认渲染——自定义过导航顺序的用户每次刷新都会
+ * 先看到默认排序、接口回来后再重排一次，肉眼可见地"跳"一下（玻璃透明度、
+ * 蒙版同理）。这里把上一次拿到的偏好整份存下来，下次启动时首帧就直接按它
+ * 渲染，接口返回后再以服务端值为准纠正。
+ *
+ * 与 lib/backdrop-cache.ts 是同一套思路，同样刻意不 import 任何运行时模块
+ * （只用 `import type`）：http.ts 在 401 时要清它，带运行时依赖会形成循环。
+ *
+ * 三条约定：
+ *   - **缓存只是首帧优化**，真实状态永远以 GET /ui/preferences 为准；缓存脏了
+ *     （换了设备上改的顺序）也只是首帧短暂显示旧值，接口回来即纠正；
+ *   - 读出来的内容不可信（用户可改、也可能是旧版本写的），必须过一遍
+ *     `normalizeUiPreferences` 补齐缺项，因此这里只负责 JSON 解析；
+ *   - **账号切换时必须清除**，否则共享浏览器上换个账号登录会先闪出上一个人的
+ *     导航顺序（清除点与背景缓存一致：登录成功、退出登录、401 跳登录页）。
+ */
+export const UI_PREFS_CACHE_KEY = "movieclaw.ui-prefs";
+
+/** 读取上次缓存的偏好；无缓存 / 已损坏 / localStorage 不可用时返回 null。
+ *  返回值是"生的"，调用方须自行补齐默认值。 */
+export function readUiPrefsCache(): Partial<UiPreferences> | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(UI_PREFS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    // 只接受对象字面量：数组、字符串、null 都是被写坏的缓存，直接当没有
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Partial<UiPreferences>;
+  } catch {
+    return null;
+  }
+}
+
+/** 写入首帧缓存。失败（隐私模式、配额满）只是失去首帧优化，不影响功能。 */
+export function writeUiPrefsCache(prefs: UiPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(UI_PREFS_CACHE_KEY, JSON.stringify(prefs));
+  } catch {
+    // 忽略写入失败
+  }
+}
+
+/** 清除首帧缓存。账号切换时必须调用，避免共享浏览器短暂显示上一账号的界面偏好。 */
+export function clearUiPrefsCache(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(UI_PREFS_CACHE_KEY);
+  } catch {
+    // localStorage 不可用只会失去首帧优化，不影响服务端的账号隔离。
+  }
+}

--- a/apps/web/lib/ui-prefs.tsx
+++ b/apps/web/lib/ui-prefs.tsx
@@ -10,11 +10,12 @@ import {
 } from "react";
 
 import {
-  DEFAULT_UI_PREFS,
   fetchUiPreferences,
+  normalizeUiPreferences,
   updateUiPreferences,
   type UiPreferences,
 } from "@/lib/api/ui";
+import { readUiPrefsCache, writeUiPrefsCache } from "@/lib/ui-prefs-cache";
 
 /**
  * 界面偏好（按页面分组的样式设定）的全局状态。
@@ -22,6 +23,11 @@ import {
  * 与 backdrop / search-prefs 同款 Context 模式：应用启动时向后端拉**一次**
  * `ui.preferences` 整个配置域，之后全站（设置页、各业务页面）共享同一份状态
  * ——SPA 内切换页面不会重复请求；设置页改动即时保存并同步到所有消费者。
+ *
+ * 首帧不等接口：初始值取自 localStorage 缓存（上次拉到的偏好，见
+ * lib/ui-prefs-cache.ts），接口返回后再以服务端值为准覆盖并回写缓存。
+ * 没有这层缓存，自定义过导航顺序的用户每次刷新都会先看到默认排序、
+ * 接口回来后再重排一次——这一跳是肉眼可见的（玻璃透明度、蒙版同理）。
  *
  * 扩展方式：后端配置域加字段 → lib/api/ui.ts 的类型与 DEFAULT_UI_PREFS 对齐
  * → 消费页面从 useUiPrefs().prefs.<页面> 取值。本文件无需再动。
@@ -45,16 +51,27 @@ interface UiPrefsContextValue {
 const UiPrefsContext = createContext<UiPrefsContextValue | null>(null);
 
 export function UiPrefsProvider({ children }: { children: React.ReactNode }) {
-  const [prefs, setPrefs] = useState<UiPreferences>(DEFAULT_UI_PREFS);
+  // 惰性初始化读缓存：本 Provider 只在 AuthGate 确认登录后于客户端渲染
+  // （见 components/app-shell.tsx），不参与 SSR，故可直接读 localStorage。
+  // 缓存内容不可信，统一过一遍 normalizeUiPreferences 补齐缺项（无缓存时
+  // 它补出来的就是 DEFAULT_UI_PREFS，与改动前的初始值完全一致）。
+  const [prefs, setPrefs] = useState<UiPreferences>(() =>
+    normalizeUiPreferences(readUiPrefsCache()),
+  );
   const [preview, setPreview] = useState<UiPreferences | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
     fetchUiPreferences()
-      .then((data) => !cancelled && setPrefs(data))
+      .then((data) => {
+        if (cancelled) return;
+        setPrefs(data);
+        // 服务端值即下次启动的首帧值
+        writeUiPrefsCache(data);
+      })
       .catch((err) => {
-        // 拉取失败不致命：静默沿用各页面默认样式（与后端默认一致）
+        // 拉取失败不致命：静默沿用首帧缓存里的偏好（没有缓存时即内置默认样式）
         console.warn("读取界面设置失败，暂用默认样式：", err);
       })
       .finally(() => !cancelled && setLoading(false));
@@ -79,7 +96,9 @@ export function UiPrefsProvider({ children }: { children: React.ReactNode }) {
       // 乐观更新：开关立即生效；保存失败回滚并抛给调用方提示
       setPrefs(next);
       try {
-        setPrefs(await updateUiPreferences(next));
+        const saved = await updateUiPreferences(next);
+        setPrefs(saved);
+        writeUiPrefsCache(saved);
         // 保存成功后草稿使命完成，撤销以免遮住刚落库的新值
         setPreview(null);
       } catch (err) {


### PR DESCRIPTION
## 问题

侧栏导航顺序存在服务端 `ui.preferences.nav.order`，由 `UiPrefsProvider` 挂载后异步拉取。接口返回前 `prefs` 恒为 `DEFAULT_UI_PREFS`（`nav.order = []`），侧栏只能按 `SIDEBAR_NAV_ITEMS` 的内置默认顺序先画一帧，接口回来后再重排——自定义过顺序的用户每次刷新都会肉眼看到这一跳。侧栏玻璃透明度、全站蒙版同理，首帧都是默认值。

## 改动

沿用背景图已有的首帧缓存思路（`lib/backdrop-cache.ts`）。背景图靠 `layout.tsx` 的内联脚本恢复 CSS 变量，导航顺序是 React 渲染的用不了内联脚本，但缓存机制一样：

- 新增 `apps/web/lib/ui-prefs-cache.ts`：整份界面偏好的 localStorage 读/写/清。只用 `import type`，不引入任何运行时依赖——`http.ts` 要在 401 时清它，带运行时依赖会形成循环。
- `UiPrefsProvider` 惰性初始化时直接读缓存渲染首帧；接口返回后以服务端值覆盖并回写缓存，保存成功时同样回写。该 Provider 只在 AuthGate 确认登录后于客户端渲染、不参与 SSR，读 localStorage 没有水合不一致问题（与 `app-shell.tsx` 里侧栏折叠态的做法一致）。
- 缓存内容不可信（用户可改、也可能是旧版本写的），读出来统一过 `lib/api/ui.ts` 的补默认值函数——原 `withDefaults` 导出为 `normalizeUiPreferences` 复用，没有再写一份。
- 账号切换时清缓存：登录成功、退出登录、401 跳登录页，三个清除点与背景缓存完全一致，避免共享浏览器上闪出上一账号的导航顺序。

缓存的是整份 `UiPreferences` 而不是单独 `nav.order`：代码更少，顺带把玻璃/蒙版的首帧闪烁一起消掉。

## 语义边界

缓存只是首帧优化，真实状态仍以 `GET /ui/preferences` 为准。换设备改过顺序后，首帧会短暂显示旧序、接口返回即纠正。设置页本来就有「已保存值变化时对齐草稿」的 effect，草稿/未保存改动的判定不受影响。

## 验证

- `pnpm web:typecheck`、`pnpm web:lint` 通过
- 用桩 localStorage 跑过缓存模块：空缓存、回读、数组形态的坏缓存、坏 JSON、清除后，返回值均符合预期
- `npm test`（web）94 通过 / 5 失败；5 个失败全在 `subscription-ui.test.mjs`，在本分支改动前的 base 上跑同样是 94/5，与本次改动无关

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAu5cbHrNWEvjHt4JQ8A2y)_