### PR TITLE
fix(tracker): 修复异步账号密码表单提交

### DIFF
--- a/src/movieclaw_tracker/auth.py
+++ b/src/movieclaw_tracker/auth.py
@@ -382,10 +382,15 @@ class CredentialAuthProvider(AuthProvider):
             for key, value in sel.extra_form_data:
                 self._set_form_field(form_data, key, value)
 
-            # 4. POST 登录
-            headers = {"Referer": login_url}
+            # 4. POST 登录。httpx.AsyncClient 不支持以键值对列表作为 data；
+            # 先编码为标准表单字节，既保留重复字段，也避免生成同步请求流。
+            headers = {
+                "Referer": login_url,
+                "Content-Type": "application/x-www-form-urlencoded",
+            }
             post_url = self._form_action(form, login_url)
-            res = await client.raw_post(post_url, data=form_data, headers=headers)
+            form_body = urllib.parse.urlencode(form_data, doseq=True).encode("utf-8")
+            res = await client.raw_post(post_url, content=form_body, headers=headers)
             response_text = res.text
 
             # 5. 判定登录结果

--- a/tests/tracker/unit/test_credential_auth.py
+++ b/tests/tracker/unit/test_credential_auth.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import httpx
@@ -149,6 +150,12 @@ def _make_client(*responses: httpx.Response) -> MagicMock:
     return client
 
 
+def _posted_form(client: MagicMock) -> list[tuple[str, str]]:
+    """解析登录请求中已经编码的表单内容。"""
+    content = client.raw_post.call_args.kwargs["content"]
+    return urllib.parse.parse_qsl(content.decode(), keep_blank_values=True)
+
+
 def _make_provider(**kwargs) -> CredentialAuthProvider:
     """创建已绑定站点上下文的 CredentialAuthProvider。"""
     provider = CredentialAuthProvider(
@@ -194,8 +201,8 @@ async def test_login_success_no_captcha() -> None:
     # 验证 POST 提交了正确的表单数据
     call_kwargs = client.raw_post.call_args
     assert call_kwargs.args[0] == "https://example.com/login.php"
-    assert ("username", "user") in call_kwargs.kwargs["data"]
-    assert ("password", "pass") in call_kwargs.kwargs["data"]
+    assert ("username", "user") in _posted_form(client)
+    assert ("password", "pass") in _posted_form(client)
 
 
 @pytest.mark.asyncio
@@ -217,7 +224,40 @@ async def test_login_posts_to_form_action_and_includes_hidden_fields() -> None:
     assert result.success is True
     assert result.cookies == {"access_token": "jwt-fixture"}
     assert client.raw_post.call_args.args[0] == "https://tjupt.org/takelogin.php"
-    assert ("logout", "7") in client.raw_post.call_args.kwargs["data"]
+    assert ("logout", "7") in _posted_form(client)
+
+
+@pytest.mark.asyncio
+async def test_login_submits_repeated_fields_with_real_http_client() -> None:
+    """真实异步客户端应正确发送重复字段及需转义的账号密码。"""
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, text=LOGIN_PAGE_WITH_LEADING_SEARCH_FORM)
+        return httpx.Response(200, text=SUCCESS_PAGE, headers={"set-cookie": "sid=ok"})
+
+    from movieclaw_tracker.http import HttpClient
+
+    client = HttpClient(transport=httpx.MockTransport(handler))
+    provider = CredentialAuthProvider(username="user+name", password="p&ss=word")
+    provider.bind(base_url="https://example.com")
+
+    try:
+        result = await provider.authenticate(client)
+    finally:
+        await client.close()
+
+    assert result.success is True
+    assert len(requests) == 2
+    assert requests[1].headers["content-type"].startswith("application/x-www-form-urlencoded")
+    assert urllib.parse.parse_qsl(requests[1].content.decode(), keep_blank_values=True) == [
+        ("token", "first"),
+        ("token", "second"),
+        ("username", "user+name"),
+        ("password", "p&ss=word"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -250,7 +290,7 @@ async def test_login_selects_form_with_configured_credential_fields() -> None:
     await provider.authenticate(client)
 
     assert client.raw_post.call_args.args[0] == "https://example.com/takelogin.php"
-    assert client.raw_post.call_args.kwargs["data"] == [
+    assert _posted_form(client) == [
         ("token", "first"),
         ("token", "second"),
         ("username", "user"),
@@ -320,7 +360,7 @@ async def test_login_success_with_captcha() -> None:
     solver.solve.assert_called_once_with(b"fake-image-bytes")
 
     # 验证表单中包含验证码字段
-    form_data = client.raw_post.call_args.kwargs["data"]
+    form_data = _posted_form(client)
     assert ("imagestring", "x7k9") in form_data
     assert ("imagehash", "abc123") in form_data
 
@@ -469,7 +509,7 @@ async def test_extra_form_data() -> None:
     result = await provider.authenticate(client)
 
     assert result.success is True
-    form_data = client.raw_post.call_args.kwargs["data"]
+    form_data = _posted_form(client)
     assert ("passan", "") in form_data
     assert ("passid", "0") in form_data
     assert ("lang", "0") in form_data
@@ -498,6 +538,6 @@ async def test_select_defaults_only_submit_fields_present_in_form() -> None:
 
     await provider.authenticate(client)
 
-    form_data = client.raw_post.call_args.kwargs["data"]
+    form_data = _posted_form(client)
     assert ("logout", "7") in form_data
     assert not any(key == "missing" for key, _ in form_data)


### PR DESCRIPTION
## 修复内容

- 将账号密码登录表单显式编码为 `application/x-www-form-urlencoded` 字节内容后提交
- 保留重复隐藏字段，并正确转义 `+`、`&`、`=` 等特殊字符
- 增加使用真实 `HttpClient` 与 `httpx.AsyncClient` 请求链路的回归测试，避免 Mock 掩盖同步请求流兼容问题

## 问题原因

PR #132 为保留重复表单字段，将提交数据改成键值对列表。`httpx 0.28.1` 的 `AsyncClient` 直接接收该列表作为 `data` 时会生成同步请求流，并在发送前报错：

```text
RuntimeError: Attempted to send an sync request with an AsyncClient instance.
```

## 验证

- `uv run pytest tests/tracker/unit/test_credential_auth.py tests/tracker/unit/test_tjupt_config.py -q`：19 passed
- `uv run ruff check src/movieclaw_tracker/auth.py tests/tracker/unit/test_credential_auth.py`：通过
- `git diff --check`：通过

全量非集成测试已执行，但当前上游在本地环境存在与本修复无关的既有失败（图片代理 DNS fixture、Docker 脚本、enrich 模型相关）；本次涉及的 tracker 测试全部通过。

Fixes the credential login regression introduced after #132.
