### PR TITLE
fix(player): 堵住软解同意闭环与转码会话孤儿 ffmpeg 的四条来路

### DIFF
--- a/apps/web/components/player/consent-dialog.tsx
+++ b/apps/web/components/player/consent-dialog.tsx
@@ -53,11 +53,17 @@ export function ConsentDialog({
 
   return (
     // role=dialog 兼具语义与 media-controller 的自动淡出豁免（它的隐藏规则
-    // 明确跳过 [role=dialog]）——等用户拍板的弹窗绝不能自己隐身
+    // 明确跳过 [role=dialog]）——等用户拍板的弹窗绝不能自己隐身。
+    //
+    // pointer-events-auto 必须显式写（2026-08-26 用户反馈「确认按钮点着没反应」
+    // 的根因）：media-chrome 的浮层容器是 pointer-events:none，靠
+    // `::slotted(...)` 规则给子元素恢复命中，但那条规则**同样明确跳过
+    // [role=dialog]**（media-container 的样式表里两处豁免是同一个选择器）。
+    // 不自己声明的话整个弹窗继承 none——看得见、点不中，点击穿透到画面上。
     <div
       role="dialog"
       aria-modal="true"
-      className="absolute inset-0 z-30 flex items-center justify-center bg-black/75 px-6"
+      className="pointer-events-auto absolute inset-0 z-30 flex items-center justify-center bg-black/75 px-6"
     >
       {/* 面板外观照抄站内 Modal（components/modal.tsx）：同一个圆角、描边、
           底色与投影——它就是一个模态，不该长得像另一套系统 */}

--- a/apps/web/components/player/consent-dialog.tsx
+++ b/apps/web/components/player/consent-dialog.tsx
@@ -37,7 +37,13 @@ export function ConsentDialog({
     setSaving(true);
     setError(null);
     try {
-      await savePlaybackPolicy({ software_transcode_enabled: true });
+      const saved = await savePlaybackPolicy({ software_transcode_enabled: true });
+      // 保存接口回显的就是落库后的取值：不是 true 说明开关根本没生效，此时
+      // 绝不能 onGranted——重新决策还会弹回同一个窗，用户只会觉得「点了没
+      // 反应」。把失败明确说出来，让人知道该去查什么。
+      if (!saved.software_transcode_enabled) {
+        throw new Error("软件转码开关保存后未生效，请刷新页面重试或查看服务端日志");
+      }
       onGranted();
     } catch (err) {
       setError(err instanceof Error ? err.message : "开启失败，请稍后重试");

--- a/apps/web/components/player/video-player.tsx
+++ b/apps/web/components/player/video-player.tsx
@@ -559,6 +559,16 @@ export function VideoPlayer(props: VideoPlayerProps) {
   /** `?t=` 起播覆盖只吃一次：切集之后回到「各自的续播点」默认语义。 */
   const overrideConsumedRef = useRef(false);
 
+  /**
+   * 刚在同意弹窗里点过「开启并播放」（保存成功后置位）。
+   *
+   * 用来识别「开关已保存、下一次决策却仍要求同意」的异常闭环：不识别的话
+   * 一模一样的弹窗会在几百毫秒内原样闪回，用户看到的就是「确认按钮点了
+   * 没反应」，而真正的故障（设置未生效/服务端异常）被完全吞掉。命中时改走
+   * 明确的错误页（见起播 effect）。正常拿到非 consent 决策即清零。
+   */
+  const consentGrantedRef = useRef(false);
+
   // hls.js 热身与会话请求并行，别等会话回来才开始下载（§6.10）
   useEffect(() => {
     preloadHlsEngine();
@@ -585,6 +595,7 @@ export function VideoPlayer(props: VideoPlayerProps) {
     // 上一集的「会话已死」标记不能带进新的一集：带着的话，起播完成前用户点
     // 播放会被当成「重开死会话」，凭空多拉一次决策
     deadSessionRef.current = false;
+    consentGrantedRef.current = false;
     setAutoplay(null);
     dispatch({ type: "reset" });
 
@@ -604,7 +615,10 @@ export function VideoPlayer(props: VideoPlayerProps) {
     const phase = state.phase;
     if (phase !== "deciding" && phase !== "degrading" && phase !== "session-starting") return;
 
-    const key = `${unitKey}|${phase}|${state.startMs}|${failedKey}|${state.failureCount}|${state.attempt}|${requestedAudio ?? ""}|${requestedSubtitle ?? ""}`;
+    // 指纹必须覆盖**全部**会影响请求参数的依赖（quality 也在内）：漏一项的
+    // 后果是该项单独变化时 effect 重跑却撞上相同指纹被去重跳过，而上一次
+    // 在途请求已被 cancelled——响应回来没人认领，起播就永远停在转圈里。
+    const key = `${unitKey}|${phase}|${state.startMs}|${failedKey}|${state.failureCount}|${state.attempt}|${requestedAudio ?? ""}|${requestedSubtitle ?? ""}|${quality ?? ""}`;
     if (startedKeyRef.current === key) return;
     startedKeyRef.current = key;
 
@@ -626,7 +640,35 @@ export function VideoPlayer(props: VideoPlayerProps) {
           audio_track: requestedAudio ?? undefined,
           subtitle_track: requestedSubtitle ?? undefined,
         });
-        if (cancelled) return;
+        if (cancelled) {
+          // 请求已被超越（退出播放器/切集/换参数重发）：响应里可能带着一个
+          // 刚拉起的转码会话，此后没有任何代码会认领它——心跳、释放器都只认
+          // 落进状态机的会话。不当场掐掉的话，这路 ffmpeg 会占着转码并发
+          // 名额空烧三分钟 CPU，直到服务端超时回收（「关了播放 ffmpeg 还在
+          // 跑」的主要来路；同文件重开有 stop_for_file 兜底，这里补上退出与
+          // 跨文件切换的口子）。
+          if (session.session_id) {
+            void stopPlaybackSession(session.session_id).catch(() => undefined);
+          }
+          return;
+        }
+        if (session.decision.outcome === "consent") {
+          // 刚点过「开启并播放」、开关也保存成功，服务端却仍要求同意：这是
+          // 异常闭环（设置没生效/后端异常），绝不能把一模一样的弹窗原样闪
+          // 回去——那在用户眼里就是「确认按钮点了没反应」，出错这件事被完全
+          // 吞掉。翻成明确的错误页，用户至少知道出了什么、该做什么。
+          if (consentGrantedRef.current) {
+            dispatch({
+              type: "fatal",
+              message: "软件转码开关已保存，但服务端仍在请求开启确认",
+              suggestion:
+                "开关可能没有生效（例如服务端刚重启）。请刷新页面重试；若反复出现，请查看服务端日志排查。",
+            });
+            return;
+          }
+        } else {
+          consentGrantedRef.current = false;
+        }
         if (state.startMs === null) {
           // 起点是服务端定的（续播点）：seek 目标与时间轴预填都跟上，
           // 不填的话起播那几秒进度条停在 00:00，看起来像「时间没加载出来」
@@ -2187,7 +2229,12 @@ export function VideoPlayer(props: VideoPlayerProps) {
         {state.phase === "consent" && state.decision ? (
           <ConsentDialog
             decision={state.decision}
-            onGranted={() => dispatch({ type: "consent-granted" })}
+            onGranted={() => {
+              // 置位在重新决策之前：新决策若仍是 consent 就走错误页而不是
+              // 把弹窗原样闪回（见 consentGrantedRef 的注释）
+              consentGrantedRef.current = true;
+              dispatch({ type: "consent-granted" });
+            }}
             onCancel={onExit}
           />
         ) : null}

--- a/apps/web/lib/player/machine.ts
+++ b/apps/web/lib/player/machine.ts
@@ -212,11 +212,16 @@ export function playerReducer(state: PlayerState, event: PlayerEvent): PlayerSta
         };
       }
       const failedTiers = nextFailedTiers(state, tier);
-      // 兜底档本身都失败了：没有更低的档可退，只能报错并建议换播放器
+      // 兜底档本身都失败了：没有更低的档可退，只能报错并建议换播放器。
+      // session 必须一并置空（与 fatal/degrading 同一不变式，见
+      // awaitsUserDecision 的注释）：留着的话心跳还在给这个会话续命、
+      // 引擎还挂着在拉流——用户对着错误页，服务端的软转 ffmpeg 却一直
+      // 烧着 CPU，正是「播放都停了 ffmpeg 还在跑」的一条来路。
       if (tier >= FALLBACK_TIER) {
         return {
           ...state,
           phase: "error",
+          session: null,
           failedTiers,
           failureCount: state.failureCount + 1,
           error: {

--- a/apps/web/test/player-machine.test.mjs
+++ b/apps/web/test/player-machine.test.mjs
@@ -100,6 +100,17 @@ test("兜底档也失败：进错误态并给出换播放器的建议", () => {
   assert.match(state.error.suggestion, /原生播放器/);
 });
 
+test("兜底档失败进错误态时会话必须清空——错误页背后不能还挂着转码", () => {
+  // 不清的话心跳继续给这个会话续命、引擎还在拉流：用户对着错误页，
+  // 服务端的软转 ffmpeg 却一直烧 CPU（「播放停了 ffmpeg 还在跑」的来路之一）。
+  const state = run([
+    { type: "request", startMs: 0 },
+    { type: "session", session: planSession(4) },
+    { type: "failed", reason: "软转也放不出来" },
+  ]);
+  assert.equal(state.session, null);
+});
+
 test("需要同意软件转码时进 consent 态，同意后回到决策", () => {
   const consent = planSession(4);
   consent.decision = {

--- a/src/movieclaw_api/services/playback/session.py
+++ b/src/movieclaw_api/services/playback/session.py
@@ -300,8 +300,14 @@ class TranscodeSessionManager:
         self._sessions[session.id] = session
         try:
             await self._spawn(session, command)
-        except Exception:
-            await self.stop(session.id)
+        except BaseException:
+            # 捕 BaseException 而不只是 Exception：客户端在起播途中断开连接
+            # （关页面/切集）时，uvicorn 会**取消**本请求协程，抛出来的是
+            # CancelledError（BaseException）。只捕 Exception 的话会话留在
+            # 表里、ffmpeg 继续空转到超时回收——「关了播放 ffmpeg 还在跑」
+            # 的一条服务端来路。清理后原样重抛，取消语义不变。
+            with contextlib.suppress(Exception):
+                await self.stop(session.id)
             raise
         return session
 
@@ -716,8 +722,18 @@ class TranscodeSessionManager:
         session = self._sessions.pop(session_id, None)
         if session is None:
             return False
+        # 先置状态再抢重启锁：正在排队等锁的 VOD 分片重启会在临界区入口看到
+        # stopped 直接放弃。终止必须与 _maybe_restart_for 互斥——不互斥的话，
+        # 一次「杀旧进程 → 拉新进程」的重启可能在本次 killpg **之后**才把新
+        # ffmpeg 拉起来，而会话已经不在表里，那个进程从此没人管（孤儿
+        # ffmpeg，「关了播放 ffmpeg 还在跑」的一条来路）。
         session.state = "stopped"
-        await self._terminate(session)
+        async with session._restart_lock:
+            # 锁内再置一次：恰好在临界区里的那次重启会经由 _spawn 把状态写回
+            # spawning/ready，把外面置的 stopped 盖掉——不重申终态的话，还挂着
+            # 的分片等待者下一拍又能通过状态检查再拉起一个 ffmpeg。
+            session.state = "stopped"
+            await self._terminate(session)
         shutil.rmtree(session.directory, ignore_errors=True)
         return True
 

--- a/tests/playback/test_session_manager.py
+++ b/tests/playback/test_session_manager.py
@@ -976,3 +976,61 @@ async def test_ensure_segment_bails_out_on_stopped_session(manager, tmp_path):
     session.state = "stopped"
     assert await manager.ensure_segment(session, 5) is None
     assert session.process is None  # 没有试图重启
+
+
+@pytest.mark.asyncio
+async def test_cancelled_start_leaves_no_session_behind(manager, monkeypatch):
+    """回归：客户端在起播途中断开（关页面/切集）时，uvicorn 会**取消**本次
+    请求协程，start 里抛出的是 CancelledError（BaseException）。只清理
+    Exception 的话，会话留在表里、ffmpeg 继续空转到超时回收——「关了播放
+    ffmpeg 还在跑」的一条服务端来路。"""
+    # playlist 延迟 0.5 秒出现：把 spawn 的等待窗口拉长，好让取消落在中途
+    install_fake(monkeypatch, WRITES_PLAYLIST_THEN_SLEEPS, delay=0.5)
+    task = asyncio.create_task(
+        manager.start(make_plan(), source_path="/m/a.mkv", member_id=0)
+    )
+    assert await wait_until(
+        lambda: bool(manager.active()) and manager.active()[0].process is not None
+    )
+    pid = manager.active()[0].process.pid
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert manager.active() == []  # 会话没有留在表里
+    assert await wait_until(lambda: not pid_alive(pid))  # 进程组整个被收掉
+
+
+@pytest.mark.asyncio
+async def test_stop_during_vod_restart_leaves_no_process(manager, monkeypatch):
+    """回归：stop 与 VOD 分片重启不互斥的话，一次「杀旧进程 → 拉新进程」的
+    重启可能在 stop 的 killpg 之后才把新 ffmpeg 拉起来——会话已出表，那个
+    进程从此没人管。stop 必须拿重启锁：要么排在重启后面把新进程一并杀掉，
+    要么先到并让排队的重启放弃；锁内重申 stopped 终态，后续等待者也不会
+    再拉起下一轮。"""
+    install_fake(monkeypatch, NEVER_WRITES_PLAYLIST)
+    monkeypatch.setattr(TranscodeSessionManager, "_SEGMENT_WAIT_S", 2.0)
+    session = await manager.start(
+        make_plan(), source_path="/m/a.mkv", member_id=0, segment_plan=_boundaries(800)
+    )
+    pids = [session.process.pid]
+    real_spawn = manager._spawn
+
+    async def slow_spawn(sess, command):
+        # 拉长重启临界区，确保 stop 在「旧进程已杀、新进程未起」的窗口到达
+        await asyncio.sleep(0.3)
+        await real_spawn(sess, command)
+        if sess.process is not None:
+            pids.append(sess.process.pid)
+
+    monkeypatch.setattr(manager, "_spawn", slow_spawn)
+    ensure = asyncio.create_task(manager.ensure_segment(session, 50))
+    await asyncio.sleep(0.1)  # 让重启进入临界区
+    try:
+        assert await manager.stop(session.id) is True
+        await ensure
+        assert session.state == "stopped"  # 终态没有被重启写回 ready
+        for pid in pids:
+            assert await wait_until(lambda p=pid: not pid_alive(p)), f"进程 {pid} 泄漏"
+        assert manager.get(session.id) is None
+    finally:
+        await manager.shutdown()


### PR DESCRIPTION
用户反馈两个问题：首次开软解时确认按钮「点了没反应」；关闭播放后
后台 ffmpeg 还在跑。排查后修复以下缺陷：

前端：
- 起播请求被超越（退出播放器/切集/换参数）后，响应里带回的转码会话
  无人认领——当场调 DELETE 掐掉，不再让 ffmpeg 空烧到服务端超时回收
- 兜底档（软转）播放失败进错误态时清空 session：否则心跳继续给会话
  续命、引擎还在拉流，错误页背后 ffmpeg 一直烧 CPU
- 同意弹窗点「开启并播放」后若下一次决策仍要求同意，改走明确错误页，
  不再把一模一样的弹窗原样闪回（表现即「确认按钮点了没反应」）；
  保存开关的响应也校验真实生效
- 起播去重指纹补上 quality：漏项会让该项单独变化时请求被去重吞掉，
  起播永远停在转圈

后端（转码会话管理）：
- start 中途被取消（客户端断开，CancelledError）也要清会话杀进程，
  原来只捕 Exception 会留下空转的 ffmpeg
- stop 与 VOD 分片重启加互斥：不互斥时重启可能在 killpg 之后才拉起
  新 ffmpeg，而会话已出表，进程从此无人管；锁内重申 stopped 终态，
  防止临界区内的重启把状态写回 ready 后又被等待者拉起下一轮

以上均有回归测试覆盖（新增 2 条前端 + 2 条后端，后端两条已验证在
未修复代码上确实失败）。

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FzDemobU7E8eiMBSz8L4VH