### PR TITLE
fix(library): 附属文件判定收敛到一处，并补上 trickplay bif

### DIFF
--- a/src/movieclaw_api/services/library/organize.py
+++ b/src/movieclaw_api/services/library/organize.py
@@ -65,13 +65,14 @@ from sqlmodel import select
 from movieclaw_api.services import jobs
 from movieclaw_api.services.library.config import sanitize_folder_name
 from movieclaw_api.services.library.fsops import rename_no_replace
-from movieclaw_api.services.library.layout import SCAN_VIDEO_EXTS, entry_dir_of
+from movieclaw_api.services.library.layout import entry_dir_of
 from movieclaw_api.services.library.naming import (
     entry_dir_name_of,
     episode_file_name,
     movie_file_name,
     season_dir_name,
 )
+from movieclaw_api.services.library.sidecar import SIDECAR_SKIP_EXTS, find_sidecars
 from movieclaw_api.services.task_state import TaskState
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import FileState, Library, LibraryFile, MediaItem, utcnow
@@ -80,9 +81,10 @@ from movieclaw_media.models import MediaKind
 
 logger = logging.getLogger("movieclaw_api.library_organize")
 
-# 视频类文件（含 strm 占位与原盘 iso）。两处用它：附属文件枚举时排除
-# （同名不同容器的视频是独立版本，不是附属）；判断旧条目目录是否已被搬空
-_VIDEO_LIKE_EXTS = SCAN_VIDEO_EXTS | {".iso"}
+# 视频类文件（含 strm 占位与原盘 iso）：判断旧条目目录是否已被搬空。
+# 与附属文件判定共用同一集合——``library.sidecar`` 是唯一定义处，那边把
+# 这些扩展名当"独立版本"排除，这边把它们当"还没搬完"的证据，同一份语义
+_VIDEO_LIKE_EXTS = SIDECAR_SKIP_EXTS
 
 # 条目目录级镜像资产的固定文件名（media_scrape.mirror_media_dir_assets 写出）。
 # 它们不以主文件名开头，附属文件规则（"主文件名."前缀）认不出来，条目目录
@@ -415,34 +417,14 @@ def _root_of(roots: list[str], file_path: str) -> str | None:
     return best
 
 
-# 附属文件的前缀形态：``主文件名.`` 是通例（字幕 foo.zh.srt、单文件 NFO
-# foo.nfo）；``主文件名-thumb.`` 是镜像写分集剧照用的 Kodi/Emby 约定
-# （foo-thumb.jpg），它不带那个点，按通例会被漏掉、留在旧目录变成垃圾
-_SIDECAR_PREFIX_SUFFIXES = (".", "-thumb.")
-
-
 def _find_sidecars(action: RenameAction) -> list[SidecarMove]:
-    """主文件的附属文件：同目录、文件名以"主文件名."或"主文件名-thumb."开头
-    （如 foo.zh.srt / foo.nfo / foo-thumb.jpg）。
-
-    同名不同容器的视频（foo.mkv 旁的 foo.mp4）是独立版本不是附属，排除。
-    """
+    """主文件的附属文件，判定口径见 ``library.sidecar``（整理/转移/回收共用）。"""
     src = Path(action.source_path)
     dst = Path(action.target_path)
