### PR TITLE
ci(release): 发布改两段式 draft→publish，堵住产物不齐与半成品 Release 窗口

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -45,14 +45,20 @@ description: 发布 movieclaw 新版本。当用户要求发版、发布新版�
    以 GITHUB_TOKEN 代为触发 release.yml（在 main HEAD 上创建 tag），
    并自动删除点火分支。人工兜底：到 Actions → release 手动
    Run workflow 输入 tag）
-4. release.yml 自动构建并上传 Release assets：
-   app-web.tar.gz / app-backend.tar.gz / manifest.json（可选 manifest.json.sig）；
-   产物上传成功后自动发布多架构 Docker 镜像到 Docker Hub
+4. release.yml 两段式发布（draft → publish）：先以 draft 创建 Release，
+   各作业往上传产物——应用三件套（app-web.tar.gz / app-backend.tar.gz /
+   manifest.json，可选 manifest.json.sig）、mclaw 六平台归档 + checksums、
+   macOS Worker zip（可选附件）——同时发布多架构 Docker 镜像到 Docker Hub
    （movieclaw/movieclaw，正式版打 vX.Y.Z + runtime-N + latest，
-   预发布版只打 vX.Y.Z-… 不动 latest）
-5. changelog：写 docs/changelog/vX.Y.Z.md 合入 main，release-notes.yml 会
-   自动把它同步为 Release body（应用内更新界面原文展示）；先合 changelog
-   后发 Release 也没关系，Release 创建后再触碰一次该文件即可触发同步。
+   预发布版只打 vX.Y.Z-… 不动 latest）。最后 publish 作业校验产物齐全、
+   镜像发布成功后把 draft 转正；此前 Release 对应用内更新和
+   install-cli.sh 都不可见。**任何作业失败时 Release 停在 draft，
+   修复后到 Actions 重跑整个 release 工作流即可**（上传均带 --clobber，
+   安全重入）；仅 Worker 挂了不拦转正，重跑 worker-macos 作业补传即可。
+5. changelog：写 docs/changelog/vX.Y.Z.md 合入 main。changelog 先于发版
+   合入（推荐，可与发版 PR 同 PR）时，release.yml 建 Release 会直接用它
+   当 body；后合入也没关系，release-notes.yml 会自动同步为 Release body
+   （应用内更新界面原文展示）。
    **撰写规则（保证不漏、不流水账）**：
    - 检索范围用 `git log --first-parent 上一tag..HEAD --oneline`，
      以合并 PR 为单位枚举区间内全部变更（含直接推 main 的提交），
@@ -97,10 +103,13 @@ docker-image 手动 Run workflow 输入标签即可。本地/离线构建仍可�
 1. 训练产出三件套：`model.int8.onnx`、`tokenizer.json`、`labels.json`
 2. 生成更新清单（tag 必须与将要创建的 Release tag 一致，后端会强校验）：
    `./scripts/build-model-manifest.sh <模型目录> torrent-ner-vN`
-3. 创建 tag 为 `torrent-ner-vN` 的 GitHub Release（N 递增），上传
-   三件套 + `manifest.json`（+ 签名时的 `manifest.json.sig`）
-4. **不要**把模型 Release 标成 latest 之外还需担心什么——应用更新检查
-   按 tag 正则过滤，模型 Release 不会干扰应用更新
+3. 创建 tag 为 `torrent-ner-vN` 的 GitHub Release（N 递增），**必须带
+   `--latest=false`**（如 `gh release create torrent-ner-vN --latest=false …`），
+   上传三件套 + `manifest.json`（+ 签名时的 `manifest.json.sig`）
+4. 为什么 `--latest=false` 是硬约束：install-cli.sh / install-cli.ps1 从
+   `releases/latest/download` 取 mclaw，模型 Release 一旦成为 latest，
+   CLI 安装立刻 404。除此之外无需担心其他干扰——应用更新检查按 tag
+   正则过滤，模型 Release 不会干扰应用更新
 5. 没带 manifest.json 的模型 Release 无法被应用内安装（会提示用户），
    只能作为镜像构建的 `NER_MODEL_BASE` 来源
 
