### PR TITLE
feat(llm): 检测 gpt-oss Harmony 格式残留并告警引导用户修复推理后端

### DIFF
--- a/src/movieclaw_llm/protocols/openai_chat.py
+++ b/src/movieclaw_llm/protocols/openai_chat.py
@@ -43,9 +43,16 @@ from movieclaw_llm.models import (
     TokenUsage,
     ToolCall,
 )
+from movieclaw_llm.tools import HARMONY_RESIDUE_HINT, has_harmony_residue
 from movieclaw_net import egress_transport
 
 logger = logging.getLogger(__name__)
+
+
+def _warn_harmony_residue_in_content(content: str | None) -> None:
+    """正文里泄漏 Harmony 标记（如整段思考被当正文返回）时告警，引导用户修后端。"""
+    if has_harmony_residue(content):
+        logger.warning("模型返回的正文含 Harmony 格式残留。%s", HARMONY_RESIDUE_HINT)
 
 
 def sdk_default_user_agent() -> str:
@@ -240,6 +247,7 @@ class OpenAIChatProtocol(BaseLlmProtocol):
                 self._parse_tool_call(tc.id, tc.function.name, tc.function.arguments or "")
                 for tc in msg.tool_calls
             ]
+        _warn_harmony_residue_in_content(msg.content)
         return ChatResponse(
             content=msg.content,
             thinking=self._read_thinking(msg),
@@ -353,6 +361,7 @@ class OpenAIChatProtocol(BaseLlmProtocol):
             return
 
         # 收尾：工具参数完整了，逐个解析并发 toolcall_end
+        _warn_harmony_residue_in_content("".join(acc.content))
         for index in acc.tool_order:
             tc = acc.finalize_tool(index, self._parse_tool_call)
             yield ChatStreamEvent(type="toolcall_end", tool_call=tc, partial=acc.snapshot())

--- a/src/movieclaw_llm/tools.py
+++ b/src/movieclaw_llm/tools.py
@@ -8,9 +8,42 @@ tool 结果回喂给模型，让模型自行修正后重试（pi-ai 的 validate
 
 from __future__ import annotations
 
+import logging
+
 import jsonschema
 
 from movieclaw_llm.models import ToolCall, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+#: gpt-oss 系模型 Harmony 输出格式的特殊标记。这些标记本应由推理后端
+#: （vLLM / Ollama / llama.cpp 等）在解析阶段消化掉；一旦泄漏到工具名或
+#: 正文里，说明后端没有正确配置 gpt-oss 的输出解析（如未启用对应的
+#: 工具调用解析器、chat 模板不对），属于部署问题，应用层无法修复。
+_HARMONY_MARKERS = (
+    "<|channel|>",
+    "<|message|>",
+    "<|call|>",
+    "<|constrain|>",
+    "<|start|>",
+    "<|end|>",
+    "<|return|>",
+)
+
+#: 引导用户排查部署的提示。既打进日志，也回喂给模型/展示在会话里，
+#: 让非开发者部署时也能定位到是推理后端的问题而不是 movieclaw 的问题。
+HARMONY_RESIDUE_HINT = (
+    "检测到 gpt-oss Harmony 格式残留标记（如 <|channel|>）。"
+    "这通常说明推理后端未正确解析 gpt-oss 的输出，请检查部署配置："
+    "vLLM 需启用 gpt-oss 的工具调用解析器，Ollama / llama.cpp 需升级到"
+    "支持该模型的版本并使用正确的 chat 模板。此问题无法在 movieclaw 侧修复，"
+    "修复前建议换用其他模型。"
+)
+
+
+def has_harmony_residue(text: str | None) -> bool:
+    """判断文本中是否泄漏了 Harmony 特殊标记（推理后端解析失败的特征）。"""
+    return bool(text) and any(marker in text for marker in _HARMONY_MARKERS)
 
 
 def validate_tool_call(
@@ -24,6 +57,15 @@ def validate_tool_call(
     tool = next((t for t in tools if t.name == tool_call.name), None)
     if tool is None:
         names = ", ".join(t.name for t in tools) or "（无）"
+        if has_harmony_residue(tool_call.name):
+            logger.warning(
+                "模型返回的工具名 %r 含 Harmony 格式残留。%s",
+                tool_call.name,
+                HARMONY_RESIDUE_HINT,
+            )
+            return None, (
+                f"工具「{tool_call.name}」不存在。{HARMONY_RESIDUE_HINT}（可用工具：{names}）"
+            )
         return None, f"工具「{tool_call.name}」不存在，可用工具：{names}"
     if tool_call.parse_error:
         return None, f"工具参数解析失败：{tool_call.parse_error}，请重新以合法 JSON 输出参数"

--- a/tests/llm/unit/test_openai_chat.py
+++ b/tests/llm/unit/test_openai_chat.py
@@ -365,3 +365,21 @@ def test_error_message_contains_provider_and_chinese_hint():
 def test_protocol_constructs_for_all_presets(provider_type):
     # openai_compat 无预设 base_url 时也能构造（用户覆盖前 SDK 用官方默认）
     make_protocol(provider_type)
+
+
+# -- Harmony 残留告警 -------------------------------------------------------
+
+
+def test_content_with_harmony_residue_logs_warning(caplog):
+    """正文泄漏 Harmony 标记（后端解析失败的特征）→ 打中文告警引导修后端。"""
+    from movieclaw_llm.protocols.openai_chat import _warn_harmony_residue_in_content
+
+    with caplog.at_level("WARNING"):
+        _warn_harmony_residue_in_content("<|channel|>analysis<|message|>思考内容……")
+    assert any("Harmony" in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        _warn_harmony_residue_in_content("正常的回答文本")
+        _warn_harmony_residue_in_content(None)
+    assert not caplog.records

--- a/tests/llm/unit/test_tools.py
+++ b/tests/llm/unit/test_tools.py
@@ -40,3 +40,19 @@ def test_parse_error_propagates():
     args, err = validate_tool_call([SEARCH_TOOL], tc)
     assert args is None
     assert "解析失败" in err
+
+
+def test_harmony_residue_in_tool_name_reports_backend_hint(caplog):
+    """工具名混入 Harmony 标记 → 错误信息引导用户排查推理后端，并打告警日志。"""
+    tc = ToolCall(id="1", name="search<|channel|>commentary")
+    with caplog.at_level("WARNING"):
+        args, err = validate_tool_call([SEARCH_TOOL], tc)
+    assert args is None
+    assert "Harmony" in err and "推理后端" in err and "search" in err
+    assert any("Harmony" in r.message for r in caplog.records)
+
+
+def test_plain_unknown_tool_name_has_no_harmony_hint():
+    """普通的幻觉工具名不应误报 Harmony 残留。"""
+    _, err = validate_tool_call([SEARCH_TOOL], ToolCall(id="1", name="downloadd"))
+    assert "Harmony" not in err


### PR DESCRIPTION
自建 gpt-oss 端点（vLLM/Ollama 等）未正确配置 Harmony 输出解析时，
工具名会混入 <|channel|> 等特殊标记（如 mclaw<|channel|>commentary），
整段思考也会当正文返回，Agent 表现为工具调用时好时坏、满屏内心独白。

这属于部署问题，应用层不做修复，只做定位引导：
- validate_tool_call 识别工具名中的 Harmony 残留，回喂模型/展示在会话
  里的错误信息与告警日志均指向推理后端配置，附排查建议
- openai_chat 协议层在非流式响应与流式收尾处检测正文残留并打中文告警

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RKizHjm23CKohds1URDuQP