### PR TITLE
fix(agent): 空响应先重试一次，失败文案改成用户看得懂的话

### DIFF
--- a/src/movieclaw_agent/runner.py
+++ b/src/movieclaw_agent/runner.py
@@ -6,7 +6,8 @@
   「tool_calls 但数组为空」两类在案怪癖（vLLM/Kimi 等）；
 - 有工具调用 → 顺序执行每一个（参数先过 JSON Schema 校验），结果作为
   tool 消息回喂，进入下一步；无工具调用且有正文 → STOP，正常结束；
-  无工具调用且正文为空 → 判为空响应，以 agent_error 收尾（详见循环内注释）；
+  无工具调用且正文为空 → 判为空响应，原样重试一次，仍空则以 agent_error
+  收尾（详见循环内注释）；
 - 工具的校验失败与执行异常都不中断循环：错误文本作为失败结果回喂，
   让模型自行修正（pi-agent / Claude Code 同款韧性设计）；
 - max_steps（默认 200）防失控；错误一律以 agent_error 事件收尾，不抛异常。
@@ -49,6 +50,10 @@ logger = logging.getLogger(__name__)
 
 #: tool_result 事件里输出的截断长度（完整输出仍进对话上下文喂给模型）
 _EVENT_OUTPUT_LIMIT = 2000
+
+#: 空响应的原样重试次数。模型偶发返回 0 token 的 STOP（供应商抖动、限流降级、
+#: 安全过滤等），多为瞬时故障，原样重发一次通常就能拿到正常回复。
+_MAX_EMPTY_RETRIES = 1
 
 
 class AgentRunner:
@@ -123,6 +128,8 @@ class AgentRunner:
             yield compact_event
 
         usage = TokenUsage()