@@ -150,11 +159,15 @@ ffmpeg 版本，发版前按下表逐项过一遍。
 - [ ] 版本号三处一致（应用发版）
 - [ ] bump 版本号后已跑 `scripts/export-spec.sh`（服务端与 Go CLI 两份 spec）
 - [ ] 本次改动是否触碰运行时依赖？触碰了 → `docker/runtime-version` +1（镜像随发版自动发布）
+- [ ] 改了 Worker 握手协议（`REMOTE_WORKER_PROTOCOL_VERSION` 与 macOS Worker
+      的 `BuildInfo.protocolVersion` 同步 +1）→ 旧 Worker 会被服务端拒绝握手，
+      changelog 显著位置写明「需要更新 Mac Worker」
 - [ ] 数据库迁移向前兼容（alembic 迁移是单向的，用户回退靠自动备份）
-- [ ] Release 产物齐全（CI 完成后到 Release 页核对）：应用更新三件套 +
-      mclaw 五平台产物（`mclaw_{linux,darwin}_{amd64,arm64}.tar.gz`、
-      `mclaw_windows_amd64.zip`、`checksums.txt`）
-- [ ] 启用签名的仓库：`.sig` 已随产物上传
+- [ ] Release 产物齐全：publish 作业已自动校验（应用三件套 + mclaw 六平台
+      归档 `mclaw_{linux,darwin}_{amd64,arm64}.tar.gz`、
+      `mclaw_windows_{amd64,arm64}.zip`、`checksums.txt`，启用签名时含
+      `.sig`），人工只需确认 release 工作流全绿、Release 已从 draft 转正；
+      worker-macos 作业红了 → Worker zip 缺失，重跑该作业补传
 - [ ] changelog 已写入 `docs/changelog/vX.Y.Z.md` 并合入 main（release-notes.yml
       自动同步为 Release body，应用内更新界面会原文展示给用户）
 - [ ] 改动了播放/转码 → 第五节的硬件矩阵人工验收已过（CI 覆盖不到）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@
 #     季集相关的一批测试会稳定失败——所以先从模型 Release 下载三个文件，
 #     并用 actions/cache 按 tag 缓存，避免每次跑 CI 都拉 15MB。
 #   - web 作业：eslint + tsc，与 release.yml 的前端环境保持同一套版本。
-#   - cli-go 作业：mclaw（Go）的 vet、gofmt、单测与五平台交叉编译。命令树
+#   - cli-go 作业：mclaw（Go）的 vet、gofmt、单测与六平台交叉编译。命令树
 #     快照、豁免端点清单、域帮助覆盖这些命令面守护全在 go test 里，改了路由
 #     忘了同步会在这里红。
 #   - worker-macos 作业：macOS Worker 的 Swift 构建与单测。它只能在 macOS
@@ -101,11 +101,12 @@ jobs:
         working-directory: cli
         run: go test ./...
 
-      # 五个分发目标都得编得过：任何一个挂了，那批用户就装不上
-      - name: 交叉编译五平台
+      # 六个分发目标都得编得过：任何一个挂了，那批用户就装不上
+      # （目标清单与 cli/.goreleaser.yaml 的 goos × goarch 保持一致）
+      - name: 交叉编译六平台
         working-directory: cli
         run: |
-          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
             CGO_ENABLED=0 GOOS=${target%/*} GOARCH=${target#*/} \
               go build -trimpath -o /tmp/mclaw-check ./cmd/mclaw
             echo "✓ $target"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,37 @@
 # =============================================================================
 # 发版流水线（docs/design/in-app-update.md M1）
 #
