### PR TITLE
perf(jobs): 拆掉大库整理/转移被自己进度拖垮的放大链

### DIFF
--- a/src/movieclaw_api/api/routes/jobs.py
+++ b/src/movieclaw_api/api/routes/jobs.py
@@ -40,9 +40,20 @@ def _origin(principal: Principal, client_name: str | None) -> str:
     return "cli" if principal.kind == "pat" else "web"
 
 
-def _job_view(job: Job, resources: list[JobResource]) -> JobView:
+# 列表响应里整体裁掉的 input_data 键：值是 MB 级的执行快照（整理/转移把
+# 完整计划落在这里做崩溃恢复凭据），前端从不读它，而任务中心每收到一个
+# 事件就要拉两次列表——带上它，一次快照就是几 MB 的序列化 + 传输，全部
+# 压在事件循环上（实测单次 150ms+，能把同机的后台任务拖慢一个数量级）。
+# 详情接口（jobs.show）不裁剪，需要完整输入的场景走详情。
+_BULKY_INPUT_KEYS = frozenset({"plan"})
+
+
+def _job_view(job: Job, resources: list[JobResource], *, slim_input: bool = False) -> JobView:
     progress = jobs.default_progress()
     progress.update(job.progress or {})
+    input_data = job.input_data
+    if slim_input and any(key in input_data for key in _BULKY_INPUT_KEYS):
+        input_data = {k: v for k, v in input_data.items() if k not in _BULKY_INPUT_KEYS}
     return JobView(
         id=job.id,
         job_type=job.job_type,
@@ -52,7 +63,7 @@ def _job_view(job: Job, resources: list[JobResource]) -> JobView:
         prompt_revision=job.prompt_revision,
         provider_ref=job.provider_ref,
         status=job.status,
-        input_data=job.input_data,
+        input_data=input_data,
         progress=progress,  # type: ignore[arg-type]
         result=job.result,
         error=job.error,
@@ -89,9 +100,10 @@ async def job_view(session: AsyncSession, job: Job) -> JobView:
 
 
 async def job_views(session: AsyncSession, rows: list[Job]) -> list[JobView]:
-    """列表只批量读取一次资源索引，避免任务中心产生 N+1 查询。"""
+    """列表只批量读取一次资源索引，避免任务中心产生 N+1 查询；
+    并裁掉 MB 级的输入快照（见 _BULKY_INPUT_KEYS）。"""
     resource_map = await jobs.resources_for_jobs(session, [row.id for row in rows])
-    return [_job_view(row, resource_map.get(row.id, [])) for row in rows]
+    return [_job_view(row, resource_map.get(row.id, []), slim_input=True) for row in rows]
 
 
 def _parse_statuses(value: str | None) -> list[JobStatus]:

--- a/src/movieclaw_api/services/jobs.py
+++ b/src/movieclaw_api/services/jobs.py
@@ -629,6 +629,23 @@ class JobContext:
         self.job_id = job_id
         self._lease_token = lease_token
         self._lease_lost = lease_lost
+        # progress_due 的节流时钟：初值取“过去”，任务的第一次写不被节流
+        self._last_progress_write = time.monotonic() - 3600.0
+
+    def progress_due(self, *, min_interval: float = 1.0) -> bool:
+        """高频循环里是否该持久化一次进度（时间节流）。
+
+        进度写入 = 一次 Job 行更新 + 一条事件 + 一次 SSE 广播 + 每个打开着
+        任务中心的客户端各拉两次列表快照。逐文件写会把这整条放大链跑成
+        每秒几十遍（实测能把整理任务拖慢一个数量级，也把前端刷成常亮）。
+        循环体应当 ``if done == total or context.progress_due():`` 再写；
+        节流丢掉的只是中间观察值，恢复检查点始终以领域台账为准。
+        """
+        now = time.monotonic()
+        if now - self._last_progress_write < min_interval:
+            return False
+        self._last_progress_write = now
+        return True
 
     async def update_progress(
         self,
@@ -655,20 +672,46 @@ class JobContext:
             "phase_count": phase_count,
             "details": details or {},
         }
+        values: dict[str, Any] = {"progress": progress}
+        if usage is not None:
+            # 用量和进度共享同一事务，前端、CLI 与 Agent 读取任一 revision
+            # 都不会看到“进度已完成但 token 仍滞后”的撕裂状态。
+            values["usage"] = usage
         db = get_database()
         async with db.session() as session:
-            job = await session.get(Job, self.job_id)
-            if job is None or job.status in TERMINAL_JOB_STATUSES:
+            # 定向 UPDATE，全程不加载 ORM 整行：input_data 可能是 MB 级
+            # （整理/转移把完整计划存在里面），而进度是最高频写路径——
+            # 逐文件把大行读一遍再写回，会让单文件成本随计划体积线性膨胀
+            # （实测 4000 文件的库每文件从 8ms 恶化到 53ms）。
+            # revision 由数据库原子自增，语义与 _record_transition 一致。
+            now = utcnow()
+            claimed = await session.execute(
+                update(Job)
+                .where(
+                    Job.id == self.job_id,
+                    Job.lease_owner == self._lease_token,
+                    Job.status.not_in([status.value for status in TERMINAL_JOB_STATUSES]),
+                )
+                .values(revision=Job.revision + 1, updated_at=now, **values)
+            )
+            if not claimed.rowcount:
+                owner = (
+                    await session.execute(select(Job.lease_owner).where(Job.id == self.job_id))
+                ).scalar_one_or_none()
+                if owner != self._lease_token:
+                    self._lease_lost.set()
                 return
-            if job.lease_owner != self._lease_token:
-                self._lease_lost.set()
-                return
-            job.progress = progress
-            if usage is not None:
-                # 用量和进度共享同一事务，前端、CLI 与 Agent 读取任一 revision
-                # 都不会看到“进度已完成但 token 仍滞后”的撕裂状态。
-                job.usage = usage
-            await _record_transition(session, job, "progress", progress)
+            revision = (
+                await session.execute(select(Job.revision).where(Job.id == self.job_id))
+            ).scalar_one()
+            session.add(
+                JobEvent(
+                    job_id=self.job_id,
+                    revision=revision,
+                    event_type="progress",
+                    payload=progress,
+                )
+            )
             await session.commit()
         await notify_job_change()
 
@@ -680,22 +723,33 @@ class JobContext:
         """
         db = get_database()
         async with db.session() as session:
-            job = await session.get(Job, self.job_id)
-            if job is None or job.lease_owner != self._lease_token:
+            # 只取需要的两列：Job 整行可能带着 MB 级 input_data
+            row = (
+                await session.execute(
+                    select(Job.progress, Job.lease_owner).where(Job.id == self.job_id)
+                )
+            ).one_or_none()
+            if row is None or row.lease_owner != self._lease_token:
                 self._lease_lost.set()
                 return default_progress("任务执行租约已失效")
-            return dict(job.progress or {})
+            return dict(row.progress or {})
 
     async def cancel_requested(self) -> bool:
         if self._lease_lost.is_set():
             return True
         db = get_database()
         async with db.session() as session:
-            job = await session.get(Job, self.job_id)
+            # 同 current_progress：取消检查在逐文件循环里高频调用，
+            # 只读两个小列，不搬 input_data 大行
+            row = (
+                await session.execute(
+                    select(Job.lease_owner, Job.cancel_requested_at).where(Job.id == self.job_id)
+                )
+            ).one_or_none()
             return bool(
-                job is None
-                or job.lease_owner != self._lease_token
-                or job.cancel_requested_at is not None
+                row is None
+                or row.lease_owner != self._lease_token
+                or row.cancel_requested_at is not None
             )
 
     async def raise_if_cancelled(self) -> None:

--- a/src/movieclaw_api/services/library/organize.py
+++ b/src/movieclaw_api/services/library/organize.py
@@ -422,38 +422,42 @@ async def _organize(
                 percent=0.0 if plan.renames else 100.0,
                 details={"errors": 0},
             )
+        # 一次性把本库台账行拉进会话身份映射：随后逐文件的 session.get
+        # 全部命中内存，不再每个文件都打一次数据库
+        await session.execute(select(LibraryFile).where(LibraryFile.library_id == library_id))
         dirty_parents: set[Path] = set()
+        total = len(plan.renames)
         for done, action in enumerate(plan.renames, start=1):
             if context is not None:
                 await context.raise_if_cancelled()
             row = await session.get(LibraryFile, action.file_id)
             if row is None:
                 summary.errors.append(f"台账文件已不存在，跳过：{action.source_path}")
-                _organize_tasks.update(library_id, (done, len(plan.renames)))
+                _organize_tasks.update(library_id, (done, total))
                 continue
             src = Path(action.source_path)
             dst = Path(action.target_path)
-            relocated = row.file_path == action.target_path and dst.exists()
+            # 台账已指向目标 = 上次执行连台账都提交过了，确认磁盘在位即可
+            ledger_done = row.file_path == action.target_path
             try:
-                if not relocated:
-                    if row.file_path != action.source_path:
+                if ledger_done:
+                    if not await asyncio.to_thread(dst.exists):
                         raise _MoveError(f"台账路径已被其他操作修改，跳过：{row.file_path}")
-                    if src.exists() and not dst.exists():
-                        await asyncio.to_thread(_move_no_clobber, src, dst)
-                    elif not src.exists() and dst.exists():
-                        # 服务可能停在“磁盘改名成功、台账提交前”。持久化计划
-                        # 能证明目标属于本任务，此时只补台账，不重复改名。
-                        pass
-                    elif src.exists() and dst.exists():
-                        raise _MoveError(f"源与目标同时存在，跳过以免覆盖：{src} → {dst}")
-                    else:
-                        raise _MoveError(f"源与目标都不存在，无法继续整理：{src}")
+                elif row.file_path != action.source_path:
+                    raise _MoveError(f"台账路径已被其他操作修改，跳过：{row.file_path}")
+                else:
+                    await asyncio.to_thread(
+                        _resolve_and_move,
+                        src,
+                        dst,
+                        missing_message=f"源与目标都不存在，无法继续整理：{src}",
+                    )
             except _MoveError as exc:
                 summary.errors.append(str(exc))
-                _organize_tasks.update(library_id, (done, len(plan.renames)))
+                _organize_tasks.update(library_id, (done, total))
                 continue
             # 改名成功立即随迁台账：中途失败不会留下账实不符的批量烂摊子
-            if not relocated:
+            if not ledger_done:
                 container = dst.suffix.lstrip(".").lower() or None
                 await repo.relocate(
                     action.file_id, file_path=action.target_path, container=container
@@ -464,28 +468,28 @@ async def _organize(
                 sidecar_src = Path(sidecar.source_path)
                 sidecar_dst = Path(sidecar.target_path)
                 try:
-                    if sidecar_src.exists() and not sidecar_dst.exists():
-                        await asyncio.to_thread(_move_no_clobber, sidecar_src, sidecar_dst)
-                    elif not sidecar_src.exists() and sidecar_dst.exists():
-                        pass  # 上次执行已改名，重启后直接确认完成
-                    elif sidecar_src.exists() and sidecar_dst.exists():
-                        raise _MoveError(
-                            f"源与目标同时存在，跳过以免覆盖：{sidecar_src} → {sidecar_dst}"
-                        )
-                    else:
-                        raise _MoveError(f"附属文件已不存在：{sidecar_src}")
+                    await asyncio.to_thread(
+                        _resolve_and_move,
+                        sidecar_src,
+                        sidecar_dst,
+                        missing_message=f"附属文件已不存在：{sidecar_src}",
+                    )
                     summary.sidecars_renamed += 1
                 except _MoveError as exc:
                     summary.errors.append(f"附属文件改名失败：{exc}")
-            _organize_tasks.update(library_id, (done, len(plan.renames)))
-            if context is not None:
+            _organize_tasks.update(library_id, (done, total))
+            # 进度持久化按秒节流（最后一个文件必写）：逐文件写会触发
+            # “事件 → SSE → 所有任务中心客户端各拉两次列表”的放大链，
+            # 实测能把整轮整理拖慢一个数量级。实时进度由上面的内存态
+            # _organize_tasks 提供，节流不影响接口里的进行中读数
+            if context is not None and (done == total or context.progress_due()):
                 await context.update_progress(
                     mode="determinate",
                     phase="organizing",
-                    message=f"已整理 {done} / {len(plan.renames)} 个文件",
+                    message=f"已整理 {done} / {total} 个文件",
                     current=done,
-                    total=len(plan.renames),
-                    percent=(done / len(plan.renames) * 100) if plan.renames else 100.0,
+                    total=total,
+                    percent=(done / total * 100) if total else 100.0,
                     details={"errors": len(summary.errors)},
                 )
 
@@ -583,6 +587,29 @@ async def _run_organize_job(
     if summary.errors:
         message += f"，{len(summary.errors)} 个问题已跳过"
     return {"message": message, **asdict(summary)}
+
+
+def _resolve_and_move(src: Path, dst: Path, *, missing_message: str) -> None:
+    """（线程池内运行）看一眼现场，把该做的改名做掉。
+
+    exists 判定与改名收进同一次线程跳转：省去逐文件三四次跨线程 stat 的
+    调度开销，更重要的是网络挂载上这些都是可能阻塞的调用，一律不允许
+    落在事件循环里（一次挂住会冻住全站请求）。
+
+    源在目标不在 → 改名；源不在目标在 → 无事（服务可能停在“磁盘改名
+    成功、台账提交前”，持久化计划能证明目标属于本任务，调用方只补台账）；
+    其余现场说明磁盘被并发修改，抛 _MoveError 逐条跳过。
+    """
+    src_exists = src.exists()
+    dst_exists = dst.exists()
+    if src_exists and not dst_exists:
+        _move_no_clobber(src, dst)
+        return
+    if not src_exists and dst_exists:
+        return
+    if src_exists and dst_exists:
+        raise _MoveError(f"源与目标同时存在，跳过以免覆盖：{src} → {dst}")
+    raise _MoveError(missing_message)
 
 
 def _move_no_clobber(src: Path, dst: Path) -> None:

--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -83,7 +83,7 @@ from movieclaw_api.services.library.subtitles import discover_external_subtitles
 from movieclaw_api.services.library.units import resolve_units
 from movieclaw_api.services.media_discover import get_tmdb_client
 from movieclaw_api.services.media_library import MediaLibraryService
-from movieclaw_api.services.media_probe import probe_media
+from movieclaw_api.services.media_probe import MediaSpec, probe_media
 from movieclaw_api.services.task_state import TaskState
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import (
@@ -255,6 +255,13 @@ _ASSET_CONCURRENCY = 3
 # 只覆盖显式身份（NFO / [tmdbid=N]）：靠文件名解析的条目要先搜一次 TMDB
 # 才知道 id，预取不了；它们照常走原来的串行链路，不受影响。
 _PREFETCH_WINDOW = 16
+
+# 介质探测预取窗口：入账链路每个新文件都要等一次 ffprobe 子进程（本地盘
+# 30ms 起、网络挂载常在数百毫秒），且严格串行——新库首扫的主要等待项。
+# 这里为"接下来几个要走入账链的文件"提前在线程池起探测，让探测与当前
+# 文件的识别/落账重叠。窗口小而有界：不放大对存储的并发压力（机械盘/
+# 网络挂载经不起大并发随机读），预取过头的浪费也至多几个子进程。
+_PROBE_AHEAD_WINDOW = 4
 
 
 class ScanPhase(StrEnum):
@@ -915,6 +922,9 @@ async def _scan(
             if bridge is not None:
                 await bridge.checkpoint(state, summary, before_write=session.commit)
 
+        # 介质探测预取（_PROBE_AHEAD_WINDOW 的说明）：pending 索引 → 预取
+        # 任务；不需要探测的位置记 None，避免每轮重复判定
+        probe_ahead: dict[int, asyncio.Task[MediaSpec | None] | None] = {}
         for done, (root_path, file, is_disc) in enumerate(pending, start=1):
             if bridge is not None:
                 await bridge.raise_if_cancelled()
@@ -929,6 +939,18 @@ async def _scan(
                     pending[done - 1 : done - 1 + _PREFETCH_WINDOW],
                     known,
                 )
+            # 为下一窗要走入账链的文件提前起 ffprobe，与当前文件的识别/落账
+            # 重叠；轮到自己时把结果领走（跳过路径直接丢弃，外壳保证无害）
+            for ahead in range(done - 1, min(done - 1 + _PROBE_AHEAD_WINDOW, len(pending))):
+                if ahead in probe_ahead:
+                    continue
+                _root_ahead, file_ahead, disc_ahead = pending[ahead]
+                probe_ahead[ahead] = (
+                    asyncio.create_task(_probe_quietly(file_ahead))
+                    if _probe_ahead_eligible(known.get(str(file_ahead)), file_ahead, disc_ahead)
+                    else None
+                )
+            probe_task = probe_ahead.pop(done - 1, None)
             # 用户请求停止：提前收尾。已入账的保留，剩余文件下次扫描继续
             if _scan_tasks.stop_requested(library_id):
                 summary.cancelled = True
@@ -1037,12 +1059,20 @@ async def _scan(
                     existing=existing,
                     dir_names=dir_files.get(str(file.parent)),
                     added_batch_id=added_batch_id,
+                    prefetched_probe=probe_task,
                 )
             except Exception as exc:  # noqa: BLE001 -- 单文件失败不断整轮
                 await recover_failed_session()
                 logger.exception("扫描文件失败：%s", file)
                 summary.errors.append(f"「{file.name}」处理失败：{exc}")
             await advance(done)
+
+        # 手动停止/提前收尾时窗口里可能还挂着几个预取任务：取消掉，别让
+        # 它们在扫描结束后继续占线程池（子进程本身很快自然结束）
+        for leftover in probe_ahead.values():
+            if leftover is not None:
+                leftover.cancel()
+        probe_ahead.clear()
 
         if mtime_backfilled or rows_refreshed:
             await session.commit()
@@ -2231,6 +2261,38 @@ async def _refresh_known_row(
     return changed
 
 
+def _probe_ahead_eligible(existing: LibraryFile | None, file: Path, is_disc: bool) -> bool:
+    """该文件轮到时是否会需要一次 ffprobe（介质探测预取的判定）。
+
+    原盘不预取（要先解析盘内主流文件，现场处理）；strm 不预取（无媒体流）；
+    已识别且在位的秒过行与已忽略行不会走入账链，同样不预取。判定与
+    ``_scan`` 主循环的秒过条件保持一致；判错的代价不对称且都可接受——
+    漏预取只是退回现场探测，多预取至多白跑一个子进程。
+    """
+    if is_disc or file.suffix.lower() == STRM_EXT:
+        return False
+    if existing is not None and existing.ignored_at is not None:
+        return False
+    return not (
+        existing is not None
+        and existing.state != FileState.MISSING
+        and existing.media_item_id is not None
+    )
+
+
+async def _probe_quietly(file: Path) -> MediaSpec | None:
+    """预取探测的外壳：任何异常收敛为 None（与探测失败同语义）。
+
+    预取任务可能因文件被跳过（暂缓入账等）而被丢弃，不能让未取回的
+    异常在事件循环里报"Task exception was never retrieved"。
+    """
+    try:
+        return await asyncio.to_thread(probe_media, file)
+    except Exception:  # noqa: BLE001 -- 预取失败退化为"没探测到"，不断扫描
+        logger.exception("介质探测预取失败：%s", file)
+        return None
+
+
 async def _ingest_file(
     session,
     repo: LibraryFileRepository,
@@ -2248,9 +2310,12 @@ async def _ingest_file(
     existing: LibraryFile | None = None,
     dir_names: list[str] | None = None,
     added_batch_id: str,
+    prefetched_probe: asyncio.Task[MediaSpec | None] | None = None,
 ) -> None:
     """把一个文件识别并写入台账。``existing`` 是该路径已有的台账行：
-    在位但待识别 → 本次是识别重试；标记过 missing → 文件回归。"""
+    在位但待识别 → 本次是识别重试；标记过 missing → 文件回归。
+    ``prefetched_probe``：主循环预取的介质探测任务（普通视频文件才有，
+    见 _PROBE_AHEAD_WINDOW），没给就现场探测。"""
     if existing is None or existing.state == FileState.MISSING:
         summary.scanned += 1  # 新文件 / 回归的 missing 文件
     else:
@@ -2261,7 +2326,13 @@ async def _ingest_file(
     # 还违背 strm"扫库零流量"的初衷，规格列留空即可
     is_strm = not is_disc and file.suffix.lower() == STRM_EXT
     probe_target = None if is_strm else (disc_main_stream(file) if is_disc else file)
-    spec = await asyncio.to_thread(probe_media, probe_target) if probe_target is not None else None
+    if probe_target is None:
+        spec = None
+    elif prefetched_probe is not None:
+        # 预取只覆盖普通视频文件（probe_target 必然是文件本身），原盘仍走现场
+        spec = await prefetched_probe
+    else:
+        spec = await asyncio.to_thread(probe_media, probe_target)
     if spec is not None and is_disc and (file / "BDMV").is_dir():
         # m2ts 常常不带语言描述符；同编号 CLPI 用 PID 补齐，已有 ffprobe
         # 语言保持不动。缺失/损坏 CLPI 只降级，不影响原盘入账。
@@ -2330,7 +2401,10 @@ async def _ingest_file(
         unidentified_reason, candidates = identified.reason, identified.candidates
         unidentified_code = identified.code
         item_id = identified.item.id if identified.item is not None else None
-        season, episode = (0, 0) if is_disc else _unit_for(kind, file)
+        # 季集解析进线程池：要读分集 NFO（磁盘 IO），解析层兜底还会跑 NER
+        season, episode = (
+            (0, 0) if is_disc else await asyncio.to_thread(_unit_for, kind, file)
+        )
         identity_source = identified.source if item_id is not None else None
         resolved_version = RESOLVER_VERSION if item_id is not None else None
         review_suggestion = None
@@ -2672,13 +2746,16 @@ async def _try_relink(
             continue
         if row.state == FileState.TRASHED:
             continue  # 待回收行不参与改名归并——归并会复活它
-        if row.state == FileState.IN_PLACE and await asyncio.to_thread(Path(row.file_path).exists):
-            continue
         if (
             duration_seconds
             and row.duration_seconds
             and abs(duration_seconds - row.duration_seconds) > _RELINK_DURATION_TOLERANCE_SECONDS
         ):
+            continue
+        # 磁盘 stat 放最后：前面全是零成本的内存判定，先筛掉注定落选的
+        # 候选，才轮到唯一需要 IO 的"路径是否仍在磁盘"（线程池，网络挂载
+        # 上可能阻塞）——同尺寸候选多时省下的就是一串白付的往返
+        if row.state == FileState.IN_PLACE and await asyncio.to_thread(Path(row.file_path).exists):
             continue
         candidates.append(row)
     if len(candidates) != 1:
@@ -2744,6 +2821,19 @@ def _hint_for(file: Path, hints: list[_SubtitleHint]) -> _SubtitleHint | None:
     return None
 
 
+def _local_identity_evidence(
+    kind: MediaKind, root: Path, file: Path, *, is_disc: bool
+) -> tuple[NfoIdentity | None, str | None, LocalEvidence | None]:
+    """（线程池内运行）识别链的本地证据：NFO → 类型冲突判定 → 名称证据。
+
+    类型冲突时不再收集名称证据（与原串行逻辑一致：冲突即早退，证据用不上）。
+    """
+    nfo = _entry_nfo(kind, root, file, is_disc=is_disc)
+    conflict = _kind_conflict(kind, file, nfo, is_disc=is_disc)
+    evidence = None if conflict is not None else guess_evidence(kind, root, file, is_disc=is_disc)
+    return nfo, conflict, evidence
+
+
 async def _identify(
     media_service: MediaLibraryService,
     kind: MediaKind,
@@ -2763,15 +2853,15 @@ async def _identify(
     与"确实找不到匹配"区分开：前者修好网络重扫即可，后者需要人工认领。
     收敛器给出候选时一并带回（``candidates``），让用户在清单里直接点选。
     """
-    nfo = _entry_nfo(kind, root, file, is_disc=is_disc)
-
+    # 本地证据三件套整体放线程池：NFO 查找要逐级 stat/读盘（网络挂载上
+    # 可能长阻塞），guess_evidence 内含 NER 推理（CPU 数毫秒）——都不该
+    # 占用事件循环；一次线程跳转拿齐，省去逐项跨线程的调度开销
+    nfo, conflict, evidence = await asyncio.to_thread(
+        _local_identity_evidence, kind, root, file, is_disc=is_disc
+    )
     # ⓪ 类型冲突：文件实际是剧集/电影，与所在库的类型对不上（零网络成本）
-    conflict = _kind_conflict(kind, file, nfo, is_disc=is_disc)
     if conflict is not None:
         return _Identified(None, conflict, code=UnidentifiedCode.KIND_MISMATCH)
-
-    # 本地证据先算出来：既是步骤②的输入，也是步骤①校验钉死身份的标尺
-    evidence = guess_evidence(kind, root, file, is_disc=is_disc)
 
     # ① 显式精确身份：路径 tmdbid 标记（就近优先）→ NFO
     # 各级路径上的标记互相矛盾时全部不采信（实测：目录标着正主、文件名
@@ -2873,7 +2963,9 @@ async def _resolve_by_name(
     if kind is MediaKind.TV:
         directory = file.parent
         if directory not in episodes_cache:
-            episodes_cache[directory] = local_episode_count(directory)
+            # 统计要列目录 + 对每个文件名跑集号解析（含 NER），放线程池；
+            # 缓存写回仍在事件循环，单飞扫描不存在并发写
+            episodes_cache[directory] = await asyncio.to_thread(local_episode_count, directory)
         evidence.local_episodes = episodes_cache[directory]
     key = (
         evidence.title,

--- a/src/movieclaw_api/services/library/transfer.py
+++ b/src/movieclaw_api/services/library/transfer.py
@@ -516,7 +516,9 @@ async def _transfer(
                 )
                 summary.files_relocated += 1
             state.processed = done
-            if context is not None:
+            # 按秒节流（最后一条必写）：逐路径写进度会触发“事件 → SSE →
+            # 客户端拉列表”的放大链；实时读数由内存态 _transfer_tasks 提供
+            if context is not None and (done == len(plan.moves) or context.progress_due()):
                 await context.update_progress(
                     mode="determinate",
                     phase="transferring",

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -454,3 +454,69 @@ async def test_job_api_lists_waits_events_and_cancels(job_db, job_client: AsyncC
     cancelled = await job_client.post(f"/jobs/{created.job.id}/cancel")
     assert cancelled.status_code == 200
     assert cancelled.json()["data"]["job"]["status"] == "cancelled"
+
+
+async def test_update_progress_from_stale_lease_writes_nothing(job_db) -> None:
+    """列级进度写路径的租约守卫：令牌不符时不落任何东西，只举失联旗。"""
+    async with job_db.session() as session:
+        created = await jobs.create_job(session, job_type="test.stale-lease", input_data={})
+        row = await jobs.get_job(session, created.job.id)
+        assert row is not None
+        row.status = JobStatus.RUNNING
+        row.lease_owner = "lease-current"
+        await session.commit()
+
+    lease_lost = asyncio.Event()
+    context = jobs.JobContext(created.job.id, lease_token="lease-stale", lease_lost=lease_lost)
+    await context.update_progress(mode="determinate", phase="work", message="过期执行的进度")
+
+    assert lease_lost.is_set()
+    async with job_db.session() as session:
+        row = await jobs.get_job(session, created.job.id)
+        events = await jobs.job_events(session, created.job.id)
+    assert row is not None
+    assert row.progress.get("message") != "过期执行的进度"
+    assert all(event.event_type != "progress" for event in events)
+
+
+async def test_update_progress_after_terminal_state_is_ignored(job_db) -> None:
+    """终态后迟到的进度写入必须被丢弃：结果页不能被回退成“进行中”。"""
+    async with job_db.session() as session:
+        created = await jobs.create_job(session, job_type="test.terminal-progress", input_data={})
+        row = await jobs.get_job(session, created.job.id)
+        assert row is not None
+        row.status = JobStatus.SUCCEEDED
+        row.lease_owner = "lease-done"
+        await session.commit()
+
+    context = jobs.JobContext(created.job.id, lease_token="lease-done", lease_lost=asyncio.Event())
+    await context.update_progress(mode="determinate", phase="work", message="迟到的进度")
+
+    async with job_db.session() as session:
+        row = await jobs.get_job(session, created.job.id)
+        events = await jobs.job_events(session, created.job.id)
+    assert row is not None
+    assert row.status is JobStatus.SUCCEEDED
+    assert row.progress.get("message") != "迟到的进度"
+    assert all(event.event_type != "progress" for event in events)
+
+
+async def test_job_list_slims_bulky_plan_but_detail_keeps_it(
+    job_db, job_client: AsyncClient
+) -> None:
+    """列表响应裁掉 MB 级计划快照（任务中心高频拉取），详情保留完整输入。"""
+    big_plan = {"library_id": 1, "renames": [{"source_path": f"/a/{i}.mkv"} for i in range(50)]}
+    async with job_db.session() as session:
+        created = await jobs.create_job(
+            session,
+            job_type="library.organize",
+            input_data={"library_id": 1, "plan": big_plan},
+        )
+
+    listed = await job_client.get("/jobs")
+    item = next(x for x in listed.json()["data"]["items"] if x["id"] == created.job.id)
+    assert "plan" not in item["input_data"]
+    assert item["input_data"]["library_id"] == 1  # 小键保留，前端详情芯片仍可用
+
+    detail = await job_client.get(f"/jobs/{created.job.id}")
+    assert detail.json()["data"]["input_data"]["plan"] == big_plan

--- a/tests/api/test_library_organize.py
+++ b/tests/api/test_library_organize.py
@@ -336,3 +336,62 @@ async def test_scan_and_organize_are_mutually_exclusive(db, tmp_path):
         assert scan_summary.scanned == 0
     finally:
         organize_mod._organize_tasks.finish(library_id)
+
+
+@pytest.mark.asyncio
+async def test_organize_job_progress_is_throttled_but_conclusion_exact(db, tmp_path):
+    """进度持久化按秒节流：事件数远小于文件数，但结论与终态进度必须精确。
+
+    逐文件写进度会触发“事件 → SSE → 每个任务中心客户端拉两次列表”的
+    放大链（大库整理被拖慢一个数量级的元凶之一）。节流只该丢中间观察值：
+    改名结果、最终 current/total 一个都不能差。
+    """
+    import asyncio
+
+    from movieclaw_api.services import jobs as jobs_svc
+    from movieclaw_db.models import JobStatus
+
+    root = tmp_path / "movies"
+    file_count = 24
+    async with db.session() as session:
+        library = await _make_library(session, kind=MediaKind.MOVIE, root=root)
+        for i in range(file_count):
+            movie = await _make_item(
+                session, kind=MediaKind.MOVIE, tmdb_id=9000 + i, title=f"影片{i}", year=2020
+            )
+            messy = root / f"Movie.{i}.2020.1080p" / f"movie.{i}.mkv"
+            messy.parent.mkdir(parents=True)
+            messy.write_bytes(b"x")
+            _add_file(session, library, movie, messy)
+        await session.commit()
+        plan = await organize_mod.build_organize_plan(session, library)
+        created = await organize_mod.enqueue_organize_job(session, library, plan)
+
+    await jobs_svc.init_job_dispatcher(max_parallel=1)
+    try:
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while True:
+            async with db.session() as session:
+                row = await jobs_svc.get_job(session, created.job.id)
+                assert row is not None
+                if row.status is JobStatus.SUCCEEDED:
+                    break
+                assert row.status not in (JobStatus.FAILED, JobStatus.BLOCKED), row.error
+            assert asyncio.get_running_loop().time() < deadline, "整理作业未在期限内完成"
+            await asyncio.sleep(0.05)
+
+        async with db.session() as session:
+            row = await jobs_svc.get_job(session, created.job.id)
+            events = await jobs_svc.job_events(session, created.job.id)
+        assert row is not None and row.result is not None
+        assert row.result["renamed"] == file_count
+        assert row.progress["percent"] == 100.0
+        progress_events = [e for e in events if e.event_type == "progress"]
+        # 节流后事件数应当只与耗时（秒级）相关，而不是与文件数同阶
+        assert len(progress_events) < file_count / 2
+        # 终态前最后一条进度必须是精确的 total/total（最后一个文件强制落盘）
+        final = [e for e in progress_events if e.payload.get("phase") == "organizing"][-1]
+        assert final.payload["current"] == file_count
+        assert final.payload["total"] == file_count
+    finally:
+        await jobs_svc.close_job_dispatcher()


### PR DESCRIPTION
线上现场：3823 文件的库整理十小时卡在 64%。根因不是单个文件卡死，而是
三层互相放大的固定成本，让单文件开销随库规模与围观客户端数持续膨胀：

1. 整理/转移把完整计划落在 Job.input_data（4000 文件约 2MB）做崩溃恢复
   凭据，而 JobContext 的进度写、取消检查、进度读每次都 session.get 整行
   ——每个文件都要把这 2MB 读一到两遍，单文件成本从 8ms 恶化到 53ms 且
   随计划体积线性变差（整体 O(n²)）；
2. 进度逐文件持久化，每条都产生 job_events + SSE 广播，每个打开着任务
   中心的页面收到事件就拉两次列表快照；
3. 列表接口原样返回 input_data，上述每次快照都是 2MB 级序列化 + 传输，
   全部压在事件循环上（单次 150ms+），反过来又把整理任务饿慢。

对应三刀，全部不改任何领域语义：

- JobContext.update_progress / cancel_requested / current_progress 改为
  列级定向读写，全程不加载 input_data 大行；revision 仍由数据库原子自增，
  事件时间线与租约/终态守卫语义不变（新增测试锁住）；
- 整理/转移的进度持久化按秒节流（JobContext.progress_due，最后一条必写）；
  实时读数仍由内存态 TaskState 提供，恢复检查点本就以领域台账为准，
  节流只丢中间观察值；
- 任务列表响应裁掉 input_data 里的大计划快照（详情接口保留完整输入），
  前端只读小标量键，行为不变。

顺手收口两处同源问题：整理循环的 exists 判定全部并入线程池的单次跳转
（网络挂载上的阻塞调用不再落在事件循环，也省去逐文件多次跨线程 stat），
并在循环前把本库台账行一次性拉进会话身份映射，免去逐文件查库。

全链路仿真验证（uvicorn 子进程 + 3 个任务中心 SSE 用户 + 3 个库页用户，
1200 文件同参对比）：整理 99s → 6.2s，SSE 事件 3615 → 36，快照体积
677KB → 0.9KB；事故规模 3823 文件 25.5s 完成（基线同规模约 750ms/文件），
期间无关接口 p50 延迟 <25ms。稳态重扫快路径实测本就健康（3.4ms/文件），
亦受益于取消检查变轻。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TNLFtdk4Thj6CLqppWxiUi