### PR TITLE
fix(web): 入库之后「下载」里程碑不再永远停在"进行中"

### DIFF
--- a/apps/web/components/subscription-inspector-view.tsx
+++ b/apps/web/components/subscription-inspector-view.tsx
@@ -1496,11 +1496,16 @@ function milestonesOf(
   }
 
   // 4. 下载
-  if (w.downloaded_at) {
+  // 里程碑链是顺序的：入库发生过就说明下载必然已经完成。后端把 downloaded
+  // 这一档折叠掉了（文件落盘即整理入库，``wanted_item.downloaded_at`` 至今
+  // 没有任何写入方），只看它会让这一格在入库之后仍然停在"进行中"，与下一格
+  // 的"已整理入库"自相矛盾——用户据此以为没入库
+  const downloadedAt = w.downloaded_at ?? w.imported_at;
+  if (downloadedAt) {
     M.push({
       lab: "下载",
       state: "done",
-      time: formatRelativeTime(w.downloaded_at),
+      time: formatRelativeTime(downloadedAt),
       det: "全部落盘",
     });
   } else if (w.grabbed_at) {


### PR DESCRIPTION
## 问题

订阅详情的里程碑链里，「下载」这一格只看 `wanted_item.downloaded_at`：

```ts
if (w.downloaded_at)      → done「全部落盘」
else if (w.grabbed_at)    → now「进行中」「已提交下载器，等待进度汇报」
```

但后端把 downloaded 这一档折叠掉了——文件落盘即整理入库，工单状态机实际只走
`wanted → grabbed → imported`。

`downloaded_at` **至今没有任何写入方**。全仓只有两处碰它，都是赋 `None`：

- `services/subscription/core.py:806` — 重置工单时
- `services/download_progress.py:1120` — 构造时

`WantedStatus.DOWNLOADED` 同样从未被赋过。

## 实际影响

任何一条已入库的订阅，「下载」都永远显示"进行中"，而紧邻的下一格是"入库 ·
已整理入库 · 8 小时前"——时间线自相矛盾。

实测一个 9 条工单的库：

```sql
select count(*) from wanted_item where imported_at is not null and downloaded_at is null;
-- 8

select count(*) from wanted_item where imported_at is not null;
-- 8

select status, count(*) from wanted_item group by status;
-- [('imported', 8), ('wanted', 1)]        ← downloaded 从未出现

select count(*) from wanted_item where downloaded_at is not null;
-- 0
```

**8/8**，即全部已完成的订阅都在这个状态。

这不是无害的显示瑕疵：库主看到「下载 进行中」+「已入库 0」（后者是
`imported - upgrading` 的正常语义），会直接判断成"没入库"并开始排查——我就是
被这个问过一遍才追到这里。

## 修复

里程碑链是顺序的：入库发生过就说明下载必然已经完成。让「下载」回落到
`imported_at`：

```ts
const downloadedAt = w.downloaded_at ?? w.imported_at;
if (downloadedAt) { ... }
```

既修掉矛盾，也不依赖后端是否补写 `downloaded_at`。

## 关于另一种修法

如果维护者更希望**后端补齐这一档**（下载器确认完成时真正写入 `downloaded_at`
并置 `WantedStatus.DOWNLOADED`），本改动不冲突——那时 `w.downloaded_at` 有值，
回落分支自然不再触发。选哪条路取决于 `downloaded` 这一档是有意折叠还是待补，
我从代码里看不出结论，所以只修显示、不动状态机。

## 测试

改动在前端渲染层，仓库的 web 检查（lint + build）覆盖。提交环境没有
`node_modules`（装依赖代价不成比例），按 AGENTS.md「测试门禁由 CI 承担」，
本地未跑 —— 已确认 `downloaded_at` 与 `imported_at` 在
`apps/web/lib/api/subscriptions.ts` 里同为 `string | null`，`??` 类型安全。

未动运行时依赖，无需 bump `docker/runtime-version`。
