### PR TITLE
fix(agent): 模型空响应按失败收尾，不再让通道侧静默丢弃

### DIFF
--- a/src/movieclaw_agent/runner.py
+++ b/src/movieclaw_agent/runner.py
@@ -5,7 +5,8 @@
   继续循环——finish_reason 只作参考，因为兼容端点存在「stop 但带调用」
   「tool_calls 但数组为空」两类在案怪癖（vLLM/Kimi 等）；
 - 有工具调用 → 顺序执行每一个（参数先过 JSON Schema 校验），结果作为
-  tool 消息回喂，进入下一步；无工具调用 → STOP，正常结束；
+  tool 消息回喂，进入下一步；无工具调用且有正文 → STOP，正常结束；
+  无工具调用且正文为空 → 判为空响应，以 agent_error 收尾（详见循环内注释）；
 - 工具的校验失败与执行异常都不中断循环：错误文本作为失败结果回喂，
   让模型自行修正（pi-agent / Claude Code 同款韧性设计）；
 - max_steps（默认 200）防失控；错误一律以 agent_error 事件收尾，不抛异常。
@@ -173,6 +174,28 @@ class AgentRunner:
             # 循环判据：以 tool_calls 内容为准（finish_reason 只作参考）——
             # 覆盖「stop 但带调用」与「tool_calls 但数组为空」两类兼容怪癖
             if not final.tool_calls:
+                # 既没有工具调用、正文也是空的：这不是「答完了」，而是模型或中转
+                # 端点返回了空响应（实测成因之一：中转把缺了父调用的历史喂给模型，
+                # 模型回一个 0 token 的 STOP）。当成正常结束的话通道侧无话可发，
+                # 微信/Telegram 上就表现为对话毫无征兆地静默中断，日志里只留一行
+                # 「运行已结束」，排查时极难定位。这里明确按失败收尾。
+                # 注意要在 _notify 之前返回：空的 assistant 消息不该写进会话历史，
+                # 否则下一轮续聊会把这段空白也带上。
+                if not (final.content or "").strip():
+                    logger.warning(
+                        "Agent 收到空响应 run=%s step=%d finish_reason=%s",
+                        run_id,
+                        step,
+                        final.finish_reason,
+                    )
+                    yield AgentEvent(
+                        type="agent_error",
+                        run_id=run_id,
+                        error="模型返回了空响应（既没有正文，也没有工具调用），本次运行没有结果。"
+                        "通常是模型服务或中转端点异常，请重试；若反复出现，请检查模型供应商配置。",
+                    )
+                    return
+
                 await self._notify(final.to_message(), final)
                 yield AgentEvent(
                     type="agent_done",

--- a/tests/agent/unit/test_runner.py
+++ b/tests/agent/unit/test_runner.py
@@ -34,7 +34,9 @@ SEARCH_TOOL_DEF = ToolDefinition(
 _probe: dict = {}
 
 
-def make_runner(protocol_cls, monkeypatch, *, handler=None, max_steps=200) -> AgentRunner:
+def make_runner(
+    protocol_cls, monkeypatch, *, handler=None, max_steps=200, on_message=None
+) -> AgentRunner:
     monkeypatch.setitem(PROTOCOLS, "openai_chat", protocol_cls)
     _probe.clear()
     _probe["requests"] = []
@@ -55,7 +57,7 @@ def make_runner(protocol_cls, monkeypatch, *, handler=None, max_steps=200) -> Ag
         ]
     )
     tools = [AgentTool(definition=SEARCH_TOOL_DEF, handler=handler or default_handler)]
-    return AgentRunner(router, tools=tools, max_steps=max_steps)
+    return AgentRunner(router, tools=tools, max_steps=max_steps, on_message=on_message)
 
 
 class ToolLoopProtocol(BaseLlmProtocol):
@@ -65,6 +67,8 @@ class ToolLoopProtocol(BaseLlmProtocol):
     first_finish = "tool_calls"
     #: 首步的工具调用（子类覆盖以模拟坏参数/未知工具）
     first_calls = [ToolCall(id="c1", name="search", arguments={"q": "沙丘"})]
+    #: 首步的正文（子类覆盖；无工具调用时决定是「有话说」还是空响应）
+    first_content = ""
 
     async def chat(self, request, model_id):  # pragma: no cover
         raise NotImplementedError
