### PR TITLE
fix(library): 扫描不再丢掉名称里的 remux 标记，存量内容洗版基线不再恒为未知

### DIFF
--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -104,6 +104,7 @@ from movieclaw_db.models.scheduled_task import TriggerType
 from movieclaw_db.repositories.library_file_repo import LibraryFileRepository
 from movieclaw_db.repositories.library_repo import LibraryRepository
 from movieclaw_enrich import enrich
+from movieclaw_enrich.models import TorrentAttrs
 from movieclaw_enrich.structure import title_candidates
 from movieclaw_media.models import MediaKind
 from movieclaw_scheduler.registry import register_task
@@ -1762,6 +1763,29 @@ def unit_name(file: Path, is_disc: bool) -> str:
     return file.name if is_disc else file.stem
 
 
+def scanned_media_source(attrs: TorrentAttrs) -> str | None:
+    """扫描落库用的片源值：把只存在于名称里的 remux 标记折进 ``media_source``。
+
+    ``library_file`` 没有 remux 布尔列——按既有设计，Remux 以 ``media_source``
+    取值 ``"Remux"`` 表达（``decision.source_tier`` 对该值直接判 T5，人工标注
+    走的也是这条路）。但 enrich 把 remux 解析成**独立布尔位**，而扫描此前只
+    落 ``media_source`` 与 ``release_group``，这一位就地丢失。
+
+    受害的是"写了 Remux、却没写片源词"的命名——Emby / MoviePilot 的整理模板
+    正是这种（``片名 (年份) - 2160p Remux CHD.mkv``）：enrich 解析结果是
+    ``media_source=None`` + ``remux=True``，落库后变成"片源未知"，洗版基线
+    不可比。更糟的是整理改名会把这段技术串一起抹掉，之后连重新解析的机会
+    都没有（``snapshot_from_file`` 正是靠 ``library_file.media_source`` 回补
+    才不受改名影响，remux 没有对应列可回补）。
+
+    只在 ``media_source`` 缺席时折入：名称同时给出片源与 remux（如
+    ``UHD BluRay REMUX``）时保留更具体的片源值，不覆盖既有信息。
+    """
+    if attrs.remux and not attrs.media_source:
+        return "Remux"
+    return attrs.media_source
+
+
 def disc_main_stream(disc_dir: Path) -> Path | None:
     """原盘主流文件（探测用）：蓝光优先按 MPLS 主播放列表，损坏盘降级取最大流。"""
     playlist = read_main_playlist(disc_dir)
