### PR TITLE
fix: 支持原盘自动入库并防止下载器失联误放行

### DIFF
--- a/alembic/versions/20260827_1400_c8e3f0b56d42_add_download_ingest_anchors.py
+++ b/alembic/versions/20260827_1400_c8e3f0b56d42_add_download_ingest_anchors.py
@@ -1,0 +1,60 @@
+"""为监听入库保存下载器真实名称与落点
+
+Revision ID: c8e3f0b56d42
+Revises: b7d2e9a45c31
+Create Date: 2026-08-27 14:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c8e3f0b56d42"
+down_revision: str | None = "b7d2e9a45c31"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("manual_download_intent", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("downloader_id", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("download_name", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("save_path", sa.Text(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_manual_download_intent_downloader_id",
+            "downloader_client",
+            ["downloader_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_index(
+            "ix_manual_download_intent_downloader_id", ["downloader_id"], unique=False
+        )
+        batch_op.create_index(
+            "ix_manual_download_intent_download_name", ["download_name"], unique=False
+        )
+
+    with op.batch_alter_table("subscription_download_attempt", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("download_name", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("save_path", sa.Text(), nullable=True))
+        batch_op.create_index(
+            "ix_subscription_download_attempt_download_name", ["download_name"], unique=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("subscription_download_attempt", schema=None) as batch_op:
+        batch_op.drop_index("ix_subscription_download_attempt_download_name")
+        batch_op.drop_column("save_path")
+        batch_op.drop_column("download_name")
+
+    with op.batch_alter_table("manual_download_intent", schema=None) as batch_op:
+        batch_op.drop_index("ix_manual_download_intent_download_name")
+        batch_op.drop_index("ix_manual_download_intent_downloader_id")
+        batch_op.drop_constraint("fk_manual_download_intent_downloader_id", type_="foreignkey")
+        batch_op.drop_column("save_path")
+        batch_op.drop_column("download_name")
+        batch_op.drop_column("downloader_id")

--- a/src/movieclaw_api/api/routes/downloaders.py
+++ b/src/movieclaw_api/api/routes/downloaders.py
@@ -220,6 +220,9 @@ async def submit_download(
             info_hash=result.info_hash,
             media_item_id=manual_item.id,
             library_id=library.id,
+            downloader_id=row.id,
+            download_name=result.name or None,
+            save_path=derived_path,
             site_id=payload.site_id,
             torrent_id=payload.torrent_id,
         )

--- a/src/movieclaw_api/services/library/bluray.py
+++ b/src/movieclaw_api/services/library/bluray.py
@@ -1,4 +1,4 @@
-"""蓝光原盘 CLPI 语言元数据解析与 ffprobe 结果合并。
+"""蓝光原盘 MPLS 主播放列表、CLPI 语言元数据解析与 ffprobe 结果合并。
 
 BDMV 的 m2ts 是 MPEG-TS 流文件，ffprobe 能稳定拿到编码、声道与流 PID，
 但不少原盘没有把语言描述符写进 TS；真实语言位于同编号的
@@ -18,6 +18,133 @@ from pathlib import Path
 from movieclaw_api.services.media_probe import MediaSpec
 
 logger = logging.getLogger("movieclaw_api.bluray")
+
+_MPLS_CLOCK_HZ = 45_000
+
+
+class MplsParseError(ValueError):
+    """MPLS 结构不完整或字段越界。"""
+
+
+@dataclass(frozen=True)
+class MplsPlayItem:
+    """播放列表里的一个剪辑及有效播放区间。"""
+
+    clip_id: str
+    in_time: int
+    out_time: int
+
+    @property
+    def duration_seconds(self) -> float:
+        return max(0, self.out_time - self.in_time) / _MPLS_CLOCK_HZ
+
+
+@dataclass(frozen=True)
+class MplsPlaylist:
+    """可用于选主片的 MPLS 播放列表。"""
+
+    path: Path
+    items: tuple[MplsPlayItem, ...]
+
+    @property
+    def duration_seconds(self) -> int:
+        return round(sum(item.duration_seconds for item in self.items))
+
+    @property
+    def clip_ids(self) -> tuple[str, ...]:
+        return tuple(item.clip_id for item in self.items)
+
+
+def parse_mpls_playlist(data: bytes, *, path: Path = Path("unknown.mpls")) -> MplsPlaylist:
+    """解析 MPLS 的 PlayList 小节。
+
+    这里只读取选择主片所需的 clip id 与 IN/OUT 时间；STN、角度和 SubPath
+    都保留在完整原盘目录中，不需要为了入库而解释或改写。
+    """
+    if len(data) < 20 or data[:4] != b"MPLS":
+        raise MplsParseError("文件签名不是 MPLS 或文件头过短")
+    playlist_offset = int.from_bytes(data[8:12], "big")
+    if playlist_offset + 10 > len(data):
+        raise MplsParseError("PlayList 偏移越界")
+    section_length = int.from_bytes(data[playlist_offset : playlist_offset + 4], "big")
+    section_end = playlist_offset + 4 + section_length
+    if section_end > len(data):
+        raise MplsParseError("PlayList 长度越界")
+    pos = playlist_offset + 4
+    _require(pos, 6, section_end, "PlayList header")
+    pos += 2  # reserved
+    play_item_count = int.from_bytes(data[pos : pos + 2], "big")
+    pos += 4  # number_of_play_items + number_of_sub_paths
+    items: list[MplsPlayItem] = []
+    for _ in range(play_item_count):
+        _require(pos, 2, section_end, "PlayItem length")
+        item_length = int.from_bytes(data[pos : pos + 2], "big")
+        item_start = pos + 2
+        item_end = item_start + item_length
+        _require(item_start, item_length, section_end, "PlayItem")
+        # clip id(5) + codec id(4) + flags(2) + stc id(1) + in/out(8)
+        _require(item_start, 20, item_end, "PlayItem core")
+        clip_raw = data[item_start : item_start + 5]
+        codec_raw = data[item_start + 5 : item_start + 9]
+        try:
+            clip_id = clip_raw.decode("ascii")
+            codec = codec_raw.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise MplsParseError("PlayItem 标识不是 ASCII") from exc
+        if not clip_id.isdigit() or codec != "M2TS":
+            raise MplsParseError("PlayItem 的 clip/codec 标识无效")
+        in_time = int.from_bytes(data[item_start + 12 : item_start + 16], "big")
+        out_time = int.from_bytes(data[item_start + 16 : item_start + 20], "big")
+        if out_time < in_time:
+            raise MplsParseError("PlayItem 的 OUT_time 早于 IN_time")
+        items.append(MplsPlayItem(clip_id=clip_id, in_time=in_time, out_time=out_time))
+        pos = item_end
+    if not items:
+        raise MplsParseError("播放列表没有 PlayItem")
+    return MplsPlaylist(path=path, items=tuple(items))
+
+
+def read_main_playlist(disc_dir: Path) -> MplsPlaylist | None:
+    """从完整 BDMV 中选择主播放列表；损坏/伪列表只降级，不阻断扫描。
+
+    候选必须引用实际存在的 STREAM 文件。按有效播放时长优先，同一剪辑序列
+    只保留一个，避免不同语言/菜单入口的等价 MPLS 放大候选数量。
+    """
+    playlist_dir = disc_dir / "BDMV" / "PLAYLIST"
+    stream_dir = disc_dir / "BDMV" / "STREAM"
+    if not playlist_dir.is_dir() or not stream_dir.is_dir():
+        return None
+    by_sequence: dict[tuple[str, ...], MplsPlaylist] = {}
+    try:
+        paths = sorted(
+            path
+            for path in playlist_dir.iterdir()
+            if path.is_file() and path.suffix.lower() == ".mpls"
+        )
+        streams = {
+            path.stem: path
+            for path in stream_dir.iterdir()
+            if path.is_file() and path.suffix.lower() == ".m2ts"
+        }
+    except OSError:
+        return None
+    for path in paths:
+        try:
+            playlist = parse_mpls_playlist(path.read_bytes(), path=path)
+        except (OSError, MplsParseError) as exc:
+            logger.warning("蓝光 MPLS 解析失败，跳过候选：%s（%s）", path, exc)
+            continue
+        if not all(clip_id in streams for clip_id in playlist.clip_ids):
+            continue
+        current = by_sequence.get(playlist.clip_ids)
+        if current is None or playlist.duration_seconds > current.duration_seconds:
+            by_sequence[playlist.clip_ids] = playlist
+    return max(
+        by_sequence.values(),
+        key=lambda row: (row.duration_seconds, len(row.items), row.path.name),
+        default=None,
+    )
+
 
 # 写进音轨/字幕 JSON 的内部版本戳。API 会显式投影公开字段，因此不会把它暴露
 # 给前端；存量补探靠它区分“旧数据尚未读 CLPI”和“读过但语言确实未知”。

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -20,7 +20,8 @@
    整种未完成时按单文件完成字节数构造安全白名单，已完成且没有其他种子仍在
    写同一路径的文件先入库，其余继续等待——这是暂停种子误判与同目录长尾
    阻塞的共同解法；
-   匹配不到（网盘/浏览器等非种子来源）或下载器不可达时退回启发式：
+   匹配不到且没有持久化投递锚（网盘/浏览器等非种子来源）时才退回启发式；
+   启用中的下载器不可达/未验证完成时保持等待，绝不猜测完成：
 1. **进行中标记排除**：条目树内存在下载器的未完成标记文件
    （qBittorrent ``.!qB`` / aria2 ``.aria2`` / 浏览器 ``.crdownload`` 等）
    即视为下载中，并重置静默计时（标记与权威信号矛盾时从严，按下载中处理）；
@@ -101,10 +102,12 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from difflib import SequenceMatcher
 from pathlib import Path, PurePosixPath
 from typing import NamedTuple
 from uuid import uuid4
@@ -114,6 +117,11 @@ from sqlmodel import select
 
 from movieclaw_api.services import jobs
 from movieclaw_api.services.import_watch_config import rule_target_label
+from movieclaw_api.services.library.bluray import (
+    enrich_spec_with_clpi,
+    read_clpi_languages,
+    read_main_playlist,
+)
 from movieclaw_api.services.library.config import (
     derive_entry_dir,
     derive_save_path,
@@ -127,7 +135,7 @@ from movieclaw_api.services.library.layout import (
     is_disc_dir,
 )
 from movieclaw_api.services.library.resolve import verify_resolve
-from movieclaw_api.services.library.scan import guess_evidence
+from movieclaw_api.services.library.scan import disc_main_stream, guess_evidence
 from movieclaw_api.services.library.units import FileUnit, resolve_units
 from movieclaw_api.services.media_discover import get_tmdb_client
 from movieclaw_api.services.media_library import MediaLibraryService
@@ -135,6 +143,7 @@ from movieclaw_api.services.media_probe import ffprobe_available, probe_media
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import (
     ACTIVE_JOB_STATUSES,
+    DownloaderClient,
     FileSource,
     ImportWatch,
     IngestEntry,
@@ -150,6 +159,7 @@ from movieclaw_db.models import (
     NoticeSeverity,
     utcnow,
 )
+from movieclaw_db.models.manual_download_intent import MANUAL_DOWNLOAD_INTENT_TTL
 from movieclaw_db.models.scheduled_task import TriggerType
 from movieclaw_db.repositories.library_file_repo import LibraryFileRepository
 from movieclaw_db.repositories.library_repo import LibraryRepository
@@ -326,6 +336,7 @@ class _EntrySnapshot:
     has_marker: bool  # 树内存在下载中标记文件
     has_disc: bool  # 树内存在原盘结构（BDMV/VIDEO_TS）
     videos: list[Path] = field(default_factory=list)  # 可入库的视频文件
+    disc_roots: list[Path] = field(default_factory=list)  # 完整原盘根（其下含标志目录）
 
 
 @dataclass(frozen=True)
@@ -351,8 +362,9 @@ def _snapshot(entry: Path) -> _EntrySnapshot:
     has_marker = False
     has_disc = False
     videos: list[Path] = []
+    disc_roots: set[Path] = set()
 
-    def visit(file: Path) -> None:
+    def visit(file: Path, *, inside_disc: bool = False) -> None:
         nonlocal total, count, max_mtime, has_marker
         try:
             stat = file.stat()
@@ -365,18 +377,23 @@ def _snapshot(entry: Path) -> _EntrySnapshot:
         if any(lower.endswith(marker) for marker in IN_PROGRESS_MARKERS):
             has_marker = True
             return
-        if Path(lower).suffix in VIDEO_EXTS and not any(m in lower for m in _IGNORE_MARKERS):
+        if (
+            not inside_disc
+            and Path(lower).suffix in VIDEO_EXTS
+            and not any(m in lower for m in _IGNORE_MARKERS)
+        ):
             videos.append(file)
 
     if entry.is_file():
         visit(entry)
     else:
-        stack = [entry]
+        stack = [(entry, False)]
         while stack:
-            current = stack.pop()
+            current, inside_disc = stack.pop()
             if current.name.upper() in ("BDMV", "VIDEO_TS"):
                 has_disc = True
-                continue
+                inside_disc = True
+                disc_roots.add(current.parent)
             try:
                 children = sorted(current.iterdir())
             except OSError:
@@ -384,14 +401,15 @@ def _snapshot(entry: Path) -> _EntrySnapshot:
             for child in children:
                 if child.is_dir():
                     if not child.name.startswith("."):
-                        stack.append(child)
+                        stack.append((child, inside_disc))
                 elif child.is_file():
-                    visit(child)
+                    visit(child, inside_disc=inside_disc)
     return _EntrySnapshot(
         fingerprint=f"{total}:{count}:{int(max_mtime)}",
         has_marker=has_marker,
         has_disc=has_disc,
         videos=sorted(videos),
+        disc_roots=sorted(disc_roots),
     )
 
 
@@ -674,6 +692,11 @@ async def _sweep_dir(
         if not rule.process_existing and not rule.baseline_done:
             # 「跳过存量」基线：本轮只盖章不处理，下轮起只有基线外的新条目
             # 会被消费（正在下载中的条目不进基线，完成后按新增处理）
+            if briefs is None:
+                # 无法确认哪些条目仍在下载时不能盖「存量已完成」基线。
+                for entry in entries:
+                    _deferred.setdefault(str(entry), time.monotonic())
+                return
             await _baseline_existing(rule, library, entries, briefs)
             return
         seen = {str(e) for e in entries}
@@ -818,10 +841,11 @@ async def refresh_source_notice(session, source_path: str, present: set[str] | N
 
 
 async def _downloader_briefs() -> list | None:
-    """全部可用下载器的种子概览（带短缓存）；无下载器/全部不可达返回 None。
+    """全部可用下载器的种子概览（带短缓存）。
 
-    None 表示"权威信号缺席"——调用方退回启发式检测，而不是把所有条目
-    误判成"未在下载"。
+    ``[]`` 表示没有配置下载器或可达下载器确实没有任务；``None`` 只表示
+    配置过下载器但本轮全部不可达。后者必须 fail closed，不能拿静默窗口
+    猜完成——API 短暂失联正是未完成文件被提前入库的根因。
     """
     global _briefs_cache
     now = time.monotonic()
