### PR TITLE
feat(刮削): 主语言译名缺失时用同地区 alternative_titles 补位

### DIFF
--- a/src/movieclaw_media/library.py
+++ b/src/movieclaw_media/library.py
@@ -204,8 +204,10 @@ async def fetch_media_profile(
     translations = _translation_index(data)
     # 标题回落：主语言没有翻译时（TMDB 会静默退回原名），先用**主语言同地区**
     # 的 alternative_titles 补位，再按优先级取下一语言的译名。
-    # 主语言有翻译时 data 里的 title 就是它，不用动
-    if not _translation_text(translations, primary, "title", "name"):
+    # 判据要求 title 与原名相等——这才是"确实退回了原名"的证据。只看
+    # translations 里有没有主语言条目不够：载荷里译名缺席、而顶层 title 已经
+    # 是译名的情况存在，那时 title 是对的，任何回落都是把好数据换成差数据。
+    if title == original_title and not _translation_text(translations, primary, "title", "name"):
         fallback_title = _alt_region_title(data, primary)
         for lang in languages[1:]:
             if fallback_title:

--- a/src/movieclaw_media/library.py
+++ b/src/movieclaw_media/library.py
@@ -202,14 +202,17 @@ async def fetch_media_profile(
     release_date = data.get("release_date") or data.get("first_air_date") or ""
 
     translations = _translation_index(data)
-    # 标题回落：主语言没有翻译时（TMDB 会静默退回原名），按优先级取
-    # 下一语言的译名。主语言有翻译时 data 里的 title 就是它，不用动
+    # 标题回落：主语言没有翻译时（TMDB 会静默退回原名），先用**主语言同地区**
+    # 的 alternative_titles 补位，再按优先级取下一语言的译名。
+    # 主语言有翻译时 data 里的 title 就是它，不用动
     if not _translation_text(translations, primary, "title", "name"):
+        fallback_title = _alt_region_title(data, primary)
         for lang in languages[1:]:
-            fallback_title = _translation_text(translations, lang, "title", "name")
             if fallback_title:
-                title = fallback_title
                 break
+            fallback_title = _translation_text(translations, lang, "title", "name")
+        if fallback_title:
+            title = fallback_title
 
     seasons: list[SeasonProfile] = []
     if kind is MediaKind.TV:
@@ -722,6 +725,35 @@ async def _fetch_season(
         poster_path=data.get("poster_path"),
         episodes=episodes,
     )
+
+
+def _alt_region_title(data: dict, language_tag: str) -> str | None:
+    """``alternative_titles`` 里该语言标签对应地区的别名（``zh-CN`` → ``CN``）。
+
+    TMDB 的「译名」（translations）与「地区别名」（alternative_titles）是两套
+    独立维护的数据，缺一方是常态。华语内容尤其典型：大量条目的 ``zh-CN``
+    译名槽是空的，API 于是静默退回原名（英文），而大陆通行译名其实好端端
+    地躺在 ``alternative_titles`` 的 ``CN`` 区里。实测 8 部这类电影，7 部能
+    在这里取到译名，且给出的都是大陆通行译名——而回落到 ``zh-SG`` 拿到的
+    是新马/港台译名（「捍卫战士：独行侠」而非「壮志凌云2：独行侠」）。
+
+    只给**主语言**补位、且只在主语言没有译名时：别名是用户投稿，质量不如
+    译名，用来补"用户真正想要的那个语言"的缺是划算的；次位语言本来就是
+    妥协档，再翻它的别名收益有限，故不做——保守一点，够解决问题即可。
+
+    没有地区段的标签（如 ``zh``）无从定位地区，返回 None。
+    """
+    region = language_tag.partition("-")[2].upper()
+    if not region:
+        return None
+    alt = data.get("alternative_titles") or {}
+    # TMDB 的接口差异：电影用 "titles" 键，剧集用 "results" 键
+    for entry in alt.get("titles") or alt.get("results") or []:
+        if entry.get("iso_3166_1") == region:
+            value = (entry.get("title") or "").strip()
+            if value:
+                return value
+    return None
 
 
 def _build_aliases(data: dict, title: str, original_title: str) -> list[str]:

--- a/tests/media/test_alt_region_title.py
+++ b/tests/media/test_alt_region_title.py
@@ -1,0 +1,66 @@
+"""主语言译名缺失时用同地区 alternative_titles 补位（``_alt_region_title``）。
+
+TMDB 的译名与地区别名是两套独立数据。华语内容大量条目 ``zh-CN`` 译名槽为空，
+API 静默退回原名（英文），而大陆通行译名躺在 ``alternative_titles`` 的 ``CN``
+区里——这些用例用真实结构的载荷固定该行为。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from movieclaw_media.library import _alt_region_title
+
+# 结构照搬 TMDB /movie/{id}?append_to_response=alternative_titles 的真实响应
+SPIDER_MAN = {
+    "alternative_titles": {
+        "titles": [
+            {"iso_3166_1": "HK", "title": "蜘蛛俠：不戰無歸"},
+            {"iso_3166_1": "CN", "title": "蜘蛛侠：英雄无归"},
+            {"iso_3166_1": "US", "title": "Spider-Man 3"},
+        ]
+    }
+}
+
+
+def test_picks_region_of_language_tag():
+    assert _alt_region_title(SPIDER_MAN, "zh-CN") == "蜘蛛侠：英雄无归"
+    assert _alt_region_title(SPIDER_MAN, "zh-HK") == "蜘蛛俠：不戰無歸"
+    assert _alt_region_title(SPIDER_MAN, "en-US") == "Spider-Man 3"
+
+
+def test_region_match_is_case_insensitive_on_tag():
+    assert _alt_region_title(SPIDER_MAN, "zh-cn") == "蜘蛛侠：英雄无归"
+
+
+def test_missing_region_returns_none():
+    """该地区没有别名 → None，交回上层继续按语言优先级回落。"""
+    assert _alt_region_title(SPIDER_MAN, "zh-SG") is None
+
+
+def test_language_tag_without_region_returns_none():
+    """``zh`` 这类没有地区段的标签无从定位地区。"""
+    assert _alt_region_title(SPIDER_MAN, "zh") is None
+    assert _alt_region_title(SPIDER_MAN, "") is None
+
+
+def test_tv_payload_uses_results_key():
+    """TMDB 的接口差异：电影用 ``titles``，剧集用 ``results``。"""
+    tv = {"alternative_titles": {"results": [{"iso_3166_1": "CN", "title": "怪奇物语"}]}}
+    assert _alt_region_title(tv, "zh-CN") == "怪奇物语"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"alternative_titles": None},
+        {"alternative_titles": {}},
+        {"alternative_titles": {"titles": []}},
+        {"alternative_titles": {"titles": [{"iso_3166_1": "CN", "title": ""}]}},
+        {"alternative_titles": {"titles": [{"iso_3166_1": "CN", "title": "   "}]}},
+    ],
+)
+def test_empty_payloads_return_none(payload):
+    """载荷缺失/为空/别名是空白串都要回 None，不能把空串当译名写进标题。"""
+    assert _alt_region_title(payload, "zh-CN") is None

--- a/tests/media/test_media_library.py
+++ b/tests/media/test_media_library.py
@@ -166,8 +166,12 @@ async def test_fetch_movie_overview_falls_back_via_translations() -> None:
     assert profile.tagline == "EN tagline"
 
 
-async def test_fetch_movie_title_falls_back_when_primary_untranslated() -> None:
-    """主语言无标题翻译时，标题按优先级取下一语言的译名。"""
+async def test_fetch_movie_title_prefers_same_region_alias_when_primary_untranslated() -> None:
+    """主语言无译名时先取**同地区别名**（CN），而不是直接落到下一语言。
+
+    TMDB 的译名与地区别名是两套独立数据，华语内容常见 zh-CN 译名缺席、
+    CN 区别名却齐全；此时给简体用户回英文是明显更差的选择。
+    """
     detail = {
         **_MOVIE_DETAIL,
         "title": "Dune: Part Two",  # TMDB 无 zh 翻译时静默退回原名
@@ -185,7 +189,42 @@ async def test_fetch_movie_title_falls_back_when_primary_untranslated() -> None:
     profile = await fetch_media_profile(
         client, MediaKind.MOVIE, 693134, languages=["zh-CN", "en-US"]
     )
+    # _MOVIE_DETAIL 的 alternative_titles 里有 CN 区别名
+    assert profile.title == "沙丘：第二部"
+
+
+async def test_fetch_movie_title_falls_back_when_primary_untranslated() -> None:
+    """主语言既无译名、同地区也无别名时，才按优先级取下一语言的译名。"""
+    detail = {
+        **_MOVIE_DETAIL,
+        "title": "Dune: Part Two",  # TMDB 无 zh 翻译时静默退回原名
+        # CN 区别名一并去掉，只留无关地区——回落必须继续走到 en-US
+        "alternative_titles": {"titles": [{"iso_3166_1": "FR", "title": "Dune Deuxième Partie"}]},
+        "translations": {
+            "translations": [
+                {
+                    "iso_639_1": "en",
+                    "iso_3166_1": "US",
+                    "data": {"title": "Dune: Part Two", "overview": "x"},
+                },
+            ]
+        },
+    }
+    client = _client({"/3/movie/693134": detail})
+    profile = await fetch_media_profile(
+        client, MediaKind.MOVIE, 693134, languages=["zh-CN", "en-US"]
+    )
     assert profile.title == "Dune: Part Two"
+
+
+async def test_fetch_movie_title_keeps_translated_title_without_translations_payload() -> None:
+    """顶层 title 已是译名（≠ 原名）时不许回落——回落会把好数据换成差数据。"""
+    detail = {**_MOVIE_DETAIL, "translations": {"translations": []}}
+    client = _client({"/3/movie/693134": detail})
+    profile = await fetch_media_profile(
+        client, MediaKind.MOVIE, 693134, languages=["zh-CN", "en-US"]
+    )
+    assert profile.title == "沙丘2"
 
 
 _TV_DETAIL = {


### PR DESCRIPTION
## 问题

TMDB 的「译名」（`translations`）与「地区别名」（`alternative_titles`）是两套
**独立维护**的数据，缺一方是常态。华语内容尤其典型 —— 大量条目的 `zh-CN`
译名槽是空的：

```
Spider-Man: No Way Home (tmdb 634649)，请求 language=zh-CN
  顶层 title = "Spider-Man: No Way Home"     ← API 静默退回原名
  translations:
      zh-CN  title = ''                      ← 空
      zh-SG  title = '蜘蛛侠：英雄无归'
      zh-TW  title = '蜘蛛人：無家日'
  alternative_titles:
      CN     蜘蛛侠：英雄无归                  ← 大陆通行译名在这里
```

现有的标题回落只查 `translations`，于是这类条目一路落到 `en-US`，最终以英文
入库、以英文建目录。

实测一个 923 部电影的库，有 8 部踩中（其余 6 部标题非中文是本来就该如此 ——
`1917` / `2012` / `X` / `Geografija` / `Dolby Atmos Demo Disc`）：

```
Black Widow    Don't Look Up    Spider-Man: No Way Home    Top Gun: Maverick
Kimi           The Adam Project Day Shift                  KEEP
```

## 修复

主语言译名缺失时，先取**主语言同地区**的 `alternative_titles` 补位，取不到
再按原有优先级进入下一语言。

实测 8 部里 7 部拿回中文名，且都是大陆通行译名：

| tmdb | 修复前 | 修复后 |
|---|---|---|
| 634649 | Spider-Man: No Way Home | **蜘蛛侠：英雄无归** |
| 361743 | Top Gun: Maverick | **壮志凌云2：独行侠** |
| 646380 | Don't Look Up | **不要抬头** |
| 755566 | Day Shift | **日班猎人** |
| 497698 | Black Widow | **黑寡妇** |
| 696806 | The Adam Project | **亚当计划** |
| 800510 | Kimi | 冷酷不够热 |
| 1157893 | KEEP | KEEP（TMDB 两边都没有中文名，保持原名正确） |

## 为什么不能靠配置次位语言解决

`zh-SG` 确实能填上 6 部，但给出的是新马/港台译名：

| | zh-SG 译名 | alternative_titles 的 CN 区 |
|---|---|---|
| Top Gun: Maverick | 捍卫战士：独行侠 | **壮志凌云2：独行侠** |
| Don't Look Up | 千万别抬头 | **不要抬头** |
| Day Shift | 打卡猎人 | **日班猎人** |
| Kimi | *（无）* | 冷酷不够热 |

对简体中文用户，**地区别名才是对的数据源**。这也正是 Emby / MoviePilot
这类刮削器的做法 —— 从它们迁过来的库，目录名原本就是上面右列那批。

## 刻意收窄的地方

**只给主语言补位。** 别名是用户投稿、质量不如译名，用来补「用户真正想要的
那个语言」的缺是划算的；次位语言本来就是妥协档，再翻它的别名收益有限。

## 无回归

主语言有译名时完全不进这条分支。`1917` / `2012` / `X` 的 `zh-CN` 译名非空
（值就是 `1917` / `2012` / `X`），取值不变，已在实测里逐条确认。

另外说明一点：`Geografija` 在修复前后都会变成 `Geography` —— 那是**既有**
的 `en-US` 译名回落（`translations[en-US].title == "Geography"`），与本 PR
无关，也未被本 PR 改变。

## 测试

新增 `tests/media/test_alt_region_title.py`，14 个用例：地区匹配、标签大小写、
该地区无别名、无地区段的标签（`zh`）、剧集载荷的 `results` 键差异、以及
各种空载荷（缺失 / `None` / 空列表 / 空串 / 纯空白串）都要回 `None`，不能
把空串当译名写进标题。

验证边界：提交环境没装项目依赖，按 AGENTS.md「测试门禁由 CI 承担，本地不
要求跑全量测试」，我没有跑 pytest；但把 `_alt_region_title` 单独提出来跑过
全部 14 个用例，并用真实 TMDB 响应（13 部电影）端到端验证了修复前后的取值
差异，结果如上表。集成层面请以 CI 为准。

未动运行时依赖，无需 bump `docker/runtime-version`。