+        #: 连续空响应次数，收到有效响应即清零
+        empty_retries = 0
         for step in range(1, self._max_steps + 1):
             request = ChatRequest(
                 model=params.model,
@@ -171,31 +178,43 @@ class AgentRunner:
 
             usage = _add_usage(usage, final.usage)
 
-            # 循环判据：以 tool_calls 内容为准（finish_reason 只作参考）——
-            # 覆盖「stop 但带调用」与「tool_calls 但数组为空」两类兼容怪癖
-            if not final.tool_calls:
-                # 既没有工具调用、正文也是空的：这不是「答完了」，而是模型或中转
-                # 端点返回了空响应（实测成因之一：中转把缺了父调用的历史喂给模型，
-                # 模型回一个 0 token 的 STOP）。当成正常结束的话通道侧无话可发，
-                # 微信/Telegram 上就表现为对话毫无征兆地静默中断，日志里只留一行
-                # 「运行已结束」，排查时极难定位。这里明确按失败收尾。
-                # 注意要在 _notify 之前返回：空的 assistant 消息不该写进会话历史，
-                # 否则下一轮续聊会把这段空白也带上。
-                if not (final.content or "").strip():
+            # 空响应：既没有工具调用、正文也是空的。这不是「答完了」，而是模型
+            # 或中转端点这一轮什么都没返回（0 token 的 STOP）。当成正常结束的话
+            # 通道侧无话可发，微信/Telegram 上表现为对话毫无征兆地静默中断，
+            # 日志里只留一行「运行已结束」，排查时极难定位。
+            # 成因多为瞬时故障（供应商抖动、限流降级、安全过滤），所以先原样重发
+            # 一次——messages 没动过，continue 即重试；连续空才判定失败。
+            # 注意要在 _notify 之前处理：空的 assistant 消息不该写进会话历史，
+            # 否则下一轮续聊会把这段空白也带上。
+            if not final.tool_calls and not (final.content or "").strip():
+                if empty_retries < _MAX_EMPTY_RETRIES:
+                    empty_retries += 1
                     logger.warning(
-                        "Agent 收到空响应 run=%s step=%d finish_reason=%s",
+                        "Agent 收到空响应，原样重试第 %d 次 run=%s step=%d finish_reason=%s",
+                        empty_retries,
                         run_id,
                         step,
                         final.finish_reason,
                     )
-                    yield AgentEvent(
-                        type="agent_error",
-                        run_id=run_id,
-                        error="模型返回了空响应（既没有正文，也没有工具调用），本次运行没有结果。"
-                        "通常是模型服务或中转端点异常，请重试；若反复出现，请检查模型供应商配置。",
-                    )
-                    return
+                    continue
+                logger.warning(
+                    "Agent 连续空响应，判定失败 run=%s step=%d finish_reason=%s",
+                    run_id,
+                    step,
+                    final.finish_reason,
+                )
+                yield AgentEvent(
+                    type="agent_error",
+                    run_id=run_id,
+                    error="我连续两次都没能生成回复，可能是临时故障。请稍后再发一遍试试。",
+                )
+                return
+            # 拿到了有效响应，重置重试计数
+            empty_retries = 0
 
+            # 循环判据：以 tool_calls 内容为准（finish_reason 只作参考）——
+            # 覆盖「stop 但带调用」与「tool_calls 但数组为空」两类兼容怪癖
+            if not final.tool_calls:
                 await self._notify(final.to_message(), final)
                 yield AgentEvent(
                     type="agent_done",

--- a/tests/agent/unit/test_runner.py
+++ b/tests/agent/unit/test_runner.py
@@ -196,8 +196,8 @@ async def test_tool_calls_finish_reason_with_empty_calls_ends(monkeypatch):
     assert events[-1].result.steps == 1
 
 
-async def test_empty_response_ends_with_agent_error(monkeypatch):
-    """空响应（无工具调用且正文为空）→ agent_error，不能伪装成正常完成。
+async def test_empty_response_retries_then_ends_with_agent_error(monkeypatch):
+    """连续空响应（无工具调用且正文为空）→ 重试一次后 agent_error。
 
     伪装成 agent_done 的话，通道侧拿到空文本会静默丢弃，用户看到的是对话
     毫无征兆地中断。
@@ -215,9 +215,49 @@ async def test_empty_response_ends_with_agent_error(monkeypatch):
     events = await collect(runner, AgentStartParams(input="x"))
 
     assert events[-1].type == "agent_error"
-    assert "空响应" in events[-1].error
+    # 面向终端用户的文案：不出现「工具调用」「中转端点」这类开发者术语
+    assert events[-1].error == "我连续两次都没能生成回复，可能是临时故障。请稍后再发一遍试试。"
+    # 判定失败前原样重发过一次：共两次模型调用
+    assert len(_probe["requests"]) == 2
+    # 重试用的是同一份上下文，没有被空响应污染
+    assert [m.role for m in _probe["requests"][1].messages] == ["system", "user"]
     # 空的 assistant 消息不能写进会话历史，否则续聊会把空白带上
     assert not [m for m in recorded if m.role == "assistant"]
+
+
+async def test_empty_response_recovers_on_retry(monkeypatch):
+    """空响应多为瞬时故障：重试拿到正常回复就照常收尾，用户无感。"""
+
+    class FlakyProtocol(ToolLoopProtocol):
+        """首次调用空回，重试给出正文。"""
+
+        first_calls = []
+
+        async def chat_stream(self, request, model_id):
+            _probe["requests"].append(request)
+            snap = ChatResponse(model=model_id, provider=self.config.name)
+            yield ChatStreamEvent(type="start", partial=snap)
+            first_call = len(_probe["requests"]) == 1
+            content = "" if first_call else "重试之后的答复"
+            if content:
+                yield ChatStreamEvent(type="text_delta", delta=content, partial=snap)
+            yield ChatStreamEvent(
+                type="done",
+                partial=ChatResponse(
+                    content=content or None,
+                    finish_reason="stop",
+                    usage=TokenUsage(prompt_tokens=10, completion_tokens=0 if first_call else 6),
+                    model=model_id,
+                    provider=self.config.name,
+                ),
+            )
+
+    runner = make_runner(FlakyProtocol, monkeypatch)
+    events = await collect(runner, AgentStartParams(input="x"))
+
+    assert events[-1].type == "agent_done"
+    assert events[-1].result.text == "重试之后的答复"
+    assert len(_probe["requests"]) == 2
 
 
 async def test_invalid_tool_args_fed_back_as_error(monkeypatch):


### PR DESCRIPTION
接 #233 的后续。#233 把空响应从「静默丢弃」改成了 `agent_error`，止住了最坏的情况；这个 PR 处理它留下的两个问题。

## 1. 空响应大多是瞬时故障，直接判失败太早

提 #233 时我的判断是「重试没用」——因为当时手上的成因是确定性的（中转把缺了父调用的历史喂给模型，重发一次照样空）。那个根因已经在中转侧修掉了。

剩下的成因就不一样了：供应商抖动、限流降级、安全过滤误伤，**基本都是瞬时的**。同一份上下文原样重发一次，大概率就能拿到正常回复。现在的行为是本来重试就能答上来的场景，直接甩给用户一句失败。

改成：空响应先原样重试一次（`messages` 没动过，`continue` 即重试），连续两次才判定失败。重试也占一个 step，`max_steps` 的语义（每步 = 一次模型调用）不变。

## 2. 面向终端用户的文案里塞了开发者术语

原文案：

> ⚠️ 处理失败:模型返回了空响应（既没有正文，也没有工具调用），本次运行没有结果。通常是模型服务或中转端点异常，请重试；若反复出现，请检查模型供应商配置。

这条会原样发到微信/Telegram 上。「没有正文」「工具调用」「中转端点」「模型供应商配置」对家里人没有意义，最后那句建议他们也执行不了。

改成：

> ⚠️ 处理失败:我连续两次都没能生成回复，可能是临时故障。请稍后再发一遍试试。

技术细节全部下沉到日志（`finish_reason`、`step`、第几次重试都在），符合 AGENTS.md 里「日志用中文输出明确错误信息」的约定——需要细节的人去看日志，用户只需要知道该怎么办。

## 改动

`runner.py` 里把空响应判据从 `not final.tool_calls` 分支内部提到外面（既无调用也无正文才算空），加 `_MAX_EMPTY_RETRIES = 1` 与 `empty_retries` 计数器，收到有效响应清零。仍然在 `_notify` 之前处理——空的 assistant 消息不该写进会话历史。

## 测试

- `test_empty_response_retries_then_ends_with_agent_error`（由 #233 的用例改造）：断言判定失败前确实重发过一次、重试用的是同一份未被污染的上下文、空 assistant 消息没进历史，并把文案锁进断言防回归。
- `test_empty_response_recovers_on_retry`（新增）：首次空回、重试给出正文 → 正常 `agent_done`，用户无感。

`tests/agent` + `tests/channel` 全绿。
