### PR TITLE
fix: 阻止原盘流分段误入库与任务膨胀

### DIFF
--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -418,6 +418,18 @@ def _relative_entry_file(entry: Path, file: Path) -> str | None:
     return relative.as_posix() if relative.parts else None
 
 
+def _disc_relative_path(relative_path: str) -> bool:
+    """下载器文件清单里的路径是否属于蓝光/DVD 原盘结构。
+
+    整树快照会在下钻时识别 ``BDMV`` / ``VIDEO_TS``，但边下边入库只拿到
+    下载器放行的文件白名单，不能靠目录遍历补判。这里直接检查相对路径的
+    目录段，既覆盖单片原盘 ``BDMV/STREAM/...``，也覆盖合集里嵌套的
+    ``影片名/BDMV/STREAM/...``。
+    """
+    parts = PurePosixPath(relative_path.replace("\\", "/")).parts
+    return any(part.upper() in {"BDMV", "VIDEO_TS"} for part in parts)
+
+
 def _snapshot_ready_files(
     entry: Path, ready_files: list[_ReadyDownloadFile]
 ) -> _EntrySnapshot:
@@ -930,6 +942,12 @@ async def _completed_file_batch(entry: Path, matches: list) -> _DownloadFileBatc
             if relative is None:
                 continue
             mapped_selected += 1