-# 打 v* tag 时构建应用内更新产物并上传到 GitHub Release：
-#   app-web.tar.gz / app-backend.tar.gz / manifest.json
-# 同时构建并上传 macOS 远程转码 Worker（MovieClawTranscoder-macos-arm64.zip）：
-# 此前这个 App 只能由用户自己 clone 仓库 + 装 Xcode + swift build，对一个
-# 面向 NAS 用户的开源项目来说等同于劝退。
+# 打 v* tag 时构建全部发版产物并发布 GitHub Release：
+#   - 应用更新三件套：app-web.tar.gz / app-backend.tar.gz / manifest.json
+#   - mclaw CLI 六平台归档 + checksums.txt（goreleaser 构建）
+#   - macOS 远程转码 Worker（MovieClawTranscoder-macos-arm64.zip）：
+#     此前这个 App 只能由用户自己 clone 仓库 + 装 Xcode + swift build，对一个
+#     面向 NAS 用户的开源项目来说等同于劝退。
 # 产物上传成功后自动调用 docker-image.yml，同步发布同版本号的
 # Docker 镜像（多架构，标签策略见该工作流头注释）。
+#
+# 发布是两段式的（draft → publish）：Release 先以 draft 创建，各作业往
+# draft 上传产物，最后 publish 作业校验产物齐全、镜像发布成功后才转正。
+# 为什么：Release 一旦可见，应用内更新检查器和 install-cli.sh 的
+# latest/download 立刻会读它——产物陆续上传的窗口期里，用户会撞上
+# 「latest 里没有 mclaw」的 404，或在应用内看到 --generate-notes 的 PR
+# 清单。draft 对两者都不可见（app_update.py 也显式过滤 draft），产物
+# 齐全前用户永远看不到半成品 Release。任何作业失败时 Release 停在
+# draft，修复后重跑本工作流即可——所有上传都带 --clobber，可安全重入。
 # =============================================================================
 name: release
+
+# 同一 tag 的发版串行执行，避免重跑/连发时产物与镜像标签交错
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
 
 on:
   push:
     tags: ["v*"]
   # 手动触发通道：远程会话（Claude Code 等）的 git 凭证通常只能推分支、
-  # 推不了 tag。这里输入目标 tag 后，由「创建 Release」步骤经 gh 一并创建
-  # tag（指向触发时的 main HEAD）。GITHUB_TOKEN 创建的 tag 不会再触发
-  # 本工作流的 push 事件，无递归风险。
+  # 推不了 tag。这里输入目标 tag 后先创建 draft Release（--target 指向
+  # 触发时的 main HEAD），publish 作业转正时才真正创建 tag。GITHUB_TOKEN
+  # 创建的 tag 不会再触发本工作流的 push 事件，无递归风险。
   workflow_dispatch:
     inputs:
       tag:
@@ -66,7 +80,7 @@ jobs:
         run: |
           VERSION="${RELEASE_TAG#v}" ./scripts/build-release-artifacts.sh dist/release
 
-      - name: 上传 Release assets（Release 不存在则创建）
+      - name: 上传 Release assets（Release 不存在则创建 draft）
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -76,20 +90,28 @@ jobs:
           case "$RELEASE_TAG" in
             *-*) PRERELEASE_FLAG="--prerelease" ;;
           esac
+          # Release body 优先取已合入的 changelog 文件——应用内更新界面会
+          # 原文展示 body，不该让用户看到 --generate-notes 的 PR 清单。
+          # changelog 后合入的情况仍由 release-notes.yml 兜底同步。
+          NOTES_ARGS=(--generate-notes)
+          if [ -f "docs/changelog/$RELEASE_TAG.md" ]; then
+            NOTES_ARGS=(--notes-file "docs/changelog/$RELEASE_TAG.md")
+          fi
           if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            # --target：tag 不存在时（手动触发通道）在该提交上创建 tag；