@@ -834,21 +858,135 @@ async def _downloader_briefs() -> list | None:
 
     db = get_database()
     async with db.session() as session:
+        enabled_exists = (
+            await session.execute(
+                select(DownloaderClient.id).where(DownloaderClient.enabled.is_(True))  # type: ignore[union-attr]
+            )
+        ).first() is not None
         downloaders = await _usable_downloaders(session)
+    if not downloaders:
+        # 没有启用任何下载器才表示“确实没有权威状态源”。启用中的配置若仍在
+        # pending/verifying/failed，则只是当前不可用，必须和连接异常一样
+        # fail closed；否则服务启动的验证窗口会把预分配文件误当成已完成。
+        result = None if enabled_exists else []
+        _briefs_cache = (now, result)
+        return result
     briefs: list = []
-    any_ok = False
+    all_ok = True
     for row, config in downloaders:
         adapter = create_downloader(config)
         try:
             briefs.extend(await adapter.list_torrents())
-            any_ok = True
-        except Exception as exc:  # noqa: BLE001 -- 单台不可达降级继续
+        except Exception as exc:  # noqa: BLE001 -- 继续关闭/检查其余连接后整体降级
+            all_ok = False
             logger.warning("列出下载器「%s」的种子失败：%s", row.name, exc)
         finally:
             await adapter.close()
-    result = briefs if any_ok else None
+    # 任一台缺席时，这份列表都不能证明“某目录不属于下载任务”。宁可让所有
+    # 未决条目暂等，也不能用另一台的成功响应替失联下载器作否定判断。
+    result = briefs if all_ok else None
     _briefs_cache = (now, result)
     return result