+            # 原盘的 m2ts/vob 是播放列表引用的传输流分段，不是可独立入库的
+            # 正片。下载中若按“已完成文件”放行，会把几秒钟的小分段误当电影，
+            # 还会随每批分段完成不断制造新作业。原盘沿用既有整树语义：等整种
+            # 完成后由 _snapshot 标记 has_disc，并只生成一条“暂不支持”结论。
+            if _disc_relative_path(relative):
+                return _DownloadFileBatch(files=(), consumable_hashes=())
             lower = source.name.lower()
             if source.suffix.lower() not in VIDEO_EXTS or any(
                 marker in lower for marker in _IGNORE_MARKERS
@@ -977,13 +995,13 @@ async def _completed_file_batch(entry: Path, matches: list) -> _DownloadFileBatc
     return _DownloadFileBatch(files=tuple(ready), consumable_hashes=consumable)
 
 
-async def _claimed_by_blocked_batches(session, entry_path: str) -> frozenset[str]:
-    """已被挂起的分批入库作业认领的文件（条目内相对路径）。
+async def _claimed_by_file_batches(session, entry_path: str) -> frozenset[str]:
+    """所有既有分批入库作业已经认领的文件（条目内相对路径）。
 
-    挂起批次的白名单钉死了这些文件，它们只能等人工或解析能力升级。后续批次
-    必须避开——否则新一批会把同一个识别不出的文件再拉进来、整批跟着挂起，
-    剩下的集依旧进不了库（连坐的第二种形态：不是被旧作业拦住，而是被它带的
-    那个坏文件拖住）。
+    文件白名单一经持久化就归属于原作业：blocked 等人工，succeeded 已入库，
+    failed/cancelled 只能显式重试原作业。后续批次若再次带上这些旧文件，不仅
+    重做无用功，还会让一个历史坏文件反复拖住整批；因此新作业只接真正新增的
+    ready 文件。原作业自身的重试直接使用已保存白名单，不经过这里，不受影响。
     """
     from movieclaw_db.models import Job
 
@@ -992,7 +1010,6 @@ async def _claimed_by_blocked_batches(session, entry_path: str) -> frozenset[str
         await session.execute(
             select(Job).where(
                 Job.dedupe_key.startswith(f"{prefix}:"),  # type: ignore[union-attr]
-                Job.status == JobStatus.BLOCKED,
             )
         )
     ).scalars()
@@ -1198,26 +1215,28 @@ async def _process_entry(
                     _deferred.pop(path_str, None)
                 _failed_retry.pop(path_str, None)
                 return
-            if partial_batch is not None:
-                # 放行的新批次要避开挂起批次已认领的文件。剔除后重算快照：
-                # 指纹要与真实白名单一致，它同时是本批的去重分桶键。
-                claimed = await _claimed_by_blocked_batches(session, path_str)
-                remaining = tuple(
-                    ready for ready in partial_batch.files if ready.relative_path not in claimed
-                )
-                if not remaining:
-                    return  # 本轮完成的文件全在挂起批次里：等人工，无事可做
-                if len(remaining) != len(partial_batch.files):
-                    # 仍有文件卡在挂起批次里，种子不能算消费完毕
-                    partial_batch = _DownloadFileBatch(files=remaining, consumable_hashes=())
-                    try:
-                        snap = await asyncio.to_thread(
-                            _snapshot_ready_files, entry, list(remaining)
-                        )
-                    except IngestSourceChanged:
-                        return
-                    if not snap.videos:
-                        return
+
+        if partial_batch is not None:
+            # 每轮都避开所有历史分批作业已认领的文件，而不只在“最新作业恰好
+            # blocked”时做。真实坏例是：大批次挂起后，一个新文件单独成功，
+            # 最新作业随即变成 succeeded；旧实现下一轮便忘掉更早的 blocked，
+            # 也再次带上已成功文件，把上千个旧文件连同新文件再建一批，任务
+            # 中心因此指数式膨胀。
+            claimed = await _claimed_by_file_batches(session, path_str)
+            remaining = tuple(
+                ready for ready in partial_batch.files if ready.relative_path not in claimed
+            )
+            if not remaining:
+                return  # 本轮完成的文件全在挂起批次里：等人工，无事可做
+            if len(remaining) != len(partial_batch.files):
+                # 仍有文件卡在挂起批次里，种子不能算消费完毕
+                partial_batch = _DownloadFileBatch(files=remaining, consumable_hashes=())
+                try:
+                    snap = await asyncio.to_thread(_snapshot_ready_files, entry, list(remaining))
+                except IngestSourceChanged:
+                    return
+                if not snap.videos:
+                    return
 
         if snap is None:
             snap = await asyncio.to_thread(_snapshot, entry)
@@ -2853,6 +2872,58 @@ async def reconcile_ignored_entry_jobs() -> int:
     return cancelled
 
 
+async def reconcile_disc_batch_jobs() -> int:
+    """启动时收口旧版把原盘流分段当视频建立的活跃作业。
+
+    只依据作业已经持久化的文件白名单判定，不扫描 NAS 目录；普通电影、剧集
+    批次和终态作业都不受影响。升级后这一步会清掉任务中心里的历史红项，新的
+    原盘下载则由 ``_completed_file_batch`` 在建作业前直接拦住。
+    """
+    try:
+        async with get_database().session() as session:
+            rows = list(
+                (
+                    await session.execute(
+                        select(Job).where(
+                            Job.job_type == "library.ingest",
+                            Job.status.in_(
+                                [
+                                    status.value
+                                    for status in ACTIVE_JOB_STATUSES
+                                    if status is not JobStatus.CANCELLING
+                                ]
+                            ),
+                        )
+                    )
+                ).scalars()
+            )
+            cancelled = 0
+            for active in rows:
+                ready_files = (active.input_data or {}).get("ready_files") or ()
+                if not any(
+                    isinstance(ready, dict)
+                    and isinstance(ready.get("path"), str)
+                    and _disc_relative_path(ready["path"])
+                    for ready in ready_files
+                ):
+                    continue
+                _, changed = await jobs.request_cancel(
+                    session,
+                    active.id,
+                    requested_by="system:disc-batch-reconcile",
+                    reason="原盘流分段不是独立视频，本批次由升级后的入库逻辑自动收口",
+                )
+                cancelled += int(changed)
+    except Exception:  # noqa: BLE001 -- 历史清理失败不能让整个服务拒绝启动
+        logger.warning(
+            "原盘分批入库的遗留作业对账失败（不影响启动，下次启动将重试）", exc_info=True
+        )
+        return 0
+    if cancelled:
+        logger.info("启动对账已收口 %d 个原盘分批入库遗留作业", cancelled)
+    return cancelled
+
+
 async def restore_entry(session, entry_id: int) -> IngestEntry:
     """恢复处理：置空指纹让下轮巡检必然重处理，并立即请求巡检。
 
@@ -3332,6 +3403,9 @@ async def init_ingest_watcher() -> None:
     # v0.18.0 及更早版本只取消同一条目的最新作业，旧 blocked 批次会一直
     # 挂在任务中心。监听启动前做一次纯数据库对账，升级镜像即可自动修复。
     await reconcile_ignored_entry_jobs()
+    # v0.18.0 的边下边入库会把 BDMV/VIDEO_TS 流分段误当独立视频并持续建
+    # 作业；同样在监听启动前只读作业白名单并收口，不触碰媒体文件。
+    await reconcile_disc_batch_jobs()
     _watcher = IngestWatcher()
     await _watcher.start()
 

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -2876,30 +2876,32 @@ async def reconcile_disc_batch_jobs() -> int:
     """启动时收口旧版把原盘流分段当视频建立的活跃作业。
 
     只依据作业已经持久化的文件白名单判定，不扫描 NAS 目录；普通电影、剧集
-    批次和终态作业都不受影响。升级后这一步会清掉任务中心里的历史红项，新的
-    原盘下载则由 ``_completed_file_batch`` 在建作业前直接拦住。
+    批次和无关终态作业都不受影响。升级后这一步会同时清掉任务中心里的历史
+    红项与监听页残留的 ``pending`` 台账；新的原盘下载则由
+    ``_completed_file_batch`` 在建作业前直接拦住。
     """
     try:
         async with get_database().session() as session:
+            active_statuses = [
+                status.value for status in ACTIVE_JOB_STATUSES if status is not JobStatus.CANCELLING
+            ]
             rows = list(
                 (
                     await session.execute(
                         select(Job).where(
                             Job.job_type == "library.ingest",
-                            Job.status.in_(
-                                [
-                                    status.value
-                                    for status in ACTIVE_JOB_STATUSES
-                                    if status is not JobStatus.CANCELLING
-                                ]
+                            or_(
+                                Job.status.in_(active_statuses),
+                                Job.cancel_requested_by == "system:disc-batch-reconcile",
                             ),
                         )
                     )
                 ).scalars()
             )
             cancelled = 0
-            for active in rows:
-                ready_files = (active.input_data or {}).get("ready_files") or ()
+            disc_job_ids: set[str] = set()
+            for job in rows:
+                ready_files = (job.input_data or {}).get("ready_files") or ()
                 if not any(
                     isinstance(ready, dict)
                     and isinstance(ready.get("path"), str)
@@ -2907,13 +2909,54 @@ async def reconcile_disc_batch_jobs() -> int:
                     for ready in ready_files
                 ):
                     continue
+                disc_job_ids.add(job.id)
+                if job.status not in active_statuses:
+                    continue
                 _, changed = await jobs.request_cancel(
                     session,
-                    active.id,
+                    job.id,
                     requested_by="system:disc-batch-reconcile",
                     reason="原盘流分段不是独立视频，本批次由升级后的入库逻辑自动收口",
                 )
                 cancelled += int(changed)
+
+            # v0.18.0 的 Job 与监听台账是两套持久化状态。只取消 Job 会让前端
+            # 继续显示旧的“已取最大文件、忽略其余 N 个视频”。资源关系能精确
+            # 找回这些 Job 对应的台账，不需要扫描 NAS，也不会碰普通 pending。
+            reconciled_entries = 0
+            if disc_job_ids:
+                resource_ids = (
+                    await session.execute(
+                        select(JobResource.resource_id).where(
+                            JobResource.job_id.in_(disc_job_ids),  # type: ignore[union-attr]
+                            JobResource.resource_type == "ingest_entry",
+                        )
+                    )
+                ).scalars()
+                entry_ids = {
+                    int(resource_id) for resource_id in resource_ids if str(resource_id).isdigit()
+                }
+                if entry_ids:
+                    records = list(
+                        (
+                            await session.execute(
+                                select(IngestEntry).where(
+                                    IngestEntry.id.in_(entry_ids),  # type: ignore[union-attr]
+                                    IngestEntry.status == IngestStatus.PENDING,
+                                )
+                            )
+                        ).scalars()
+                    )
+                    for record in records:
+                        record.status = IngestStatus.SKIPPED
+                        record.message = (
+                            "旧版原盘流分段的待处理记录已自动收口；"
+                            "原盘目录（BDMV/VIDEO_TS）暂不支持自动入库，请手动整理"
+                        )
+                        record.updated_at = utcnow()
+                    reconciled_entries = len(records)
+                    if records:
+                        await session.commit()
     except Exception:  # noqa: BLE001 -- 历史清理失败不能让整个服务拒绝启动
         logger.warning(
             "原盘分批入库的遗留作业对账失败（不影响启动，下次启动将重试）", exc_info=True
@@ -2921,6 +2964,8 @@ async def reconcile_disc_batch_jobs() -> int:
         return 0
     if cancelled:
         logger.info("启动对账已收口 %d 个原盘分批入库遗留作业", cancelled)
+    if reconciled_entries:
+        logger.info("启动对账已收口 %d 个原盘分批监听台账", reconciled_entries)
     return cancelled
 
 

--- a/src/movieclaw_matcher/identity.py
+++ b/src/movieclaw_matcher/identity.py
@@ -31,6 +31,14 @@ _MOVIE_YEAR_TOLERANCE = 1
 # 别名对标题段的最小覆盖率：低于此值说明别名只是段内一小截，多半是别的作品
 _MIN_COVERAGE = 0.6
 
+# 单部电影候选不能横跨多个发行年份。PT 合集常把首部片名和起始年放在最前，
+# 例如 ``The Fast And The Furious 2001-2023``；旧逻辑会把它精确命中 2001
+# 年首部电影并投递整套合集。年份范围是比“合集/Trilogy”词表更稳定的结构证据，
+# 也不依赖 NER 是否恰好抽出 complete。
+_MOVIE_YEAR_RANGE_RE = re.compile(
+    r"(?<!\d)((?:19|20)\d{2})\s*[-–—~～]\s*((?:19|20)\d{2})(?!\d)"
+)
+
 # 标题段边界：场景命名里片名之后的第一个标记（年份/季集/画质/发布类标记），
 # 命中任一边界即认为片名部分结束
 _BOUNDARY_RE = re.compile(
@@ -131,6 +139,21 @@ def _match_alias(candidate: TorrentCandidate, media: MediaIdentity) -> str | Non
     return None
 
 
+def _is_multi_year_movie_pack(candidate: TorrentCandidate) -> bool:
+    """候选是否明确写了跨年份电影合集。"""
+    attrs = candidate.attrs
+    text = " ".join(
+        (
+            candidate.title,
+            candidate.subtitle,
+            *attrs.titles_zh,
+            *attrs.titles_en,
+            *attrs.title_candidates,
+        )
+    )
+    return any(start != end for start, end in _MOVIE_YEAR_RANGE_RE.findall(text))
+
+
 def match_identity(
     candidate: TorrentCandidate, media: MediaIdentity
 ) -> IdentityMatch | None:
@@ -141,6 +164,11 @@ def match_identity(
     # 注意只信 media_type 字段——电影种子可能被误提取出 seasons 噪音
     # （如 "Zombi VIII" 的罗马数字），不能拿 seasons 是否为空当类型信号。
     if attrs.media_type is not None and attrs.media_type != media.kind:
+        return None
+
+    # 单片订阅不能用跨年份合集来满足。即使合集带首部电影的 IMDb/Douban ID，
+    # 也不能让精确 ID 绕过该结构守卫——当前下载/入库契约只接受一个电影单元。
+    if media.kind == "movie" and _is_multi_year_movie_pack(candidate):
         return None
 
     # -- 信号一：外部 ID 精确相等 -------------------------------------------

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -279,12 +279,70 @@ async def test_ignored_entry_job_reconcile_failure_does_not_block_startup(db, mo
 
 
 @pytest.mark.asyncio
+async def test_disc_batch_job_reconcile_cancels_only_active_disc_batches(db):
+    """升级只收口原盘分段批次；普通剧集批次和历史终态不被改写。"""
+    async with db.session() as session:
+        session.add_all(
+            [
+                Job(
+                    id="job_disc_direct",
+                    job_type="library.ingest",
+                    status=JobStatus.BLOCKED,
+                    input_data={"ready_files": [{"path": "BDMV/STREAM/00001.m2ts"}]},
+                ),
+                Job(
+                    id="job_disc_nested",
+                    job_type="library.ingest",
+                    status=JobStatus.QUEUED,
+                    input_data={
+                        "ready_files": [
+                            {"path": "电影一/VIDEO_TS/VTS_01_1.VOB"},
+                        ]
+                    },
+                ),
+                Job(
+                    id="job_episode_blocked",
+                    job_type="library.ingest",
+                    status=JobStatus.BLOCKED,
+                    input_data={"ready_files": [{"path": "Season 01/S01E01.mkv"}]},
+                ),
+                Job(
+                    id="job_disc_succeeded",
+                    job_type="library.ingest",
+                    status=JobStatus.SUCCEEDED,
+                    input_data={"ready_files": [{"path": "BDMV/STREAM/00002.m2ts"}]},
+                ),
+            ]
+        )
+        await session.commit()
+
+    assert await ingest_mod.reconcile_disc_batch_jobs() == 2
+    assert await ingest_mod.reconcile_disc_batch_jobs() == 0
+
+    async with db.session() as session:
+        direct = await session.get(Job, "job_disc_direct")
+        nested = await session.get(Job, "job_disc_nested")
+        episode = await session.get(Job, "job_episode_blocked")
+        succeeded = await session.get(Job, "job_disc_succeeded")
+    assert direct is not None and direct.status == JobStatus.CANCELLED
+    assert nested is not None and nested.status == JobStatus.CANCELLED
+    assert direct.cancel_requested_by == "system:disc-batch-reconcile"
+    assert nested.cancel_requested_by == "system:disc-batch-reconcile"
+    assert episode is not None and episode.status == JobStatus.BLOCKED
+    assert succeeded is not None and succeeded.status == JobStatus.SUCCEEDED
+
+
+@pytest.mark.asyncio
 async def test_ingest_watcher_reconciles_ignored_jobs_before_starting(monkeypatch):
     """应用启动监听时先修旧台账，再接收新文件事件。"""
     calls: list[str] = []
 
     async def reconcile() -> int:
-        calls.append("reconcile")
+        calls.append("reconcile-ignored")
+        return 1
+
+    async def reconcile_disc() -> int:
+        calls.append("reconcile-disc")
         return 1
 
     class Watcher:
@@ -295,11 +353,12 @@ async def test_ingest_watcher_reconciles_ignored_jobs_before_starting(monkeypatc
             calls.append("stop")
 
     monkeypatch.setattr(ingest_mod, "reconcile_ignored_entry_jobs", reconcile)
+    monkeypatch.setattr(ingest_mod, "reconcile_disc_batch_jobs", reconcile_disc)
     monkeypatch.setattr(ingest_mod, "IngestWatcher", Watcher)
     await ingest_mod.init_ingest_watcher()
-    assert calls == ["reconcile", "start"]
+    assert calls == ["reconcile-ignored", "reconcile-disc", "start"]
     await ingest_mod.close_ingest_watcher()
-    assert calls == ["reconcile", "start", "stop"]
+    assert calls == ["reconcile-ignored", "reconcile-disc", "start", "stop"]
 
 
 async def _wait_job_status(job_id: str, status: JobStatus, timeout: float = 3.0) -> Job:
@@ -1020,6 +1079,92 @@ async def test_completed_torrent_creates_file_scoped_job_while_sibling_downloads
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "BDMV/STREAM/00001.m2ts",
+        "电影一 (2001)/BDMV/STREAM/00001.m2ts",
+    ],
+    ids=["single-disc", "collection-with-nested-disc"],
+)
+async def test_downloading_disc_never_imports_completed_stream_segments(
+    db, tmp_path, monkeypatch, relative_path
+):
+    """原盘下载中已完成的 m2ts 不是正片；单盘和合集嵌套盘都必须整种等待。"""
+    from movieclaw_downloader import TorrentBrief, TorrentFile, TorrentStatus
+
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    await _make_rule(db, library_id=library_id, source=watch)
+    entry = watch / "Movie.Collection.2001-2023.UHD.BluRay"
+    stream = entry.joinpath(*relative_path.split("/"))
+    stream.parent.mkdir(parents=True)
+    stream.write_bytes(b"ten-second-bluray-segment")
+    download_complete = {"value": False}
+
+    async def briefs():
+        return [
+            TorrentBrief(
+                name=entry.name,
+                content_name=entry.name,
+                completed=download_complete["value"],
+                info_hash="disc-hash",
+            )
+        ]
+
+    async def statuses(_matches):
+        return [
+            (
+                SimpleNamespace(path_mappings=None),
+                TorrentStatus(
+                    info_hash="disc-hash",
+                    name=entry.name,
+                    progress=0.5,
+                    completed=False,
+                    save_path=str(watch),
+                    files=[
+                        TorrentFile(
+                            path=f"{entry.name}/{relative_path}",
+                            size_bytes=stream.stat().st_size,
+                            completed_bytes=stream.stat().st_size,
+                        )
+                    ],
+                ),
+            )
+        ]
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", briefs)
+    monkeypatch.setattr(ingest_mod, "_matched_torrent_statuses", statuses)
+    async with db.session() as session:
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+        library = await session.get(Library, library_id)
+        assert library is not None
+
+    # 下载中：即便流分段已完成，也不能产生作业、台账或假入库文件。
+    await ingest_mod._sweep_dir(rule, library)
+    async with db.session() as session:
+        assert list((await session.execute(select(Job))).scalars()) == []
+        assert list((await session.execute(select(IngestEntry))).scalars()) == []
+        assert list((await session.execute(select(LibraryFile))).scalars()) == []
+    assert str(entry) in ingest_mod._deferred
+
+    # 整种完成：整树识别出原盘，只生成一条可理解的“暂不支持”结论。
+    download_complete["value"] = True
+    await ingest_mod._sweep_dir(rule, library)
+    async with db.session() as session:
+        job = (await session.execute(select(Job))).scalar_one()
+    await jobs.init_job_dispatcher(max_parallel=1)
+    await _wait_job_status(job.id, JobStatus.SUCCEEDED)
+    async with db.session() as session:
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+        files = list((await session.execute(select(LibraryFile))).scalars())
+    assert record.status == IngestStatus.SKIPPED
+    assert "原盘目录" in (record.message or "")
+    assert files == []
+
+
+@pytest.mark.asyncio
 async def test_file_scoped_blocked_job_not_woken_by_tree_fingerprint(db, tmp_path, monkeypatch):
     """文件级批次 blocked 后不被全树指纹差异反复唤醒；升级补偿仍只唤醒一次。
 
@@ -1146,14 +1291,21 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
 
     monkeypatch.setattr("movieclaw_api.services.media_scrape.ensure_assets", no_assets)
     # ep1 解析不出集号 → 第一批挂起；ep2 正常
-    _stub_unit(monkeypatch, lambda file: (1, 0) if file.stem == "ep1" else (1, 2))
+    _stub_unit(
+        monkeypatch,
+        lambda file: (1, 0)
+        if file.stem == "ep1"
+        else (1, int(file.stem.removeprefix("ep"))),
+    )
 
     entry = watch / "Collateral.Show.S01"
     entry.mkdir()
     ep1 = entry / "ep1.mkv"
     ep2 = entry / "ep2.mkv"
+    ep3 = entry / "ep3.mkv"
     ep1.write_bytes(b"episode-1")
     ep2.write_bytes(b"episode-2-partial")
+    ep3.write_bytes(b"episode-3-partial")
     completed = TorrentBrief(
         name=entry.name, content_name=entry.name, completed=True, info_hash="done-hash"
     )
@@ -1178,8 +1330,29 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
             ],
         )
 
-    # 可变开关：第二轮把 ep2 也切成已完成
-    ep2_done = {"value": False}
+    # 可变开关：后续轮次依次把 ep2、ep3 切成已完成
+    completed_later = {ep2.name: False, ep3.name: False}
+
+    def _writing_status() -> TorrentStatus:
+        files = []
+        for file in (ep2, ep3):
+            size = file.stat().st_size
+            done = completed_later[file.name]
+            files.append(
+                TorrentFile(
+                    path=f"{entry.name}/{file.name}",
+                    size_bytes=size,
+                    completed_bytes=size if done else 3,
+                )
+            )
+        return TorrentStatus(
+            info_hash=downloading.info_hash,
+            name=entry.name,
+            progress=0.75,
+            completed=False,
+            save_path=str(watch),
+            files=files,
+        )
 
     async def briefs():
         return [completed, downloading]
@@ -1187,10 +1360,7 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
     async def statuses(_matches):
         return [
             (SimpleNamespace(path_mappings=None), _status(completed.info_hash, ep1, True)),
-            (
-                SimpleNamespace(path_mappings=None),
-                _status(downloading.info_hash, ep2, ep2_done["value"]),
-            ),
+            (SimpleNamespace(path_mappings=None), _writing_status()),
         ]
 
     monkeypatch.setattr(ingest_mod, "_downloader_briefs", briefs)
@@ -1209,7 +1379,7 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
     assert blocked.error["code"] == "INGEST_EPISODE_PARSE_REQUIRED"
 
     # 第二轮：ep2 落盘，必须另立作业，而不是并回挂起的那一批
-    ep2_done["value"] = True
+    completed_later[ep2.name] = True
     await ingest_mod._sweep_dir(rule, library)
     async with db.session() as session:
         all_jobs = list((await session.execute(select(Job))).scalars())
@@ -1224,6 +1394,19 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
         still_blocked = await session.get(Job, first.id)
         assert still_blocked is not None
         assert still_blocked.status == JobStatus.BLOCKED
+
+    # 第三轮：ep2 的成功作业已成为“最新作业”，仍不能因此忘掉更早 blocked
+    # 认领的 ep1。新作业白名单只能包含真正新增的 ep3，否则会重现 NAS 上
+    # 1300 个旧 m2ts 被反复带入下一批、任务中心持续膨胀的坏例。
+    completed_later[ep3.name] = True
+    await ingest_mod._sweep_dir(rule, library)
+    async with db.session() as session:
+        all_jobs = list((await session.execute(select(Job))).scalars())
+    assert len(all_jobs) == 3
+    third = max(all_jobs, key=lambda job: job.created_at)
+    assert [ready["path"] for ready in third.input_data["ready_files"]] == [ep3.name]
+    await _wait_job_status(third.id, JobStatus.SUCCEEDED)
+    assert (season / "连坐测试剧 (2026) - S01E03.mkv").read_bytes() == b"episode-3-partial"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -280,8 +280,49 @@ async def test_ignored_entry_job_reconcile_failure_does_not_block_startup(db, mo
 
 @pytest.mark.asyncio
 async def test_disc_batch_job_reconcile_cancels_only_active_disc_batches(db):
-    """升级只收口原盘分段批次；普通剧集批次和历史终态不被改写。"""
+    """升级收口原盘分段 Job 与 pending 台账；普通批次和无关终态不被改写。"""
     async with db.session() as session:
+        direct_entry = IngestEntry(
+            entry_path="/watch/disc-direct",
+            fingerprint="ready:direct",
+            status=IngestStatus.PENDING,
+            message="已取最大文件为正片，忽略其余 37 个视频",
+        )
+        nested_entry = IngestEntry(
+            entry_path="/watch/disc-nested",
+            fingerprint="ready:nested",
+            status=IngestStatus.PENDING,
+        )
+        episode_entry = IngestEntry(
+            entry_path="/watch/episode",
+            fingerprint="ready:episode",
+            status=IngestStatus.PENDING,
+        )
+        succeeded_entry = IngestEntry(
+            entry_path="/watch/disc-succeeded",
+            fingerprint="ready:succeeded",
+            status=IngestStatus.PENDING,
+        )
+        previously_reconciled_entry = IngestEntry(
+            entry_path="/watch/disc-already-cancelled",
+            fingerprint="ready:already-cancelled",
+            status=IngestStatus.PENDING,
+        )
+        session.add_all(
+            [
+                direct_entry,
+                nested_entry,
+                episode_entry,
+                succeeded_entry,
+                previously_reconciled_entry,
+            ]
+        )
+        await session.flush()
+        assert direct_entry.id is not None
+        assert nested_entry.id is not None
+        assert episode_entry.id is not None
+        assert succeeded_entry.id is not None
+        assert previously_reconciled_entry.id is not None
         session.add_all(
             [
                 Job(
@@ -312,6 +353,38 @@ async def test_disc_batch_job_reconcile_cancels_only_active_disc_batches(db):
                     status=JobStatus.SUCCEEDED,
                     input_data={"ready_files": [{"path": "BDMV/STREAM/00002.m2ts"}]},
                 ),
+                Job(
+                    id="job_disc_already_cancelled",
+                    job_type="library.ingest",
+                    status=JobStatus.CANCELLED,
+                    cancel_requested_by="system:disc-batch-reconcile",
+                    input_data={"ready_files": [{"path": "BDMV/STREAM/00003.m2ts"}]},
+                ),
+                JobResource(
+                    job_id="job_disc_direct",
+                    resource_type="ingest_entry",
+                    resource_id=str(direct_entry.id),
+                ),
+                JobResource(
+                    job_id="job_disc_nested",
+                    resource_type="ingest_entry",
+                    resource_id=str(nested_entry.id),
+                ),
+                JobResource(
+                    job_id="job_episode_blocked",
+                    resource_type="ingest_entry",
+                    resource_id=str(episode_entry.id),
+                ),
+                JobResource(
+                    job_id="job_disc_succeeded",
+                    resource_type="ingest_entry",
+                    resource_id=str(succeeded_entry.id),
+                ),
+                JobResource(
+                    job_id="job_disc_already_cancelled",
+                    resource_type="ingest_entry",
+                    resource_id=str(previously_reconciled_entry.id),
+                ),
             ]
         )
         await session.commit()
@@ -324,12 +397,28 @@ async def test_disc_batch_job_reconcile_cancels_only_active_disc_batches(db):
         nested = await session.get(Job, "job_disc_nested")
         episode = await session.get(Job, "job_episode_blocked")
         succeeded = await session.get(Job, "job_disc_succeeded")
+        direct_record = await session.get(IngestEntry, direct_entry.id)
+        nested_record = await session.get(IngestEntry, nested_entry.id)
+        episode_record = await session.get(IngestEntry, episode_entry.id)
+        succeeded_record = await session.get(IngestEntry, succeeded_entry.id)
+        previously_reconciled_record = await session.get(
+            IngestEntry, previously_reconciled_entry.id
+        )
     assert direct is not None and direct.status == JobStatus.CANCELLED
     assert nested is not None and nested.status == JobStatus.CANCELLED
     assert direct.cancel_requested_by == "system:disc-batch-reconcile"
     assert nested.cancel_requested_by == "system:disc-batch-reconcile"
     assert episode is not None and episode.status == JobStatus.BLOCKED
     assert succeeded is not None and succeeded.status == JobStatus.SUCCEEDED
+    assert direct_record is not None and direct_record.status == IngestStatus.SKIPPED
+    assert nested_record is not None and nested_record.status == IngestStatus.SKIPPED
+    assert "旧版原盘流分段" in (direct_record.message or "")
+    assert episode_record is not None and episode_record.status == IngestStatus.PENDING
+    assert succeeded_record is not None and succeeded_record.status == IngestStatus.PENDING
+    assert (
+        previously_reconciled_record is not None
+        and previously_reconciled_record.status == IngestStatus.SKIPPED
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/matcher/test_identity.py
+++ b/tests/matcher/test_identity.py
@@ -91,6 +91,39 @@ def test_real_sample_movie_without_media_type() -> None:
     assert match.is_pack is False
 
 
+def test_multi_year_movie_pack_cannot_satisfy_single_movie() -> None:
+    """NAS 真实坏例：首部片名/年份命中也不能把十一部合集当成一部电影。"""
+    candidate = _candidate(
+        "The Fast And The Furious 2001-2023 UHD Blu-ray 2160p HEVC DTS-X",
+        "速度与激情 2001-2023 十一部合集 含特别行动",
+        media_type="movie",
+        year=2001,
+        titles_en=["The Fast And The Furious"],
+        titles_zh=["速度与激情 2001-2023 十一部合集"],
+        title_candidates=["速度与激情 2001-2023 十一部合集 含特别行动"],
+    )
+    media = _movie(
+        ["速度与激情", "The Fast and the Furious"],
+        2001,
+        imdb_id="tt0232500",
+    )
+
+    assert match_identity(candidate, media) is None
+
+
+def test_single_year_movie_still_matches_after_pack_guard() -> None:
+    """普通单片资源不受跨年份合集守卫影响。"""
+    candidate = _candidate(
+        "The Fast and the Furious 2001 2160p UHD BluRay REMUX",
+        "速度与激情",
+        media_type="movie",
+        year=2001,
+    )
+    media = _movie(["速度与激情", "The Fast and the Furious"], 2001)
+
+    assert match_identity(candidate, media) is not None
+
+
 def test_real_sample_movie_with_seasons_noise() -> None:
     """真实样本：Zombi VIII——罗马数字被误提取成 seasons=[8]，
     media_type=movie 时季噪音必须被忽略，不影响电影命中。"""


### PR DESCRIPTION
## 问题

NAS 实际出现 209 个 library.ingest 待处理作业，其中《速度与激情》合集占 90 个、《速度与激情10》原盘占 24 个；任务里的“忽略其余 900/1000 个视频”实际上主要是 BDMV 的 .m2ts 流分段，并不是 900/1000 部电影。

这是三个相互放大的代码缺陷：

1. 边下边入库只看下载器已完成文件，文件级快照固定写成 has_disc=False，因此把几秒钟的 .m2ts/.VOB 分段当成电影正片；
2. 新批次只在“最新作业恰好 blocked”时排除旧 blocked 白名单。一旦中间有一个小批次 succeeded，下一轮便重新带上所有旧文件，产生上千文件的重复批次；
3. 单片订阅会把 The Fast And The Furious 2001-2023 这种跨年份合集命中为 2001 年首部电影并投递整套合集。

生产数据已验证前两项会造成假入库：两条被标记为已入库的电影文件实际只有 6,955,008 bytes / 10 秒和 2,224,128 bytes / 10 秒。

## 修复

- 下载器文件路径只要位于任意层级的 BDMV / VIDEO_TS，就禁用文件级提前入库；等待整种完成后沿用现有整树原盘判定，只生成一条“原盘暂不支持自动入库”的结论。
- 新分批作业排除所有既有文件级作业已经认领的路径，而不只排除当前最新 blocked 作业；原作业显式重试仍使用自己的持久化白名单。
- 单部电影身份匹配拒绝标题/副标题/NER 候选名中明确跨年份的电影合集；普通单年份电影不受影响。
- 应用启动时纯数据库对账旧版原盘分批作业并自动取消，升级即可清掉历史待处理红项；不扫描 NAS 全盘，也不删除媒体文件。

## 覆盖

- 单片 BDMV 下载中完成流分段
- 多电影合集内嵌 BDMV 下载中完成流分段
- 整种完成后的单一原盘结论
- blocked → succeeded → 新文件完成的三轮分批序列
- 普通剧集分批入库保持可用
- 旧原盘批次启动自愈，普通剧集批次和历史终态隔离
- 真实 2001-2023 十一部合集拒绝 + 普通单片正例

## 验证

- pytest -q tests/matcher/test_identity.py tests/api/test_library_ingest.py：通过
- CLI 受影响组在当前 worktree PYTHONPATH 下：通过
- ruff check .：通过
- pnpm web:lint：通过（仅 main 既有 3 条 warning，0 error）
- pnpm web:typecheck：通过

全量本地测试另受两个既有环境条件影响：复用旧 editable venv 时 CLI 子进程加载旧工作树；本机 127.0.0.1:3000 已有 Node 服务占用，容器监管测试无法独占固定端口。GitHub CI 会在干净环境重新执行全套门禁。

## 升级边界

本 PR 会阻止未来误入库，并自动收口历史原盘分批待处理作业；不会自动删除已经误入库的短 .m2ts 文件，也不会擅自重置订阅工单。现有 NAS 上两条假入库需要在部署验证后单独、经用户确认清理。
