### PR TITLE
feat(web): 活动任务支持复制诊断信息

### DIFF
--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -12,6 +12,7 @@ import {
   TaskActionsMenu,
   TaskStatusDot,
 } from "@/components/job-center";
+import { CopyButton } from "@/components/copy-button";
 import { useToast } from "@/components/feedback";
 import {
   ChevronRightIcon,
@@ -48,6 +49,10 @@ import {
 } from "@/lib/api/jobs";
 import { useJobs } from "@/lib/jobs";
 import type { TaskCenterViewName } from "@/lib/task-center";
+import {
+  backgroundJobDiagnosticText,
+  downloadTaskDiagnosticText,
+} from "@/lib/task-diagnostics";
 import {
   ACTIVE_FEED_JOB_STATUSES,
   ATTENTION_JOB_STATUSES,
@@ -658,16 +663,23 @@ function ActiveJobFeedItem({
             )}
           </p>
         </div>
-        {cancellable && (
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={cancelling}
-            className="shrink-0 rounded-lg px-2.5 py-1.5 text-caption font-medium text-white/45 transition hover:bg-white/[0.06] hover:text-white/75 disabled:cursor-wait disabled:opacity-45"
-          >
-            {cancelling ? "正在取消…" : "取消任务"}
-          </button>
-        )}
+        <div className="flex shrink-0 items-center gap-1">
+          <CopyButton
+            text={backgroundJobDiagnosticText(job)}
+            label="复制诊断信息"
+            className="px-2.5 py-1.5 text-caption font-medium text-white/45 hover:bg-white/[0.06] hover:text-white/75"
+          />
+          {cancellable && (
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={cancelling}
+              className="shrink-0 rounded-lg px-2.5 py-1.5 text-caption font-medium text-white/45 transition hover:bg-white/[0.06] hover:text-white/75 disabled:cursor-wait disabled:opacity-45"
+            >
+              {cancelling ? "正在取消…" : "取消任务"}
+            </button>
+          )}
+        </div>
       </div>
       {job.progress.message && (
         <OverflowText lines={2} className="mt-1.5 text-caption leading-5 text-white/42">
@@ -1352,14 +1364,21 @@ function DownloadTaskFeedItem({
             </p>
           )}
         </div>
-        {(task.page_url != null || task.downloader_id != null) && (
-          <DownloadTaskActionsMenu
-            task={task}
-            deleting={deleting}
-            replacing={replacing}
-            onDelete={onDelete}
+        <div className="flex shrink-0 items-center gap-1">
+          <CopyButton
+            text={downloadTaskDiagnosticText(task, ingestJob)}
+            label="复制诊断信息"
+            className="px-2.5 py-1.5 text-caption font-medium text-white/45 hover:bg-white/[0.06] hover:text-white/75"
           />
-        )}
+          {(task.page_url != null || task.downloader_id != null) && (
+            <DownloadTaskActionsMenu
+              task={task}
+              deleting={deleting}
+              replacing={replacing}
+              onDelete={onDelete}
+            />
+          )}
+        </div>
       </div>
       {note && (
         <OverflowText lines={2} className="mt-1.5 text-caption leading-5 text-white/42">

--- a/apps/web/components/task-center-view.tsx
+++ b/apps/web/components/task-center-view.tsx
@@ -12,7 +12,7 @@ import {
   TaskActionsMenu,
   TaskStatusDot,
 } from "@/components/job-center";
-import { CopyButton } from "@/components/copy-button";
+import { CopyButton, copyText } from "@/components/copy-button";
 import { useToast } from "@/components/feedback";
 import {
   ChevronRightIcon,
@@ -1364,21 +1364,13 @@ function DownloadTaskFeedItem({
             </p>
           )}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <CopyButton
-            text={downloadTaskDiagnosticText(task, ingestJob)}
-            label="复制诊断信息"
-            className="px-2.5 py-1.5 text-caption font-medium text-white/45 hover:bg-white/[0.06] hover:text-white/75"
-          />
-          {(task.page_url != null || task.downloader_id != null) && (
-            <DownloadTaskActionsMenu
-              task={task}
-              deleting={deleting}
-              replacing={replacing}
-              onDelete={onDelete}
-            />
-          )}
-        </div>
+        <DownloadTaskActionsMenu
+          task={task}
+          diagnosticText={downloadTaskDiagnosticText(task, ingestJob)}
+          deleting={deleting}
+          replacing={replacing}
+          onDelete={onDelete}
+        />
       </div>
       {note && (
         <OverflowText lines={2} className="mt-1.5 text-caption leading-5 text-white/42">
@@ -1570,14 +1562,13 @@ function DownloadTaskCard({
               <OverflowText>{title}</OverflowText>
             </h3>
           </div>
-          {(task.page_url != null || task.downloader_id != null) && (
-            <DownloadTaskActionsMenu
-              task={task}
-              deleting={deleting}
-              replacing={replacing}
-              onDelete={onDelete}
-            />
-          )}
+          <DownloadTaskActionsMenu
+            task={task}
+            diagnosticText={downloadTaskDiagnosticText(task, ingestJob)}
+            deleting={deleting}
+            replacing={replacing}
+            onDelete={onDelete}
+          />
         </div>
         {(torrentName || taskNote) && (
           <div
@@ -2005,18 +1996,25 @@ function DownloadLifecycle({
   );
 }
 
-/** 打开种子页与删除收进右上角菜单；查看订阅由分组标题承担，不在此重复。 */
+/**
+ * 右上角 ⋯ 菜单：复制诊断信息恒在（任何任务都可定位），打开种子页与删除
+ * 按可用性追加；查看订阅由分组标题承担，不在此重复。
+ * 复制走菜单项而非独立按钮，是为了不打破任务行「单菜单」的原有布局。
+ */
 function DownloadTaskActionsMenu({
   task,
+  diagnosticText,
   deleting,
   replacing,
   onDelete,
 }: {
   task: DownloadTask;
+  diagnosticText: string;
   deleting: boolean;
   replacing: boolean;
   onDelete: (task: DownloadTask) => void;
 }) {
+  const toast = useToast();
   return (
     <TaskActionsMenu
       ariaLabel={`${task.name || task.info_hash}的更多操作`}
@@ -2033,6 +2031,15 @@ function DownloadTaskActionsMenu({
               },
             ]
           : []),
+        {
+          id: "copy-diagnostic",
+          label: "复制诊断信息",
+          onSelect: () => {
+            void copyText(diagnosticText)
+              .then(() => toast.success("诊断信息已复制，可直接发给 AI 排查"))
+              .catch(() => toast.error("复制失败，请检查浏览器剪贴板权限"));
+          },
+        },
         ...(task.downloader_id != null
           ? [
               {

--- a/apps/web/lib/task-diagnostics.ts
+++ b/apps/web/lib/task-diagnostics.ts
@@ -1,0 +1,60 @@
+import type { DownloadTask } from "@/lib/api/downloaders";
+import type { JobView } from "@/lib/api/jobs";
+
+type JobDiagnosticSource = Pick<
+  JobView,
+  "id" | "job_type" | "status" | "root_job_id"
+>;
+
+type DownloadDiagnosticSource = Pick<
+  DownloadTask,
+  "id" | "info_hash" | "downloader_id" | "source" | "state" | "subscriptions"
+>;
+
+/**
+ * 生成可直接交给 AI 的后台作业定位信息。除当前任务 ID 外保留根任务 ID，
+ * 让重试产生新作业后仍能沿整条执行链排查，而不需要用户解释两者关系。
+ */
+export function backgroundJobDiagnosticText(job: JobDiagnosticSource): string {
+  const lines = [
+    "MovieClaw 后台任务诊断信息",
+    `job_id: ${job.id}`,
+    `job_type: ${job.job_type}`,
+    `status: ${job.status}`,
+  ];
+  if (job.root_job_id && job.root_job_id !== job.id) {
+    lines.push(`root_job_id: ${job.root_job_id}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * 下载任务来自下载器实时快照，前端 id 是组合定位键，并非后台 Job ID。
+ * 因此同时带上 infohash、下载器、订阅和关联入库 Job，避免 AI 把下载阶段
+ * 与后续入库阶段误认成同一种任务。
+ */
+export function downloadTaskDiagnosticText(
+  task: DownloadDiagnosticSource,
+  ingestJob: Pick<JobView, "id"> | null,
+): string {
+  const lines = [
+    "MovieClaw 下载任务诊断信息",
+    `download_task_key: ${task.id}`,
+    `info_hash: ${task.info_hash}`,
+    `source: ${task.source}`,
+    `state: ${task.state}`,
+  ];
+  if (task.downloader_id != null) {
+    lines.push(`downloader_id: ${task.downloader_id}`);
+  }
+  const subscriptionIds = [
+    ...new Set(task.subscriptions.map((subscription) => subscription.id)),
+  ].sort((left, right) => left - right);
+  if (subscriptionIds.length > 0) {
+    lines.push(`subscription_ids: ${subscriptionIds.join(",")}`);
+  }
+  if (ingestJob) {
+    lines.push(`ingest_job_id: ${ingestJob.id}`);
+  }
+  return lines.join("\n");
+}

--- a/apps/web/test/task-diagnostics.test.mjs
+++ b/apps/web/test/task-diagnostics.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  backgroundJobDiagnosticText,
+  downloadTaskDiagnosticText,
+} from "../lib/task-diagnostics.ts";
+
+test("后台任务诊断信息提供 AI 可直接查询的当前与根任务 ID", () => {
+  assert.equal(
+    backgroundJobDiagnosticText({
+      id: "job_current",
+      job_type: "library.ingest",
+      status: "running",
+      root_job_id: "job_root",
+    }),
+    [
+      "MovieClaw 后台任务诊断信息",
+      "job_id: job_current",
+      "job_type: library.ingest",
+      "status: running",
+      "root_job_id: job_root",
+    ].join("\n"),
+  );
+});
+
+test("根后台任务不重复输出相同的根任务 ID", () => {
+  assert.equal(
+    backgroundJobDiagnosticText({
+      id: "job_root",
+      job_type: "library.scan",
+      status: "queued",
+      root_job_id: "job_root",
+    }),
+    [
+      "MovieClaw 后台任务诊断信息",
+      "job_id: job_root",
+      "job_type: library.scan",
+      "status: queued",
+    ].join("\n"),
+  );
+});
+
+test("下载任务诊断信息同时定位下载器、订阅和关联入库任务", () => {
+  assert.equal(
+    downloadTaskDiagnosticText(
+      {
+        id: "2:abcdef",
+        info_hash: "abcdef",
+        downloader_id: 2,
+        source: "subscription",
+        state: "completed",
+        subscriptions: [{ id: 19 }, { id: 7 }, { id: 19 }],
+      },
+      { id: "job_ingest" },
+    ),
+    [
+      "MovieClaw 下载任务诊断信息",
+      "download_task_key: 2:abcdef",
+      "info_hash: abcdef",
+      "source: subscription",
+      "state: completed",
+      "downloader_id: 2",
+      "subscription_ids: 7,19",
+      "ingest_job_id: job_ingest",
+    ].join("\n"),
+  );
+});
+
+test("外部下载任务缺少可选关联时仍保留可用定位键", () => {
+  assert.equal(
+    downloadTaskDiagnosticText(
+      {
+        id: "missing:abcdef",
+        info_hash: "abcdef",
+        downloader_id: null,
+        source: "external",
+        state: "missing",
+        subscriptions: [],
+      },
+      null,
+    ),
+    [
+      "MovieClaw 下载任务诊断信息",
+      "download_task_key: missing:abcdef",
+      "info_hash: abcdef",
+      "source: external",
+      "state: missing",
+    ].join("\n"),
+  );
+});


### PR DESCRIPTION
## 背景

活动页虽然已经拿到后台作业 ID、下载任务 infohash 等定位信息，但没有提供给用户。

用户向 AI 描述任务问题时只能依赖任务标题和状态，多个相似任务同时存在时容易定位错误。

## 改动

- 在活动页的后台作业上增加「复制诊断信息」
- 在下载任务上增加「复制诊断信息」
- 后台作业诊断信息包含：
  - `job_id`
  - `job_type`
  - `status`
  - `root_job_id`（存在重试链时）
- 下载任务诊断信息包含：
  - `download_task_key`
  - `info_hash`
  - `source`
  - `state`
  - `downloader_id`
  - `subscription_ids`
  - `ingest_job_id`（已进入入库阶段时）
- 复用现有 `CopyButton`，保留局域网 HTTP 环境的剪贴板兼容逻辑和「已复制」反馈
- 抽离诊断文本生成函数，并补充单元测试

## API 与数据

无需新增后端接口或字段，直接使用前端已经收到的任务数据。

不涉及：

- 数据库迁移
- 运行时依赖变更
- Docker runtime version 变更

## 验证

- `node --test test/task-diagnostics.test.mjs`
- `npx eslint components/task-center-view.tsx lib/task-diagnostics.ts test/task-diagnostics.test.mjs`
- `npx tsc --noEmit`
- `npm run build`

以上检查均通过。