+
+
+def _claim_path_matches(entry: Path, save_path: str | None) -> bool:
+    """持久化投递路径是否覆盖当前监听条目；旧行无路径时按真实名称认领。"""
+    if not save_path:
+        return True
+    expected = Path(os.path.normpath(save_path))
+    actual = Path(os.path.normpath(str(entry)))
+    return expected in {actual, actual.parent}
+
+
+def _download_name_matches(entry_name: str, recorded_name: str | None) -> bool:
+    """兼容站点标题与下载器内容名的轻微差异，不做宽松片名猜测。"""
+    if not recorded_name:
+        return False
+    if entry_name == recorded_name:
+        return True
+    compact_entry = re.sub(r"[^a-z0-9]+", "", entry_name.lower())
+    compact_recorded = re.sub(r"[^a-z0-9]+", "", recorded_name.lower())
+    if compact_entry == compact_recorded:
+        return True
+    if min(len(compact_entry), len(compact_recorded)) < 20:
+        return False
+    years_entry = set(re.findall(r"(?:19|20)\d{2}", compact_entry))
+    years_recorded = set(re.findall(r"(?:19|20)\d{2}", compact_recorded))
+    if years_entry and years_recorded and not years_entry.intersection(years_recorded):
+        return False
+    return SequenceMatcher(None, compact_entry, compact_recorded).ratio() >= 0.90
+
+
+async def _has_managed_download_claim(session, entry: Path) -> bool:
+    """条目是否仍由 MovieClaw 投递台账管理，即使下载器概览暂时漏掉它。"""
+    from movieclaw_db.models import (
+        DownloadAttemptStatus,
+        SiteTorrent,
+        SubscriptionDownloadAttempt,
+    )
+
+    manual = list(
+        (
+            await session.execute(
+                select(ManualDownloadIntent, SiteTorrent.title)
+                .outerjoin(
+                    SiteTorrent,
+                    (SiteTorrent.site_id == ManualDownloadIntent.site_id)
+                    & (SiteTorrent.torrent_id == ManualDownloadIntent.torrent_id),
+                )
+                .where(
+                    ManualDownloadIntent.created_at
+                    >= utcnow() - MANUAL_DOWNLOAD_INTENT_TTL,  # type: ignore[arg-type]
+                    or_(
+                        ManualDownloadIntent.download_name == entry.name,
+                        ManualDownloadIntent.download_name.is_(None),  # type: ignore[union-attr]
+                        ManualDownloadIntent.download_name == "",
+                    )
+                )
+            )
+        ).all()
+    )
+    if any(
+        _claim_path_matches(entry, intent.save_path)
+        and (
+            _download_name_matches(entry.name, intent.download_name)
+            or _download_name_matches(entry.name, site_title)
+        )
+        for intent, site_title in manual
+    ):
+        return True
+
+    active = (
+        DownloadAttemptStatus.ACTIVE,
+        DownloadAttemptStatus.REPLACEMENT_PENDING,
+        DownloadAttemptStatus.TRIAL,
+        DownloadAttemptStatus.CLEANUP_PENDING,
+        DownloadAttemptStatus.COMPLETED,
+    )
+    attempts = list(
+        (
+            await session.execute(
+                select(SubscriptionDownloadAttempt).where(
+                    SubscriptionDownloadAttempt.status.in_(active),  # type: ignore[union-attr]
+                    or_(
+                        SubscriptionDownloadAttempt.download_name == entry.name,
+                        SubscriptionDownloadAttempt.download_name.is_(None),  # type: ignore[union-attr]
+                        SubscriptionDownloadAttempt.download_name == "",
+                    ),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return any(
+        _claim_path_matches(entry, row.save_path)
+        and (
+            _download_name_matches(entry.name, row.download_name)
+            or _download_name_matches(entry.name, row.torrent_title)
+        )
+        for row in attempts
+    )
 
 
 def _match_briefs(entry_name: str, briefs: list | None) -> list:
@@ -1024,9 +1162,9 @@ async def _claimed_by_file_batches(session, entry_path: str) -> frozenset[str]:
 async def _deferred_flipped(prefix: str) -> bool:
     """挂起条目是否出现整种完成或新的单文件安全批次。
 
-    任一条目的种子翻转成完成、或从下载器消失（用户删了任务 → 退回启发式
-    检测）、或下载器整体不可达（权威信号缺席 → 同样退回启发式）都算翻转
-    ——巡检自会走完整判定链得出结论。仍在下载时只补查下载器文件状态并
+    任一条目的种子翻转成完成、或从下载器消失（巡检将结合持久化投递锚
+    再判定）都算翻转；下载器整体不可达时继续等待，绝不退回启发式。
+    仍在下载时只补查下载器文件状态并
     stat 已被确认完成的少量文件；与台账指纹不同才唤醒完整巡检。
     """
     paths = [p for p in _deferred if p.startswith(prefix)]
@@ -1034,7 +1172,7 @@ async def _deferred_flipped(prefix: str) -> bool:
         return False
     briefs = await _downloader_briefs()
     if briefs is None:
-        return True
+        return False
     db = get_database()
     for path in paths:
         entry = Path(path)
@@ -1050,9 +1188,7 @@ async def _deferred_flipped(prefix: str) -> bool:
             continue
         async with db.session() as session:
             record = (
-                await session.execute(
-                    select(IngestEntry).where(IngestEntry.entry_path == path)
-                )
+                await session.execute(select(IngestEntry).where(IngestEntry.entry_path == path))
             ).scalar_one_or_none()
         if record is None or record.fingerprint != snap.fingerprint:
             return True
@@ -1149,6 +1285,12 @@ async def _process_entry(
     execute_inline: bool,
 ) -> None:
     path_str = str(entry)
+    if briefs is None:
+        # 下载器配置存在但本轮全部不可达：绝不能回退到静默时间猜测。把条目
+        # 留在挂起表，API 恢复后由状态轮询重新判定，不读整棵目录。
+        _stability.pop(path_str, None)
+        _deferred.setdefault(path_str, time.monotonic())
+        return
     # 权威信号优先：能匹配到下载器种子时以下载器状态为准。报未完成的条目
     # 先尝试按文件完成证据拆出安全批次；没有可放行文件时只记入挂起表，
     # 状态轮询期间不做目录全树快照——绝不能
@@ -1199,6 +1341,12 @@ async def _process_entry(
         if record is not None and record.status == IngestStatus.IGNORED:
             _failed_retry.pop(path_str, None)  # 失败后被人工忽略：不再退避重试
             return  # 用户拍板（或存量基线）永久忽略：指纹变化也不复活，恢复走接口
+        if verdict is None and await _has_managed_download_claim(session, entry):
+            # 可达 API 偶尔在重启/恢复窗口返回空列表，或展示名尚未同步。真实
+            # 投递名与落点已持久化时继续 fail closed，避免第二条误放行路径。
+            _stability.pop(path_str, None)
+            _deferred.setdefault(path_str, time.monotonic())
+            return
         latest_job = None if execute_inline else await _latest_ingest_job(session, path_str)
         parser_retry = _parser_gap_auto_retry(rule, record)
         if latest_job is not None and latest_job.status in ACTIVE_JOB_STATUSES:
@@ -1240,11 +1388,24 @@ async def _process_entry(
 
         if snap is None:
             snap = await asyncio.to_thread(_snapshot, entry)
+        disc_retry = bool(
+            snap.has_disc
+            and record is not None
+            and record.status == IngestStatus.SKIPPED
+            and "原盘目录（BDMV/VIDEO_TS）暂不支持自动入库" in (record.message or "")
+        )
         if latest_job is not None and latest_job.status in {
             JobStatus.CANCELLED,
             JobStatus.FAILED,
         }:
-            # 用户取消或重试耗尽后，同一磁盘版本不能被启动补扫悄悄复活。
+            reconciled_disc_job = bool(
+                disc_retry
+                and latest_job.status == JobStatus.CANCELLED
+                and latest_job.cancel_requested_by == "system:disc-batch-reconcile"
+            )
+            # 用户取消或重试耗尽后，同一磁盘版本不能被启动补扫悄悄复活；
+            # 唯一例外是升级对账主动取消的旧版原盘分段 Job——那不是用户意图，
+            # 必须允许新处理器按完整原盘重新建立一次作业。
             # 已取消代表用户明确停止，只能显式重试；失败任务可由人工“恢复”
             # 清空台账指纹，或在源内容真的变化后由监听器建立一条新作业。
             terminal_fingerprint = (
@@ -1252,7 +1413,10 @@ async def _process_entry(
                 if record is not None
                 else str(latest_job.input_data.get("detected_fingerprint") or "")
             )
-            if latest_job.status == JobStatus.CANCELLED or terminal_fingerprint == snap.fingerprint:
+            if not reconciled_disc_job and (
+                latest_job.status == JobStatus.CANCELLED
+                or terminal_fingerprint == snap.fingerprint
+            ):
                 return
         # 标记文件与权威信号矛盾（说完成却还有 .!qB 等）说明匹配可疑，从严按
         # 下载中处理。必须在静默观察表留痕：CIFS/NFS 等不产生 fs 事件的挂载
@@ -1264,7 +1428,7 @@ async def _process_entry(
             return
 
         if record is not None and record.fingerprint == snap.fingerprint:
-            if record.status != IngestStatus.FAILED and not parser_retry:
+            if record.status != IngestStatus.FAILED and not parser_retry and not disc_retry:
                 return  # 已处理且没变化（pending 等的是人工拍板，不是时间）
             if record.status == IngestStatus.FAILED:
                 elapsed = (utcnow() - record.attempted_at).total_seconds()
@@ -1282,7 +1446,7 @@ async def _process_entry(
             # 下载器确认完成：整种或单文件证据都跳过静默窗口，立即处理。
             _stability.pop(path_str, None)
         else:
-            # 启发式兜底（非种子来源/下载器不可用）：
+            # 启发式兜底（没有权威任务或持久化投递锚的非种子来源）：
             # 同一指纹连续稳定 QUIET_SECONDS 才认为下载落定
             now = time.monotonic()
             previous = _stability.get(path_str)
@@ -1449,11 +1613,7 @@ async def _ingest_entry(
             item,
             schedule_retry=job_context is None,
         )
-        if (
-            status is IngestStatus.IMPORTED
-            and job_context is not None
-            and imported_files
-        ):
+        if status is IngestStatus.IMPORTED and job_context is not None and imported_files:
             await job_context.update_progress(
                 mode="determinate",
                 phase="finalizing",
@@ -1471,16 +1631,35 @@ async def _ingest_entry(
             )
         return saved
 
-    if snap.has_disc:
-        return await conclude(
-            IngestStatus.SKIPPED, "原盘目录（BDMV/VIDEO_TS）暂不支持自动入库，请手动整理"
-        )
-    if not snap.videos:
-        return await conclude(IngestStatus.SKIPPED, "条目中没有视频文件，已跳过")
-
     # kind 先验：指定库取库类型；auto 规则取规则声明（识别链按 movie/tv 分叉）
     kind = MediaKind(library.kind if library is not None else rule.kind)
-    main = max(snap.videos, key=lambda f: f.stat().st_size)
+    disc_root: Path | None = None
+    if snap.has_disc:
+        if kind is not MediaKind.MOVIE:
+            return await conclude(IngestStatus.PENDING, "剧集原盘暂不能确定季集边界，请人工整理")
+        if any(root == watch_root for root in snap.disc_roots):
+            return await conclude(
+                IngestStatus.PENDING,
+                "BDMV/VIDEO_TS 不能直接作为监听目录的顶层条目；"
+                "请先放进单独的「标题 (年份)」目录，避免越界处理同目录其他下载",
+            )
+        if len(snap.disc_roots) != 1 or snap.videos:
+            return await conclude(
+                IngestStatus.PENDING,
+                f"条目包含 {len(snap.disc_roots)} 个原盘或混合视频，"
+                "无法安全判定电影边界，请人工整理",
+            )
+        disc_root = snap.disc_roots[0]
+        main = await asyncio.to_thread(disc_main_stream, disc_root)
+        if main is None:
+            return await conclude(
+                IngestStatus.FAILED,
+                "原盘缺少可读取的主播放流，可能尚未下载完整；文件变化后自动重试",
+            )
+    else:
+        if not snap.videos:
+            return await conclude(IngestStatus.SKIPPED, "条目中没有视频文件，已跳过")
+        main = max(snap.videos, key=lambda f: f.stat().st_size)
     if job_context is not None:
         await job_context.update_progress(
             mode="indeterminate",
@@ -1496,6 +1675,13 @@ async def _ingest_entry(
             IngestStatus.FAILED,
             f"主视频「{main.name}」探测失败——可能尚未下载完成或已损坏，文件变化后自动重试",
         )
+    if spec is not None and disc_root is not None and (disc_root / "BDMV").is_dir():
+        languages = await asyncio.to_thread(read_clpi_languages, main)
+        if languages is not None:
+            spec = enrich_spec_with_clpi(spec, languages)
+        playlist = await asyncio.to_thread(read_main_playlist, disc_root)
+        if playlist is not None and playlist.duration_seconds > 0:
+            spec = replace(spec, duration_seconds=playlist.duration_seconds)
 
     # 身份优先级：人工认领（forced_item，用户拍板最高权威）→ 订阅工单认领
     # （info_hash 命中在途投递 → 继承投递时锚定的精确身份，零猜测）→
@@ -1537,7 +1723,7 @@ async def _ingest_entry(
             identity_source = "manual" if item is not None else None
         if item is None:
             try:
-                item = await _identify(session, kind, watch_root, main, spec)
+                item = await _identify(session, kind, watch_root, disc_root or main, spec)
             except IdentifyUnavailable as exc:
                 # 环境故障：网络恢复后重试就能过，不该钉进待处理清单
                 return await conclude(IngestStatus.FAILED, f"识别中断：{exc}；将自动重试")
@@ -1621,11 +1807,121 @@ async def _ingest_entry(
         version_label = (
             (spec.resolution if spec else None) or release_attrs.media_source or "V2"
         )
-        dest_dir = _avoid_disc_entry_dir(dest_dir, version_label)
+        if disc_root is None:
+            dest_dir = _avoid_disc_entry_dir(dest_dir, version_label)
     base = entry_base_name(item)
     repo = LibraryFileRepository(session)
     assert item.id is not None
     assert staging is not None or (dest_library is not None and dest_library.id is not None)
+
+    if disc_root is not None:
+        label = (spec.resolution if spec else None) or release_attrs.media_source or "原盘"
+        try:
+            if job_context is None:
+                final, created = await asyncio.to_thread(
+                    _transfer_disc_tree, disc_root, Path(dest_dir), strategy, label
+                )
+            else:
+
+                async def report_disc_copy(copied: int, total: int) -> None:
+                    percent = copied / total * 100 if total else 100.0
+                    await job_context.update_progress(
+                        mode="determinate",
+                        phase="transferring",
+                        message=(
+                            f"正在{'复制' if strategy == 'copy' else '硬链接'}完整原盘"
+                        ),
+                        current=copied,
+                        total=total,
+                        percent=round(percent, 1),
+                        phase_index=3,
+                        phase_count=4,
+                        details={
+                            "entry_name": entry.name,
+                            "library_id": dest_library.id if dest_library else None,
+                            "bytes_copied": copied,
+                        },
+                    )
+
+                final, created = await _transfer_disc_tree_for_job(
+                    disc_root,
+                    Path(dest_dir),
+                    strategy,
+                    label,
+                    job_context,
+                    report_disc_copy,
+                )
+        except (IngestConflictError, IngestError) as exc:
+            return await conclude(IngestStatus.FAILED, str(exc))
+        imported_files.append(final.name)
+        if staging is not None:
+            verb = "硬链接" if strategy == "hardlink" else "复制"
+            return await conclude(
+                IngestStatus.IMPORTED,
+                f"已识别为《{item.title}》，完整原盘已{verb}到 {final}；"
+                "文件进入媒体库根目录后将自动入账",
+                1 if created else 0,
+            )
+        assert dest_library is not None and dest_library.id is not None
+        stat = final.stat()
+        await repo.upsert_by_path(
+            LibraryFile(
+                library_id=dest_library.id,
+                media_item_id=item.id,
+                season_number=0,
+                episode_number=0,
+                file_path=str(final),
+                size_bytes=await asyncio.to_thread(_disc_total_size, final),
+                file_mtime_ns=stat.st_mtime_ns,
+                container="bluray" if (final / "BDMV").is_dir() else "dvd",
+                resolution=spec.resolution if spec else None,
+                video_codec=spec.video_codec if spec else None,
+                hdr=spec.hdr if spec else None,
+                bit_depth=spec.bit_depth if spec else None,
+                duration_seconds=spec.duration_seconds if spec else None,
+                bit_rate=spec.bit_rate if spec else None,
+                frame_rate=spec.frame_rate if spec else None,
+                color_space=spec.color_space if spec else None,
+                audio_streams=list(spec.audio_streams) if spec else None,
+                subtitle_streams=list(spec.subtitle_streams) if spec else None,
+                media_source=release_attrs.media_source,
+                release_group=release_attrs.release_group,
+                source=FileSource.IMPORTED,
+                site_id=prov_site,
+                torrent_id=prov_torrent,
+                added_batch_id=added_batch_id,
+            )
+        )
+        await LibraryRepository(session).refresh_stats([dest_library.id])
+        from movieclaw_api.services.library.nfo import write_entry_nfo
+        from movieclaw_api.services.subscription import close_fulfilled_wanted
+
+        await asyncio.to_thread(write_entry_nfo, final, item)
+        await close_fulfilled_wanted(session, item.id)
+        from movieclaw_api.services.media_scrape import ensure_assets
+
+        if job_context is None:
+            asyncio.get_running_loop().create_task(ensure_assets(item.id))
+        else:
+            await job_context.update_progress(
+                mode="indeterminate",
+                phase="finalizing",
+                message=f"正在补齐《{item.title}》的图片与媒体目录资产",
+                phase_index=4,
+                phase_count=4,
+                details={
+                    "entry_name": entry.name,
+                    "media_item_id": item.id,
+                    "library_id": dest_library.id,
+                },
+            )
+            await ensure_assets(item.id)
+        message = (
+            f"已识别为《{item.title}》"
+            + (f"，{route_note}" if route_note else "")
+            + f"，完整原盘已{'硬链接' if strategy == 'hardlink' else '复制'}到 {final}"
+        )
+        return await conclude(IngestStatus.IMPORTED, message, 1 if created else 0)
 
     files = [main] if kind is MediaKind.MOVIE else list(snap.videos)
     # 季集号按**整批**解析（设计见 library/units.py）：同一个包里的文件季号
@@ -1637,9 +1933,7 @@ async def _ingest_entry(
         known_seasons = set(
             (
                 await session.execute(
-                    select(MediaSeason.season_number).where(
-                        MediaSeason.media_item_id == item.id
-                    )
+                    select(MediaSeason.season_number).where(MediaSeason.media_item_id == item.id)
                 )
             ).scalars()
         )
@@ -2053,7 +2347,7 @@ def _entry_nfo_paths(kind: MediaKind, watch_root: Path, main: Path) -> list[Path
     目录里每个条目都毒成同一部片）的 movie/tvshow.nfo。
     """
     names = ["movie.nfo", "tvshow.nfo"] if kind is MediaKind.MOVIE else ["tvshow.nfo", "movie.nfo"]
-    paths = [main.with_suffix(".nfo")]
+    paths = [main / names[0], main / names[1]] if main.is_dir() else [main.with_suffix(".nfo")]
     current = main.parent
     while current != watch_root and current != current.parent:
         paths.extend(current / n for n in names)
@@ -2087,7 +2381,7 @@ async def _identify(
         except Exception as exc:
             raise IdentifyUnavailable(f"读到 NFO 身份但 TMDB 建档失败（{exc}）") from exc
 
-    evidence = guess_evidence(kind, watch_root, main)
+    evidence = guess_evidence(kind, watch_root, main, is_disc=main.is_dir())
     if evidence is None:
         return None
     evidence.duration_seconds = spec.duration_seconds if spec else None
@@ -2115,6 +2409,284 @@ def _same_payload(a: Path, b: Path) -> bool:
         return a.stat().st_size == b.stat().st_size
     except OSError:
         return False
+
+
+def _disc_total_size(disc_dir: Path) -> int:
+    """原盘整树体积；不可读文件由后续搬运报错，不在这里伪造体积。"""
+    return sum(path.stat().st_size for path in disc_dir.rglob("*") if path.is_file())
+
+
+def _same_disc_payload(source: Path, target: Path) -> bool:
+    """整树是否已落位：相对路径一致，文件为同一 inode 或尺寸与 mtime 一致。
+
+    普通单文件历史逻辑只比尺寸；原盘往往有大量固定尺寸的流分段，单凭尺寸
+    更容易把不同盘面误判成同一内容。复制路径保留源 mtime，因此无需读取数百
+    GB 内容，也能比“路径 + 尺寸”多一道低成本身份校验。
+    """
+    try:
+        source_files = {
+            path.relative_to(source): path for path in source.rglob("*") if path.is_file()
+        }
+        target_files = {
+            path.relative_to(target): path for path in target.rglob("*") if path.is_file()
+        }
+        if source_files.keys() != target_files.keys():
+            return False
+        for relative, path in source_files.items():
+            other = target_files[relative]
+            if os.path.samefile(path, other):
+                continue
+            source_stat = path.stat()
+            target_stat = other.stat()
+            if (
+                source_stat.st_size != target_stat.st_size
+                or source_stat.st_mtime_ns != target_stat.st_mtime_ns
+            ):
+                return False
+        return True
+    except OSError:
+        return False
+
+
+def _disc_destination(source: Path, base: Path, version_label: str) -> tuple[Path, bool]:
+    """选择完整原盘目录落点，返回（目录，是否已存在同内容）。"""
+    if not base.exists():
+        return base, False
+    if is_disc_dir(base) and _same_disc_payload(source, base):
+        return base, True
+    label = sanitize_folder_name(f"{version_label}原盘")
+    candidate = base.with_name(f"{base.name} - {label}")
+    serial = 2
+    while candidate.exists():
+        if is_disc_dir(candidate) and _same_disc_payload(source, candidate):
+            return candidate, True
+        candidate = base.with_name(f"{base.name} - {label} ({serial})")
+        serial += 1
+    return candidate, False
+
+
+def _transfer_disc_tree(
+    source: Path, base: Path, strategy: str, version_label: str
+) -> tuple[Path, bool]:
+    """完整保留 BDMV/VIDEO_TS 树并一次发布；不 remux、不拼接、不修改保种源。"""
+    final, already_present = _disc_destination(source, base, version_label)
+    if already_present:
+        return final, False
+    try:
+        final.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise IngestError(f"创建原盘目标目录失败（{exc.strerror}）：{final.parent}") from exc
+    stage = final.parent / f".{final.name}.{uuid4().hex[:8]}.part"
+    try:
+        stage.mkdir()
+        copied = 0
+        for path in sorted(source.rglob("*")):
+            relative = path.relative_to(source)
+            target = stage / relative
+            if path.is_symlink():
+                raise IngestError(f"原盘包含符号链接，拒绝自动搬运：{relative}")
+            if path.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not path.is_file():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if strategy == "copy":
+                shutil.copy2(path, target)
+            else:
+                try:
+                    os.link(path, target)
+                except OSError as exc:
+                    if exc.errno == errno.EXDEV:
+                        raise IngestError(
+                            "原盘硬链接失败：监听目录与目标目录不在同一文件系统；"
+                            "请把该监听规则改为「复制」"
+                        ) from exc
+                    raise
+            copied += 1
+        if copied == 0:
+            raise IngestError("原盘目录中没有可搬运文件")
+        rename_no_replace(stage, final)
+        return final, True
+    except FileExistsError as exc:
+        raise IngestConflictError(f"原盘目标目录已被并发占用：{final.name}") from exc
+    except IngestError:
+        raise
+    except OSError as exc:
+        verb = "复制" if strategy == "copy" else "硬链接"
+        raise IngestError(f"原盘{verb}失败（{exc.strerror}）：{source.name} → {final}") from exc
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+
+
+def _disc_ingest_paths(final: Path) -> tuple[Path, Path]:
+    """完整原盘 Job 的隐藏续传目录与源版本边车。"""
+    stage = final.parent / f".{final.name}.movieclaw-ingest.part"
+    return stage, stage.with_name(stage.name + ".json")
+
+
+def _prepare_disc_ingest(
+    source: Path, stage: Path, state_path: Path
+) -> tuple[list[Path], list[tuple[Path, Path, int, int]], int]:
+    """校验原盘源版本并准备稳定续传目录，返回文件清单与总字节数。"""
+    directories: list[Path] = []
+    files: list[tuple[Path, Path, int, int]] = []
+    for path in sorted(source.rglob("*")):
+        relative = path.relative_to(source)
+        if path.is_symlink():
+            raise IngestError(f"原盘包含符号链接，拒绝自动搬运：{relative}")
+        if path.is_dir():
+            directories.append(relative)
+            continue
+        if not path.is_file():
+            continue
+        stat = path.stat()
+        files.append((path, relative, stat.st_size, stat.st_mtime_ns))
+    if not files:
+        raise IngestError("原盘目录中没有可搬运文件")
+    expected = {
+        "source": str(source),
+        "directories": [relative.as_posix() for relative in directories],
+        "files": [
+            [relative.as_posix(), size, mtime_ns]
+            for _path, relative, size, mtime_ns in files
+        ],
+    }
+    valid = False
+    if stage.is_dir() and state_path.is_file():
+        try:
+            valid = json.loads(state_path.read_text(encoding="utf-8")) == expected
+        except (OSError, json.JSONDecodeError):
+            valid = False
+    if not valid:
+        if stage.exists():
+            if stage.is_dir():
+                shutil.rmtree(stage)
+            else:
+                stage.unlink()
+        state_path.unlink(missing_ok=True)
+    stage.parent.mkdir(parents=True, exist_ok=True)
+    stage.mkdir(exist_ok=True)
+    if not state_path.exists():
+        temp = state_path.with_name(state_path.name + ".tmp")
+        temp.write_text(json.dumps(expected, ensure_ascii=False), encoding="utf-8")
+        os.replace(temp, state_path)
+    return directories, files, sum(size for _path, _relative, size, _mtime_ns in files)
+
+
+async def _transfer_disc_tree_for_job(
+    source: Path,
+    base: Path,
+    strategy: str,
+    version_label: str,
+    context: jobs.JobContext,
+    on_progress: Callable[[int, int], Awaitable[None]],
+) -> tuple[Path, bool]:
+    """Job 专用完整原盘搬运：复制可续传，整树完成后才原子发布。"""
+    final, already_present = await asyncio.to_thread(
+        _disc_destination, source, base, version_label
+    )
+    if already_present:
+        stage, state_path = _disc_ingest_paths(final)
+        if stage.exists():
+            await asyncio.to_thread(shutil.rmtree, stage, True)
+        state_path.unlink(missing_ok=True)
+        return final, False
+    stage, state_path = _disc_ingest_paths(final)
+    try:
+        directories, files, total = await asyncio.to_thread(
+            _prepare_disc_ingest, source, stage, state_path
+        )
+        for relative in directories:
+            await asyncio.to_thread((stage / relative).mkdir, parents=True, exist_ok=True)
+        completed = 0
+        for path, relative, size, mtime_ns in files:
+            await context.raise_if_cancelled()
+            target = stage / relative
+            await asyncio.to_thread(target.parent.mkdir, parents=True, exist_ok=True)
+            if strategy == "hardlink":
+                same_link = False
+                if target.exists():
+                    try:
+                        same_link = os.path.samefile(path, target)
+                    except OSError:
+                        same_link = False
+                    if not same_link:
+                        target.unlink()
+                if not same_link:
+                    try:
+                        await asyncio.to_thread(os.link, path, target)
+                    except OSError as exc:
+                        if exc.errno == errno.EXDEV:
+                            raise IngestError(
+                                "原盘硬链接失败：监听目录与目标目录不在同一文件系统；"
+                                "请把该监听规则改为「复制」"
+                            ) from exc
+                        raise
+                completed += size
+                await on_progress(completed, total)
+                continue
+
+            target_complete = False
+            if target.is_file():
+                stat = target.stat()
+                target_complete = stat.st_size == size and stat.st_mtime_ns == mtime_ns
+                if not target_complete:
+                    target.unlink()
+            if target_complete:
+                completed += size
+                await on_progress(completed, total)
+                continue
+
+            partial = target.with_name(f".{target.name}.part")
+            if partial.exists() and partial.stat().st_size > size:
+                partial.unlink()
+            if size == 0:
+                partial.touch(exist_ok=True)
+            copied = partial.stat().st_size if partial.exists() else 0
+            await on_progress(completed + copied, total)
+            while copied < size:
+                await context.raise_if_cancelled()
+                copied = await asyncio.to_thread(
+                    _copy_ingest_chunk,
+                    path,
+                    partial,
+                    expected_size=size,
+                    expected_mtime_ns=mtime_ns,
+                )
+                await on_progress(completed + copied, total)
+            await asyncio.to_thread(rename_no_replace, partial, target)
+            target_stat = target.stat()
+            await asyncio.to_thread(
+                os.utime,
+                target,
+                ns=(target_stat.st_atime_ns, mtime_ns),
+            )
+            completed += size
+
+        await context.raise_if_cancelled()
+        try:
+            await asyncio.to_thread(rename_no_replace, stage, final)
+        except FileExistsError as exc:
+            if await asyncio.to_thread(_same_disc_payload, source, final):
+                await asyncio.to_thread(shutil.rmtree, stage, True)
+                state_path.unlink(missing_ok=True)
+                return final, False
+            raise IngestConflictError(f"原盘目标目录已被并发占用：{final.name}") from exc
+        state_path.unlink(missing_ok=True)
+        return final, True
+    except IngestSourceChanged:
+        if stage.exists():
+            await asyncio.to_thread(shutil.rmtree, stage, True)
+        state_path.unlink(missing_ok=True)
+        raise
+    except (jobs.JobCancelled, asyncio.CancelledError, IngestError):
+        # 更新/取消与暂态错误保留已确认字节；下一次执行按源版本边车续传。
+        raise
+    except OSError as exc:
+        verb = "复制" if strategy == "copy" else "硬链接"
+        raise IngestError(f"原盘{verb}暂未完成（{exc}）：{source.name} → {final}") from exc
 
 
 def _avoid_disc_entry_dir(dest_dir: str, version_label: str) -> str:
@@ -2548,8 +3120,25 @@ async def _execute_ingest_job(
         details={**persisted_details, "rule_id": rule_id, "entry_name": entry.name},
     )
     briefs = await _downloader_briefs()
+    if briefs is None:
+        raise jobs.JobRetry(
+            "下载器当前不可达，无法确认条目已经完整；恢复连接后自动继续",
+            delay_seconds=DEFERRED_POLL_SECONDS,
+        )
     matches = _match_briefs(entry.name, briefs)
     verdict = _torrent_verdict(matches)
+    if verdict is None and stored_hashes:
+        raise jobs.JobRetry(
+            "下载器暂未返回该受管任务，等待状态同步后自动继续",
+            delay_seconds=DEFERRED_POLL_SECONDS,
+        )
+    if verdict is None:
+        async with db.session() as session:
+            if await _has_managed_download_claim(session, entry):
+                raise jobs.JobRetry(
+                    "下载器暂未返回该受管任务，等待状态同步后自动继续",
+                    delay_seconds=DEFERRED_POLL_SECONDS,
+                )
     if file_scoped and verdict == "downloading":
         current_batch = await _completed_file_batch(entry, matches)
         current_ready = {
@@ -2588,9 +3177,7 @@ async def _execute_ingest_job(
         entry_name=entry.name,
     )
     current_hashes = (
-        []
-        if file_scoped
-        else [brief.info_hash.lower() for brief in matches if brief.info_hash]
+        [] if file_scoped else [brief.info_hash.lower() for brief in matches if brief.info_hash]
     )
     matched_hashes = sorted(set(stored_hashes) | set(current_hashes))
 
@@ -2610,7 +3197,17 @@ async def _execute_ingest_job(
             # 中转记录的补偿限制见 _parser_gap_auto_retry；被限制的记录在此
             # 照旧短路/挂起，等用户改名或恢复时以新指纹走完整重跑
             parser_retry = _parser_gap_auto_retry(rule, record)
-            if record.status in {IngestStatus.IMPORTED, IngestStatus.SKIPPED} and not parser_retry:
+            disc_retry = bool(
+                snap.has_disc
+                and record.status == IngestStatus.SKIPPED
+                and "原盘目录（BDMV/VIDEO_TS）暂不支持自动入库"
+                in (record.message or "")
+            )
+            if (
+                record.status in {IngestStatus.IMPORTED, IngestStatus.SKIPPED}
+                and not parser_retry
+                and not disc_retry
+            ):
                 return {
                     "message": record.message or "监听条目已处理",
                     "entry_id": record.id,

--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -59,6 +59,7 @@ from movieclaw_api.services import jobs
 from movieclaw_api.services.library.bluray import (
     enrich_spec_with_clpi,
     read_clpi_languages,
+    read_main_playlist,
     streams_have_clpi_metadata,
 )
 from movieclaw_api.services.library.layout import (
@@ -1762,7 +1763,21 @@ def unit_name(file: Path, is_disc: bool) -> str:
 
 
 def disc_main_stream(disc_dir: Path) -> Path | None:
-    """原盘的主流文件：BDMV/STREAM 或 VIDEO_TS 下最大的流文件（探测用）。"""
+    """原盘主流文件（探测用）：蓝光优先按 MPLS 主播放列表，损坏盘降级取最大流。"""
+    playlist = read_main_playlist(disc_dir)
+    if playlist is not None:
+        stream_dir = disc_dir / "BDMV" / "STREAM"
+        try:
+            by_stem = {
+                path.stem: path
+                for path in stream_dir.iterdir()
+                if path.is_file() and path.suffix.lower() == ".m2ts"
+            }
+        except OSError:
+            by_stem = {}
+        existing = [by_stem[clip_id] for clip_id in playlist.clip_ids if clip_id in by_stem]
+        if existing:
+            return max(existing, key=lambda path: path.stat().st_size)
     for sub, exts in (("BDMV/STREAM", {".m2ts"}), ("VIDEO_TS", {".vob"})):
         stream_dir = disc_dir / sub
         if not stream_dir.is_dir():
@@ -2339,6 +2354,9 @@ async def _ingest_file(
         languages = await asyncio.to_thread(read_clpi_languages, probe_target)
         if languages is not None:
             spec = enrich_spec_with_clpi(spec, languages)
+        playlist = await asyncio.to_thread(read_main_playlist, file)
+        if playlist is not None and playlist.duration_seconds > 0:
+            spec = replace(spec, duration_seconds=playlist.duration_seconds)
     if is_disc:
         size_bytes = await asyncio.to_thread(_disc_total_size, file)
         container = "bluray" if (file / "BDMV").is_dir() else "dvd"

--- a/src/movieclaw_api/services/subscription/dispatch.py
+++ b/src/movieclaw_api/services/subscription/dispatch.py
@@ -218,6 +218,8 @@ async def dispatch(
                 "site_id": candidate.site_id,
                 "torrent_id": candidate.torrent_id,
                 "torrent_title": candidate.title,
+                "download_name": submit_result.name or None,
+                "save_path": dispatch_dir,
                 "units": [[w.season_number, w.episode_number] for w in all_targets],
                 "quality": candidate.attrs.model_dump(exclude_defaults=True),
                 "hit_and_run": candidate.hit_and_run,
@@ -277,6 +279,10 @@ async def dispatch(
                     values["site_id"] = existing_attempt.site_id
                     values["torrent_id"] = existing_attempt.torrent_id
                     values["torrent_title"] = existing_attempt.torrent_title
+                if existing_attempt.download_name:
+                    values["download_name"] = existing_attempt.download_name
+                if existing_attempt.save_path:
+                    values["save_path"] = existing_attempt.save_path
                 if existing_attempt.quality:
                     values["quality"] = existing_attempt.quality
                 if existing_attempt.hit_and_run is not None:

--- a/src/movieclaw_api/services/subscription/replacement.py
+++ b/src/movieclaw_api/services/subscription/replacement.py
@@ -566,6 +566,8 @@ async def _try_candidates(
             site_id=candidate.site_id,
             torrent_id=candidate.torrent_id,
             torrent_title=candidate.title,
+            download_name=result.name or None,
+            save_path=decision.path,
             units=[[row.season_number, row.episode_number] for row in covered],
             quality=candidate.attrs.model_dump(exclude_defaults=True),
             hit_and_run=candidate.hit_and_run,

--- a/src/movieclaw_api/services/torrent_submit.py
+++ b/src/movieclaw_api/services/torrent_submit.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import delete
@@ -31,6 +30,7 @@ from sqlmodel import select
 from movieclaw_api.exceptions import BadRequestException, UpstreamServiceException
 from movieclaw_api.services.site_access import SiteUnavailableError, get_site_access
 from movieclaw_db.models import DownloaderClient, DownloadHint, ManualDownloadIntent, utcnow
+from movieclaw_db.models.manual_download_intent import MANUAL_DOWNLOAD_INTENT_TTL
 from movieclaw_db.models.site_credential import ConfigStatus
 from movieclaw_db.repositories.downloader_repo import DownloaderRepository
 from movieclaw_downloader.factory import create_downloader
@@ -45,7 +45,7 @@ logger = logging.getLogger("movieclaw_api.torrent_submit")
 
 # 身份锚的兜底存活窗口：正常下载远短于此；超窗仍未被入库消费的锚基本是
 # 任务已从下载器删除的孤儿行，锚定新下载时顺带清理，避免无限累积
-_INTENT_STALE_AFTER = timedelta(days=90)
+_INTENT_STALE_AFTER = MANUAL_DOWNLOAD_INTENT_TTL
 
 
 @dataclass(frozen=True)
@@ -340,6 +340,9 @@ async def anchor_manual_download(
     library_id: int,
     site_id: str,
     torrent_id: str | None = None,
+    downloader_id: int | None = None,
+    download_name: str | None = None,
+    save_path: str | None = None,
 ) -> None:
     """按 infohash 保存手动下载的已确认身份，供监听导入完成后直接认领。
 
@@ -368,6 +371,9 @@ async def anchor_manual_download(
                 info_hash=normalized,
                 media_item_id=media_item_id,
                 library_id=library_id,
+                downloader_id=downloader_id,
+                download_name=download_name,
+                save_path=save_path,
                 site_id=site_id,
                 torrent_id=torrent_id,
             )
@@ -393,8 +399,21 @@ async def anchor_manual_download(
                 library_id,
             )
             return
-    # 同一 hash 即同一份内容：旧锚缺站点种子 ID 时用本次提交补全（只补
-    # 同站信息，跨站同种不能把别站的种子 ID 配到旧站点上）；身份归属不变。
+    # 同一 hash 即同一份内容：只补旧版本没有的物理任务锚与站点种子 ID，
+    # 绝不改写首次确认的媒体/库归属。路径只有目标身份也一致时才可信——同一
+    # hash 被后来点到另一部片时，不能把旧任务静默指向新目录。
+    changed = False
+    same_target = existing.media_item_id == media_item_id and existing.library_id == library_id
+    if same_target:
+        if existing.downloader_id is None and downloader_id is not None:
+            existing.downloader_id = downloader_id
+            changed = True
+        if not existing.download_name and download_name:
+            existing.download_name = download_name
+            changed = True
+        if not existing.save_path and save_path:
+            existing.save_path = save_path
+            changed = True
     if (
         torrent_id
         and not existing.torrent_id
@@ -402,9 +421,11 @@ async def anchor_manual_download(
     ):
         existing.site_id = site_id
         existing.torrent_id = torrent_id
+        changed = True
+    if changed:
         existing.updated_at = utcnow()
         await session.commit()
-    if existing.media_item_id != media_item_id or existing.library_id != library_id:
+    if not same_target:
         logger.warning(
             "手动下载 hash=%s 已锚定到 media_item=%s/library=%s；"
             "忽略本次不同目标 media_item=%s/library=%s",

--- a/src/movieclaw_db/models/manual_download_intent.py
+++ b/src/movieclaw_db/models/manual_download_intent.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 from sqlalchemy import Column, ForeignKey, Integer, Text
 from sqlmodel import Field
 
 from movieclaw_db.models.base import TimestampMixin
+
+# 手动下载锚只用于覆盖“投递成功到入库完成”的在途窗口。超窗仍未被消费的
+# 记录通常对应已从下载器删除的孤儿任务；查询与写入清理必须共用同一口径，
+# 否则旧锚会让监听条目永久停在“等待下载器”。
+MANUAL_DOWNLOAD_INTENT_TTL = timedelta(days=90)
 
 
 class ManualDownloadIntent(TimestampMixin, table=True):
@@ -42,6 +49,26 @@ class ManualDownloadIntent(TimestampMixin, table=True):
             index=True,
         ),
         description="按收藏范围路由后确认的目标媒体库",
+    )
+    downloader_id: int | None = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("downloader_client.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        description="实际承载任务的下载器；NULL=旧数据",
+    )
+    download_name: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True, index=True),
+        description="下载器返回的真实任务/内容名；用于监听目录可靠关联",
+    )
+    save_path: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+        description="MovieClaw 视角的投递路径；用于同名任务消歧",
     )
     site_id: str | None = Field(default=None, description="来源站点（追溯用）")
     # 站点内种子 ID：与 site_id 一起反查 site_torrent 的详情页，供任务中心

--- a/src/movieclaw_db/models/subscription.py
+++ b/src/movieclaw_db/models/subscription.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 from datetime import date, datetime
 from enum import StrEnum
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, UniqueConstraint, text
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlmodel import Field
 
 from movieclaw_db.models.base import TimestampMixin, utcnow
@@ -368,6 +378,16 @@ class SubscriptionDownloadAttempt(TimestampMixin, table=True):
     site_id: str | None = Field(default=None, description="候选来源站点")
     torrent_id: str | None = Field(default=None, description="站点内种子 ID")
     torrent_title: str = Field(default="", description="投递时的种子标题快照")
+    download_name: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True, index=True),
+        description="下载器返回的真实任务/内容名；用于监听目录可靠关联",
+    )
+    save_path: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+        description="MovieClaw 视角的投递路径；用于同名任务消歧",
+    )
     units: list = Field(
         default_factory=list,
         sa_column=Column(JSON, nullable=False),

--- a/tests/api/test_bluray_clpi.py
+++ b/tests/api/test_bluray_clpi.py
@@ -10,12 +10,74 @@ from movieclaw_api.services.library.bluray import (
     ClpiParseError,
     enrich_spec_with_clpi,
     parse_clpi_languages,
+    parse_mpls_playlist,
     read_clpi_languages,
+    read_main_playlist,
     streams_have_clpi_metadata,
 )
+from movieclaw_api.services.library.scan import disc_main_stream
 from movieclaw_api.services.media_probe import MediaSpec, _parse_probe
 from movieclaw_api.services.subtitle_gen.auto import _has_target_subtitle
 from movieclaw_db.models import LibraryFile
+
+
+def _mpls(*items: tuple[str, int, int]) -> bytes:
+    """构造只含主链 PlayItem 的最小合法 MPLS。时间单位为 45 kHz。"""
+    body = bytearray(b"\0\0" + len(items).to_bytes(2, "big") + b"\0\0")
+    for clip_id, in_time, out_time in items:
+        core = (
+            clip_id.encode("ascii")
+            + b"M2TS"
+            + b"\0\0"
+            + b"\0"
+            + in_time.to_bytes(4, "big")
+            + out_time.to_bytes(4, "big")
+        )
+        body += len(core).to_bytes(2, "big") + core
+    header = bytearray(b"MPLS0100" + (20).to_bytes(4, "big") + b"\0" * 8)
+    return bytes(header + len(body).to_bytes(4, "big") + body)
+
+
+def test_mpls_parser_and_main_playlist_selection(tmp_path):
+    disc = tmp_path / "Movie"
+    playlist_dir = disc / "BDMV" / "PLAYLIST"
+    stream_dir = disc / "BDMV" / "STREAM"
+    playlist_dir.mkdir(parents=True)
+    stream_dir.mkdir()
+    (stream_dir / "00001.m2ts").write_bytes(b"a")
+    (stream_dir / "00002.m2ts").write_bytes(b"bb")
+    (stream_dir / "99999.m2ts").write_bytes(b"menu-or-bonus" * 10)
+    short = _mpls(("00001", 0, 45_000 * 60))
+    long = _mpls(("00001", 0, 45_000 * 60), ("00002", 0, 45_000 * 120))
+    (playlist_dir / "00001.mpls").write_bytes(short)
+    (playlist_dir / "00800.mpls").write_bytes(long)
+    (playlist_dir / "broken.mpls").write_bytes(b"broken")
+
+    parsed = parse_mpls_playlist(long)
+    assert parsed.clip_ids == ("00001", "00002")
+    assert parsed.duration_seconds == 180
+    selected = read_main_playlist(disc)
+    assert selected is not None
+    assert selected.path.name == "00800.mpls"
+    assert selected.duration_seconds == 180
+    assert disc_main_stream(disc) == stream_dir / "00002.m2ts"
+
+
+def test_main_playlist_accepts_uppercase_disc_extensions(tmp_path):
+    """原盘扩展名大小写由制作/解包工具决定，Linux 上也必须正常识别。"""
+    disc = tmp_path / "Movie"
+    playlist_dir = disc / "BDMV" / "PLAYLIST"
+    stream_dir = disc / "BDMV" / "STREAM"
+    playlist_dir.mkdir(parents=True)
+    stream_dir.mkdir()
+    playlist = _mpls(("00001", 0, 45_000 * 60))
+    (playlist_dir / "00001.MPLS").write_bytes(playlist)
+    stream = stream_dir / "00001.M2TS"
+    stream.write_bytes(b"main")
+
+    selected = read_main_playlist(disc)
+    assert selected is not None and selected.path.suffix == ".MPLS"
+    assert disc_main_stream(disc) == stream
 
 
 def _coding_info(coding_type: int, language: str) -> bytes:

--- a/tests/api/test_download_submit.py
+++ b/tests/api/test_download_submit.py
@@ -294,9 +294,7 @@ def test_dispatch_preview_routes_and_warnings(client) -> None:
         "/api/v1/libraries",
         json={"name": "预检电影库", "kind": "movie", "root_paths": ["/vol1/media/movies"]},
     ).json()["data"]
-    r = client.get(
-        "/api/v1/subscriptions/download-routing-preview", params={"kind": "movie"}
-    )
+    r = client.get("/api/v1/subscriptions/download-routing-preview", params={"kind": "movie"})
     assert r.status_code == 200
     assert r.json()["data"]["ok"] is False
     assert "默认下载器" in r.json()["data"]["warning"]
@@ -566,6 +564,9 @@ def test_auto_route_submits_to_watch_and_anchors_info_hash(client, monkeypatch) 
     intent = asyncio.run(load_intent())
     assert intent.info_hash == "a" * 40
     assert intent.library_id == library["id"]
+    assert intent.downloader_id == selected_downloader_id
+    assert intent.download_name == "Some.Movie.2024.2160p"
+    assert intent.save_path == "/downloads/manual/movies"
     # 站点种子 ID 随身份锚落库，任务中心据此反查详情页提供「打开种子页」
     assert intent.torrent_id == "8866"
 
@@ -614,6 +615,50 @@ def test_anchor_sweeps_stale_orphan_intents(client) -> None:
     assert asyncio.run(run()) == {"c" * 40, "d" * 40}
 
 
+def test_anchor_backfills_new_task_identity_columns_on_legacy_row(client) -> None:
+    """重复提交旧版锚时补真实任务名和落点，但保持首次媒体/库归属。"""
+    from movieclaw_api.services.torrent_submit import anchor_manual_download
+
+    async def run() -> ManualDownloadIntent:
+        async with get_database().session() as session:
+            item = MediaItem(
+                kind="movie",
+                tmdb_id=2,
+                title="旧锚影片",
+                original_title="Legacy Anchor",
+                year=2020,
+                aliases=[],
+            )
+            library = Library(name="旧锚库", kind="movie", root_paths=["/media/movies"])
+            session.add_all([item, library])
+            await session.commit()
+            await session.refresh(item)
+            await session.refresh(library)
+            legacy = ManualDownloadIntent(
+                info_hash="e" * 40,
+                media_item_id=item.id,
+                library_id=library.id,
+                site_id="mteam",
+            )
+            session.add(legacy)
+            await session.commit()
+            await anchor_manual_download(
+                session,
+                info_hash="e" * 40,
+                media_item_id=item.id,
+                library_id=library.id,
+                site_id="mteam",
+                download_name="Legacy.Anchor.2020.2160p",
+                save_path="/downloads/movies",
+            )
+            await session.refresh(legacy)
+            return legacy
+
+    intent = asyncio.run(run())
+    assert intent.download_name == "Legacy.Anchor.2020.2160p"
+    assert intent.save_path == "/downloads/movies"
+
+
 def test_submit_with_disabled_default_downloader(client) -> None:
     did = _add_default_downloader(client)
     client.patch(f"/api/v1/downloaders/{did}/status", json={"enabled": False})
@@ -637,9 +682,7 @@ def test_submit_with_specified_downloader(client) -> None:
 def test_submit_with_specified_downloader_unavailable(client) -> None:
     """指定的下载器停用/不存在：指向明确的中文错误，不静默回落默认台。"""
     _add_default_downloader(client)
-    second = _add_default_downloader(
-        client, name="备用机", url="http://192.168.1.30:8080"
-    )
+    second = _add_default_downloader(client, name="备用机", url="http://192.168.1.30:8080")
     client.patch(f"/api/v1/downloaders/{second}/status", json={"enabled": False})
     r = client.post("/api/v1/downloaders/submit", json={**_SUBMIT, "downloader_id": second})
     assert r.status_code == 400

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -10,7 +10,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
+from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -27,6 +29,7 @@ from movieclaw_api.services.library.layout import explicit_unit
 from movieclaw_db.engine import dispose_db, get_database, init_db
 from movieclaw_db.migrations import run_migrations
 from movieclaw_db.models import (
+    DownloaderClient,
     FileSource,
     ImportWatch,
     IngestEntry,
@@ -40,6 +43,9 @@ from movieclaw_db.models import (
     MediaItem,
 )
 from movieclaw_db.models.base import utcnow
+from movieclaw_db.models.downloader_client import ClientType
+from movieclaw_db.models.manual_download_intent import MANUAL_DOWNLOAD_INTENT_TTL
+from movieclaw_db.models.site_credential import ConfigStatus
 from movieclaw_db.repositories.library_repo import LibraryRepository
 from movieclaw_media.models import MediaKind
 
@@ -419,6 +425,73 @@ async def test_disc_batch_job_reconcile_cancels_only_active_disc_batches(db):
         previously_reconciled_record is not None
         and previously_reconciled_record.status == IngestStatus.SKIPPED
     )
+
+
+@pytest.mark.asyncio
+async def test_reconciled_legacy_disc_job_is_replaced_by_complete_disc_ingest(
+    db, tmp_path, monkeypatch
+):
+    """升级取消旧分段 Job 后自动建立整盘 Job，不能被“已取消”通用门禁拦住。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    await _make_rule(db, library_id=library_id, source=watch)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="升级原盘", year=2026)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+
+    entry = watch / "Legacy.Disc.2026"
+    stream = entry / "BDMV" / "STREAM" / "00001.m2ts"
+    stream.parent.mkdir(parents=True)
+    stream.write_bytes(b"complete-main-feature")
+    fingerprint = ingest_mod._snapshot(entry).fingerprint
+    async with db.session() as session:
+        record = IngestEntry(
+            entry_path=str(entry),
+            fingerprint=fingerprint,
+            status=IngestStatus.PENDING,
+            message="已取最大文件为正片，忽略其余 37 个视频",
+        )
+        session.add(record)
+        await session.flush()
+        assert record.id is not None
+        old_job = Job(
+            id="job_legacy_disc_upgrade",
+            job_type="library.ingest",
+            status=JobStatus.BLOCKED,
+            input_data={"ready_files": [{"path": "BDMV/STREAM/00001.m2ts"}]},
+        )
+        session.add(old_job)
+        session.add(
+            JobResource(
+                job_id=old_job.id,
+                resource_type="ingest_entry",
+                resource_id=str(record.id),
+            )
+        )
+        await session.commit()
+
+    assert await ingest_mod.reconcile_disc_batch_jobs() == 1
+    async with db.session() as session:
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+        library = await session.get(Library, library_id)
+        assert library is not None
+    await ingest_mod._sweep_dir(rule, library)
+    await ingest_mod._sweep_dir(rule, library)
+    async with db.session() as session:
+        rows = list((await session.execute(select(Job))).scalars())
+    assert len(rows) == 2
+    replacement = next(row for row in rows if row.id != "job_legacy_disc_upgrade")
+    assert "ready_files" not in replacement.input_data
+
+    await jobs.init_job_dispatcher(max_parallel=1)
+    await _wait_job_status(replacement.id, JobStatus.SUCCEEDED)
+    async with db.session() as session:
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+        files = list((await session.execute(select(LibraryFile))).scalars())
+    assert record.status == IngestStatus.IMPORTED
+    assert len(files) == 1 and files[0].container == "bluray"
+    assert Path(files[0].file_path).is_dir()
 
 
 @pytest.mark.asyncio
@@ -968,9 +1041,7 @@ async def test_completed_files_are_ingested_while_same_torrent_keeps_downloading
     await ingest_mod._sweep_dir(
         _fixed_rule(watch, library_id=library_id), library, execute_inline=True
     )
-    assert (season / "分批剧集 (2026) - S01E02.mkv").read_bytes() == (
-        b"episode-2-partial"
-    )
+    assert (season / "分批剧集 (2026) - S01E02.mkv").read_bytes() == (b"episode-2-partial")
     assert str(entry) in ingest_mod._deferred
     async with db.session() as session:
         record = (await session.execute(select(IngestEntry))).scalar_one()
@@ -1153,11 +1224,9 @@ async def test_completed_torrent_creates_file_scoped_job_while_sibling_downloads
     ]
     assert job.input_data["consume_info_hashes"] == ["completed-hash"]
     assert job.input_data["keep_deferred"] is True
-    assert {
-        row.resource_id
-        for row in resources[job.id]
-        if row.resource_type == "download"
-    } == {"completed-hash"}
+    assert {row.resource_id for row in resources[job.id] if row.resource_type == "download"} == {
+        "completed-hash"
+    }
 
     await jobs.init_job_dispatcher(max_parallel=1)
     await _wait_job_status(job.id, JobStatus.SUCCEEDED)
@@ -1186,6 +1255,9 @@ async def test_downloading_disc_never_imports_completed_stream_segments(
     watch.mkdir()
     library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
     await _make_rule(db, library_id=library_id, source=watch)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="原盘电影", year=2001)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
     entry = watch / "Movie.Collection.2001-2023.UHD.BluRay"
     stream = entry.joinpath(*relative_path.split("/"))
     stream.parent.mkdir(parents=True)
@@ -1238,7 +1310,7 @@ async def test_downloading_disc_never_imports_completed_stream_segments(
         assert list((await session.execute(select(LibraryFile))).scalars()) == []
     assert str(entry) in ingest_mod._deferred
 
-    # 整种完成：整树识别出原盘，只生成一条可理解的“暂不支持”结论。
+    # 整种完成：完整原盘树一次性硬链接入库，仍不会产生任何分片条目。
     download_complete["value"] = True
     await ingest_mod._sweep_dir(rule, library)
     async with db.session() as session:
@@ -1248,8 +1320,406 @@ async def test_downloading_disc_never_imports_completed_stream_segments(
     async with db.session() as session:
         record = (await session.execute(select(IngestEntry))).scalar_one()
         files = list((await session.execute(select(LibraryFile))).scalars())
-    assert record.status == IngestStatus.SKIPPED
-    assert "原盘目录" in (record.message or "")
+    assert record.status == IngestStatus.IMPORTED
+    assert "完整原盘" in (record.message or "")
+    assert len(files) == 1
+    final = Path(files[0].file_path)
+    assert files[0].container == "bluray"
+    assert (final / "BDMV" / "STREAM" / "00001.m2ts").stat().st_ino == stream.stat().st_ino
+
+
+@pytest.mark.asyncio
+async def test_downloader_outage_fails_closed_without_snapshot_ingest(db, tmp_path, monkeypatch):
+    """配置下载器全部不可达时不再退回静默时间猜测，恢复前零入库。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="未完成电影", year=2026)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+
+    entry = watch / "Incomplete.Movie.2026"
+    entry.mkdir()
+    (entry / "movie.mkv").write_bytes(b"preallocated-partial")
+
+    async def unavailable():
+        return None
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", unavailable)
+    await _sweep_twice(db, library_id, watch)
+    assert not (root / "未完成电影 (2026)").exists()
+    assert str(entry) in ingest_mod._deferred
+    async with db.session() as session:
+        assert list((await session.execute(select(IngestEntry))).scalars()) == []
+
+
+@pytest.mark.asyncio
+async def test_queued_ingest_job_rechecks_downloader_outage_before_snapshot(
+    db, tmp_path, monkeypatch
+):
+    """巡检后、Job 执行前下载器掉线时也必须 fail closed，不能从队列绕过门禁。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    await _make_rule(db, library_id=library_id, source=watch)
+    async with db.session() as session:
+        rule_id = (await session.execute(select(ImportWatch.id))).scalar_one()
+    entry = watch / "Queued.Incomplete.Movie.2026"
+    entry.mkdir()
+    (entry / "movie.mkv").write_bytes(b"preallocated-partial")
+
+    async def unavailable():
+        return None
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", unavailable)
+
+    class Context:
+        async def current_progress(self):
+            return {}
+
+        async def update_progress(self, **_kwargs):
+            return None
+
+    with pytest.raises(jobs.JobRetry, match="下载器当前不可达"):
+        await ingest_mod._execute_ingest_job(
+            Context(),
+            {
+                "rule_id": rule_id,
+                "entry_path": str(entry),
+                "detected_fingerprint": "queued-before-outage",
+            },
+        )
+    assert not (root / "Queued Incomplete Movie (2026)").exists()
+    async with db.session() as session:
+        assert list((await session.execute(select(IngestEntry))).scalars()) == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_queued_torrent_job_waits_when_reachable_api_returns_empty(
+    db, tmp_path, monkeypatch
+):
+    """升级前 Job 只有 infohash 也足以证明受管，空列表不能把它当普通文件放行。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    await _make_rule(db, library_id=library_id, source=watch)
+    async with db.session() as session:
+        rule_id = (await session.execute(select(ImportWatch.id))).scalar_one()
+    entry = watch / "Legacy.Managed.Movie.2026"
+    entry.mkdir()
+    (entry / "movie.mkv").write_bytes(b"preallocated-partial")
+
+    async def empty():
+        return []
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", empty)
+
+    class Context:
+        async def current_progress(self):
+            return {}
+
+        async def update_progress(self, **_kwargs):
+            return None
+
+    with pytest.raises(jobs.JobRetry, match="暂未返回该受管任务"):
+        await ingest_mod._execute_ingest_job(
+            Context(),
+            {
+                "rule_id": rule_id,
+                "entry_path": str(entry),
+                "info_hashes": ["a" * 40],
+                "detected_fingerprint": "queued-before-upgrade",
+            },
+        )
+    assert list(root.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_enabled_unverified_downloader_is_unavailable_not_unconfigured(db):
+    """启用中的 pending/failed 配置仍是权威状态源，验证窗口不能启发式放行。"""
+    async with db.session() as session:
+        row = DownloaderClient(
+            name="等待验证的下载器",
+            client_type=ClientType.QBITTORRENT,
+            url="http://127.0.0.1:65535",
+            enabled=True,
+            status=ConfigStatus.PENDING,
+        )
+        session.add(row)
+        await session.commit()
+
+    ingest_mod._briefs_cache = (float("-inf"), None)
+    assert await ingest_mod._downloader_briefs() is None
+
+    async with db.session() as session:
+        row = (await session.execute(select(DownloaderClient))).scalar_one()
+        row.enabled = False
+        await session.commit()
+    ingest_mod._briefs_cache = (float("-inf"), None)
+    assert await ingest_mod._downloader_briefs() == []
+
+
+@pytest.mark.asyncio
+async def test_one_unreachable_downloader_makes_combined_brief_incomplete(
+    db, monkeypatch
+):
+    """多下载器只成功一台时不能把部分列表当完整事实，未命中条目继续等待。"""
+    async with db.session() as session:
+        session.add_all(
+            [
+                DownloaderClient(
+                    name="可达下载器",
+                    client_type=ClientType.QBITTORRENT,
+                    url="http://reachable.invalid",
+                    enabled=True,
+                    status=ConfigStatus.ACTIVE,
+                ),
+                DownloaderClient(
+                    name="失联下载器",
+                    client_type=ClientType.QBITTORRENT,
+                    url="http://offline.invalid",
+                    enabled=True,
+                    status=ConfigStatus.ACTIVE,
+                ),
+            ]
+        )
+        await session.commit()
+
+    class Adapter:
+        def __init__(self, url: str):
+            self.url = url
+
+        async def list_torrents(self):
+            if "offline" in self.url:
+                raise OSError("offline")
+            return []
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "movieclaw_downloader.create_downloader",
+        lambda config: Adapter(config.url),
+    )
+    ingest_mod._briefs_cache = (float("-inf"), None)
+    assert await ingest_mod._downloader_briefs() is None
+
+
+@pytest.mark.asyncio
+async def test_persisted_download_name_blocks_transient_empty_torrent_list(
+    db, tmp_path, monkeypatch
+):
+    """API 可达却暂时返回空列表时，真实投递名锚仍阻止受管任务被误放行。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="受管电影", year=2026)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+    entry = watch / "Managed.Movie.2026"
+    entry.mkdir()
+    (entry / "movie.mkv").write_bytes(b"preallocated-partial")
+    async with db.session() as session:
+        session.add(
+            ManualDownloadIntent(
+                info_hash="a" * 40,
+                media_item_id=item.id,
+                library_id=library_id,
+                download_name=entry.name,
+                save_path=str(watch),
+            )
+        )
+        await session.commit()
+
+    async def empty():
+        return []
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", empty)
+    await _sweep_twice(db, library_id, watch)
+    assert not (root / "受管电影 (2026)").exists()
+    assert str(entry) in ingest_mod._deferred
+
+
+@pytest.mark.asyncio
+async def test_stale_manual_download_name_no_longer_blocks_ingest(db, tmp_path):
+    """任务被删除且 90 天未入库的孤儿锚不能让同名目录永久等待。"""
+    root = tmp_path / "movies"
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="旧任务", year=2026)
+    entry = tmp_path / "watch" / "Stale.Managed.Movie.2026"
+    async with db.session() as session:
+        intent = ManualDownloadIntent(
+            info_hash="f" * 40,
+            media_item_id=item.id,
+            library_id=library_id,
+            download_name=entry.name,
+            save_path=str(entry.parent),
+        )
+        intent.created_at = utcnow() - MANUAL_DOWNLOAD_INTENT_TTL - timedelta(days=1)
+        session.add(intent)
+        await session.commit()
+        assert await ingest_mod._has_managed_download_claim(session, entry) is False
+
+
+def test_legacy_site_title_matches_real_downloader_name_without_crossing_movie_year():
+    """旧台账没有真实下载名时，站点标题允许发布属性差异，但不同年份不串。"""
+    actual = "Mission.Impossible.1996.2160p.BluRay.DoVi.x265.10bit.TrueHD5.1-WiKi"
+    site = "Mission: Impossible 1996 2160p BluRay DoVi x265 10bit 3Audios TrueHD 5.1-WiKi"
+    assert ingest_mod._download_name_matches(actual, site)
+    assert not ingest_mod._download_name_matches(actual, site.replace("1996", "2018"))
+
+
+def test_disc_tree_copy_is_atomic_and_idempotent(tmp_path):
+    """跨盘策略保留完整目录树；再次执行识别为同内容，不复制第二份。"""
+    source = tmp_path / "source" / "Movie"
+    stream = source / "BDMV" / "STREAM" / "00001.m2ts"
+    playlist = source / "BDMV" / "PLAYLIST" / "00001.mpls"
+    stream.parent.mkdir(parents=True)
+    playlist.parent.mkdir(parents=True)
+    (source / "BDMV" / "AUXDATA").mkdir()
+    (source / "BDMV" / "AUXDATA" / "empty.bin").touch()
+    stream.write_bytes(b"main-feature")
+    playlist.write_bytes(b"playlist")
+    base = tmp_path / "library" / "电影 (2026)"
+
+    final, created = ingest_mod._transfer_disc_tree(source, base, "copy", "2160p")
+    assert created is True and final == base
+    assert (final / "BDMV" / "STREAM" / "00001.m2ts").read_bytes() == b"main-feature"
+    assert (final / "BDMV" / "PLAYLIST" / "00001.mpls").read_bytes() == b"playlist"
+    assert (final / "BDMV" / "STREAM" / "00001.m2ts").stat().st_ino != stream.stat().st_ino
+    again, created_again = ingest_mod._transfer_disc_tree(source, base, "copy", "2160p")
+    assert again == final and created_again is False
+
+
+def test_disc_tree_same_sizes_with_different_mtime_is_not_deduplicated(tmp_path):
+    """路径和尺寸碰巧相同的另一张盘不能被静默当成已入库内容。"""
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first_stream = first / "BDMV" / "STREAM" / "00001.m2ts"
+    second_stream = second / "BDMV" / "STREAM" / "00001.m2ts"
+    first_stream.parent.mkdir(parents=True)
+    second_stream.parent.mkdir(parents=True)
+    first_stream.write_bytes(b"first-disc")
+    second_stream.write_bytes(b"other-disc")
+    os.utime(first_stream, ns=(1_000_000_000, 1_000_000_000))
+    os.utime(second_stream, ns=(2_000_000_000, 2_000_000_000))
+    base = tmp_path / "library" / "电影 (2026)"
+
+    final, created = ingest_mod._transfer_disc_tree(first, base, "copy", "2160p")
+    assert created is True and final == base
+    alternate, already_present = ingest_mod._disc_destination(second, base, "2160p")
+    assert already_present is False
+    assert alternate != base
+
+
+@pytest.mark.asyncio
+async def test_disc_tree_job_copy_resumes_and_publishes_atomically(tmp_path, monkeypatch):
+    """原盘复制被服务更新打断后保留确认字节，重跑续传并只发布完整目录。"""
+    source = tmp_path / "source" / "Movie"
+    stream = source / "BDMV" / "STREAM" / "00001.m2ts"
+    playlist = source / "BDMV" / "PLAYLIST" / "00001.mpls"
+    stream.parent.mkdir(parents=True)
+    playlist.parent.mkdir(parents=True)
+    (source / "BDMV" / "AUXDATA").mkdir()
+    (source / "BDMV" / "AUXDATA" / "empty.bin").touch()
+    stream.write_bytes(bytes(range(32)))
+    playlist.write_bytes(b"playlist")
+    base = tmp_path / "library" / "电影 (2026)"
+    monkeypatch.setattr(ingest_mod, "_INGEST_COPY_CHUNK_BYTES", 8)
+
+    class Context:
+        async def raise_if_cancelled(self):
+            return None
+
+    interrupted = False
+
+    async def interrupt_after_first_chunk(copied: int, total: int):
+        nonlocal interrupted
+        if copied and copied < total and not interrupted:
+            interrupted = True
+            raise jobs.JobCancelled
+
+    with pytest.raises(jobs.JobCancelled):
+        await ingest_mod._transfer_disc_tree_for_job(
+            source,
+            base,
+            "copy",
+            "2160p",
+            Context(),
+            interrupt_after_first_chunk,
+        )
+    stage, state_path = ingest_mod._disc_ingest_paths(base)
+    assert stage.is_dir() and state_path.is_file()
+    assert not base.exists()
+    assert any(path.stat().st_size == 8 for path in stage.rglob("*.part"))
+
+    offsets: list[int] = []
+
+    async def record_progress(copied: int, _total: int):
+        offsets.append(copied)
+
+    final, created = await ingest_mod._transfer_disc_tree_for_job(
+        source,
+        base,
+        "copy",
+        "2160p",
+        Context(),
+        record_progress,
+    )
+    assert created is True and final == base
+    assert offsets[:2] == [0, 8], "重跑从零复制，没有复用上次确认的字节"
+    assert stream.read_bytes() == (final / "BDMV" / "STREAM" / "00001.m2ts").read_bytes()
+    assert playlist.read_bytes() == (final / "BDMV" / "PLAYLIST" / "00001.mpls").read_bytes()
+    assert (final / "BDMV" / "AUXDATA").is_dir()
+    assert (final / "BDMV" / "AUXDATA" / "empty.bin").stat().st_size == 0
+    assert not stage.exists() and not state_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_multi_disc_collection_stays_pending_without_partial_import(
+    db, tmp_path, monkeypatch
+):
+    """合集含多个 BDMV 时不能猜电影边界，完整保留源并只生成一条待处理结论。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    entry = watch / "Movie.Collection"
+    for number in (1, 2):
+        stream = entry / f"Movie {number}" / "BDMV" / "STREAM" / "00001.m2ts"
+        stream.parent.mkdir(parents=True)
+        stream.write_bytes(f"disc-{number}".encode())
+
+    await _sweep_twice(db, library_id, watch)
+    async with db.session() as session:
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+        files = list((await session.execute(select(LibraryFile))).scalars())
+    assert record.status == IngestStatus.PENDING
+    assert "包含 2 个原盘" in (record.message or "")
+    assert files == []
+    assert all(path.exists() for path in entry.rglob("*.m2ts"))
+
+
+@pytest.mark.asyncio
+async def test_direct_bdmv_entry_never_treats_whole_watch_root_as_disc(db, tmp_path):
+    """BDMV 直接位于监听根时只能待人工，绝不能把兄弟下载一起搬进媒体库。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    stream = watch / "BDMV" / "STREAM" / "00001.m2ts"
+    stream.parent.mkdir(parents=True)
+    stream.write_bytes(b"disc")
+    sibling = watch / "Other.Download" / "keep.txt"
+    sibling.parent.mkdir()
+    sibling.write_text("must-stay", encoding="utf-8")
+
+    await _sweep_twice(db, library_id, watch)
+    async with db.session() as session:
+        records = list((await session.execute(select(IngestEntry))).scalars())
+        files = list((await session.execute(select(LibraryFile))).scalars())
+    bdmv = next(record for record in records if Path(record.entry_path).name == "BDMV")
+    assert bdmv.status == IngestStatus.PENDING
+    assert "不能直接作为监听目录的顶层条目" in (bdmv.message or "")
+    assert sibling.read_text(encoding="utf-8") == "must-stay"
     assert files == []
 
 
@@ -1382,9 +1852,7 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
     # ep1 解析不出集号 → 第一批挂起；ep2 正常
     _stub_unit(
         monkeypatch,
-        lambda file: (1, 0)
-        if file.stem == "ep1"
-        else (1, int(file.stem.removeprefix("ep"))),
+        lambda file: (1, 0) if file.stem == "ep1" else (1, int(file.stem.removeprefix("ep"))),
     )
 
     entry = watch / "Collateral.Show.S01"
@@ -1713,9 +2181,7 @@ async def test_name_conflict_with_same_tier_version_skips_as_imported(db, tmp_pa
     await _sweep_twice(db, library_id, watch)
 
     async with db.session() as session:
-        record = (
-            await session.execute(select(IngestEntry))
-        ).scalar_one()
+        record = (await session.execute(select(IngestEntry))).scalar_one()
     assert record.status == IngestStatus.IMPORTED
     assert "已有同档或更高版本" in (record.message or "")
     # 来件没有落任何新文件
@@ -1828,9 +2294,7 @@ async def test_subscription_extra_same_tier_file_not_imported_as_new_version(
     async with db.session() as session:
         record = (await session.execute(select(IngestEntry))).scalar_one()
         imported_row = (
-            await session.execute(
-                select(LibraryFile).where(LibraryFile.episode_number == 2)
-            )
+            await session.execute(select(LibraryFile).where(LibraryFile.episode_number == 2))
         ).scalar_one()
     assert record.status == IngestStatus.IMPORTED
     assert "1 个文件在库中已有同档或更高版本，跳过" in (record.message or "")
@@ -2566,9 +3030,7 @@ async def test_model_upgrade_wakes_blocked_parser_gap_job(db, tmp_path, monkeypa
 
     await ingest_mod._sweep_dir(rule, library)
     completed = await _wait_job_status(job.id, JobStatus.SUCCEEDED)
-    assert (
-        completed.handler_revision == f"{ingest_mod._INGEST_HANDLER_REVISION}+torrent-ner-v9"
-    )
+    assert completed.handler_revision == f"{ingest_mod._INGEST_HANDLER_REVISION}+torrent-ner-v9"
 
     async with db.session() as session:
         all_jobs = list((await session.execute(select(Job))).scalars())


### PR DESCRIPTION
## 问题

这次修复的是两条会在监听入库中交叉放大的链路：

1. 蓝光原盘的 `BDMV/STREAM/*.m2ts` 是播放列表片段，不是多份独立电影。旧逻辑虽然已禁止下载中按片段建立入库批次，但整种完成后仍不会按完整原盘自动入库，历史分段 Job/台账也可能继续留在“待处理”。
2. qBittorrent/Transmission 暂时不可达、尚未完成连接验证，或多下载器只返回部分结果时，监听巡检和已经排队的 Job 仍可能退回“目录静默 + ffprobe”猜测完成；对预分配文件和可探测的残缺片段，这会造成提前入库。

升级前的历史残留示例：

![旧版把合集与原盘片段留在待处理清单](https://raw.githubusercontent.com/o1xhack/movieclaw/pr-assets/docs/pr-assets/disc-ingest-legacy-pending.jpg)

## 修改

- 解析 MPLS 主播放列表，按播放时长选择主片候选；用播放列表引用的流做探测，并用 MPLS 总时长覆盖单片段时长。
- 电影单盘在整种完成后完整保留 `BDMV` / `VIDEO_TS` 目录树，一次性原子发布并只写一条 `LibraryFile`；不 remux、不拼接、不修改保种源。
- 硬链接保持零额外空间；跨盘复制按 64 MiB 分块续传，容器更新/取消后可从已确认字节继续，完成前目录对媒体库不可见。
- 对多盘合集、剧集原盘、原盘与普通视频混装，以及 `BDMV/VIDEO_TS` 直接暴露在监听根的危险布局保持待人工处理，绝不猜电影边界或越过下载条目。
- 启动时收口旧版原盘分段 Job 和 pending 台账，并允许升级对账取消的旧 Job 自动替换成完整原盘 Job。
- 下载器状态改为 fail closed：任一启用中的下载器不可用，巡检和 Job 执行阶段都等待恢复；多下载器只成功一部分也不把部分列表当成完整事实。
- 手动下载和订阅投递持久化真实下载器、任务名与 MovieClaw 视角落点。下载器短暂返回空列表时仍能识别受管任务；90 天未消费的孤儿手动锚不再永久阻塞同名目录。
- 新增向前兼容数据库迁移 `c8e3f0b56d42`。

## 安全边界

- 源目录只读，硬链接/复制都不删除、不改名保种文件。
- 目标冲突不覆盖；完整树只有全部文件准备完毕后才原子发布。
- 路径和尺寸相同但 mtime 不同的另一张盘不视为重复，避免静默吞掉不同盘面。
- 大小写形式的 `.MPLS/.M2TS` 均支持。

## 本地 Code Review

正式 push 前已基于最新 `main` 审查完整 diff。审查不是只覆盖当前个例，而是检查下载器状态、历史任务迁移、重启恢复、NAS 大文件复制、重复判断和危险目录边界。本轮共发现并修复 15 个具体边界问题，归为以下五类：

- **下载器事实源（4 项）**：排队 Job 执行前再次校验下载器；空列表但存在任务锚点时继续等待；启用但仍在验证/失败的下载器按状态不完整处理；多下载器任一读取失败时禁止拿部分结果放行。
- **下载任务锚点（3 项）**：旧手动任务补齐下载器、任务名和保存路径；空任务名统一归一化；超过 90 天的孤儿锚点不再永久阻塞目录。
- **历史原盘任务迁移（2 项）**：升级对账取消的旧分段 Job 可以生成新的整盘 Job；旧版已跳过的分段记录不会继续短路新任务。
- **NAS 安全复制与幂等（4 项）**：稳定暂存目录、64 MiB 断点续传和原子发布；使用路径、大小、mtime/同 inode 判断同一来源；保留空目录与零字节文件；最终目录存在时清理过期暂存状态。
- **原盘边界与兼容性（2 项）**：监听根直接暴露 `BDMV/VIDEO_TS` 时保持待处理，避免把相邻目录一起复制；兼容大写 `.MPLS/.M2TS`。

审查后的完整 commit 为 `ceac6df3a73efebc86fbdffbd9932164cef29819`，当前没有遗留的本地 review finding。

## 验证

- 相关与相邻回归：223 passed（监听入库、原盘解析、下载提交、订阅投递/换源/路由）。
- `ruff check`：passed（全部变更 Python 文件）。
- `alembic heads`：仅 `c8e3f0b56d42 (head)`。
- `git diff --check`：passed。
- GitHub CI：Python `ruff + pytest`、Web `eslint + typecheck` 均 passed。
- 另执行完整 `pytest -m "not integration"`。剩余 18 项失败可在未修改的 `origin/main` 复现，分别是 CLI 测试仍期望 `subscriptions/library`、而当前命令面已是 `sub/lib`，以及本机已有前端占用 3000 端口导致 entrypoint supervision 测试撞到真实服务；与本 PR 文件无交集。
