### PR TITLE
fix(agent): 修复进程重启后工具回执顺序异常

### DIFF
--- a/src/movieclaw_api/api/routes/agent.py
+++ b/src/movieclaw_api/api/routes/agent.py
@@ -171,7 +171,7 @@ async def _accept_user_message(
             raise NotFoundException("Agent 会话不存在")
         if is_running(row):
             raise BadRequestException("该会话已有正在进行的运行，请先停止或等待完成")
-        history = store.build_history(session_id)
+        history = store.prepare_history(session_id)
         _, existing_entries = store.read(session_id)
         entry_count = len(existing_entries)
     else:
@@ -377,6 +377,8 @@ async def compact_session_context(
         raise BadRequestException("该会话正在运行中，请等待完成后再压缩")
 
     llm_router = await acquire_llm_router(session)
+    # 压缩失败时不能提前改写事实轨迹；build_history 会在内存投影中补齐
+    # 缺失回执，只有压缩成功后才由下方 append_compaction 产生持久化写入。
     history = store.build_history(session_id)
     if not history:
         raise BadRequestException("会话没有可压缩的内容")
@@ -455,7 +457,7 @@ async def retry_session_message(
     tools = get_agent_tools(await _cli_env(session_id))
 
     store.discard_from_user_message(session_id, payload.message_id)
-    history = store.build_history(session_id)
+    history = store.prepare_history(session_id)
     _, remaining_entries = store.read(session_id)
     summary = store.summarize(session_id)
     await repo.resync_after_discard(

--- a/src/movieclaw_api/services/agent_sessions.py
+++ b/src/movieclaw_api/services/agent_sessions.py
@@ -7,8 +7,8 @@
    唯一例外是 ``discard_from_user_message``（retry 的历史替换），见该方法
    的说明；除它以外，任何写入路径都只准 append。
 2. **只落定稿消息，不落流式 delta**：SSE 增量属于 UI 通道；文件里的
-   ``message`` 就是 LLM API 原样格式（ChatMessage），resume 重建上下文
-   零转换。
+   ``message`` 保留事实发生顺序，resume 投影时只修复进程重启可能造成的
+   工具回执迟到/缺失，不改写完整轨迹。
 3. **entry 带 uuid / parent_uuid**：v1 是纯线性链（parent 永远指向上一
    条），字段先留好，将来做历史分支时无需迁移文件格式。
 4. **SQLite 的 agent_session 表只是查询索引**：任何时候都能由本目录的
@@ -47,6 +47,9 @@ SESSION_FORMAT_VERSION = 2
 
 #: 会话标题 / 最后提示预览的截断长度（DB 索引列用，全文始终在文件里）
 PREVIEW_MAX_CHARS = 80
+
+#: 进程退出时给尚未完成的工具调用回填的统一结果文本。
+_INTERRUPTED_TOOL_RESULT = "操作已被中断，工具未执行完成。"
 
 
 def _now_iso() -> str:
@@ -147,6 +150,67 @@ def _messages_after_last_compaction(
     return [e.message for e in entries[last + 1 :] if isinstance(e, SessionMessageEntry)]
 
 
+def _normalize_tool_call_history(
+    messages: list[ChatMessage],
+) -> tuple[list[ChatMessage], int, int, int]:
+    """把工具结果投影到对应 assistant 调用之后，返回修复后的模型上下文。
+
+    OpenAI 工具协议不只要求 call id 存在，还要求每组 assistant tool_calls 在
+    下一条普通消息之前收齐结果。应用重启可能留下「assistant → user → tool」的
+    迟到回执；完整转录仍保留事实发生顺序，这里只修复发送给模型的投影：
+
+    - 迟到回执移动到对应调用之后；
+    - 完全缺失的回执生成中断结果，避免坏历史永久阻断续聊；
+    - 找不到对应调用的孤立 tool 消息不进入模型上下文。
+
+    额外返回（补写数、迟到数、孤立数），供调用方输出可理解的诊断日志。
+    """
+    outputs_by_id: dict[str, list[tuple[int, ChatMessage]]] = {}
+    tool_indexes: set[int] = set()
+    for index, message in enumerate(messages):
+        if message.role != "tool":
+            continue
+        tool_indexes.add(index)
+        if message.tool_call_id:
+            outputs_by_id.setdefault(message.tool_call_id, []).append((index, message))
+
+    normalized: list[ChatMessage] = []
+    used_tool_indexes: set[int] = set()
+    synthesized = 0
+    late = 0
+    for call_index, message in enumerate(messages):
+        if message.role == "tool":
+            continue
+        normalized.append(message)
+        if message.role != "assistant" or not message.tool_calls:
+            continue
+        for tool_call in message.tool_calls:
+            matched: tuple[int, ChatMessage] | None = None
+            for output_index, output in outputs_by_id.get(tool_call.id, []):
+                if output_index > call_index and output_index not in used_tool_indexes:
+                    matched = (output_index, output)
+                    break
+            if matched is None:
+                normalized.append(
+                    ChatMessage(
+                        role="tool",
+                        content=_INTERRUPTED_TOOL_RESULT,
+                        tool_call_id=tool_call.id,
+                        name=tool_call.name,
+                    )
+                )
+                synthesized += 1
+                continue
+            output_index, output = matched
+            used_tool_indexes.add(output_index)
+            if any(messages[index].role != "tool" for index in range(call_index + 1, output_index)):
+                late += 1
+            normalized.append(output)
+
+    orphaned = len(tool_indexes - used_tool_indexes)
+    return normalized, synthesized, late, orphaned
+
+
 class AgentSessionStore:
     """会话 JSONL 文件的读写入口。
 
@@ -237,9 +301,9 @@ class AgentSessionStore:
     def seal_pending_tool_calls(self, session_id: str) -> int:
         """中断收尾：给没有结果的 tool_call 补写错误回执，返回补写条数。
 
-        保证文件里 assistant 的 tool_calls 与 tool 消息任何时刻都配对完整，
-        resume 直接回喂 API 不需要修复逻辑（Claude Code 是吃到 400 再反应式
-        修复，我们在写入侧一次做对更省事）。
+        正常终态保证文件里的 assistant tool_calls 都有 tool 回执。进程硬退出
+        无法运行本方法，续聊时由 prepare_history 再补；若旧版已经把新 user
+        写在回执前面，build_history 会在模型上下文投影中恢复协议顺序。
 
         只检查最后一条压缩行之后的消息：更早的往返已被压缩挡在上下文之外，
         给死上下文补回执毫无意义。
@@ -256,7 +320,7 @@ class AgentSessionStore:
                     session_id,
                     ChatMessage(
                         role="tool",
-                        content="操作已被中断，工具未执行完成。",
+                        content=_INTERRUPTED_TOOL_RESULT,
                         tool_call_id=tc.id,
                         name=tc.name,
                     ),
@@ -331,8 +395,9 @@ class AgentSessionStore:
     def build_history(self, session_id: str) -> list[ChatMessage]:
         """把会话重建成 LLM 上下文消息列表（resume 喂回模型用）。
 
-        文件里存的就是 API 原样消息，这里只做投影不做转换；system 提示词
-        不入库（随代码版本演进），由 runner 每次运行时重新拼装。
+        文件里保存完整事实轨迹；system 提示词不入库（随代码版本演进），由
+        runner 每次运行时重新拼装。投影到模型上下文时会修复重启窗口产生的
+        迟到/缺失工具回执，避免一条坏顺序让整个会话永久无法续聊。
 
         有压缩行时，从**最后一条**压缩行的替换历史起步、只追加其后的增量
         消息——压缩前的原始消息仍完整留在文件里（回放展示用），但不再进入
@@ -341,11 +406,30 @@ class AgentSessionStore:
         _, entries = self.read(session_id)
         last = _last_compaction_index(entries)
         if last < 0:
-            return [e.message for e in entries if isinstance(e, SessionMessageEntry)]
-        return [
-            *entries[last].replacement_history,
-            *(e.message for e in entries[last + 1 :] if isinstance(e, SessionMessageEntry)),
-        ]
+            messages = [e.message for e in entries if isinstance(e, SessionMessageEntry)]
+        else:
+            messages = [
+                *entries[last].replacement_history,
+                *(e.message for e in entries[last + 1 :] if isinstance(e, SessionMessageEntry)),
+            ]
+        history, synthesized, late, orphaned = _normalize_tool_call_history(messages)
+        if synthesized or late or orphaned:
+            logger.warning(
+                "会话历史工具回执顺序已在模型上下文中修复 "
+                "session=%s 补回执=%d 迟到=%d 孤立=%d",
+                session_id,
+                synthesized,
+                late,
+                orphaned,
+            )
+        return history
+
+    def prepare_history(self, session_id: str) -> list[ChatMessage]:
+        """续聊前补齐尾部未完成调用，再构建协议合法的模型上下文。"""
+        sealed = self.seal_pending_tool_calls(session_id)
+        if sealed:
+            logger.info("续聊前已补齐中断的工具调用 session=%s 数量=%d", session_id, sealed)
+        return self.build_history(session_id)
 
     def summarize(self, session_id: str) -> SessionSummary:
         """扫描单个会话文件生成索引摘要。"""

--- a/src/movieclaw_api/services/im_channel.py
+++ b/src/movieclaw_api/services/im_channel.py
@@ -533,8 +533,9 @@ class ImChannelService:
 
         store = get_agent_session_store()
         session_id = await self._ensure_agent_session(msg)
-        history = store.build_history(session_id)
-        recorder = AgentSessionRecorder(store, session_id, entry_count=len(history))
+        history = store.prepare_history(session_id)
+        _, entries = store.read(session_id)
+        recorder = AgentSessionRecorder(store, session_id, entry_count=len(entries))
         await recorder.record_user_message(msg.text)
 
         runner = AgentRunner(

--- a/src/movieclaw_api/services/weixin_channel.py
+++ b/src/movieclaw_api/services/weixin_channel.py
@@ -324,8 +324,9 @@ class WeixinChannelService:
         # 2) 会话持久化:历史从转录重建;定稿消息经 recorder 持续追加
         store = get_agent_session_store()
         session_id = await self._ensure_agent_session(msg)
-        history = store.build_history(session_id)
-        recorder = AgentSessionRecorder(store, session_id, entry_count=len(history))
+        history = store.prepare_history(session_id)
+        _, entries = store.read(session_id)
+        recorder = AgentSessionRecorder(store, session_id, entry_count=len(entries))
         await recorder.record_user_message(msg.text)
 
         runner = AgentRunner(

--- a/tests/api/test_agent.py
+++ b/tests/api/test_agent.py
@@ -14,7 +14,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from movieclaw_api.core.config import get_settings
-from movieclaw_llm import ChatResponse, ProviderInfo, TokenUsage
+from movieclaw_llm import ChatResponse, ProviderInfo, TokenUsage, ToolCall
 from movieclaw_llm.base import BaseLlmProtocol
 from movieclaw_llm.models import ChatStreamEvent
 from movieclaw_llm.protocols import PROTOCOLS
@@ -325,6 +325,57 @@ def test_manual_compact_endpoint(client, monkeypatch) -> None:
 
     missing = client.post("/api/v1/sessions/not-exist/compact-context")
     assert missing.status_code == 404
+
+
+def test_manual_compact_failure_does_not_persist_tool_repair(client, monkeypatch) -> None:
+    """压缩失败不能因上下文修复而提前改写转录，造成文件与索引失步。"""
+
+    class _CompactFailureProtocol(_StreamProtocol):
+        async def chat_stream(self, request, model_id):
+            if request.tools is None:
+                yield ChatStreamEvent(
+                    type="error",
+                    partial=ChatResponse(
+                        finish_reason="error",
+                        error="模拟压缩失败",
+                        model=model_id,
+                        provider=self.config.name,
+                    ),
+                )
+                return
+            async for event in super().chat_stream(request, model_id):
+                yield event
+
+    monkeypatch.setitem(PROTOCOLS, "openai_chat", _CompactFailureProtocol)
+    configure_provider(client)
+    started = client.post("/api/v1/sessions", json={"content": "执行任务"})
+    session_id = started.json()["data"]["session_id"]
+    client.get(f"/api/v1/sessions/{session_id}/events")
+    _wait_run_settled(client, session_id)
+
+    # 模拟进程在 assistant tool_call 落盘后硬退出，并先把索引校准到该事实轨迹。
+    from movieclaw_api.services.agent_session_recorder import rebuild_agent_session_index
+    from movieclaw_api.services.agent_sessions import get_agent_session_store
+    from movieclaw_llm import ChatMessage
+
+    store = get_agent_session_store()
+    store.append(
+        session_id,
+        ChatMessage(
+            role="assistant",
+            tool_calls=[ToolCall(id="call_crashed", name="bash", arguments={})],
+        ),
+    )
+    asyncio.run(rebuild_agent_session_index())
+    before = client.get(f"/api/v1/sessions/{session_id}").json()["data"]
+    assert before["session"]["entry_count"] == len(before["entries"])
+
+    failed = client.post(f"/api/v1/sessions/{session_id}/compact-context")
+
+    assert failed.status_code == 502
+    after = client.get(f"/api/v1/sessions/{session_id}").json()["data"]
+    assert after["entries"] == before["entries"]
+    assert after["session"]["entry_count"] == len(after["entries"])
 
 
 def test_stop_session_ends_with_cancelled_event(client, monkeypatch) -> None:

--- a/tests/api/test_agent_sessions.py
+++ b/tests/api/test_agent_sessions.py
@@ -113,6 +113,60 @@ def test_seal_pending_tool_calls_completes_pairing(tmp_path) -> None:
     assert store.seal_pending_tool_calls(sid) == 0
 
 
+def test_prepare_history_seals_pending_call_before_next_user(tmp_path) -> None:
+    """续聊前先把崩溃遗留的调用补齐，不能让新 user 插到 call/result 中间。"""
+    store = AgentSessionStore(tmp_path)
+    sid = store.create().session_id
+    store.append(sid, ChatMessage(role="user", content="执行任务"))
+    store.append(
+        sid,
+        ChatMessage(
+            role="assistant",
+            tool_calls=[ToolCall(id="call_sleep", name="bash", arguments={"command": "sleep 8"})],
+        ),
+    )
+
+    history = store.prepare_history(sid)
+    store.append(sid, ChatMessage(role="user", content="怎样了"))
+
+    assert [message.role for message in history] == ["user", "assistant", "tool"]
+    assert history[-1].tool_call_id == "call_sleep"
+    _, entries = store.read(sid)
+    assert [entry.message.role for entry in entries] == ["user", "assistant", "tool", "user"]
+
+
+def test_build_history_moves_late_tool_result_before_intervening_user(tmp_path) -> None:
+    """已损坏转录保持原样，但喂给模型的投影必须恢复合法工具调用顺序。"""
+    store = AgentSessionStore(tmp_path)
+    sid = store.create().session_id
+    store.append(sid, ChatMessage(role="user", content="执行任务"))
+    store.append(
+        sid,
+        ChatMessage(
+            role="assistant",
+            tool_calls=[ToolCall(id="call_sleep", name="bash", arguments={"command": "sleep 8"})],
+        ),
+    )
+    store.append(sid, ChatMessage(role="user", content="怎样了"))
+    store.append(
+        sid,
+        ChatMessage(
+            role="tool",
+            content="操作已被中断，工具未执行完成。",
+            tool_call_id="call_sleep",
+            name="bash",
+        ),
+    )
+
+    history = store.build_history(sid)
+
+    assert [message.role for message in history] == ["user", "assistant", "tool", "user"]
+    assert history[2].tool_call_id == "call_sleep"
+    # 完整轨迹仍保持事实发生顺序；只修复发送给模型的上下文投影。
+    _, entries = store.read(sid)
+    assert [entry.message.role for entry in entries] == ["user", "assistant", "user", "tool"]
+
+
 def test_summarize_and_scan_all(tmp_path) -> None:
     store = AgentSessionStore(tmp_path)
     sid = store.create().session_id
@@ -509,6 +563,52 @@ def test_followup_message_builds_history_from_transcript(client, monkeypatch) ->
     assert item["entry_count"] == 4
     assert item["last_prompt"] == "第二轮"
     assert item["title"] == "第一轮"  # 标题保持首轮
+
+
+def test_followup_seals_crash_orphan_before_new_user(client, monkeypatch) -> None:
+    """进程崩溃遗留的 tool call 必须在续聊 user 落盘和请求上游前补齐。"""
+    captured_roles: list[list[str]] = []
+
+    class _CaptureProtocol(_StreamProtocol):
+        async def chat_stream(self, request, model_id):
+            captured_roles.append([message.role for message in request.messages])
+            async for event in super().chat_stream(request, model_id):
+                yield event
+
+    monkeypatch.setitem(PROTOCOLS, "openai_chat", _CaptureProtocol)
+    client.put(
+        "/api/v1/llm/provider",
+        json={
+            "provider_type": "bailian",
+            "api_key": "sk-session-orphan",
+            "default_model": "qwen3.7-max",
+        },
+    )
+    session_id, _ = _send_message_and_wait(client, {"content": "执行任务"})
+    _wait_not_running(client, session_id)
+
+    from movieclaw_api.services.agent_sessions import get_agent_session_store
+
+    store = get_agent_session_store()
+    store.append(
+        session_id,
+        ChatMessage(
+            role="assistant",
+            tool_calls=[ToolCall(id="call_sleep", name="bash", arguments={"command": "sleep 8"})],
+        ),
+    )
+
+    resumed, _ = _send_message_and_wait(
+        client,
+        {"content": "怎样了", "session_id": session_id},
+    )
+    assert resumed == session_id
+    assert captured_roles[-1][-3:] == ["assistant", "tool", "user"]
+
+    _, entries = store.read(session_id)
+    roles = [entry.message.role for entry in entries]
+    assert roles[-4:] == ["assistant", "tool", "user", "assistant"]
+    assert entries[-3].message.tool_call_id == "call_sleep"
 
 
 def test_send_message_to_unknown_session_returns_404(client) -> None:


### PR DESCRIPTION
## 问题背景

Agent 在发起工具调用后，如果 MovieClaw 恰好发生进程重启，可能只来得及持久化 assistant tool call，没有写入对应的 tool result。

用户随后继续会话时，新 user 消息会先于补写的工具回执进入历史，形成：

    assistant(tool_calls) → user → tool

该顺序不符合上游工具调用协议，转发后会收到类似错误：

    No tool output found for function call call_xxx

call_ 是正常的工具调用 ID 前缀，问题实际出在 MovieClaw 持久化历史中的消息顺序。

## 修复内容

- 续聊前为进程中断遗留的工具调用补写中断回执。
- 构建模型上下文时，将迟到的工具回执移动到对应 assistant 调用之后，为完全缺失的回执生成中断结果，并忽略无法匹配调用的孤立工具消息。
- 保留原始 JSONL 的事实发生顺序，只修复发送给模型的上下文投影。
- 网页续聊、重试、微信和其他 IM 渠道统一使用修复后的历史准备流程。
- 手动压缩只进行内存投影；压缩失败时不会提前改写转录，避免 JSONL 与数据库索引失步。
- 渠道会话计数改为使用完整转录条目数，正确包含压缩记录和补写回执。

## 测试

新增回归测试覆盖：

- 崩溃遗留的工具调用在新 user 消息前完成补写；
- 已损坏的 assistant → user → tool 历史恢复为合法模型上下文；
- API 续聊发送给上游的顺序为 assistant → tool → user；
- 手动压缩失败时不修改转录或数据库索引。

相关 API、Agent、LLM 和渠道测试共 118 项通过，Ruff 与 diff 检查通过。