### PR TITLE
fix: 收口已忽略入库条目的遗留作业

### DIFF
--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -109,7 +109,7 @@ from pathlib import Path, PurePosixPath
 from typing import NamedTuple
 from uuid import uuid4
 
-from sqlalchemy import or_, update
+from sqlalchemy import String, cast, or_, update
 from sqlmodel import select
 
 from movieclaw_api.services import jobs
@@ -139,6 +139,8 @@ from movieclaw_db.models import (
     ImportWatch,
     IngestEntry,
     IngestStatus,
+    Job,
+    JobResource,
     JobStatus,
     Library,
     LibraryFile,
@@ -1369,8 +1371,6 @@ async def _ingest_entry(
             # 作业（白名单钉死、等人工）已被彻底取代，就地收口——否则它们会
             # 以「需要处理」永远挂在任务中心（升级补偿只唤醒每个条目最新的
             # 作业，轮不到这些历史批次；NAS 实测滞留 4 条）
-            from movieclaw_db.models import Job
-
             stale_batches = (
                 (
                     await session.execute(
@@ -2784,16 +2784,69 @@ async def ignore_entry(session, entry_id: int) -> IngestEntry:
     record.message = "已手动忽略；如需处理可在清单中恢复"
     record.updated_at = utcnow()
     await session.commit()
-    active = await jobs.latest_job_for_resource(session, "ingest_entry", entry_id)
-    if active is not None and active.status in ACTIVE_JOB_STATUSES:
-        await jobs.request_cancel(
-            session,
-            active.id,
-            requested_by="监听导入清单",
-            reason="条目已在监听导入清单中手动忽略，任务随之取消；如需处理可在清单中恢复",
-        )
+    await _cancel_active_entry_jobs(
+        session,
+        entry_id=entry_id,
+        requested_by="监听导入清单",
+        reason="条目已在监听导入清单中手动忽略，任务随之取消；如需处理可在清单中恢复",
+    )
     await refresh_source_notice(session, str(Path(record.entry_path).parent))
     return record
+
+
+async def _cancel_active_entry_jobs(
+    session,
+    *,
+    entry_id: int | None = None,
+    requested_by: str,
+    reason: str,
+) -> int:
+    """取消条目关联的全部活跃作业；``entry_id=None`` 时对账所有已忽略条目。
+
+    同一条目可能因增量下载、重试或升级补偿留下多个作业。只取 ``latest`` 会
+    让较早的 blocked 作业永远留在任务中心。这里按资源关系一次找全，但不改
+    succeeded/failed/cancelled 等终态历史；重复运行时查不到活跃行，天然幂等。
+    """
+    statement = select(Job).join(JobResource, JobResource.job_id == Job.id)
+    statement = statement.where(
+        JobResource.resource_type == "ingest_entry",
+        # cancelling 已经收到过取消请求；重复对账不再追加同义事件。
+        Job.status.in_(
+            [status.value for status in ACTIVE_JOB_STATUSES if status is not JobStatus.CANCELLING]
+        ),
+    )
+    if entry_id is None:
+        statement = statement.join(
+            IngestEntry,
+            cast(IngestEntry.id, String) == JobResource.resource_id,
+        ).where(IngestEntry.status == IngestStatus.IGNORED)
+    else:
+        statement = statement.where(JobResource.resource_id == str(entry_id))
+
+    active_jobs = list((await session.execute(statement)).scalars().unique())
+    cancelled = 0
+    for active in active_jobs:
+        _, changed = await jobs.request_cancel(
+            session,
+            active.id,
+            requested_by=requested_by,
+            reason=reason,
+        )
+        cancelled += int(changed)
+    return cancelled
+
+
+async def reconcile_ignored_entry_jobs() -> int:
+    """启动时收口旧版本遗留在已忽略条目上的活跃作业（幂等、只查数据库）。"""
+    async with get_database().session() as session:
+        cancelled = await _cancel_active_entry_jobs(
+            session,
+            requested_by="system:ignored-ingest-reconcile",
+            reason="监听导入条目已被忽略，系统在启动对账时自动收口遗留任务",
+        )
+    if cancelled:
+        logger.info("启动对账已收口 %d 个已忽略条目的遗留作业", cancelled)
+    return cancelled
 
 
 async def restore_entry(session, entry_id: int) -> IngestEntry:
@@ -3272,6 +3325,9 @@ def get_ingest_watcher() -> IngestWatcher | None:
 async def init_ingest_watcher() -> None:
     """启动进程级监听单例（lifespan 调用）。"""
     global _watcher
+    # v0.18.0 及更早版本只取消同一条目的最新作业，旧 blocked 批次会一直
+    # 挂在任务中心。监听启动前做一次纯数据库对账，升级镜像即可自动修复。
+    await reconcile_ignored_entry_jobs()
     _watcher = IngestWatcher()
     await _watcher.start()
 

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -2837,13 +2837,17 @@ async def _cancel_active_entry_jobs(
 
 
 async def reconcile_ignored_entry_jobs() -> int:
-    """启动时收口旧版本遗留在已忽略条目上的活跃作业（幂等、只查数据库）。"""
-    async with get_database().session() as session:
-        cancelled = await _cancel_active_entry_jobs(
-            session,
-            requested_by="system:ignored-ingest-reconcile",
-            reason="监听导入条目已被忽略，系统在启动对账时自动收口遗留任务",
-        )
+    """启动时收口旧版遗留作业；失败不阻断服务，下次启动继续幂等重试。"""
+    try:
+        async with get_database().session() as session:
+            cancelled = await _cancel_active_entry_jobs(
+                session,
+                requested_by="system:ignored-ingest-reconcile",
+                reason="监听导入条目已被忽略，系统在启动对账时自动收口遗留任务",
+            )
+    except Exception:  # noqa: BLE001 -- 历史清理失败不能让整个服务拒绝启动
+        logger.warning("已忽略条目的遗留作业对账失败（不影响启动，下次启动将重试）", exc_info=True)
+        return 0
     if cancelled:
         logger.info("启动对账已收口 %d 个已忽略条目的遗留作业", cancelled)
     return cancelled

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -32,6 +32,7 @@ from movieclaw_db.models import (
     IngestEntry,
     IngestStatus,
     Job,
+    JobResource,
     JobStatus,
     Library,
     LibraryFile,
@@ -105,6 +106,189 @@ async def _get_library(db, library_id: int) -> Library:
         row = await session.get(Library, library_id)
         assert row is not None
         return row
+
+
+async def _add_ingest_job(session, *, job_id: str, entry_id: int, status: JobStatus) -> Job:
+    row = Job(id=job_id, job_type="library.ingest", status=status, input_data={})
+    session.add(row)
+    session.add(
+        JobResource(
+            job_id=job_id,
+            resource_type="ingest_entry",
+            resource_id=str(entry_id),
+        )
+    )
+    return row
+
+
+@pytest.mark.asyncio
+async def test_ignore_entry_cancels_every_active_job_without_rewriting_history(db, tmp_path):
+    """多批次/重试可留下多条活跃作业；忽略必须全部收口且不串资源。"""
+    async with db.session() as session:
+        ignored = IngestEntry(
+            entry_path=str(tmp_path / "watch" / "待忽略"),
+            fingerprint="fp-ignored",
+            status=IngestStatus.PENDING,
+        )
+        unrelated = IngestEntry(
+            entry_path=str(tmp_path / "watch" / "其他条目"),
+            fingerprint="fp-unrelated",
+            status=IngestStatus.PENDING,
+        )
+        session.add(ignored)
+        session.add(unrelated)
+        await session.commit()
+        await session.refresh(ignored)
+        await session.refresh(unrelated)
+        assert ignored.id is not None and unrelated.id is not None
+
+        for suffix, status in (
+            ("queued", JobStatus.QUEUED),
+            ("waiting", JobStatus.WAITING),
+            ("retry", JobStatus.RETRY_WAIT),
+            ("blocked", JobStatus.BLOCKED),
+            ("running", JobStatus.RUNNING),
+        ):
+            await _add_ingest_job(
+                session,
+                job_id=f"job_ignored_{suffix}",
+                entry_id=ignored.id,
+                status=status,
+            )
+        cancelling = await _add_ingest_job(
+            session,
+            job_id="job_ignored_cancelling",
+            entry_id=ignored.id,
+            status=JobStatus.CANCELLING,
+        )
+        cancelling.cancel_requested_by = "prior-request"
+        await _add_ingest_job(
+            session,
+            job_id="job_ignored_succeeded",
+            entry_id=ignored.id,
+            status=JobStatus.SUCCEEDED,
+        )
+        await _add_ingest_job(
+            session,
+            job_id="job_ignored_failed",
+            entry_id=ignored.id,
+            status=JobStatus.FAILED,
+        )
+        await _add_ingest_job(
+            session,
+            job_id="job_unrelated_blocked",
+            entry_id=unrelated.id,
+            status=JobStatus.BLOCKED,
+        )
+        await session.commit()
+
+        await ingest_mod.ignore_entry(session, ignored.id)
+
+    async with db.session() as session:
+        record = await session.get(IngestEntry, ignored.id)
+        assert record is not None and record.status == IngestStatus.IGNORED
+        for suffix in ("queued", "waiting", "retry", "blocked"):
+            row = await session.get(Job, f"job_ignored_{suffix}")
+            assert row is not None and row.status == JobStatus.CANCELLED
+            assert row.cancel_requested_by == "监听导入清单"
+        running = await session.get(Job, "job_ignored_running")
+        cancelling = await session.get(Job, "job_ignored_cancelling")
+        assert running is not None and running.status == JobStatus.CANCELLING
+        assert running.cancel_requested_by == "监听导入清单"
+        assert cancelling is not None and cancelling.status == JobStatus.CANCELLING
+        assert cancelling.cancel_requested_by == "prior-request"
+        succeeded = await session.get(Job, "job_ignored_succeeded")
+        failed = await session.get(Job, "job_ignored_failed")
+        unrelated = await session.get(Job, "job_unrelated_blocked")
+        assert succeeded is not None and succeeded.status == JobStatus.SUCCEEDED
+        assert failed is not None and failed.status == JobStatus.FAILED
+        assert unrelated is not None and unrelated.status == JobStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_ignored_entry_job_reconcile_repairs_old_rows_once(db, tmp_path):
+    """升级启动对账会修旧数据；再次运行无写入，未忽略条目和终态不受影响。"""
+    async with db.session() as session:
+        ignored = IngestEntry(
+            entry_path=str(tmp_path / "watch" / "旧版已忽略"),
+            fingerprint="fp-old-ignored",
+            status=IngestStatus.IGNORED,
+        )
+        pending = IngestEntry(
+            entry_path=str(tmp_path / "watch" / "仍待处理"),
+            fingerprint="fp-pending",
+            status=IngestStatus.PENDING,
+        )
+        session.add(ignored)
+        session.add(pending)
+        await session.commit()
+        await session.refresh(ignored)
+        await session.refresh(pending)
+        assert ignored.id is not None and pending.id is not None
+        await _add_ingest_job(
+            session,
+            job_id="job_old_queued",
+            entry_id=ignored.id,
+            status=JobStatus.QUEUED,
+        )
+        await _add_ingest_job(
+            session,
+            job_id="job_old_blocked",
+            entry_id=ignored.id,
+            status=JobStatus.BLOCKED,
+        )
+        await _add_ingest_job(
+            session,
+            job_id="job_old_cancelled",
+            entry_id=ignored.id,
+            status=JobStatus.CANCELLED,
+        )
+        await _add_ingest_job(
+            session,
+            job_id="job_pending_blocked",
+            entry_id=pending.id,
+            status=JobStatus.BLOCKED,
+        )
+        await session.commit()
+
+    assert await ingest_mod.reconcile_ignored_entry_jobs() == 2
+    assert await ingest_mod.reconcile_ignored_entry_jobs() == 0
+
+    async with db.session() as session:
+        queued = await session.get(Job, "job_old_queued")
+        blocked = await session.get(Job, "job_old_blocked")
+        terminal = await session.get(Job, "job_old_cancelled")
+        unrelated = await session.get(Job, "job_pending_blocked")
+        assert queued is not None and queued.status == JobStatus.CANCELLED
+        assert blocked is not None and blocked.status == JobStatus.CANCELLED
+        assert queued.cancel_requested_by == "system:ignored-ingest-reconcile"
+        assert blocked.cancel_requested_by == "system:ignored-ingest-reconcile"
+        assert terminal is not None and terminal.status == JobStatus.CANCELLED
+        assert unrelated is not None and unrelated.status == JobStatus.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_ingest_watcher_reconciles_ignored_jobs_before_starting(monkeypatch):
+    """应用启动监听时先修旧台账，再接收新文件事件。"""
+    calls: list[str] = []
+
+    async def reconcile() -> int:
+        calls.append("reconcile")
+        return 1
+
+    class Watcher:
+        async def start(self) -> None:
+            calls.append("start")
+
+        async def stop(self) -> None:
+            calls.append("stop")
+
+    monkeypatch.setattr(ingest_mod, "reconcile_ignored_entry_jobs", reconcile)
+    monkeypatch.setattr(ingest_mod, "IngestWatcher", Watcher)
+    await ingest_mod.init_ingest_watcher()
+    assert calls == ["reconcile", "start"]
+    await ingest_mod.close_ingest_watcher()
+    assert calls == ["reconcile", "start", "stop"]
 
 
 async def _wait_job_status(job_id: str, status: JobStatus, timeout: float = 3.0) -> Job:

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -268,6 +268,17 @@ async def test_ignored_entry_job_reconcile_repairs_old_rows_once(db, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_ignored_entry_job_reconcile_failure_does_not_block_startup(db, monkeypatch):
+    """旧数据清理是自愈项：短暂数据库异常只记日志，不能拖垮应用启动。"""
+
+    async def fail(*_args, **_kwargs):
+        raise RuntimeError("temporary database failure")
+
+    monkeypatch.setattr(ingest_mod, "_cancel_active_entry_jobs", fail)
+    assert await ingest_mod.reconcile_ignored_entry_jobs() == 0
+
+
+@pytest.mark.asyncio
 async def test_ingest_watcher_reconciles_ignored_jobs_before_starting(monkeypatch):
     """应用启动监听时先修旧台账，再接收新文件事件。"""
     calls: list[str] = []


### PR DESCRIPTION
## 问题

监听导入条目可以因增量下载、分批处理、重试或升级补偿关联多个持久化作业。此前人工点击“忽略”时只查询并取消最新作业，较早的 `blocked` 作业仍留在任务中心，被持续计入“需要处理”；监听清单已经为空，但活动页和侧栏仍显示红点。

这不是 NAS 性能或路径映射问题，而是入库台账与作业台账没有完整收口。

## 修复

- 忽略条目时按 `ingest_entry` 资源关系找出并取消全部仍可取消的活动作业，不再只处理最新一条
- 已在取消中的作业不重复追加取消事件；`succeeded`、`failed`、`cancelled` 终态历史保持不变
- 监听器启动前执行一次纯数据库幂等对账，自动修复旧版本已经留下的“ignored 条目 + active job”脏状态
- 对账不扫描媒体文件、不读取下载目录，避免为修状态唤醒 NAS 磁盘
- 对账遇到短暂数据库异常时记录告警并继续启动，下次启动再幂等重试，不让自愈逻辑影响服务可用性

升级并重启含本 PR 的版本后，既有遗留红点会自动收口，无需手工改数据库。

## 回归覆盖

- 同一条目同时存在 queued / waiting / retry_wait / blocked / running / cancelling
- 成功、失败、已取消的终态历史不被重写
- 未忽略的其他条目不受影响
- 启动对账首次修复、第二次零写入
- 应用启动顺序保证先对账、后接收新监听事件
- 启动对账异常不阻断应用启动

## 验证

- [x] 监听入库与作业相关测试：77 passed
- [x] CLI 真实子进程测试：27 passed
- [x] 除本机固定端口冲突模块外的完整后端套件：passed
- [x] `ruff check .`
- [x] `pnpm web:lint`（0 error，3 条上游既有 warning）
- [x] `pnpm web:typecheck`
- [x] `git diff --check`
- [x] GitHub Actions `python`（含 Docker 监督测试）：passed
- [x] GitHub Actions `web`：passed

本机 `127.0.0.1:3000` 正由用户的 `birdclaw` 服务占用，因此没有为运行 `tests/docker/test_entrypoint_supervision.py` 擅自中断该服务；该模块已由本 PR 的干净 GitHub runner 验证通过。