### PR TITLE
ci: pytest 并行化，CI 关键路径从 9 分半压缩到 3 分内

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,12 @@ jobs:
       - name: ruff
         run: ruff check .
 
+      # -n auto 按 runner 核数并行（ubuntu-latest 4 核，串行 9 分半 → 3 分内）。
+      # --dist loadfile 让同一文件的用例固定在同一 worker 串行执行：
+      # tests/docker/test_entrypoint_supervision.py 会绑定固定端口（8000/3001），
+      # 跨 worker 并发跑同文件用例会端口冲突，loadfile 从分发层面杜绝。
       - name: pytest
-        run: python -m pytest -q -m "not integration"
+        run: python -m pytest -q -m "not integration" -n auto --dist loadfile
 
   cli-go:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ dependencies = [
 dev = [
   "pytest>=8.4.0,<9.0.0",
   "pytest-asyncio>=1.1.0,<2.0.0",
+  # CI 并行跑测试（-n auto --dist loadfile）：2900+ 用例串行要 9 分多钟，
+  # 4 核并行压到 1/3 左右。dev 工具依赖，不进运行时，无需 bump runtime-version
+  "pytest-xdist>=3.6.0,<4.0.0",
   # 锁小版本段：ruff 新版会带新规则，放宽上限会让 CI 门禁凭空变红
   "ruff>=0.16.0,<0.17.0",
 ]

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -29,16 +29,21 @@ def mclaw_binary() -> str:
     if shutil.which("go") is None:
         pytest.skip("找不到 go 工具链，跳过需要真实 mclaw 二进制的用例")
 
-    # 编到固定位置并复用：每个测试会话只编一次
+    # 编到固定位置并复用：每个测试会话只编一次。
+    # pytest-xdist 并行时多个 worker 会同时走到这里，直接 -o 到固定路径会
+    # 互相覆盖写、可能执行到半成品二进制——先编到各自的临时文件，再原子
+    # rename 到固定位置（POSIX 同目录 rename 原子，先到先得，结果等价）。
     target = _REPO_ROOT / "cli" / ".build" / "mclaw"
     target.parent.mkdir(parents=True, exist_ok=True)
+    scratch = target.with_name(f"mclaw.build-{os.getpid()}")
     result = subprocess.run(
-        ["go", "build", "-o", str(target), "./cmd/mclaw"],
+        ["go", "build", "-o", str(scratch), "./cmd/mclaw"],
         cwd=_REPO_ROOT / "cli",
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
         pytest.skip(f"mclaw 构建失败，跳过：{result.stderr.strip()[:300]}")
+    os.replace(scratch, target)
     os.environ["MOVIECLAW_CLI_BIN"] = str(target)
     return str(target)


### PR DESCRIPTION
## 背景

python 作业的 pytest 步骤串行跑 2900+ 用例要 **9 分 30 秒**，是整个 CI 的关键路径（web / cli-go / worker-macos 三个作业都在 1 分钟内完成）。本 PR 引入 pytest-xdist 按 runner 核数并行，本地 4 核全量验证 **3 分 27 秒** 跑完，CI（ubuntu-latest 同为 4 核）预期同量级。

## 改动

- **`.github/workflows/ci.yml`**：pytest 改跑 `-n auto --dist loadfile`。`loadfile` 让同一文件的用例固定在同一 worker 串行执行——`tests/docker/test_entrypoint_supervision.py` 会绑定固定端口（8000/3001），默认按用例分发会让同文件用例跨 worker 并发、产生端口冲突。
- **`pyproject.toml`**：dev 依赖加 `pytest-xdist`。只动 optional-dependencies，不碰运行时 dependencies，无需 bump `docker/runtime-version`（runtime-guard 只比对 `project.dependencies`）。
- **`tests/agent/conftest.py`**：修复并行下的构建竞态——会话级 fixture 原来直接 `go build -o` 到固定路径 `cli/.build/mclaw`，多 worker 并发会互相覆盖写、可能执行到半成品二进制；改为先编到各 worker 独有的临时文件再原子 rename。

## 并行安全性

测试基建本就按用例隔离：每个用例 `tmp_path` 独立 SQLite；会话级迁移模板、低成本 Argon2 hasher、离线 TMDB 单例桩都是进程内状态，xdist 的 worker 是独立进程，互不干扰。本地 `-n 4 --dist loadfile` 全量通过（仅有的 3 个失败复跑确认与并行无关，是开发沙箱强制注入出口代理环境变量所致，CI 环境不存在）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C18bKusGcyZkZTcT2ebcKV

---
_Generated by [Claude Code](https://claude.ai/code/session_01C18bKusGcyZkZTcT2ebcKV)_