-    moves = []
-    try:
-        entries = list(src.parent.iterdir())
-    except OSError:
-        return []
-    prefixes = tuple(src.stem + suffix for suffix in _SIDECAR_PREFIX_SUFFIXES)
-    for entry in sorted(entries):
-        if not entry.is_file() or entry == src or not entry.name.startswith(prefixes):
-            continue
-        if entry.suffix.lower() in _VIDEO_LIKE_EXTS:
-            continue
-        tail = entry.name[len(src.stem) :]  # 含前缀本身，如 ".zh.srt" / "-thumb.jpg"
-        moves.append(SidecarMove(str(entry), str(dst.parent / (dst.stem + tail))))
-    return moves
+    return [
+        SidecarMove(str(entry), str(dst.parent / (dst.stem + tail)))
+        for entry, tail in find_sidecars(src)
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/movieclaw_api/services/library/recycle.py
+++ b/src/movieclaw_api/services/library/recycle.py
@@ -28,7 +28,7 @@ from typing import Any, Literal
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from movieclaw_api.services.library.layout import SCAN_VIDEO_EXTS
+from movieclaw_api.services.library.sidecar import find_sidecars
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import FileState, LibraryFile, utcnow
 from movieclaw_db.models.library import Library
@@ -41,11 +41,6 @@ logger = logging.getLogger("movieclaw_api.library.recycle")
 # 避免跨盘搬几十 GB）；库扫描跳过点开头目录，不会被重新收编
 TRASH_DIR_NAME = ".movieclaw-trash"
 DEFAULT_RETENTION = timedelta(days=7)
-
-# 附属文件判定要跳过的扩展名：同名不同容器的视频（含 .iso 原盘镜像、
-# .strm 占位）是独立版本不是附属，绝不能被当作字幕/NFO 连带处理。
-# 判定规则与 transfer._find_sidecars 同一套约定
-_SIDECAR_SKIP_EXTS = SCAN_VIDEO_EXTS | {".iso"}
 
 # purge_after 的哨兵缺省："由机制决定"——一律按保留期倒计时。
 # 触发方有特殊语义（如联动删除）时可显式传值覆盖
@@ -73,24 +68,8 @@ async def _library_roots(session: AsyncSession, library_id: int | None) -> list[
 
 
 def _sidecar_paths(src: Path) -> list[Path]:
-    """主文件的附属文件：同目录、文件名以「主文件名.」开头的字幕/NFO/图片
-    （foo.zh.srt / foo.nfo）。视频扩展名是独立版本，排除；原盘目录没有
-    附属概念，返回空。判定规则与 transfer._find_sidecars 保持一致。"""
-    if src.is_dir() or not src.suffix:
-        return []
-    try:
-        entries = sorted(src.parent.iterdir())
-    except OSError:
-        return []
-    prefix = src.stem + "."
-    found: list[Path] = []
-    for entry in entries:
-        if not entry.is_file() or entry == src or not entry.name.startswith(prefix):
-            continue
-        if entry.suffix.lower() in _SIDECAR_SKIP_EXTS:
-            continue
-        found.append(entry)
-    return found
+    """主文件的附属文件，判定口径见 ``library.sidecar``（整理/转移/回收共用）。"""
+    return [entry for entry, _tail in find_sidecars(src)]
 
 
 def _move_sidecars(src: Path, target: Path) -> None:

--- a/src/movieclaw_api/services/library/sidecar.py
+++ b/src/movieclaw_api/services/library/sidecar.py
@@ -1,0 +1,93 @@
+"""附属文件（sidecar）判定：整理 / 转移 / 回收三条链路的唯一口径。
+
+附属文件是"跟着主视频走"的伴生产物——字幕、单文件 NFO、分集剧照、播放器
+预览索引。主文件改名或搬走时它们必须一起动，否则会以旧名字留在原地变成
+无人认领的垃圾（回收时同理，漏删就是残留）。
+
+本模块把判定收敛到一处。此前 organize / transfer / recycle 各写了一份，
+已经出现三处分叉：
+
+- 前缀形态：``-thumb.`` 只在 organize 里补过，transfer / recycle 仍只认
+  ``主文件名.``——同一个 ``foo-thumb.jpg``，整理时会跟着走，转移时留在旧
+  目录，回收时漏删；
+- 扩展名排除集：transfer 写的是硬编码字面量，**漏了 ``.strm``**——`foo.mkv`
+  旁边的 `foo.strm` 是独立的网盘占位版本，却会被当成附属一起搬走；
+- 新形态要加三遍，漏一处就再分叉一次。
+
+判定规则（三条，全部满足才算附属）：
+
+1. 同目录、是文件、不是主文件本身；
+2. 扩展名不在 ``SIDECAR_SKIP_EXTS``——同名不同容器的视频（含 ``.iso`` 原盘
+   镜像、``.strm`` 占位）是**独立版本**不是附属，绝不能被连带处理；
+3. 文件名匹配下列任一形态：
+   - ``主文件名.``  开头 —— 通例（``foo.zh.srt`` / ``foo.nfo``）；
+   - ``主文件名-thumb.`` 开头 —— Kodi/Emby 分集剧照约定（``foo-thumb.jpg``）；
+   - ``主文件名-<数字>[-<数字>…].bif`` —— Emby/Jellyfin 的 trickplay 预览
+     索引（``foo-320-10.bif``，中缀是"宽度-间隔"，随配置变化，写不成固定
+     前缀，所以单独用模式匹配）。
+
+返回值统一是"尾巴"（含分隔符本身，如 ``.zh.srt`` / ``-thumb.jpg`` /
+``-320-10.bif``），调用方拼到新主文件名后面即得目标名。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from movieclaw_api.services.library.layout import SCAN_VIDEO_EXTS
+
+# 同名不同容器的视频是独立版本不是附属：.iso 原盘镜像、.strm 网盘占位同理
+SIDECAR_SKIP_EXTS = SCAN_VIDEO_EXTS | {".iso"}
+
+# 固定前缀形态：``主文件名`` 之后紧跟的这些串
+_PREFIX_SUFFIXES = (".", "-thumb.")
+
+# 中缀可变、写不成固定前缀的形态，改用整段尾巴的模式匹配。
+# trickplay bif：``-320-10.bif``（宽度-间隔）、``-320.bif``（只有宽度）
+_TAIL_PATTERNS = (re.compile(r"^-\d+(?:-\d+)*\.bif$", re.IGNORECASE),)
+
+
+def sidecar_tail(main: Path, entry: Path) -> str | None:
+    """``entry`` 是 ``main`` 的附属文件时返回要跟随的尾巴，否则 ``None``。
+
+    只做名字与扩展名判定，不碰磁盘（``entry`` 是否为文件由调用方按各自的
+    遍历方式确认——有的调用方手上已经有 ``iterdir`` 的结果，再 stat 一次
+    是白花的系统调用）。
+    """
+    if entry == main:
+        return None
+    if entry.suffix.lower() in SIDECAR_SKIP_EXTS:
+        return None
+    name = entry.name
+    stem = main.stem
+    if not name.startswith(stem):
+        return None
+    tail = name[len(stem) :]
+    if any(name.startswith(stem + suffix) for suffix in _PREFIX_SUFFIXES):
+        return tail
+    if any(pattern.match(tail) for pattern in _TAIL_PATTERNS):
+        return tail
+    return None
+
+
+def find_sidecars(main: Path) -> list[tuple[Path, str]]:
+    """``main`` 同目录下的全部附属文件，返回 ``(路径, 尾巴)`` 列表（按名排序）。
+
+    原盘目录（无扩展名）没有附属概念，返回空。目录不可读时按"没有附属"
+    处理——整理/转移的主流程不该因为一次 ``iterdir`` 失败整轮中断。
+    """
+    if main.is_dir() or not main.suffix:
+        return []
+    try:
+        entries = sorted(main.parent.iterdir())
+    except OSError:
+        return []
+    found: list[tuple[Path, str]] = []
+    for entry in entries:
+        if not entry.is_file():
+            continue
+        tail = sidecar_tail(main, entry)
+        if tail is not None:
+            found.append((entry, tail))
+    return found

--- a/src/movieclaw_api/services/library/transfer.py
+++ b/src/movieclaw_api/services/library/transfer.py
@@ -49,6 +49,7 @@ from movieclaw_api.services.library.layout import entry_dir_of
 # 复用整理器的"只清理自己搬空的目录"实现（非空即停、绝不删文件）——同一
 # 语义两处各写一份迟早分叉，而这段克制正是搬运类操作的安全底线
 from movieclaw_api.services.library.organize import _prune_emptied_dirs
+from movieclaw_api.services.library.sidecar import find_sidecars
 from movieclaw_api.services.task_state import TaskState
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import FileState, Library, LibraryFile, MediaItem, Subscription, utcnow
@@ -56,11 +57,6 @@ from movieclaw_db.repositories.library_file_repo import LibraryFileRepository
 from movieclaw_db.repositories.library_repo import LibraryRepository
 
 logger = logging.getLogger("movieclaw_api.library_transfer")
-
-# 跟随主文件一起搬的附属文件后缀判定：同目录、文件名以"主文件名."开头
-# （foo.zh.srt / foo.nfo）。同名不同容器的视频是独立版本不是附属，排除。
-# 与 library_organize 同一套约定
-_SIDECAR_SKIP_EXTS = {".mkv", ".mp4", ".avi", ".ts", ".m2ts", ".iso", ".wmv", ".mov", ".flv"}
 
 # 跨盘复制按块落入隐藏临时路径。每块独立交还事件循环，使取消和应用更新
 # 最多只损失当前块；下次执行按临时文件现有长度续传，不重新复制几十 GB。
@@ -307,23 +303,8 @@ def _add_file_move(
 
 
 def _find_sidecars(src: Path, dst: Path) -> list[tuple[str, str]]:
-    """主文件的附属文件（同目录、以"主文件名."开头的字幕/NFO/图片）。"""
-    if src.is_dir() or not src.suffix:
-        return []
-    try:
-        entries = sorted(src.parent.iterdir())
-    except OSError:
-        return []
-    prefix = src.stem + "."
-    moves = []
-    for entry in entries:
-        if not entry.is_file() or entry == src or not entry.name.startswith(prefix):
-            continue
-        if entry.suffix.lower() in _SIDECAR_SKIP_EXTS:
-            continue
-        tail = entry.name[len(src.stem) :]  # 含开头的 "."，如 ".zh.srt"
-        moves.append((str(entry), str(dst.parent / (dst.stem + tail))))
-    return moves
+    """主文件的附属文件，判定口径见 ``library.sidecar``（整理/转移/回收共用）。"""
+    return [(str(entry), str(dst.parent / (dst.stem + tail))) for entry, tail in find_sidecars(src)]
 
 
 def _inside_roots(path: Path, roots: list[Path]) -> bool:

--- a/tests/api/test_library_sidecar.py
+++ b/tests/api/test_library_sidecar.py
@@ -1,0 +1,91 @@
+"""附属文件判定（``library.sidecar``）的测试。
+
+覆盖：三种收录形态（``主文件名.`` / ``-thumb.`` / trickplay bif）、独立版本
+的排除（同名异容器视频 / ``.iso`` 原盘镜像 / ``.strm`` 占位 / 多版本标签
+文件）、未收录形态保持保守、目录不可读时的降级。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from movieclaw_api.services.library.sidecar import (
+    SIDECAR_SKIP_EXTS,
+    find_sidecars,
+    sidecar_tail,
+)
+
+MAIN = "华尔街之狼 (2013).mkv"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # 通例：主文件名 + "."
+        ("华尔街之狼 (2013).zh.srt", ".zh.srt"),
+        ("华尔街之狼 (2013).nfo", ".nfo"),
+        # Kodi/Emby 分集剧照
+        ("华尔街之狼 (2013)-thumb.jpg", "-thumb.jpg"),
+        # Emby/Jellyfin trickplay 预览索引：中缀是"宽度-间隔"，随配置变化
+        ("华尔街之狼 (2013)-320-10.bif", "-320-10.bif"),
+        ("华尔街之狼 (2013)-320.bif", "-320.bif"),
+        ("华尔街之狼 (2013)-320-10.BIF", "-320-10.BIF"),
+    ],
+)
+def test_recognised_sidecar_forms(tmp_path, name, expected):
+    """三种收录形态都要认出来，并返回可直接拼接的尾巴。"""
+    assert sidecar_tail(tmp_path / MAIN, tmp_path / name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "华尔街之狼 (2013).mp4",  # 同名异容器 = 另一个版本
+        "华尔街之狼 (2013).iso",  # 原盘镜像 = 另一个版本
+        "华尔街之狼 (2013).strm",  # 网盘占位 = 另一个版本
+        "华尔街之狼 (2013).mkv",  # 主文件本身
+        "华尔街之狼 (2013) - 2160p.mkv",  # 多版本标签文件，绝不能被当附属拖走
+        "华尔街之狼 (2013)-fanart.jpg",  # 未收录形态：保守不搬，宁可留下也不误搬
+        "别的片子.srt",
+    ],
+)
+def test_not_sidecar(tmp_path, name):
+    assert sidecar_tail(tmp_path / MAIN, tmp_path / name) is None
+
+
+def test_strm_is_excluded_by_skip_exts():
+    """``.strm`` 必须在排除集里——它是独立的网盘占位版本，不是附属。"""
+    assert ".strm" in SIDECAR_SKIP_EXTS
+    assert ".iso" in SIDECAR_SKIP_EXTS
+
+
+def test_find_sidecars_scans_directory(tmp_path):
+    """目录扫描：只挑出附属文件，按名排序，返回 (路径, 尾巴)。"""
+    for name in (
+        MAIN,
+        "华尔街之狼 (2013).zh.srt",
+        "华尔街之狼 (2013)-320-10.bif",
+        "华尔街之狼 (2013).mp4",
+        "无关文件.txt",
+    ):
+        (tmp_path / name).write_text("x", encoding="utf-8")
+    found = find_sidecars(tmp_path / MAIN)
+    assert [entry.name for entry, _ in found] == [
+        "华尔街之狼 (2013)-320-10.bif",
+        "华尔街之狼 (2013).zh.srt",
+    ]
+    assert [tail for _, tail in found] == ["-320-10.bif", ".zh.srt"]
+
+
+def test_disc_dir_has_no_sidecars(tmp_path):
+    """原盘目录（无扩展名）没有附属概念。"""
+    disc = tmp_path / "华尔街之狼 (2013)"
+    (disc / "BDMV").mkdir(parents=True)
+    assert find_sidecars(disc) == []
+
+
+def test_unreadable_dir_degrades_to_empty(tmp_path):
+    """目录读不到时按"没有附属"处理，不让主流程整轮中断。"""
+    assert find_sidecars(tmp_path / "不存在的目录" / MAIN) == []