@@ -95,6 +99,7 @@ class ToolLoopProtocol(BaseLlmProtocol):
             yield ChatStreamEvent(
                 type="done",
                 partial=ChatResponse(
+                    content=self.first_content or None,
                     tool_calls=self.first_calls or None,
                     finish_reason=self.first_finish,
                     usage=TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
@@ -183,11 +188,36 @@ async def test_tool_calls_finish_reason_with_empty_calls_ends(monkeypatch):
 
     class EmptyCallsProtocol(ToolLoopProtocol):
         first_calls = []
+        first_content = "不用查了，直接回答你"
 
     runner = make_runner(EmptyCallsProtocol, monkeypatch)
     events = await collect(runner, AgentStartParams(input="x"))
     assert events[-1].type == "agent_done"
     assert events[-1].result.steps == 1
+
+
+async def test_empty_response_ends_with_agent_error(monkeypatch):
+    """空响应（无工具调用且正文为空）→ agent_error，不能伪装成正常完成。
+
+    伪装成 agent_done 的话，通道侧拿到空文本会静默丢弃，用户看到的是对话
+    毫无征兆地中断。
+    """
+    recorded: list = []
+
+    async def record(message, response):
+        recorded.append(message)
+
+    class EmptyResponseProtocol(ToolLoopProtocol):
+        first_calls = []
+        first_content = ""
+
+    runner = make_runner(EmptyResponseProtocol, monkeypatch, on_message=record)
+    events = await collect(runner, AgentStartParams(input="x"))
+
+    assert events[-1].type == "agent_error"
+    assert "空响应" in events[-1].error
+    # 空的 assistant 消息不能写进会话历史，否则续聊会把空白带上
+    assert not [m for m in recorded if m.role == "assistant"]
 
 
 async def test_invalid_tool_args_fed_back_as_error(monkeypatch):


### PR DESCRIPTION
## 问题

模型返回空响应（没有 `tool_calls`，`content` 也是空的）时，`AgentRunner` 把它当成正常完成：

```python
# src/movieclaw_agent/runner.py
if not final.tool_calls:
    await self._notify(final.to_message(), final)
    yield AgentEvent(type="agent_done", ..., result=AgentDone(text=final.content, ...))
```

`agent_done` 带着空 `text` 走到通道侧，`StepReplyPusher._flush()` 对空串不发消息，`dispatcher.split_message()` 对空串返回 `[]` —— **一条消息都不会发出去**。

用户视角：微信里对话跑到一半，毫无征兆地没了下文。日志视角：只有一行看起来一切正常的收尾。

```
| INFO | movieclaw_llm.router | LLM 调用完成 provider=... tokens=3558/0 结束原因=stop
| INFO | movieclaw_api.agent_runs | Agent 后台运行已结束 run=db44797796f5 status=agent_done
```

`tokens=3558/0` 是唯一的线索 —— 0 个 completion token。

## 触发场景

我这边的直接成因在上游中转（OpenAI 兼容端点把一段缺了父调用的历史喂给模型，模型返回 0 token 的 STOP），已单独修复。但**任何**返回空响应的原因都会走到同一条静默路径：中转 bug、安全拦截、限流降级、供应商抖动。一天 369 次调用里命中 8 次，3 个会话就这么断在半路。

会话转录里的样子（最后一条 assistant 是空的，然后就没有然后了）：

```json
{"role":"assistant","content":""}   usage: {"prompt_tokens":3558,"completion_tokens":0}
```

Agent loop 对其它兼容怪癖（「stop 但带调用」「tool_calls 但数组为空」）都有明确判据，唯独空响应没有 —— 而它恰恰是唯一一个会让用户完全收不到反馈的。

## 改动

`runner.py` 里 `not final.tool_calls` 分支加一个前置判断：正文为空 → 按 `agent_error` 收尾。

- **要在 `_notify` 之前 return**：空的 assistant 消息不该写进会话历史，否则续聊会把这段空白也带上。
- `agent_error` 是既有终态，通道侧 `StepReplyPusher` 已经会渲染成 `⚠️ 处理失败:...`，Web 侧同理。所以只动了这一处，没有碰 pusher / dispatcher。
- 日志补一条 `warning`，带上 `step` 和 `finish_reason`，以后这个场景能直接搜到。

没有加重试。真实成因里历史已经被污染，重试只会再失败一次并多烧一轮 token；把失败如实告诉用户，让用户决定重发或 `/reset`，比静默或空转都更可控。

## 测试

`tests/agent/unit/test_runner.py`：

- 新增 `test_empty_response_ends_with_agent_error` —— 断言收尾是 `agent_error`、错误文案可读、且空 assistant 消息没有进 `on_message`。
- 给 `make_runner` 加了 `on_message` 透传参数（新用例需要观察写进历史的消息）。
- **调整了既有用例 `test_tool_calls_finish_reason_with_empty_calls_ends`**：它模拟的是兼容怪癖②（`finish_reason=tool_calls` 但数组为空），此前恰好没设正文，因此会命中新的空响应判据。给它补了一句正文，用例的原意（不空转、1 步安全终止）保持不变。共享的 `ToolLoopProtocol` 相应加了可覆盖的 `first_content`。

顺带说明一下这个边界：怪癖②叠加空正文，现在归类为空响应而非正常完成。我认为这是对的 —— 模型既没给调用也没给正文，对用户来说同样是零输出。如果你希望这两种情况区别对待，我可以再拆。
