### PR TITLE
perf(jellyfin): 播放器首屏扫描提速约六成，响应逐字节不变

### DIFF
--- a/scripts/perf/bench_jellyfin_scan.py
+++ b/scripts/perf/bench_jellyfin_scan.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Jellyfin 兼容层「播放器首屏扫描」压测脚本（mock 数据 + 前后对照）。
+
+背景
+----
+Infuse 之类的播放器每次启动都会对媒体库做一次密集扫描：几十次 Latest、
+几十次库分页、上百次 Shows/{id}/Seasons，全部在几十秒内打完。这个脚本
+把那一次扫描原样搬进进程内，用来量化服务端改动的实际收益。
+
+三件事一起做，缺一不可：
+
+1. **mock 数据**：按真实部署的形状生成（10 个库 / 855 个条目 / 6837 个
+   台账行 / 9353 集元数据 / 556 季 / 92 条播放状态），固定随机种子，
+   任何两次生成完全一致——不然前后对照没有意义。
+2. **请求脚本**：请求条数与端点配比抄自真实 Infuse 启动时的访问日志
+   （Latest 50 次、/Items 79 次、Seasons 107 次但只涉及 6 部剧、
+   条目详情 49 次），跑完整 HTTP 栈（TestClient → ASGI → 路由 → DB）。
+3. **响应快照**：每个请求的状态码与响应体都落进 --dump 的 JSON，
+   优化后用 --compare 逐字节比对。**性能优化不允许改变输入输出**，
+   这个比对就是那条红线的自动化守卫。
+
+用法::
+
+    # 基线：跑一遍并落快照
+    python scripts/perf/bench_jellyfin_scan.py --dump /tmp/jf-before.json
+
+    # 改完代码：再跑一遍，比对响应 + 看耗时差
+    python scripts/perf/bench_jellyfin_scan.py --compare /tmp/jf-before.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import sqlite3
+import statistics
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "src"))
+
+# 固定种子：两次生成的库必须逐字节一致
+SEED = 20260828
+NOW = datetime(2026, 8, 28, 12, 0, 0)
+NOW_S = NOW.isoformat(sep=" ")
+
+ADMIN = {"username": "admin", "password": "s3cret-pass"}
+AUTH_HEADER = (
+    'MediaBrowser Client="Infuse", Device="Apple TV", '
+    'DeviceId="bench-device-1", Version="8.2"'
+)
+
+# —— 真实部署的库形状（2026-08-28 从 NAS 生产库统计）——
+# (名称, 类型, 条目数, 目标台账行数)
+LIBRARY_PLAN = [
+    ("大陆电影", "movie", 100, 100),
+    ("大陆剧", "tv", 88, 3114),
+    ("欧美电影", "movie", 331, 334),
+    ("日韩电影", "movie", 89, 92),
+    ("港台电影", "movie", 72, 80),
+    ("日韩剧", "tv", 44, 645),
+    ("港台剧", "tv", 5, 51),
+    ("欧美剧", "tv", 49, 1155),
+    ("综艺", "tv", 10, 494),
+    ("纪录片", "tv", 38, 770),
+]
+
+# 每部剧的台账行数：生产实测是强偏态（最大 234 行，绝大多数在 10~40 行），
+# 平均分配会把 Seasons/详情这类"整剧水合"接口的成本抹平，测不出真问题
+TV_FILE_DIST = ([234, 176, 161, 149, 110, 96, 88, 80, 74, 70]
+                + [x for x in range(40, 70, 2)] * 2
+                + [x for x in range(12, 40)] * 5
+                + [x for x in range(1, 12)] * 6)
+
+# 每剧季数分布（生产实测：127 部 1 季、44 部 2 季……）
+SEASON_DIST = [1] * 127 + [2] * 44 + [3] * 27 + [4] * 13 + [5] * 6 + [6] * 7 + \
+    [7] * 5 + [8] * 1 + [9] * 3 + [10] * 3 + [11] * 1 + [12] * 1 + [13] * 1
+# 单元多版本分布（5757 个单元 1 个文件、472 个 2 个、22 个 3 个）
+VERSION_DIST = [1] * 5757 + [2] * 472 + [3] * 22
+
+CN_HEAD = ["长安", "三体", "流浪", "无间", "琅琊", "大明", "沙丘", "白夜", "隐秘",
+           "山海", "风起", "赘婿", "觉醒", "漫长", "开端", "狂飙", "繁花", "边水",
+           "唐朝", "雪中", "剑来", "凡人", "斗罗", "遮天", "武动", "天官", "魔道"]
+CN_TAIL = ["十二时辰", "之诗", "地球", "行者", "榜", "王朝", "救赎", "追凶",
+           "的角落", "情", "陇西", "年代", "季", "的季节", "时刻", "人生",
+           "小巷", "迷雾", "诡事", "神话", "仙途", "大陆", "记", "赐福"]
+EN_TITLES = ["Dune", "Oppenheimer", "Interstellar", "Arrival", "Blade Runner",
+             "The Expanse", "Severance", "Fallout", "Andor", "Foundation",
+             "Chernobyl", "Succession", "Silo", "Shogun", "Reacher", "Bosch"]
+
+RESOLUTIONS = ["2160p", "1080p", "1080p", "1080p", "720p"]
+CODECS = ["hevc", "h264", "h264", "av1"]
+HDRS = [None, None, None, "HDR10", "Dolby Vision"]
+GENRES = ["剧情", "动作", "科幻", "悬疑", "犯罪", "喜剧", "爱情", "历史"]
+STATUSES_TV = ["Returning Series", "Ended", "Canceled"]
+
+_AUDIO = json.dumps([
+    {"codec": "eac3", "profile": None, "channels": 6, "channel_layout": "5.1",
+     "language": "zho", "title": "国语", "default": True},
+    {"codec": "aac", "profile": "LC", "channels": 2, "channel_layout": "stereo",
+     "language": "eng", "title": "English", "default": False},
+], ensure_ascii=False)
+_SUBS = json.dumps([
+    {"codec": "subrip", "language": "zho", "title": "简体",
+     "forced": False, "default": True},
+    {"codec": "ass", "language": "zho", "title": "特效", "forced": False,
+     "default": False},
+], ensure_ascii=False)
+_OVERVIEW = "在一个被时代洪流裹挟的年代里，一群普通人各自挣扎、彼此照见，" \
+    "最终在命运的岔路口做出了自己的选择。" * 2
+
+
+# ---------------------------------------------------------------------------
+# mock 数据生成
+# ---------------------------------------------------------------------------
+def seed_dataset(db_path: str) -> dict:
+    """按生产形状灌入 mock 数据，返回压测脚本需要的 id 索引。"""
+    rng = random.Random(SEED)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=OFF")
+    conn.execute("PRAGMA foreign_keys=OFF")
+
+    items, metas, seasons, episodes, files = [], [], [], [], []
+    states = []
+    used: set[str] = set()
+    item_id = file_id = 0
+    lib_index: list[dict] = []
+    tv_by_size: list[tuple[int, int]] = []   # (文件数, item_id)，取热点剧用
+
+    def _title() -> str:
+        while True:
+            t = (rng.choice(CN_HEAD) + rng.choice(CN_TAIL)) if rng.random() < 0.7 \
+                else f"{rng.choice(EN_TITLES)} {rng.randint(1, 99)}"
+            if t not in used:
+                used.add(t)
+                return t
+
+    def _dt(days_back: int = 34) -> datetime:
+        # 生产库 created_at 跨度就是最近 34 天（一次性导入 + 持续入库）
+        return NOW - timedelta(seconds=rng.randint(0, days_back * 86400))
+
+    def _versions(n_versions: int, unit_created: datetime):
+        """同一单元的多个版本：入库时间随版本递增。
+
+        生产实测 495 个多版本单元里，created_at 的先后与自增 id 的先后
+        100% 一致（版本是先后扫进来的）。mock 必须复现这一点，否则会造出
+        真实世界不存在的组合，把"多版本输出顺序"这种隐式次序的比对搅浑。
+        """
+        return [unit_created + timedelta(minutes=v) for v in range(n_versions)]
+
+    for lib_id, (name, kind, item_count, target_files) in enumerate(LIBRARY_PLAN, 1):
+        lib_items: list[int] = []
+        produced = 0
+        # 剧集库按偏态分布分配台账行，再整体缩放到该库的目标行数
+        if kind == "tv":
+            quota = [rng.choice(TV_FILE_DIST) for _ in range(item_count)]
+            scale = target_files / max(sum(quota), 1)
+            quota = [max(1, round(q * scale)) for q in quota]
+        else:
+            quota = [1] * item_count
+        for _idx in range(item_count):
+            item_id += 1
+            lib_items.append(item_id)
+            title = _title()
+            year = rng.randint(1998, 2026)
+            created = _dt()
+            created_s = created.isoformat(sep=" ")
+            items.append((
+                item_id, kind, 100_000 + item_id, f"tt{7_000_000 + item_id}",
+                str(30_000_000 + item_id) if rng.random() < 0.6 else None,
+                title, title, year, "[]",
+                "Released" if kind == "movie" else rng.choice(STATUSES_TV),
+                f"/p{item_id:05d}.jpg", f"/b{item_id:05d}.jpg", created_s, created_s,
+            ))
+            metas.append((
+                item_id, _OVERVIEW, None,
+                json.dumps(rng.sample(GENRES, 2), ensure_ascii=False), "[]",
+                rng.randint(90, 150) if kind == "movie" else rng.randint(35, 60),
+                f"{year}-0{rng.randint(1, 9)}-1{rng.randint(0, 9)}", "zh", "[]",
+                "[]", round(rng.uniform(5.5, 9.5), 1), rng.randint(50, 9000),
+                "[]", "[]", f"{item_id}/poster.jpg", f"{item_id}/backdrop.jpg",
+                created_s, "zh-CN", created_s, created_s,
+            ))
+            if kind == "movie":
+                for _v, stamp in enumerate(
+                    _versions(rng.choice(VERSION_DIST), created)
+                ):
+                    file_id += 1
+                    produced += 1
+                    files.append(_file_row(rng, file_id, lib_id, item_id, 0, 0,
+                                           f"/media/{lib_id}/{item_id}_{_v}.mkv",
+                                           stamp))
+                continue
+            n_seasons = rng.choice(SEASON_DIST)
+            item_files = 0
+            want = quota[_idx]
+            for s in range(1, n_seasons + 1):
+                seasons.append((item_id, s, f"第 {s} 季",
+                                f"{year + s - 1}-01-01", want, None, None,
+                                f"{item_id}/s{s}.jpg", created_s, created_s))
+                # 生产库 media_episode(9353) 比在位台账行(6837)多约 1/3：
+                # TMDB 抓到整季元数据、但只下了其中一部分集
+                n_eps = max(1, round(want / n_seasons * 1.35))
+                have = max(1, round(want / n_seasons))
+                for e in range(1, n_eps + 1):
+                    episodes.append((
+                        item_id, s, e, f"第 {e} 集", _OVERVIEW[:120],
+                        f"{year + s - 1}-0{rng.randint(1, 9)}-01",
+                        rng.randint(35, 60), round(rng.uniform(6, 9.5), 1),
+                        None, f"{item_id}/s{s}e{e}.jpg", created_s, created_s,
+                    ))
+                    if e > have:
+                        continue  # 只有元数据、没有文件的集
+                    for _v, stamp in enumerate(
+                        _versions(rng.choice(VERSION_DIST), _dt())
+                    ):
+                        file_id += 1
+                        produced += 1
+                        item_files += 1
+                        files.append(_file_row(
+                            rng, file_id, lib_id, item_id, s, e,
+                            f"/media/{lib_id}/{item_id}/S{s:02d}E{e:02d}_{_v}.mkv",
+                            stamp))
+            tv_by_size.append((item_files, item_id))
+        lib_index.append({"id": lib_id, "name": name, "kind": kind,
+                          "items": lib_items})
+
+    # 播放状态：92 行、73 条已看（生产实测）
+    flat = [(i[0],) for i in items]
+    picked = rng.sample(flat, 92)
+    for n, (mid,) in enumerate(picked):
+        states.append((mid, 0, 0 if n % 3 else 1, 1 if n < 73 else 0,
+                       rng.randint(0, 3_600_000), rng.randint(1, 5), 0, NOW_S,
+                       0, NOW_S, NOW_S))
+
+    cur = conn.cursor()
+    cur.executemany(
+        "INSERT INTO library (id,name,kind,root_paths,is_default,sort_order,"
+        "stats_item_count,stats_episode_count,stats_file_count,"
+        "stats_total_size_bytes,stats_unidentified_count,stats_missing_count,"
+        "stats_ignored_count,stats_refreshed_at,created_at,updated_at,"
+        "match_rules,write_media_assets,auto_clear_missing,realtime_watch) "
+        "VALUES (?,?,?,?,0,?,0,0,0,0,0,0,0,?,?,?,'[]',1,0,1)",
+        [(x["id"], x["name"], x["kind"], json.dumps([f"/media/{x['id']}"]),
+          x["id"], NOW_S, NOW_S, NOW_S) for x in lib_index])
+    cur.executemany(
+        "INSERT INTO media_item (id,kind,tmdb_id,imdb_id,douban_id,title,"
+        "original_title,year,aliases,status,poster_path,backdrop_path,"
+        "created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", items)
+    cur.executemany(
+        "INSERT INTO media_metadata (media_item_id,overview,tagline,genres,"
+        "genre_ids,runtime_minutes,release_date,original_language,"
+        "origin_countries,studios,vote_average,vote_count,directors,\"cast\","
+        "poster_file,backdrop_file,scraped_at,scrape_language,created_at,"
+        "updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", metas)
+    cur.executemany(
+        "INSERT INTO media_season (media_item_id,season_number,name,air_date,"
+        "episode_count,overview,poster_path,poster_file,created_at,updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?)", seasons)
+    cur.executemany(
+        "INSERT INTO media_episode (media_item_id,season_number,episode_number,"
+        "name,overview,air_date,runtime_minutes,vote_average,still_path,"
+        "still_file,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        episodes)
+    cur.executemany(
+        "INSERT INTO library_file (id,library_id,media_item_id,season_number,"
+        "episode_number,file_path,size_bytes,container,resolution,video_codec,"
+        "hdr,bit_depth,duration_seconds,bit_rate,frame_rate,color_space,"
+        "media_source,release_group,source,state,audio_streams,subtitle_streams,"
+        "external_subtitles,added_batch_id,identity_source,resolved_version,"
+        "file_mtime_ns,media_source_manual,created_at,updated_at) VALUES "
+        "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", files)
+    cur.executemany(
+        "INSERT INTO playback_state (media_item_id,season_number,episode_number,"
+        "played,position_ms,play_count,is_favorite,last_played_at,member_id,"
+        "created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)", states)
+    conn.commit()
+    conn.execute("ANALYZE")
+    conn.commit()
+    conn.close()
+
+    tv_by_size.sort(reverse=True)
+    return {
+        "libraries": lib_index,
+        "counts": {"items": len(items), "files": len(files),
+                   "episodes": len(episodes), "seasons": len(seasons)},
+        # 扫描期被反复问 Seasons 的 6 部剧：取最大的几部（最坏情况）
+        "hot_series": [mid for _, mid in tv_by_size[:6]],
+        "all_items": [i[0] for i in items],
+    }
+
+
+def describe_dataset(db_path: str) -> dict:
+    """从一个现成的库里读出压测脚本需要的 id（不写任何数据）。
+
+    用生产库快照跑同一套脚本，是比 mock 更硬的一道验证：多版本文件、
+    0 季特辑、有元数据没文件的集、跨库条目这些真实形态，mock 造不全。
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    libs = []
+    for lib_id, name, kind in conn.execute(
+        "SELECT id,name,kind FROM library ORDER BY sort_order, id"
+    ):
+        libs.append({"id": lib_id, "name": name, "kind": kind, "items": []})
+    hot = [
+        r[0]
+        for r in conn.execute(
+            "SELECT lf.media_item_id FROM library_file lf "
+            "JOIN media_item mi ON mi.id = lf.media_item_id "
+            "WHERE lf.state='in_place' AND mi.kind='tv' "
+            "GROUP BY lf.media_item_id ORDER BY COUNT(*) DESC LIMIT 6"
+        )
+    ]
+    all_items = [
+        r[0]
+        for r in conn.execute(
+            "SELECT DISTINCT media_item_id FROM library_file "
+            "WHERE state='in_place' AND media_item_id IS NOT NULL "
+            "ORDER BY media_item_id"
+        )
+    ]
+    counts = {
+        "items": conn.execute("SELECT COUNT(*) FROM media_item").fetchone()[0],
+        "files": conn.execute("SELECT COUNT(*) FROM library_file").fetchone()[0],
+        "episodes": conn.execute("SELECT COUNT(*) FROM media_episode").fetchone()[0],
+        "seasons": conn.execute("SELECT COUNT(*) FROM media_season").fetchone()[0],
+    }
+    conn.close()
+    return {"libraries": libs, "counts": counts, "hot_series": hot,
+            "all_items": all_items}
+
+
+def _file_row(rng, file_id, lib_id, item_id, season, episode, path, created):
+    return (
+        file_id, lib_id, item_id, season, episode, path,
+        rng.randint(800_000_000, 40_000_000_000),
+        "mkv", rng.choice(RESOLUTIONS), rng.choice(CODECS), rng.choice(HDRS),
+        rng.choice([8, 10]), rng.randint(1400, 9000),
+        rng.randint(2_000_000, 40_000_000), 23.976, "bt709",
+        rng.choice(["WEB-DL", "BluRay", "Remux"]), "GROUP", "scanned",
+        "in_place", _AUDIO, _SUBS, "[]", f"batch-{lib_id}", "ner", 1,
+        1_700_000_000_000_000_000, 0, created.isoformat(sep=" "),
+        created.isoformat(sep=" "),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 请求脚本：条数与配比抄自真实 Infuse 启动扫描
+# ---------------------------------------------------------------------------
+LIST_FIELDS = ("Overview,Genres,MediaSources,MediaStreams,Path,DateCreated,"
+               "ParentId,ProviderIds,ChildCount,RecursiveItemCount,OriginalTitle")
+
+
+def build_script(ids: dict, guid_of) -> list[tuple[str, str]]:
+    """返回 [(label, url)]。label 用于按端点归并统计。"""
+    reqs: list[tuple[str, str]] = []
+    libs = ids["libraries"]
+    lib_guids = [guid_of("library", x["id"]) for x in libs]
+
+    reqs.append(("UserViews", "/UserViews"))
+    # Latest：50 次（每库 ~4 次 + 全局若干），legacy 与新路由各半
+    for round_i in range(5):
+        for g in lib_guids:
+            path = "/Users/{uid}/Items/Latest" if round_i % 2 else "/Items/Latest"
+            reqs.append(("Items/Latest",
+                         f"{path}?parentId={g}&limit=20&groupItems=true"
+                         f"&enableUserData=true&fields={LIST_FIELDS}"))
+    reqs.append(("Shows/NextUp", "/Shows/NextUp?limit=20&fields=" + LIST_FIELDS))
+    for _ in range(3):
+        reqs.append(("Resume",
+                     "/UserItems/Resume?limit=12&mediaTypes=Video"
+                     f"&fields={LIST_FIELDS}"))
+
+    # /Items 库分页：79 次
+    n = 0
+    while n < 79:
+        for x, g in zip(libs, lib_guids, strict=True):
+            for start in (0, 100):
+                if n >= 79:
+                    break
+                types = "Movie" if x["kind"] == "movie" else "Series"
+                reqs.append(("Items",
+                             f"/Items?parentId={g}&includeItemTypes={types}"
+                             f"&startIndex={start}&limit=100&sortBy=SortName"
+                             f"&sortOrder=Ascending&fields={LIST_FIELDS}"))
+                n += 1
+
+    # Shows/{id}/Seasons：107 次，只涉及 6 部剧（生产实测的重复度）
+    hot = ids["hot_series"]
+    weights = [44, 33, 13, 6, 6, 5]
+    for mid, w in zip(hot, weights, strict=False):
+        for _ in range(w):
+            reqs.append(("Shows/Seasons",
+                         f"/Shows/{guid_of('item', mid)}/Seasons"
+                         "?enableUserData=true&enableImages=true"))
+    # 剧集下钻的几种形态：整剧 / 按季 / 分页；以及剧→季、季→集两级 parentId
+    top = guid_of("item", hot[0])
+    reqs.append(("Shows/Episodes", f"/Shows/{top}/Episodes?fields={LIST_FIELDS}"))
+    reqs.append(("Shows/Episodes",
+                 f"/Shows/{top}/Episodes?limit=50&startIndex=0&fields={LIST_FIELDS}"))
+    for series in hot[:3]:
+        g = guid_of("item", series)
+        reqs.append(("Items(剧→季)",
+                     f"/Items?parentId={g}&fields={LIST_FIELDS}"))
+        for season in (1, 2):
+            sg = guid_of("season", series, season)
+            reqs.append(("Shows/Episodes(按季)",
+                         f"/Shows/{g}/Episodes?seasonId={sg}&fields={LIST_FIELDS}"))
+            reqs.append(("Items(季→集)",
+                         f"/Items?parentId={sg}&fields={LIST_FIELDS}"))
+    # 排序/搜索口径矩阵：DateCreated 与 Runtime 必须回落到整行装载，
+    # searchTerm + Episode 同理——这几条专门守着两段式装载的判定条件
+    for x, g in list(zip(libs, lib_guids, strict=True))[:4]:
+        for sort in ("DateCreated", "Runtime", "PremiereDate", "CommunityRating"):
+            reqs.append((f"Items(sortBy={sort})",
+                         f"/Items?parentId={g}&startIndex=0&limit=40"
+                         f"&sortBy={sort}&sortOrder=Descending&fields={LIST_FIELDS}"))
+        if x["kind"] == "tv":
+            reqs.append(("Items(递归 Episode)",
+                         f"/Items?parentId={g}&includeItemTypes=Episode"
+                         f"&recursive=true&startIndex=0&limit=40&sortBy=SortName"
+                         f"&fields={LIST_FIELDS}"))
+            reqs.append(("Items(搜索)",
+                         f"/Items?parentId={g}&includeItemTypes=Episode,Series"
+                         f"&recursive=true&searchTerm=a&fields={LIST_FIELDS}"))
+        reqs.append(("Items(筛选)",
+                     f"/Items?parentId={g}&startIndex=0&limit=40&isPlayed=false"
+                     f"&fields={LIST_FIELDS}"))
+    reqs.append(("Items(ids=)",
+                 "/Items?ids=" + ",".join(guid_of("item", i)
+                                          for i in ids["all_items"][:12])
+                 + f"&fields={LIST_FIELDS}"))
+
+    # 条目详情：49 次（全字段分支）
+    detail = ids["hot_series"] + ids["all_items"][:43]
+    for mid in detail[:49]:
+        reqs.append(("Items/{id}", f"/Items/{guid_of('item', mid)}"))
+    return reqs
+
+
+# ---------------------------------------------------------------------------
+# 执行
+# ---------------------------------------------------------------------------
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repeat", type=int, default=3, help="脚本重复轮数，取中位数")
+    ap.add_argument("--concurrency", type=int, default=1,
+                    help="并发客户端数。播放器扫描是并发打进来的，串行跑量不出"
+                         "排队与写锁争用——要复现生产上那条「越打越慢」的曲线就调大它")
+    ap.add_argument("--dump", help="把响应快照写到该文件")
+    ap.add_argument("--compare", help="与该快照逐字节比对（红线：不允许有差异）")
+    ap.add_argument("--keep-db", help="把生成的 mock 库留在该路径，便于单独 profile")
+    ap.add_argument("--db", help="不生成 mock，改用这个现成的库（如生产库快照）"
+                                 "；会拷贝一份到临时目录，原文件只读不改")
+    ap.add_argument("--profile", metavar="LABEL", nargs="?", const="",
+                    help="对（可选：指定端点的）请求做 cProfile，打印热点函数")
+    args = ap.parse_args()
+
+    tmp = Path(tempfile.mkdtemp(prefix="jf-bench-"))
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{tmp / 'jf.db'}"
+    os.environ["SECRET_KEY_FILE"] = str(tmp / ".secret_key")
+    os.environ["SCHEDULER_ENABLED"] = "false"
+    os.environ["METADATA_DIR"] = str(tmp / "metadata")
+    os.environ["LOG_DIR"] = str(tmp / "logs")
+    os.environ["APP_ACCESS_LOG_ENABLED"] = "false"
+    os.environ["APP_LOG_LEVEL"] = "WARNING"
+    os.environ.setdefault("TMDB_API_KEY", "bench")
+
+    from movieclaw_api.core.config import get_settings
+    from movieclaw_db.engine import dispose_db, init_db
+    from movieclaw_db.migrations import run_migrations
+    get_settings.cache_clear()
+
+    async def _migrate() -> None:
+        init_db(get_settings().database_url, echo=False)
+        await run_migrations()
+        await dispose_db()
+
+    t0 = time.perf_counter()
+    if args.db:
+        # 真实库模式：拷一份出来跑（原文件一个字节都不动），密码重置成已知值
+        import shutil
+        shutil.copy(args.db, tmp / "jf.db")
+        # 清掉全部应用配置行：其中的敏感字段是用生产主密钥加密的，本机没有
+        # 那把钥匙（也不该有）。配置内核对缺失记录返回默认值（"空库也能启动"
+        # 是架构红线），所以清空之后照常起，媒体库数据一行不动——压测要的
+        # 就是媒体数据的真实形态。
+        wipe = sqlite3.connect(str(tmp / "jf.db"))
+        wipe.execute("DELETE FROM app_setting")
+        wipe.execute("DELETE FROM site_credential")
+        wipe.execute("DELETE FROM site_cookie")
+        wipe.execute("DELETE FROM llm_provider")
+        wipe.execute("DELETE FROM downloader_client")
+        wipe.execute("DELETE FROM jellyfin_device")
+        wipe.execute("DELETE FROM channel_account")
+        wipe.execute("DELETE FROM agent_session")
+        wipe.commit()
+        wipe.close()
+        asyncio.run(_migrate())
+        ids = describe_dataset(str(tmp / "jf.db"))
+        print(f"真实库就绪（{time.perf_counter() - t0:.1f}s，来自 {args.db}）："
+              f"{len(ids['libraries'])} 个库 / {ids['counts']['items']} 条目 / "
+              f"{ids['counts']['files']} 台账行 / {ids['counts']['episodes']} 集 / "
+              f"{ids['counts']['seasons']} 季")
+    else:
+        asyncio.run(_migrate())
+        ids = seed_dataset(str(tmp / "jf.db"))
+        print(f"mock 数据就绪（{time.perf_counter() - t0:.1f}s）："
+              f"{len(ids['libraries'])} 个库 / {ids['counts']['items']} 条目 / "
+              f"{ids['counts']['files']} 台账行 / {ids['counts']['episodes']} 集 / "
+              f"{ids['counts']['seasons']} 季")
+    if args.keep_db:
+        import shutil
+        shutil.copy(tmp / "jf.db", args.keep_db)
+        print(f"mock 库已复制到 {args.keep_db}")
+
+    from fastapi.testclient import TestClient
+
+    from movieclaw_api.app import create_app
+    from movieclaw_jellyfin.ids import item_guid, library_guid, season_guid
+
+    def guid_of(kind: str, entity_id: int, season: int = 0) -> str:
+        if kind == "library":
+            return library_guid(entity_id)
+        if kind == "season":
+            return season_guid(entity_id, season)
+        return item_guid(entity_id)
+
+    app = create_app()
+    with TestClient(app) as client:
+        r = client.post("/api/v1/auth/bootstrap", json=ADMIN)
+        assert r.status_code == 200, r.text
+        username = ADMIN["username"]
+        r = client.post("/Users/AuthenticateByName",
+                        json={"Username": username, "Pw": ADMIN["password"]},
+                        headers={"Authorization": AUTH_HEADER})
+        assert r.status_code == 200, r.text
+        token = r.json()["AccessToken"]
+        uid = r.json()["User"]["Id"]
+        # ServerId 是每个实例首启随机生成的，会让逐字节比对全线报假阳性；
+        # 落快照前统一替换成占位符
+        server_id = client.get("/System/Info/Public").json()["Id"]
+        headers = {"Authorization": f'{AUTH_HEADER}, Token="{token}"'}
+
+        script = [(lbl, url.replace("{uid}", uid)) for lbl, url in
+                  build_script(ids, guid_of)]
+        print(f"请求脚本：{len(script)} 个请求")
+
+        # 预热一轮（填 lru_cache、编译 SQL），不计入统计
+        for _, url in script:
+            client.get(url, headers=headers)
+
+        if args.profile is not None:
+            import cProfile
+            import io as _io
+            import pstats
+            subset = [(label, u) for label, u in script
+                      if not args.profile or label == args.profile]
+            print(f"cProfile：{len(subset)} 个请求"
+                  f"（{args.profile or '全部端点'}）")
+            pr = cProfile.Profile()
+            pr.enable()
+            for _, url in subset:
+                client.get(url, headers=headers)
+            pr.disable()
+            buf = _io.StringIO()
+            st = pstats.Stats(pr, stream=buf).sort_stats("tottime")
+            st.print_stats(18)
+            st.sort_stats("cumulative").print_stats("movieclaw", 22)
+            print(buf.getvalue())
+            return 0
+
+        rounds: list[dict] = []
+        snapshot: dict[str, list] = {}
+        pool = (ThreadPoolExecutor(max_workers=args.concurrency)
+                if args.concurrency > 1 else None)
+        for r_i in range(args.repeat):
+            per_label: dict[str, list[float]] = defaultdict(list)
+
+            def one(job):
+                i, label, url = job
+                s = time.perf_counter()
+                resp = client.get(url, headers=headers)
+                return i, label, (time.perf_counter() - s) * 1000, resp
+
+            jobs = [(i, lbl, url) for i, (lbl, url) in enumerate(script)]
+            wall0 = time.perf_counter()
+            results = (list(pool.map(one, jobs)) if pool
+                       else [one(j) for j in jobs])
+            wall = (time.perf_counter() - wall0) * 1000
+            for i, label, ms, resp in results:
+                per_label[label].append(ms)
+                if r_i == 0:
+                    snapshot[f"{i:04d} {script[i][1]}"] = [
+                        resp.status_code,
+                        resp.text.replace(server_id, "<SERVER_ID>"),
+                    ]
+            rounds.append({"wall": wall, "per_label": dict(per_label)})
+        if pool is not None:
+            pool.shutdown()
+
+    # —— 汇总 ——
+    walls = [x["wall"] for x in rounds]
+    best = min(range(len(rounds)), key=lambda i: walls[i])
+    per = rounds[best]["per_label"]
+    print()
+    print(f"{'端点':<22}{'次数':>6}{'累计 ms':>11}{'均值 ms':>10}{'P95 ms':>9}")
+    print("-" * 58)
+    total = 0.0
+    for label in sorted(per, key=lambda k: -sum(per[k])):
+        v = sorted(per[label])
+        s = sum(v)
+        total += s
+        p95 = v[min(len(v) - 1, int(len(v) * 0.95))]
+        print(f"{label:<22}{len(v):>6}{s:>11.1f}{s / len(v):>10.1f}{p95:>9.1f}")
+    print("-" * 58)
+    print(f"{'合计':<22}{sum(len(v) for v in per.values()):>6}{total:>11.1f}")
+    print(f"\n墙钟：{[round(w) for w in walls]} ms  → 最快一轮 {min(walls):.0f} ms"
+          f"（中位 {statistics.median(walls):.0f} ms）")
+
+    if args.dump:
+        Path(args.dump).write_text(json.dumps(snapshot, ensure_ascii=False),
+                                   encoding="utf-8")
+        print(f"响应快照已写入 {args.dump}（{len(snapshot)} 条）")
+
+    if args.compare:
+        base = json.loads(Path(args.compare).read_text(encoding="utf-8"))
+        diffs = []
+        for k in sorted(set(base) | set(snapshot)):
+            a, b = base.get(k), snapshot.get(k)
+            if a != b:
+                diffs.append(k)
+        if diffs:
+            print(f"\n❌ 响应不一致：{len(diffs)}/{len(snapshot)} 条")
+            for k in diffs[:5]:
+                a, b = base.get(k), snapshot.get(k)
+                print(f"  - {k}")
+                if a and b and a[0] != b[0]:
+                    print(f"    状态码 {a[0]} → {b[0]}")
+                elif a and b:
+                    for pos in range(min(len(a[1]), len(b[1]))):
+                        if a[1][pos] != b[1][pos]:
+                            lo = max(0, pos - 60)
+                            print(f"    第 {pos} 字符起："
+                                  f"\n      基线 …{a[1][lo:pos + 80]}…"
+                                  f"\n      现在 …{b[1][lo:pos + 80]}…")
+                            break
+                    else:
+                        print(f"    长度 {len(a[1])} → {len(b[1])}")
+            return 1
+        print(f"\n✅ 响应与基线逐字节一致（{len(snapshot)} 条）")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/movieclaw_api/lifespan.py
+++ b/src/movieclaw_api/lifespan.py
@@ -19,7 +19,12 @@ from movieclaw_api.services.media_discover import close_media_service
 from movieclaw_api.services.site_access import get_site_access, init_site_access
 from movieclaw_api.settings import init_setting_store
 from movieclaw_db.crypto import init_secret_box
-from movieclaw_db.engine import dispose_db, get_database, init_db
+from movieclaw_db.engine import (
+    dispose_db,
+    get_database,
+    init_db,
+    refresh_query_statistics,
+)
 from movieclaw_db.migrations import run_migrations
 from movieclaw_db.repositories.credential_repo import CredentialRepository
 from movieclaw_db.repositories.llm_provider_repo import LlmProviderRepository
@@ -80,8 +85,11 @@ def build_lifespan(settings: Settings):
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # 先初始化引擎（会顺带创建 SQLite 文件所在目录），再执行迁移
-        init_db(settings.database_url, echo=settings.db_echo)
+        db = init_db(settings.database_url, echo=settings.db_echo)
         await run_migrations()
+        # 迁移之后立刻刷一次索引统计：没有它 SQLite 会挑错索引，把"取某个条目
+        # 的文件行"退化成整表扫描（见 refresh_query_statistics 注释）
+        await refresh_query_statistics(db)
         # Alembic 的 fileConfig 会按 alembic.ini 重置 root logger：级别设回 WARNING、
         # Handler 换成仅剩它的 console（应用挂的按天落盘 Handler 也被移除）。迁移一跑完
         # 就重新应用一次应用日志配置，恢复 INFO 级别并重挂文件 Handler，否则访问日志
@@ -280,6 +288,9 @@ def build_lifespan(settings: Settings):
             await get_site_access().aclose()
             await close_media_service()
             await close_image_proxy()
+            # 关闭前把本轮运行期间的行数变化落进统计，下次启动直接是新的。
+            # 用启动时拿到的引用，不走全局单例——启动中途失败时全局可能还没就绪
+            await refresh_query_statistics(db)
             await dispose_db()
             logger.info("应用已关闭，数据库连接已释放")
 

--- a/src/movieclaw_db/engine.py
+++ b/src/movieclaw_db/engine.py
@@ -67,6 +67,7 @@ class Database:
 
     def __init__(self, database_url: str, *, echo: bool = False) -> None:
         _ensure_sqlite_dir(database_url)
+        self.is_sqlite = database_url.startswith("sqlite")
 
         self._engine: AsyncEngine = create_async_engine(
             database_url,
@@ -102,6 +103,38 @@ class Database:
         """释放连接池。应用关闭时调用。"""
         await self._engine.dispose()
         logger.info("数据库引擎已释放")
+
+
+# ---------------------------------------------------------------------------
+# 查询计划统计
+# ---------------------------------------------------------------------------
+async def refresh_query_statistics(db: Database) -> None:
+    """刷新 SQLite 的索引选择性统计（``sqlite_stat1``）。
+
+    没有这张表时 SQLite 只能靠内置猜测挑索引，而它的猜测在本库上是错的：
+    ``library_file.state`` 全表只有 ``in_place`` 一个取值，索引
+    ``ix_library_file_state`` 命中全部行，planner 却把它当成高选择性条件优先
+    选中——于是"取某个条目的文件行"这种最高频的查询变成整表 6800 行的索引
+    扫描再回过头逐行过滤。生产库实测：跑一次统计后同一条查询 1.66ms → 0.32ms。
+    影响面是全站的，媒体库网页、Jellyfin 兼容层、播放链路都走同一批查询。
+
+    用 ``PRAGMA optimize`` 而不是裸 ``ANALYZE``：它只对"统计缺失或已经明显
+    过时"的表动手，日常启动几乎零成本；``analysis_limit`` 给单表采样设上限，
+    库再大也不会把启动卡住（生产库整轮 12ms）。
+
+    启动与关闭各跑一次：启动那次修正上一轮运行期间的增量（扫描入库会让行数
+    翻倍），关闭那次把本轮的变化落下去，下次启动即是新的。失败只记日志——
+    统计是纯优化，缺了只是慢，不该拦住应用起停。
+    """
+    if not db.is_sqlite:
+        return
+    try:
+        async with db.engine.begin() as conn:
+            await conn.exec_driver_sql("PRAGMA analysis_limit=400")
+            await conn.exec_driver_sql("PRAGMA optimize")
+    except Exception:
+        logger.warning("刷新数据库查询统计失败（不影响功能，只可能让查询变慢）",
+                       exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/movieclaw_jellyfin/catalog.py
+++ b/src/movieclaw_jellyfin/catalog.py
@@ -21,8 +21,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import and_, func, or_, select
-from sqlalchemy.orm import load_only
+from sqlalchemy import and_, func, or_, select, tuple_
+from sqlalchemy.orm import Load, load_only
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from movieclaw_db.models import (
@@ -86,11 +86,26 @@ class ItemBundle:
     states: dict[tuple[int, int], PlaybackState] = field(default_factory=dict)
     # (department, character, credit_order, Person)，演员按 credit_order 升序
     people: list[tuple[str, str | None, int, Person]] = field(default_factory=list)
+    # 两段式装载时由骨架查询回填：条目归属库（多库归属取入库最早的那行文件的库，
+    # 与整行装载路径下 files 的首行同义）。整行装载路径保持 None，走原逻辑。
+    primary_library_id: int | None = None
+
+    # units 的缓存。装载阶段一次性建好 files 的键集合，之后只往各键的列表里
+    # 追加行、不再新增键（两段式补料用 setdefault 落在已有键上），所以键集合
+    # 一旦算出就不会失效。
+    _units: list[tuple[int, int]] | None = field(default=None, repr=False)
 
     @property
     def units(self) -> list[tuple[int, int]]:
-        """有文件的 (season, episode) 单元，季集序。"""
-        return sorted(self.files)
+        """有文件的 (season, episode) 单元，季集序。
+
+        一条 Series DTO 就要问三次（ChildCount / RecursiveItemCount / 聚合
+        UserData），一次整库浏览是几百次；每次都 ``sorted`` 一遍几百个键
+        纯属重复劳动，缓存掉。
+        """
+        if self._units is None:
+            self._units = sorted(self.files)
+        return self._units
 
     def state(self, season: int, episode: int) -> PlaybackState | None:
         return self.states.get((season, episode))
@@ -107,6 +122,23 @@ class ItemBundle:
         if self.metadata and self.metadata.runtime_minutes:
             return self.metadata.runtime_minutes * 60_000
         return None
+
+
+# 叶子单元三元组 (media_item_id, season_number, episode_number)。
+# ``None`` = 不限定（装载条目名下全部单元），空集合 = 一个叶子都不渲染
+# （Series/Season 这类文件夹条目只吃"哪些单元有文件"的键集合）。
+LeafScope = set[tuple[int, int, int]] | None
+
+
+def _unit_in(item_col, season_col, episode_col, units) -> Any:
+    """(条目, 季, 集) 三元组批量匹配。
+
+    用 SQL 行值 ``(a,b,c) IN ((…),(…))``：SQLite ≥3.15 支持，且能直接命中
+    ``ix_library_file_media_unit`` 复合索引（实测计划为 COVERING INDEX
+    精确查找）。相比按条目 id 粗筛再在 Python 里过滤，它不会把一部 200 集的
+    剧全部读回来只为了取其中一集。
+    """
+    return tuple_(item_col, season_col, episode_col).in_(sorted(units))
 
 
 @dataclass(frozen=True)
@@ -238,6 +270,112 @@ def _list_load_columns(
     return item_columns, metadata_columns, file_columns, season_columns, episode_columns
 
 
+async def _load_scoped_files(
+    session: AsyncSession,
+    bundles: dict[int, ItemBundle],
+    leaf_scope: set[tuple[int, int, int]],
+    file_scope: list[Any],
+    summary_columns,
+) -> None:
+    """只为白名单单元装完整文件行，追加进已建好的骨架。"""
+    wanted = [u for u in leaf_scope if u[0] in bundles]
+    if not wanted:
+        return
+    file_q = (
+        select(LibraryFile)
+        .where(
+            *file_scope,
+            _unit_in(
+                LibraryFile.media_item_id,
+                LibraryFile.season_number,
+                LibraryFile.episode_number,
+                wanted,
+            ),
+        )
+        # 同一单元多版本时的行序即输出序（Path/Container 取第一行、
+        # MediaSources 按序展开）。旧路径没有 ORDER BY，靠的是
+        # ix_library_file_browse_unit 末列恰好是 created_at 而"碰巧"按入库
+        # 时间出行——换了 WHERE 就换计划、换计划就换顺序。这里把那个隐式
+        # 次序写成显式约束，顺带让它不再随查询计划漂移。
+        .order_by(LibraryFile.created_at, LibraryFile.id)
+    )
+    if summary_columns is not None:
+        file_q = file_q.options(load_only(*summary_columns[2]))
+    for f in (await session.execute(file_q)).scalars():
+        b = bundles.get(f.media_item_id)
+        if b is None:
+            continue
+        key = (f.season_number, f.episode_number)
+        if key not in b.files:
+            # 骨架与这里用的是同一套 file_scope，正常不会出现新键；真出现了
+            # 就把 units 缓存作废，宁可多排一次序也不能给出错的单元集合
+            b.files[key] = []
+            b._units = None
+        b.files[key].append(f)
+
+
+async def _load_scoped_episodes(
+    session: AsyncSession,
+    bundles: dict[int, ItemBundle],
+    leaf_scope: set[tuple[int, int, int]],
+    summary_columns,
+) -> None:
+    """只为白名单单元装分集元数据（电影哨兵单元 episode=0 天然不参与）。"""
+    wanted = [u for u in leaf_scope if u[0] in bundles and u[2] > 0]
+    if not wanted:
+        return
+    episode_q = select(MediaEpisode).where(
+        _unit_in(
+            MediaEpisode.media_item_id,
+            MediaEpisode.season_number,
+            MediaEpisode.episode_number,
+            wanted,
+        )
+    )
+    if summary_columns is not None:
+        episode_q = episode_q.options(load_only(*summary_columns[4]))
+    for e in (await session.execute(episode_q)).scalars():
+        b = bundles.get(e.media_item_id)
+        if b is not None:
+            b.episodes[(e.season_number, e.episode_number)] = e
+
+
+async def hydrate_leaves(
+    session: AsyncSession,
+    bundles: dict[int, ItemBundle],
+    leaf_scope: set[tuple[int, int, int]],
+    *,
+    library_id: int | None = None,
+    visible_library_ids: set[int] | None = None,
+    dto_options: DtoOptions | None = None,
+) -> None:
+    """给 ``leaf_scope=set()`` 装出来的骨架补上指定单元的文件行与分集元数据。
+
+    列表接口的筛选、排序、分页只吃"哪些单元有文件"和播放状态，直到最后
+    才知道这一页要渲染哪些叶子。先按骨架选页、再回头补这一页的料，
+    整库浏览就不用为了输出 100 行 Series 而水合几千条文件行和分集元数据。
+    """
+    if not leaf_scope:
+        return
+    summary_columns = (
+        _list_load_columns(dto_options)
+        if dto_options is not None and not dto_options.all_fields
+        else None
+    )
+    file_scope = [
+        LibraryFile.media_item_id.in_([u[0] for u in leaf_scope]),
+        LibraryFile.in_place(),
+    ]
+    if library_id is not None:
+        file_scope.append(LibraryFile.library_id == library_id)
+    if visible_library_ids is not None:
+        file_scope.append(LibraryFile.library_id.in_(visible_library_ids))
+    await _load_scoped_files(
+        session, bundles, leaf_scope, file_scope, summary_columns
+    )
+    await _load_scoped_episodes(session, bundles, leaf_scope, summary_columns)
+
+
 async def load_bundles(
     session: AsyncSession,
     item_ids: list[int],
@@ -248,6 +386,8 @@ async def load_bundles(
     include_people: bool = False,
     include_fileless: bool = False,
     dto_options: DtoOptions | None = None,
+    leaf_scope: LeafScope = None,
+    include_seasons: bool = True,
 ) -> dict[int, ItemBundle]:
     """批量装载条目素材。库参数限定时只装对应范围内的文件行。
 
@@ -266,6 +406,14 @@ async def load_bundles(
     ``dto_options`` 仅由列表接口传入。它触发最小列集读取，避免列表在不输出
     演员、音轨和字幕时仍反序列化这些大 JSON 列；全字段详情和未迁移的调用
     保持原有整行读取语义。
+
+    ``leaf_scope`` 是"这次响应真正会渲染成叶子条目（Movie/Episode）的单元"
+    白名单，由调用方在装载前就能算出来时传入（Latest 选完页、Resume 选完页、
+    库分页选完页、Seasons 一个叶子都不渲染 → 空集）。传了它就走两段式装载：
+    单元键用列查询建骨架，完整文件行与分集元数据只装白名单内的。
+    **传入的白名单必须覆盖后续所有会构建 DTO 的单元**，漏传会让那些单元
+    的 Path/MediaSources/RunTimeTicks 变空——`tests/jellyfin` 与
+    `scripts/perf/bench_jellyfin_scan.py --compare` 的逐字节比对守着这条线。
     """
     if not item_ids:
         return {}
@@ -277,55 +425,132 @@ async def load_bundles(
     if dto_options is not None:
         include_people = include_people or dto_options.has("People")
 
-    item_q = select(MediaItem).where(MediaItem.id.in_(item_ids))
-    if summary_columns is not None:
-        item_q = item_q.options(load_only(*summary_columns[0]))
-    items = (
-        (await session.execute(item_q))
-        .scalars()
-        .all()
+    # 条目与它的档案是一对一，合成一条 LEFT JOIN 取回：每条查询在 aiosqlite
+    # 下都是一次线程往返，装一个 bundle 本来就要打七八条，能并的都并掉
+    item_q = (
+        select(MediaItem, MediaMetadata)
+        .outerjoin(MediaMetadata, MediaMetadata.media_item_id == MediaItem.id)
+        .where(MediaItem.id.in_(item_ids))
     )
-    bundles = {i.id: ItemBundle(item=i) for i in items}
-
-    metadata_q = select(MediaMetadata).where(MediaMetadata.media_item_id.in_(item_ids))
     if summary_columns is not None:
-        metadata_q = metadata_q.options(load_only(*summary_columns[1]))
-    metas = (
-        (await session.execute(metadata_q))
-        .scalars()
-        .all()
-    )
-    for m in metas:
-        if m.media_item_id in bundles:
-            bundles[m.media_item_id].metadata = m
+        item_q = item_q.options(
+            Load(MediaItem).load_only(*summary_columns[0]),
+            Load(MediaMetadata).load_only(*summary_columns[1]),
+        )
+    items: list[MediaItem] = []
+    bundles: dict[int, ItemBundle] = {}
+    for item, meta in (await session.execute(item_q)).all():
+        items.append(item)
+        bundles[item.id] = ItemBundle(item=item, metadata=meta)
 
-    file_q = select(LibraryFile).where(
+    file_scope = [
         LibraryFile.media_item_id.in_(item_ids),
         LibraryFile.in_place(),
-    )
+    ]
     if library_id is not None:
-        file_q = file_q.where(LibraryFile.library_id == library_id)
+        file_scope.append(LibraryFile.library_id == library_id)
     if visible_library_ids is not None:
-        file_q = file_q.where(LibraryFile.library_id.in_(visible_library_ids))
-    if summary_columns is not None:
-        file_q = file_q.options(load_only(*summary_columns[2]))
-    for f in (await session.execute(file_q)).scalars():
-        b = bundles.get(f.media_item_id)
-        if b is not None:
-            b.files.setdefault((f.season_number, f.episode_number), []).append(f)
+        file_scope.append(LibraryFile.library_id.in_(visible_library_ids))
 
     tv_ids = [i.id for i in items if i.kind == "tv"]
-    if tv_ids:
+    if leaf_scope is None:
+        # 全量装载：单条目详情、以及排序键需要每个单元文件行的列表路径。
+        # 这里刻意不加 ORDER BY——整库口径下那是一次几千行的临时排序，而行序
+        # 本来就由 ix_library_file_browse_unit 给出（末列 created_at），
+        # 补一道显式排序只是把同样的结果重算一遍。两段式那条路径行数很少、
+        # 又换了 WHERE 会换计划，才需要显式定序（见 _load_scoped_files）。
+        file_q = select(LibraryFile).where(*file_scope)
+        if summary_columns is not None:
+            file_q = file_q.options(load_only(*summary_columns[2]))
+        for f in (await session.execute(file_q)).scalars():
+            b = bundles.get(f.media_item_id)
+            if b is not None:
+                b.files.setdefault((f.season_number, f.episode_number), []).append(f)
+    else:
+        # 两段式装载（列表路径的默认姿势）：先用**列查询**把"哪些单元有文件"
+        # 的骨架建起来——units/ChildCount/RecursiveItemCount/聚合 UserData
+        # 只认这个键集合，不需要文件行本身；再只为真正会渲染成叶子条目
+        # （Movie/Episode）的单元装完整行。
+        #
+        # 为什么值得这么绕：一次 Latest 只输出 20 条，旧路径却要为这 20 个条目
+        # 把它们名下**全部**文件行和分集元数据水合成 ORM 对象（生产实测 1499 行），
+        # 一个剧集库的浏览更是要水合整库（3114 文件 + 3416 集）。ORM 对象构造
+        # 和大 JSON 列反序列化是这条链路上最大的一笔开销，而其中 99% 的行
+        # 从头到尾没人读。
+        #
+        # 骨架里刻意不取 created_at：DATETIME 列每行都要在 Python 侧解析成
+        # datetime 对象，几千行下来比其余整型列加起来还贵。
+        # 归属库（ParentId 用）要与整行装载路径同义 = 入库最早那行文件的库。
+        # 查询已按库收口时答案就是那个库，一列都不用多取；否则条目也几乎总是
+        # 只属于一个库（生产实测 855 个条目里跨库的只有 1 个），扫骨架时顺手
+        # 判掉即可，真出现跨库条目才为那几个单独做一次入库时间比较。
+        unit_cols = [
+            LibraryFile.media_item_id,
+            LibraryFile.season_number,
+            LibraryFile.episode_number,
+        ]
+        straddling: set[int] = set()
+        if library_id is not None:
+            for b in bundles.values():
+                b.primary_library_id = library_id
+            for mid, season_no, episode_no in (
+                await session.execute(select(*unit_cols).where(*file_scope))
+            ).all():
+                b = bundles.get(mid)
+                if b is not None:
+                    b.files.setdefault((season_no, episode_no), [])
+        else:
+            unit_q = select(*unit_cols, LibraryFile.library_id).where(*file_scope)
+            for mid, season_no, episode_no, lib in (
+                await session.execute(unit_q)
+            ).all():
+                b = bundles.get(mid)
+                if b is None:
+                    continue
+                b.files.setdefault((season_no, episode_no), [])
+                if b.primary_library_id is None:
+                    b.primary_library_id = lib
+                elif b.primary_library_id != lib:
+                    straddling.add(mid)
+        if straddling:
+            # SQLite 明文保证：聚合里只有一个 min()/max() 时，同 SELECT 的裸列
+            # 取自命中该聚合的那一行。入库时间精确到微秒都相同的并列由 SQLite
+            # 任选（要求同一条目在两个库里最早的文件时间戳完全相同，现实中不会
+            # 发生），其余情况与旧路径逐行比较的结果一致。
+            owner_q = (
+                select(
+                    LibraryFile.media_item_id,
+                    LibraryFile.library_id,
+                    func.min(LibraryFile.created_at),
+                )
+                .where(*file_scope, LibraryFile.media_item_id.in_(straddling))
+                .group_by(LibraryFile.media_item_id)
+            )
+            for mid, lib, _created in (await session.execute(owner_q)).all():
+                b = bundles.get(mid)
+                if b is not None:
+                    b.primary_library_id = lib
+        await _load_scoped_files(
+            session, bundles, leaf_scope, file_scope, summary_columns
+        )
+
+    if tv_ids and include_seasons:
+        # 季元数据只有 Season/Episode DTO 会读（季名、季海报继承）。一部剧
+        # 十几行不构成开销，但整库浏览只输出 Series 行时是几百行的白装，
+        # 调用方明确不产出季/集条目就跳过（include_seasons=False）。
         season_q = select(MediaSeason).where(MediaSeason.media_item_id.in_(tv_ids))
         if summary_columns is not None:
             season_q = season_q.options(load_only(*summary_columns[3]))
         for s in (await session.execute(season_q)).scalars():
             bundles[s.media_item_id].seasons[s.season_number] = s
+    if tv_ids and leaf_scope is None:
         episode_q = select(MediaEpisode).where(MediaEpisode.media_item_id.in_(tv_ids))
         if summary_columns is not None:
             episode_q = episode_q.options(load_only(*summary_columns[4]))
         for e in (await session.execute(episode_q)).scalars():
             bundles[e.media_item_id].episodes[(e.season_number, e.episode_number)] = e
+    elif leaf_scope is not None:
+        await _load_scoped_episodes(session, bundles, leaf_scope, summary_columns)
 
     for st in (
         await session.execute(
@@ -372,6 +597,7 @@ async def latest_unit_candidates(
     library_id: int | None = None,
     visible_library_ids: set[int] | None = None,
     is_played: bool | None = None,
+    row_limit: int | None = None,
 ) -> list[LatestUnitCandidate]:
     """只查询 Latest 的排序单元，延后到选页后再装载 bundle。
 
@@ -380,6 +606,11 @@ async def latest_unit_candidates(
     聚合成一行，播放状态也在数据库侧筛掉；返回固定的小标量列，不会
     触发列表 DTO 不需要的 JSON 反序列化。``min(file.id)`` 只用于复现旧
     路径在入库时间相同的情况下的稳定顺序，不参与业务语义。
+
+    ``row_limit`` 把"只要最新的前 N 个单元"下推到 SQL。排序是全序（入库时间
+    之后还有四级 tiebreak），所以取前缀与"取全部再切片"结果完全一致。不下推
+    的话，一次只输出 20 条的 Latest 要把全库六千多个单元逐行搬进 Python 再扔掉
+    ——调用方按需放大 N 重试即可覆盖同剧聚合把多行折叠成一条的情况。
     """
     latest_created = func.max(LibraryFile.created_at).label("latest_created")
     q = (
@@ -428,6 +659,8 @@ async def latest_unit_candidates(
         LibraryFile.season_number.asc(),
         LibraryFile.episode_number.asc(),
     )
+    if row_limit is not None:
+        q = q.limit(row_limit)
     rows = (await session.execute(q)).all()
     return [
         LatestUnitCandidate(
@@ -910,7 +1143,14 @@ def _apply_parent_id(dto: dict[str, Any], parent: str | None, options: DtoOption
 
 
 def _item_library_guid(bundle: ItemBundle) -> str | None:
-    """条目所属库（多库归属取第一个文件行的库）。"""
+    """条目所属库（多库归属取第一个文件行的库）。
+
+    两段式装载下只有本页的叶子单元装了文件行，"第一个文件行"会随分页漂移，
+    所以骨架查询会把口径一致的归属库直接算好放进 ``primary_library_id``，
+    这里优先用它。
+    """
+    if bundle.primary_library_id is not None:
+        return library_guid(bundle.primary_library_id)
     for files in bundle.files.values():
         for f in files:
             return library_guid(f.library_id)

--- a/src/movieclaw_jellyfin/routes/library.py
+++ b/src/movieclaw_jellyfin/routes/library.py
@@ -25,6 +25,7 @@ from movieclaw_jellyfin.catalog import (
     LatestUnitCandidate,
     ResumeUnitCandidate,
     episode_dto,
+    hydrate_leaves,
     item_ids_with_files,
     latest_unit_candidates,
     library_view_dto,
@@ -113,6 +114,41 @@ async def viewer_scope(
     async with get_database().session() as session:
         visible = await member_visible_ids(session, member_id)
     return ViewerScope(member_id, visible)
+
+# 这些排序键要读**每一个候选条目**的文件行（入库时间 / 时长），骨架不够用
+_FULL_LEAF_SORTS = {"DateCreated", "Runtime"}
+# 这些排序/筛选口径在候选里含 Episode 时要读**每一集**的分集元数据
+_EPISODE_LEAF_SORTS = {"SortName", "Name", "PremiereDate", "CommunityRating", "Runtime"}
+
+
+@dataclass
+class _LazyLeaves:
+    """列表查询的"两段式装载"联络簿。
+
+    列表接口的筛选、排序、分页只需要"哪些单元有文件"和播放状态；真正要
+    文件行和分集元数据的只有最后那一页的叶子条目。装载侧据此决定能不能只
+    建骨架（``leaf_scope=set()``），能就把 ``used`` 回填给调用方，调用方选完
+    页再回来补这一页的料。判定放在装载侧是因为"候选里到底会不会出现
+    Episode"要看库类型和 recursive 特例，只有那里才知道。
+    """
+
+    allowed: bool
+    """排序键不依赖每个条目的文件行时为 True。"""
+
+    episode_sensitive: bool
+    """排序/搜索口径会读分集元数据（候选含 Episode 时不能只建骨架）。"""
+
+    used: bool = False
+    library_id: int | None = None
+
+    def scope_for(self, types: set[str]):
+        """返回该批候选可用的 ``leaf_scope``；None = 老路径全量装载。"""
+        if not self.allowed:
+            return None
+        if "Episode" in types and self.episode_sensitive:
+            return None
+        return set()
+
 
 # (type, payload, season, episode)：查询管线里的一条候选。
 # payload 通常是 ItemBundle；type == "Person" 时是 Person 行——人物是
@@ -476,6 +512,7 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
     # personIds 时，数据库即可完成 count/offset/limit，最终页才水合 bundle。
     simple_movie_page = False
     simple_total = 0
+    lazy: _LazyLeaves | None = None
 
     async with get_database().session() as session:
         page_entries: list[Entry] | None = None
@@ -522,6 +559,7 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
                 library_id=parent_ref.entity_id,
                 visible_library_ids=scope.visible,
                 dto_options=options,
+                leaf_scope={(item_id, 0, 0) for item_id in page_ids},
             )
             page_entries = [
                 ("Movie", bundles[item_id], 0, 0)
@@ -532,6 +570,11 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
         elif ids_raw:
             entries = await _entries_for_ids(session, ids_raw, scope, options=options)
         else:
+            lazy = _LazyLeaves(
+                allowed=not (set(sort_by) & _FULL_LEAF_SORTS),
+                episode_sensitive=bool(search_term)
+                or bool(set(sort_by) & _EPISODE_LEAF_SORTS),
+            )
             entries = await _entries_for_parent(
                 session,
                 parent_raw,
@@ -540,6 +583,7 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
                 recursive=recursive,
                 search=search_term,
                 options=options,
+                lazy=lazy,
             )
             if entries is None:
                 # 根级：返回视图列表
@@ -605,6 +649,26 @@ async def _query_items(request: Request, scope: ViewerScope) -> JSONResponse:
         entries = _sort_entries(entries, sort_by, sort_order) + person_entries
         total = len(entries)
         page = entries[start_index : start_index + limit] if limit >= 0 else entries[start_index:]
+
+    if lazy is not None and lazy.used:
+        # 两段式装载的第二段：这一页要渲染的叶子单元现在才确定，
+        # 回头只为它们补文件行与分集元数据（骨架里没有重复行，不会叠加）
+        leaves = {
+            (entry[1].item.id, entry[2], entry[3])
+            for entry in page
+            if entry[0] in ("Movie", "Episode")
+        }
+        if leaves:
+            async with get_database().session() as session:
+                await hydrate_leaves(
+                    session,
+                    {entry[1].item.id: entry[1] for entry in page
+                     if entry[0] in ("Movie", "Episode")},
+                    leaves,
+                    library_id=lazy.library_id,
+                    visible_library_ids=scope.visible,
+                    dto_options=options,
+                )
 
     dtos = [_entry_dto(ctx, e, options) for e in page]
     return JSONResponse(query_result(dtos, total, start_index))
@@ -732,6 +796,7 @@ async def _entries_for_parent(
     recursive: bool | None,
     search: SearchTerm | None,
     options: DtoOptions,
+    lazy: _LazyLeaves | None = None,
 ) -> list[Entry] | None:
     """按 parentId 语义展开候选。返回 None 表示"根级 → 视图列表"。"""
     if not parent_raw or is_empty_guid(parent_raw):
@@ -777,6 +842,7 @@ async def _entries_for_parent(
             types = (include_types & default_types) if include_types else default_types
         ids = await item_ids_with_files(session, library_id=ref.entity_id)
         ids = await _narrow_by_search(session, ids, search)
+        leaf_scope = lazy.scope_for(types) if lazy else None
         bundles = await load_bundles(
             session,
             ids,
@@ -784,32 +850,46 @@ async def _entries_for_parent(
             library_id=ref.entity_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            leaf_scope=leaf_scope,
+            # 只出 Series 行的库浏览（剧集库的默认视图）不读任何季元数据
+            include_seasons=bool(types & {"Season", "Episode"}),
         )
+        if lazy and leaf_scope is not None:
+            lazy.used = True
+            lazy.library_id = ref.entity_id
         return _build_entries(bundles, types)
 
     if ref.kind == EntityKind.ITEM:
         if not await _item_visible(session, ref.entity_id, scope):
             raise not_found()
+        types = include_types or {"Season"}
+        leaf_scope = lazy.scope_for(types) if lazy else None
         bundles = await load_bundles(
             session,
             [ref.entity_id],
             member_id=scope.member_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            leaf_scope=leaf_scope,
         )
-        types = include_types or {"Season"}
+        if lazy and leaf_scope is not None:
+            lazy.used = True
         return _build_entries(bundles, types)
 
     if ref.kind == EntityKind.SEASON:
         if not await _item_visible(session, ref.entity_id, scope):
             raise not_found()
+        leaf_scope = lazy.scope_for({"Episode"}) if lazy else None
         bundles = await load_bundles(
             session,
             [ref.entity_id],
             member_id=scope.member_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            leaf_scope=leaf_scope,
         )
+        if lazy and leaf_scope is not None:
+            lazy.used = True
         return _build_entries(bundles, {"Episode"}, season_scope=ref.season)
 
     raise not_found()
@@ -861,30 +941,45 @@ async def items_latest(
     async with get_database().session() as session:
         # 先读每个最新单元的 5 个标量列；只有通过 limit/groupItems 的最终
         # 条目才进入 load_bundles。这样 1200 部电影不会先水合整库 JSON。
-        latest_units = await latest_unit_candidates(
-            session,
-            member_id=scope.member_id,
-            library_id=library_id,
-            visible_library_ids=scope.visible,
-            is_played=is_played,
-        )
+        #
+        # 候选行数也按需下推到 SQL。取多少够用取决于"最近入库里同一部剧占了
+        # 几集"：电影库一行对一条，取 limit×4 就够；剧集库要把同剧多集折叠
+        # 成一条，生产实测最费的库要扫到 527 行才凑满 20 条，第二档 limit×32
+        # 覆盖得住。两档都不够才不加限制——无论走到哪一档，结果与全表取回
+        # 完全一致（排序是全序，取前缀等价于取全部再切片）。
         selected_units: list[LatestUnitCandidate] = []
         grouped_series: dict[int, int] = {}
-        for candidate in latest_units:
-            if len(selected_units) >= limit:
+        for row_limit in (max(limit * 4, 100), max(limit * 32, 800), None):
+            latest_units = await latest_unit_candidates(
+                session,
+                member_id=scope.member_id,
+                library_id=library_id,
+                visible_library_ids=scope.visible,
+                is_played=is_played,
+                row_limit=row_limit,
+            )
+            selected_units = []
+            grouped_series = {}
+            for candidate in latest_units:
+                if len(selected_units) >= limit:
+                    break
+                if candidate.kind == "movie":
+                    selected_units.append(candidate)
+                    continue
+                # 剧集：两态简化（设计文档偏离⑥），同剧多集新入库聚合为 Series。
+                if not groupItems:
+                    selected_units.append(candidate)
+                    continue
+                if candidate.media_item_id in grouped_series:
+                    grouped_series[candidate.media_item_id] += 1
+                    continue
+                grouped_series[candidate.media_item_id] = 1
+                selected_units.append(candidate)
+            # 选够了，或候选本身就没被截断（说明库里就这么多）→ 结果已是最终态
+            if len(selected_units) >= limit or row_limit is None or len(
+                latest_units
+            ) < row_limit:
                 break
-            if candidate.kind == "movie":
-                selected_units.append(candidate)
-                continue
-            # 剧集：两态简化（设计文档偏离⑥），同剧多集新入库聚合为 Series。
-            if not groupItems:
-                selected_units.append(candidate)
-                continue
-            if candidate.media_item_id in grouped_series:
-                grouped_series[candidate.media_item_id] += 1
-                continue
-            grouped_series[candidate.media_item_id] = 1
-            selected_units.append(candidate)
 
         selected_ids = list(dict.fromkeys(c.media_item_id for c in selected_units))
         bundles = await load_bundles(
@@ -894,6 +989,11 @@ async def items_latest(
             library_id=library_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            # 只渲染选中的这些单元：同剧聚合成 Series 的那几条也只吃单元键集合
+            leaf_scope={
+                (c.media_item_id, c.season_number, c.episode_number)
+                for c in selected_units
+            },
         )
     dtos: list[dict[str, Any]] = []
     dto_candidates: list[LatestUnitCandidate] = []
@@ -960,6 +1060,15 @@ async def items_resume(
                 member_id=scope.member_id,
                 visible_library_ids=scope.visible,
                 dto_options=options,
+                # 本页的续播单元就是全部会渲染的叶子（电影用 (0,0) 哨兵）
+                leaf_scope={
+                    (
+                        c.media_item_id,
+                        c.season_number,
+                        c.episode_number,
+                    )
+                    for c in page_candidates
+                },
             )
     else:
         page_candidates = []
@@ -1214,12 +1323,24 @@ async def get_item(
         # 单条目是全字段语义，People 恒输出；可见性先行（GUID 可枚举）
         if not await _item_visible(session, ref.entity_id, scope):
             raise not_found()
+        # GUID 自带类型，装载前就知道这次只会渲染哪一个叶子：
+        # 集 → 就那一集；剧/季 → 一个叶子都不渲染（Series/Season DTO 只吃
+        # 单元键集合 + 季元数据 + 播放状态）；电影 → (0,0) 哨兵单元。
+        # 剧条目 GUID 与电影同型，统一带上 (id,0,0)：对剧来说这个单元不存在，
+        # 不会多装任何行。
+        if ref.kind == EntityKind.EPISODE:
+            detail_scope = {(ref.entity_id, ref.season, ref.episode)}
+        elif ref.kind == EntityKind.SEASON:
+            detail_scope = set()
+        else:
+            detail_scope = {(ref.entity_id, 0, 0)}
         bundles = await load_bundles(
             session,
             [ref.entity_id],
             member_id=scope.member_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            leaf_scope=detail_scope,
         )
 
     bundle = bundles.get(ref.entity_id)
@@ -1364,6 +1485,9 @@ async def shows_seasons(
             member_id=scope.member_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            # Season DTO 只吃季元数据 + "哪些单元有文件"的键集合 + 播放状态，
+            # 一个叶子条目都不渲染——整剧的文件行与分集元数据全部不必装载
+            leaf_scope=set(),
         )
     bundle = bundles.get(ref.entity_id)
     if bundle is None or bundle.item.kind != "tv":
@@ -1405,6 +1529,12 @@ async def shows_episodes(
         if season_param is not None and season_param.lstrip("-").isdigit():
             season_scope = int(season_param)
 
+    start_index = _parse_int(q.get("startIndex"))
+    limit = _parse_int(q.get("limit"), default=-1)
+    # 不限季又不分页 = 整剧全要，那就没有"少装一点"的空间，直接走整行装载；
+    # 只要限了季或分了页，先建骨架、选完页再补料才划算
+    whole_series = season_scope is None and limit < 0 and start_index == 0
+
     async with get_database().session() as session:
         if not await _item_visible(session, target_item_id, scope):
             raise not_found_message("Series not found")
@@ -1414,27 +1544,40 @@ async def shows_episodes(
             member_id=scope.member_id,
             visible_library_ids=scope.visible,
             dto_options=options,
+            leaf_scope=None if whole_series else set(),
         )
-    bundle = bundles.get(target_item_id)
-    if bundle is None or bundle.item.kind != "tv":
-        raise not_found_message("Series not found")
-    if season_id and season_scope not in {s for s, _ in bundle.units}:
-        # seasonId 指向不存在（无文件）的季 → 404（对齐 TvShowsController.cs:238）
-        raise not_found_message(f"No season exists with Id {season_id}")
+        bundle = bundles.get(target_item_id)
+        if bundle is None or bundle.item.kind != "tv":
+            raise not_found_message("Series not found")
+        if season_id and season_scope not in {s for s, _ in bundle.units}:
+            # seasonId 指向不存在（无文件）的季 → 404（对齐 TvShowsController.cs:238）
+            raise not_found_message(f"No season exists with Id {season_id}")
 
-    units = [
-        u
-        for u in bundle.units
-        if season_scope is None or u[0] == season_scope
-    ]
-    dtos = [episode_dto(ctx, bundle, s, e, options) for s, e in units]
-    if q.get("sortBy") == "Random":
-        import random
+        units = [
+            u
+            for u in bundle.units
+            if season_scope is None or u[0] == season_scope
+        ]
+        # 洗牌对象从 DTO 换成单元：random.shuffle 只按下标置换、与元素类型无关，
+        # 同一 RNG 状态下得到的排列完全相同，但不必先把整季都构建成 DTO
+        if q.get("sortBy") == "Random":
+            import random
 
-        random.shuffle(dtos)
+            random.shuffle(units)
 
-    total = len(dtos)
-    start_index = _parse_int(q.get("startIndex"))
-    limit = _parse_int(q.get("limit"), default=-1)
-    page = dtos[start_index : start_index + limit] if limit >= 0 else dtos[start_index:]
+        total = len(units)
+        page_units = (
+            units[start_index : start_index + limit]
+            if limit >= 0
+            else units[start_index:]
+        )
+        if not whole_series:
+            await hydrate_leaves(
+                session,
+                {target_item_id: bundle},
+                {(target_item_id, s, e) for s, e in page_units},
+                visible_library_ids=scope.visible,
+                dto_options=options,
+            )
+    page = [episode_dto(ctx, bundle, s, e, options) for s, e in page_units]
     return JSONResponse(query_result(page, total, start_index))


### PR DESCRIPTION
## 背景

Infuse 每次启动都会对媒体库打一轮密集扫描。生产访问日志实测（2026-08-28）：

- 握手到首屏加载完成 **77 秒、365 个请求**，服务端累计处理 91.3 秒
- 单请求耗时从 235ms 一路涨到 **2.3 秒**——典型的排队形态
- 107 次 `Shows/{id}/Seasons` 只涉及 **6 部剧**，其中一部被请求 44 次

## 根因

「为了输出 20 条，先把上千行水合成 ORM 对象」：

| 现象 | 生产实测 |
|---|---|
| 一次 Latest 输出 20 条，却装载这 20 个条目名下**全部**文件行与分集元数据 | 1499 行 |
| 剧集库浏览水合整库才输出一页 Series | 3114 文件 + 3416 集 |
| `Shows/{id}/Seasons` 只输出几行季，却整剧水合 | 82 文件 + 40 集 |
| `latest_unit_candidates` 无 LIMIT，全库单元搬进 Python 再扔掉 | 6178 行 |

cProfile 佐证：291 个请求造了 **23 万个 ORM 对象**、做了 **25 万次 JSON 反序列化**，其中绝大多数从头到尾没人读。

另有一处**影响全站**的问题：生产库没有 `sqlite_stat1`，SQLite 只能靠内置猜测挑索引，于是把命中全表 6837 行的 `ix_library_file_state` 当成高选择性条件优先选中——「取某个条目的文件行」退化成整表索引扫描再逐行过滤（1.66ms → 0.32ms）。媒体库网页、播放链路走的是同一批查询。

## 改动

- **两段式装载**（`load_bundles(leaf_scope=...)`）：先用列查询建「哪些单元有文件」的骨架（`units`/`ChildCount`/聚合 `UserData` 只认这个键集合），只为真正会渲染成叶子条目的单元装完整行。列表接口选完页再回头补这一页的料（`hydrate_leaves`）。
- **判定回落**：排序键落在 `DateCreated`/`Runtime`，或候选含 `Episode` 且排序/搜索要读分集元数据时，自动回落原有整行装载。判定放在装载侧，因为「候选里会不会出现 Episode」要看库类型和 recursive 特例。
- **Latest 候选行数下推 SQL**：`limit×4 → limit×32 → 不限` 三档。排序是全序（入库时间后还有四级 tiebreak），取前缀等价于取全部再切片。
- **条目与元数据合并为一条 LEFT JOIN**；只出 Series 行的库浏览不读季元数据；`ItemBundle.units` 加缓存。
- **启停各跑一次 `PRAGMA analysis_limit=400; PRAGMA optimize`** 刷新索引统计（生产库整轮 12ms，只对统计缺失/过时的表动手）。

## 效果

生产库快照，330 请求的完整扫描脚本：

| | 基线 | 本 PR | |
|---|---|---|---|
| 串行 | 7211ms | **2984ms** | −59% |
| 并发 8 | 14362ms | **4888ms** | −66% |

| 端点 | 次数 | 串行 | 并发 8 |
|---|---|---|---|
| `/Items` 库浏览 | 79 | 38.9 → **11.1ms** | 988 → **151ms** |
| `/Items/Latest` | 50 | 19.3 → **11.3ms** | 438 → **112ms** |
| `/Shows/{id}/Seasons` | 107 | 11.0 → **3.9ms** | 185 → **36ms** |
| `/Items/{id}` 详情 | 49 | 11.1 → **5.9ms** | 140 → **82ms** |

## 契约守卫：响应逐字节不变

新增 `scripts/perf/bench_jellyfin_scan.py`：

- 按生产形状生成 mock 数据（10 库 / 855 条目 / 6837 台账行 / 9353 集 / 556 季，固定种子），也支持 `--db` 直接跑现成库快照
- 请求条数与端点配比抄自真实 Infuse 启动的访问日志，`--concurrency` 复刻并发打法
- `--dump` / `--compare` 把每个响应落成快照做**逐字节比对**——「性能优化不改变输入输出」这条线由它自动守着

**mock 与生产库两套数据上，330 个响应全部逐字节一致**，覆盖排序（`SortName`/`DateCreated`/`Runtime`/`PremiereDate`/`CommunityRating`）、搜索、递归 Episode、剧→季→集下钻、`ids=` 批量、筛选等口径矩阵。

比对过程中抓出两个原本会漏掉的真问题，都已处理：

1. **多版本文件的输出顺序**：旧路径没有 `ORDER BY`，靠 `ix_library_file_browse_unit` 末列恰好是 `created_at` 而「碰巧」有序——换了 WHERE 就换计划、换计划就换顺序。已在两段式路径写成显式约束。
2. **`ParentId` 会随分页漂移**：`_item_library_guid` 取「第一个文件行的库」，两段式下只装本页叶子就不对了。改成骨架扫描时顺手算出归属库；跨库条目（生产 855 个里有 1 个）才额外做一次入库时间比较。

## 测试

`pytest -m "not integration"`：**2650 passed, 0 failed**（`tests/docker/test_entrypoint_supervision.py` 在本机 macOS 上未改动的 main 也全挂，属环境问题，本次以 `--ignore=tests/docker` 跑）。ruff 干净。

无迁移、无依赖变更，`docker/runtime-version` 不需要 bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