-            # tag 推送事件里 tag 已存在，此参数被忽略
+            # --draft：产物齐全前 Release 不可见，由 publish 作业最终转正。
+            # --target：手动触发通道里 tag 尚不存在，draft 转正时会在该提交
+            # 上创建 tag；tag 推送事件里 tag 已存在，此参数被忽略
             gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-              --target "$GITHUB_SHA" \
-              --title "$RELEASE_TAG" --generate-notes $PRERELEASE_FLAG
+              --target "$GITHUB_SHA" --draft \
+              --title "$RELEASE_TAG" "${NOTES_ARGS[@]}" $PRERELEASE_FLAG
           fi
           assets=(dist/release/app-web.tar.gz dist/release/app-backend.tar.gz dist/release/manifest.json)
           [ -f dist/release/manifest.json.sig ] && assets+=(dist/release/manifest.json.sig)
           gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
 
-  # mclaw CLI（Go）。needs 只为等 Release 被创建出来，与 docker-image 并行。
-  # 不用 continue-on-error：CLI 是 Agent 操作产品的唯一入口，install-cli.sh
-  # 也直接来这里取产物；缺了它这个 Release 对 CLI 用户就是废的，该红就红。
+  # mclaw CLI（Go）。needs 只为等 draft Release 被创建出来，与 docker-image
+  # 并行。CLI 是 Agent 操作产品的唯一入口，install-cli.sh 也直接来这里取
+  # 产物——缺了它 publish 作业不会让 Release 转正，该红就红。
   cli:
     needs: release-artifacts
     runs-on: ubuntu-latest
@@ -114,39 +136,64 @@ jobs:
           python -c "import tomllib; deps = tomllib.load(open('pyproject.toml', 'rb'))['project']['dependencies']; open('requirements.txt', 'w').write('\n'.join(deps))"
           pip install --no-cache-dir -r requirements.txt
 
-      - name: 构建并上传五平台产物
+      - name: 校验基线 spec 与代码一致
+        run: |
+          # 现场重导一次并与提交的副本比对。以前靠 goreleaser 的 before hook
+          # 重导 + dirty-state 拒绝发布来兜底，但那条报错（"git is in a
+          # dirty state"）和真实原因隔了两层；这里显式比对、报中文错误。
+          scripts/export-spec.sh
+          if ! git diff --exit-code --stat -- \
+              src/movieclaw_api/data/spec.json cli/internal/spec/data/spec.json; then
+            echo "::error::基线 spec 与代码漂移：发版 PR 里漏跑了 scripts/export-spec.sh。请在发版分支重跑该脚本、合入 main 后重新发版。"
+            exit 1
+          fi
+
+      - name: 构建六平台产物
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
           workdir: cli
-          args: release --clean
+          # --skip=validate：手动触发通道里 tag 要等 draft 转正才真正创建，
+          # goreleaser 的 tag/HEAD 校验必挂；脏区与版本一致性已由上一步和
+          # build-release-artifacts.sh 显式把关。上传不走 goreleaser
+          # （GitHub API 按 tag 查不到 draft，goreleaser 会另建一个 Release），
+          # 由下一步用 gh 上传——gh 能按 tag 名找到草稿。
+          args: release --clean --skip=validate
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           GORELEASER_CURRENT_TAG: ${{ inputs.tag || github.ref_name }}
 
-  # macOS 远程转码 Worker。needs 只为等 Release 被创建出来，与 docker-image
-  # 并行；它构建失败不该拖住应用产物和镜像的发布，因此用 continue-on-error，
-  # 失败时 Release 里就是少一个可选附件，主更新链路不受影响。
+      - name: 上传到 Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --clobber \
+            cli/dist/mclaw_*.tar.gz cli/dist/mclaw_*.zip cli/dist/checksums.txt
+
+  # macOS 远程转码 Worker。needs 只为等 draft Release 被创建出来，与
+  # docker-image 并行。它构建失败不拦发布——publish 作业不看它的结果，
+  # Release 里就是少一个可选附件，主更新链路不受影响；但刻意不用
+  # continue-on-error：那样失败会藏在绿色 workflow 里没人发现，红出来
+  # 才有人去重跑补传。
   worker-macos:
     needs: release-artifacts
     runs-on: macos-14