--- a/tests/api/test_library_sidecar.py
+++ b/tests/api/test_library_sidecar.py
@@ -7,8 +7,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from movieclaw_api.services.library.sidecar import (


### PR DESCRIPTION
## 问题

附属文件判定在三条链路里各写了一份，**已经分叉**：

| | 前缀形态 | 扩展名排除集 |
|---|---|---|
| `organize._find_sidecars` | `(".", "-thumb.")` | `SCAN_VIDEO_EXTS \| {".iso"}` |
| `transfer._find_sidecars` | `(".",)` | 硬编码字面量，**漏了 `.strm`** |
| `recycle._sidecar_paths` | `(".",)` | `SCAN_VIDEO_EXTS \| {".iso"}` |

后果：

- 同一个 `foo-thumb.jpg`，**整理时跟着走、转移时留在旧目录、回收时漏删**
  —— `-thumb.` 当初只在 organize 补过；
- `foo.mkv` 旁边的 `foo.strm` 是独立的网盘占位版本，转移时却会被当成附属
  一起搬走 —— transfer 的硬编码集合里没有 `.strm`；
- 每加一种新形态要改三处，漏一处就再分叉一次。

## 修复

新增 `library/sidecar.py` 作为唯一判定口径，三处改为调用它。

理由与 transfer 复用 `_prune_emptied_dirs` 时写下的那句一致：

> 复用整理器的"只清理自己搬空的目录"实现（非空即停、绝不删文件）——同一
> 语义两处各写一份迟早分叉，而这段克制正是搬运类操作的安全底线

附属文件判定是同样的情况，而且分叉已经发生了。

## 顺带补上 trickplay bif

一种此前会被漏掉的形态：Emby / Jellyfin 的预览索引 `主文件名-320-10.bif`。

它和 `-thumb.` 是**同一类问题**，organize 里那条注释已经把病理描述清楚了：

> `主文件名-thumb.` 是镜像写分集剧照用的 Kodi/Emby 约定（foo-thumb.jpg），
> 它不带那个点，按通例会被漏掉、留在旧目录变成垃圾

bif 的中缀是"宽度-间隔"（`-320-10`），随播放器配置变化，写不成固定前缀，
所以改用整段尾巴的模式匹配：

```python
_TAIL_PATTERNS = (re.compile(r"^-\d+(?:-\d+)*\.bif$", re.IGNORECASE),)
```

**实测**：一个 918 部电影 + 185 部剧集的库整理后，留下 **567 个孤儿 bif**
（电影）和 **3766 个**（剧集），合计约 4 GB，全部以旧文件名躺在原地，
任何播放器都不会再读它们。

## 判定规则（保持保守）

只收录三种形态：

- `主文件名.` —— 通例（`foo.zh.srt` / `foo.nfo`）
- `主文件名-thumb.` —— Kodi/Emby 分集剧照
- `主文件名-<数字>[-<数字>…].bif` —— trickplay 预览索引

其余（如 `foo-fanart.jpg`）**宁可留下也不误搬**。同名不同容器的视频、
`.iso` 原盘镜像、`.strm` 占位一律排除——它们是独立版本不是附属。

## 测试

新增 `tests/api/test_library_sidecar.py`，12 个用例覆盖三种收录形态、
独立版本排除、未收录形态保持保守、原盘目录与不可读目录的降级。

其中最危险的边界单独立了用例：**`片名 (2013) - 2160p.mkv` 这类多版本标签
文件不能被当成附属拖走**（它以主文件名开头，但分隔符是"空格-连字符-空格"，
与新增的紧贴连字符规则不冲突，且扩展名排除集也会兜住）。

说明一下验证边界：提交环境没装项目依赖（服务跑在另一台 NAS 的容器里），
按 AGENTS.md「测试门禁由 CI 承担，本地不要求跑全量测试」，我**没有跑 pytest**，
但把 `sidecar_tail` / `find_sidecars` 的判定逻辑单独提出来在本地跑过全部
用例（含排序、尾巴拼接、大小写不敏感、目录降级），12 项全通过。
集成层面请以 CI 为准。

未动运行时依赖，无需 bump `docker/runtime-version`。