@@ -2461,7 +2485,7 @@ async def _ingest_file(
             audio_streams=list(spec.audio_streams) if spec else None,
             subtitle_streams=list(spec.subtitle_streams) if spec else None,
             external_subtitles=external_subtitles,
-            media_source=attrs.media_source,
+            media_source=scanned_media_source(attrs),
             release_group=attrs.release_group,
             source=FileSource.SCANNED,
             added_batch_id=added_batch_id,

--- a/tests/api/test_library_scan_media_source.py
+++ b/tests/api/test_library_scan_media_source.py
@@ -1,0 +1,52 @@
+"""扫描落库的片源取值（``scan.scanned_media_source``）测试。
+
+覆盖：只写 Remux 不写片源词的命名要折进 media_source（Emby/MoviePilot 的
+整理模板就是这种）、片源词已存在时不覆盖、非 Remux 与无信息命名保持原样，
+以及折入后能被洗版阶梯判成 T5。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from movieclaw_api.services.library.scan import scanned_media_source
+from movieclaw_enrich import enrich
+from movieclaw_matcher.decision import source_tier
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # 只写 Remux、不写片源词：此前落库为"片源未知"，洗版基线不可比
+        ("华尔街之狼 (2013) - 2160p Remux CHD", "Remux"),
+        ("怪奇物语 S01E03 - 2160p Remux HEVC", "Remux"),
+        # 片源词已存在：保留更具体的值，不被覆盖
+        ("Casino Royale 2006 UHD BluRay REMUX 2160p HEVC DTS-HD MA5.1-CHD", "UHD Blu-ray"),
+        ("Some Movie 2020 1080p WEB-DL DDP5.1 x264-GRP", "WEB-DL"),
+        # 非 Remux 且无片源词：保持未知，绝不猜
+        ("星河入梦 (2026) - 2160p H.265 CMCTV", None),
+        ("片名 (2021)", None),
+    ],
+)
+def test_scanned_media_source(name, expected):
+    assert scanned_media_source(enrich(name)) == expected
+
+
+def test_folded_remux_reaches_top_tier():
+    """折入的 "Remux" 必须能被片源阶梯判成最高档——否则折了也白折。
+
+    ``library_file`` 没有 remux 布尔列，快照从库文件行重建时 remux 恒为
+    False，只能靠 media_source 取值表达档位。
+    """
+    value = scanned_media_source(enrich("华尔街之狼 (2013) - 2160p Remux CHD"))
+    assert source_tier(value, False) == source_tier(None, True)
+
+
+def test_no_regression_for_named_sources():
+    """已有片源词的命名档位不变（回归保护）。"""
+    for name in (
+        "Some Movie 2020 1080p WEB-DL DDP5.1 x264-GRP",
+        "Some Movie 2020 1080p BluRay x264-GRP",
+    ):
+        attrs = enrich(name)
+        assert scanned_media_source(attrs) == attrs.media_source


### PR DESCRIPTION
## 问题

存量扫描解析文件名时拿到了 `attrs.remux`，但**没有落库**。

`_ingest_file` 只持久化 `media_source` 与 `release_group` 两个出处维度：

```python
attrs = enrich(unit_name(file, is_disc))          # scan.py
...
    media_source=attrs.media_source,               # attrs.remux 从此没人再碰
    release_group=attrs.release_group,
```

`library_file` 没有 remux 布尔列，这一位就地丢失。

受害的是**"写了 Remux、却没写片源词"的命名**，而 Emby / MoviePilot 的整理模板正是这种：

```
片名 (年份) - 2160p Remux CHD.mkv
  → enrich:  media_source=None,  remux=True
  → 落库:    media_source=None                ← "片源未知"，洗版基线不可比
```

## 为什么事后补不回来

`snapshot_from_file` 从库文件行重建快照时，会用 `library_file` 里存的
`media_source` / `release_group` 覆盖文件名解析结果，其 docstring 说明了原因：

> 它们是入库时对**原始名称**的解析结果，比重命名后的文件名更可靠。

出处维度三件套里，只有 remux 没有对应的列可回补——只能退回去解析**已经被整理
抹干净**的文件名，恒为 `False`。也就是说：整理跑过一次之后，这个信息就永久消失了。

## 修复

按仓库**已有的约定**：Remux 本就以 `media_source` 取值 `"Remux"` 表达。
`decision.py` 写得很明确：

```python
# T5：人工标注的 Remux 存为 media_source 值（library_file 无 remux 布尔列，
# 快照出处维度由 file.media_source 覆盖，走值比走布尔位更省一列）
_SOURCE_TIER: dict[str, int] = {"remux": _REMUX_TIER, ...}
```

人工标注 API 走的就是这条路，扫描只是没用上。本 PR 补上：

```python
def scanned_media_source(attrs: TorrentAttrs) -> str | None:
    if attrs.remux and not attrs.media_source:
        return "Remux"
    return attrs.media_source
```

保守起见**只在 `media_source` 缺席时折入**，名称同时给出片源与 remux
（如 `UHD BluRay REMUX`）时保留更具体的值，行为不变。

## 实测数据

一个 918 部电影 + 3754 集剧集的库（DSM 群晖，此前由 Emby 管理，后迁到 movieclaw）：

| | |
|---|---:|
| 电影文件 `media_source` 为空 | 909 / 918 |
| 剧集文件 `media_source` 为空 | 3754 / 3754 |
| 其中整理**前**文件名里明确写着 Remux 的电影 | 240 |

那 9 个有值的，全部来自"名称里含 `BluRay` / `WEB-DL` 字面词"或走下载管线入库。

修复后的取值对照（在真实 `enrich` 上验证）：

| 文件名 | 修复前 | 修复后 |
|---|---|---|
| `华尔街之狼 (2013) - 2160p Remux CHD` | `None` | **`Remux`** |
| `怪奇物语 S01E03 - 2160p Remux HEVC` | `None` | **`Remux`** |
| `Casino Royale 2006 UHD BluRay REMUX …-CHD` | `UHD Blu-ray` | `UHD Blu-ray`（不变） |
| `… 2022 1080p WEB-DL x264 AAC` | `WEB-DL` | `WEB-DL`（不变） |
| `星河入梦 (2026) - 2160p H.265 CMCTV` | `None` | `None`（不猜） |

并验证折入后 `source_tier("Remux", False) == source_tier(None, True) == 5`，
即与 remux 布尔位等价——否则折了也白折。

## 已知残留（本 PR 未处理）

`UHD BluRay REMUX` 这类名称落库为 `UHD Blu-ray`（T4），但它实际是 T5。
`source_tier` 内部 remux 位**优先于** media_source，说明二者语义上 remux 更高：

```python
def source_tier(media_source: str | None, remux: bool) -> int | None:
    if remux:
        return _REMUX_TIER
```

要彻底修需要给 `library_file` 加 remux 列，涉及迁移，留给维护者定夺。本 PR
刻意不越界。

## 测试

新增 `tests/api/test_library_scan_media_source.py`：折入、不覆盖、不猜、
档位等价、已有片源词的回归保护。

说明一下验证边界：提交环境没装项目依赖（服务跑在另一台 NAS 的容器里），
按 AGENTS.md「测试门禁由 CI 承担，本地不要求跑全量测试」，我**没有跑 pytest**，
但把新测试里的每一条断言都拿到运行中容器的真实 `enrich` / `source_tier`
上逐条验证过，结果如上表。集成层面请以 CI 为准。

未动运行时依赖，无需 bump `docker/runtime-version`。