-    continue-on-error: true
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # needs 满足时 tag 可能刚由上一个作业创建，默认 ref 未必包含它；
-          # 显式取触发时的提交，保证打包的就是发版那份代码
+          # 手动触发通道里 tag 要等 draft 转正才创建，默认 ref 未必是发版
+          # 提交；显式取触发时的提交，保证打包的就是发版那份代码
           ref: ${{ github.sha }}
 
       - name: 单测
         run: swift test --package-path macos/MovieClawTranscoder
 
-      - name: 打包 App（ad-hoc 签名）
+      - name: 打包 App（ad-hoc 签名，版本号注入自发版 tag）
         run: |
           chmod +x macos/MovieClawTranscoder/scripts/package-app.sh
-          macos/MovieClawTranscoder/scripts/package-app.sh
+          MOVIECLAW_WORKER_VERSION="${RELEASE_TAG#v}" \
+            macos/MovieClawTranscoder/scripts/package-app.sh
 
       - name: 压缩 App Bundle
         run: |
@@ -171,3 +218,44 @@ jobs:
     with:
       tag: ${{ inputs.tag || github.ref_name }}
     secrets: inherit
+
+  # 终审：产物齐全 + 镜像发布成功后才把 draft Release 转正。
+  # 这是发布原子性的落点——转正之前，应用内更新、install-cli.sh 的
+  # latest/download、Release 页对用户都不可见，不存在「半成品 Release」。
+  # worker-macos 失败不拦转正（可选附件），但 cli 或镜像失败时 Release
+  # 停在 draft：修复后重跑本工作流即可，全链路可安全重入。
+  publish:
+    needs: [cli, worker-macos, docker-image]
+    if: ${{ !cancelled() && needs.cli.result == 'success' && needs.docker-image.result == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      GH_TOKEN: ${{ github.token }}
+      # 只用于判断本仓库是否启用了清单签名（启用则 .sig 必须在场）
+      RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+    steps:
+      - name: 校验产物齐全并发布 Release
+        run: |
+          assets="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[].name')"
+          required="app-web.tar.gz app-backend.tar.gz manifest.json
+            mclaw_linux_amd64.tar.gz mclaw_linux_arm64.tar.gz
+            mclaw_darwin_amd64.tar.gz mclaw_darwin_arm64.tar.gz
+            mclaw_windows_amd64.zip mclaw_windows_arm64.zip
+            checksums.txt"
+          if [ -n "$RELEASE_SIGNING_KEY" ]; then
+            required="$required manifest.json.sig"
+          fi
+          missing=""
+          for f in $required; do
+            echo "$assets" | grep -qx "$f" || missing="$missing $f"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Release 产物不齐，拒绝转正（缺少:$missing）。修复对应作业后重跑本工作流即可补传。"
+            exit 1
+          fi
+          if ! echo "$assets" | grep -qx "MovieClawTranscoder-macos-arm64.zip"; then
+            echo "::warning::缺少 macOS Worker 附件（可选产物），Release 照常发布；重跑 worker-macos 作业可补传"
+          fi
+          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+          echo "Release $RELEASE_TAG 已发布"

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -47,6 +47,8 @@ changelog:
   disable: true
 
 release:
-  # Release 正文与产物由发版流程统一编排，这里只负责把二进制传上去
-  disable: false
-  mode: append
+  # 上传由 release.yml 用 gh release upload 完成，goreleaser 只负责在
+  # dist/ 产出归档与校验和。原因：Release 以 draft 创建、产物齐全后才
+  # 转正，而 goreleaser 走的 GitHub API 按 tag 查不到 draft，会另建一个
+  # 重复的 Release；gh 能按 tag 名找到草稿。
+  disable: true

--- a/docs/design/cli-go-migration.md
+++ b/docs/design/cli-go-migration.md
@@ -212,7 +212,7 @@ Python 版靠自定义 `click.Group.resolve_command`。cobra 的等价做法：�
 |---|---|
 | Dockerfile 增加 `go-builder` 阶段，二进制装到 `/usr/local/bin/mclaw` | `Dockerfile` |
 | Agent 工具改执行二进制（`MOVIECLAW_CLI_BIN`，默认 `/usr/local/bin/mclaw`） | `src/movieclaw_agent/tools/mclaw.py` |
-| 发版流程新增 cli 作业，由 GoReleaser 出五平台产物附到 Release | `.github/workflows/release.yml`、`cli/.goreleaser.yaml` |
+| 发版流程新增 cli 作业，由 GoReleaser 出六平台产物附到 Release | `.github/workflows/release.yml`、`cli/.goreleaser.yaml` |
 | 基线 spec 搬到 `src/movieclaw_api/data/`，一次导出写两处 | `scripts/export-spec.sh`、`services/spec_catalog.py`、`app_update.py:_validate_layout` |
 | CI 增加 Go lane（`go vet` / `golangci-lint` / `go test`），与既有 Swift lane 同构 | `.github/workflows/ci.yml` |
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -397,7 +397,7 @@ CLI 要装在 NAS、软路由、同事的机器和 CI 里，「先装个 Python�
 - **运行时动态生成命令树**要求框架支持程序化注册——cobra 的 `Command` 对象
   模型与 pflag 的 `Changed()`（区分「没传」与「传了零值」）正好够用。
 - 分发：① Docker 镜像内置（产品内 Agent 与 `docker exec` 用户零安装）；
-  ② GitHub Release 的五平台二进制，`scripts/install-cli.sh` / `install-cli.ps1`
+  ② GitHub Release 的六平台二进制，`scripts/install-cli.sh` / `install-cli.ps1`
   一行装好，不需要任何预装运行时。
 - 不做的事（防过度工程）：不做裸调逃生舱与结构化目录命令（less is more，
   见 §1/§4）、不做插件系统、不做本地数据库（仅「上次搜索快照」一个 JSON

--- a/macos/MovieClawTranscoder/scripts/package-app.sh
+++ b/macos/MovieClawTranscoder/scripts/package-app.sh
@@ -15,6 +15,19 @@ cp "${PROJECT_DIR}/Resources/Info.plist" "${APP_DIR}/Contents/Info.plist"
 # App 图标：Finder、访达信息面板、⌘Tab 切换器都读它（CFBundleIconFile）
 cp "${PROJECT_DIR}/Resources/AppIcon.icns" "${APP_DIR}/Contents/Resources/AppIcon.icns"
 
+# 版本注入：发版流水线传入 tag 版本（如 0.19.0），写进 bundle 的 Info.plist。
+# BuildInfo 从 CFBundleShortVersionString 读版本并在握手时上报给服务端——
+# 不注入的话每个发行版都自报源文件里的占位版本，排障时无从确认用户跑的是
+# 哪版 Worker。本地构建不传该变量，保留占位版本即可。改的是 bundle 里的
+# 拷贝而非源文件，不弄脏工作区；必须在 codesign 之前做（签名封存 Info.plist）。
+if [ -n "${MOVIECLAW_WORKER_VERSION:-}" ]; then
+    plutil -replace CFBundleShortVersionString -string "${MOVIECLAW_WORKER_VERSION}" \
+        "${APP_DIR}/Contents/Info.plist"
+    plutil -replace CFBundleVersion -string "${MOVIECLAW_WORKER_VERSION}" \
+        "${APP_DIR}/Contents/Info.plist"
+    echo "已注入版本号：${MOVIECLAW_WORKER_VERSION}"
+fi
+
 # 由内向外逐个签，不用 --deep。
 #
 # --deep 已被 Apple 标为不推荐：它对嵌套内容套用同一套参数，签出来的结果和


### PR DESCRIPTION
## 背景

发版产物从三件套长成了「应用更新包 + mclaw 六平台 + Mac Worker + Docker 镜像」四条产线，但 Release 创建即对用户可见，带来几个已确认的问题：

- **半成品窗口**：应用内更新和 `install-cli.sh` 的 `latest/download` 在产物陆续上传的窗口期就能读到 Release——用户会撞上「latest 里没有 mclaw」的 404，或在应用内看到 `--generate-notes` 的 PR 清单（更新界面原文展示 body）。
- **cli 作业失败会让 latest 永久缺 CLI 产物**，且无自动恢复路径。
- **Mac Worker 版本号硬编码 0.1.0**：每个发行版自报同一版本，服务端记录的 `worker_version` 失去排障价值。
- **worker-macos 用 `continue-on-error`**：失败藏在绿色 workflow 里，缺产物无人发现；发版检查清单里也漏了 Worker 附件。
- goreleaser 一直在发 `mclaw_windows_arm64.zip`，但 CI 交叉编译不守这个目标，文档口径也是「五平台」。

## 改动

- **release.yml 改两段式 draft → publish**：Release 以 draft 创建，新增 `publish` 终审作业——校验应用三件套、mclaw 六平台归档、checksums（启用签名时含 `.sig`）齐全且镜像发布成功后才 `--draft=false` 转正。转正前 Release 对应用内更新（`app_update.py` 显式过滤 draft）和 `latest/download` 均不可见。任何环节失败停在 draft，重跑工作流安全重入（上传均带 `--clobber`）。Worker 附件缺失只 warning 不拦。另加 `concurrency` 组防重跑交错。
- **Release body 优先取已合入的 changelog 文件**，`--generate-notes` 只做兜底；`release-notes.yml` 仍负责后合入的同步。
- **Worker 版本注入**：`package-app.sh` 支持 `MOVIECLAW_WORKER_VERSION`，发版时把 tag 版本写进 bundle 的 Info.plist（签名前注入，不弄脏工作区），`BuildInfo` 上报的就是真实版本。
- **worker-macos 去掉 `continue-on-error`**：失败红出来才有人补传；「可选附件不拦发布」改由 publish 作业不看它的结果实现。
- **goreleaser 收口**：`release.disable: true`，上传改由工作流用 `gh` 完成（GitHub API 按 tag 查不到 draft，goreleaser 会另建重复 Release；`gh` 能按 tag 名找到草稿）。隐式的 dirty-state 守卫改为显式的 spec 漂移比对，报中文错误。
- **CI 交叉编译补 windows/arm64**（本地已验证编译通过），与 goreleaser 实际的 6 个目标对齐；两份设计文档「五平台」口径一并改正。
- **SKILL.md**：发版步骤与检查清单同步 draft→publish 流程、补 Worker 附件与六平台口径；模型 Release 明确必须带 `--latest=false`（否则 install-cli 的 `latest/download` 立刻 404）；新增 Worker 协议版本 bump 的 changelog 规则。

## 验证

- 三个 YAML 均通过语法解析；`package-app.sh` 通过 `bash -n`
- `GOOS=windows GOARCH=arm64 go build ./cmd/mclaw` 本地编译通过
- runtime-guard 不受影响：`cli/.goreleaser.yaml` 在其排除清单内，未触碰运行时契约文件，无需 bump runtime-version
- draft 流程对存量机制安全：`app_update.py:473` 显式过滤 draft；`gh release view/upload/edit` 均支持按 tag 名操作草稿

## 风险与后续

新流水线（cli / worker-macos / publish 作业）尚未在真实发版中跑过——v0.18.0 早于这批产线合入。合入本 PR 后的下一次发版是首跑，也会同时修复 `install-cli.sh` 当前对着 v0.18.0（无 mclaw 产物）404 的问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXWatdzZDvAZAZxygQSqqX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXWatdzZDvAZAZxygQSqqX)_