### PR TITLE
fix(github): AI 工作流轮数调整——交互层 30→100,自动修复层取消上限

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -99,7 +99,10 @@ jobs:
                正文说明根因、修法、验证结果,并包含
                "Closes #${{ github.event.issue.number }}"。
             6. 在 issue 下评论一句已开 PR 及编号。PR 的合并永远留给人工 review。
+          # 不设轮数上限:修复本来就该跑到"复现测试通过 + 门禁全绿"为止,
+          # 中途截断只会留下半成品。失控防线由两道硬约束兜底:
+          # timeout-minutes 的一小时墙钟,以及 label 门控(每次执行都经维护者
+          # 手动授权,不存在被批量触发的路径)。
           claude_args: |
             --model claude-opus-5
-            --max-turns 50
             --allowedTools "Edit,Write,Read,Glob,Grep,Bash(git:*),Bash(python:*),Bash(pytest:*),Bash(ruff:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,7 +60,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # 不传 prompt → 交互模式,Claude 自行读取 @claude 所在的评论上下文
+          # 轮数上限 100:实测 30 轮不够——交互模式每更新一次进度评论都消耗
+          # 一轮,深度分析任务(如 #238 的跨模块存在性验证)在第 31 轮被截断,
+          # 已完成的分析全部丢失。交互层由有写权限的人手动触发,失控风险有
+          # 人兜底,上限放宽换取重任务能收尾。
           claude_args: |
             --model claude-opus-5
-            --max-turns 30
+            --max-turns 100
             --allowedTools "Edit,Write,Read,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(python:*),Bash(pytest:*),Bash(ruff:*),Bash(pip install:*)"


### PR DESCRIPTION
## 做了什么

两处轮数预算调整,均来自实测反馈:

1. **`claude.yml`(@claude 交互):`--max-turns` 30 → 100**
   实测 [run 33321154405](https://github.com/movieclaw/movieclaw/actions/runs/33321154405):在 #238 上做跨模块存在性分析,Opus 跑到第 31 轮触顶报 `error_max_turns`,已完成的分析没能写回评论,约 $1.79 额度作废。30 轮不够的原因:任务重 + 交互模式的协议开销(每更新一次进度评论/Todo 都消耗一轮),实际可用轮数远小于名义值。

2. **`claude-auto-fix.yml`(label 门控自动修复):取消 `--max-turns`(原 50)**
   修复任务应跑到「复现测试通过 + ruff/pytest 全绿」为止,轮数截断只会留下半成品。失控防线改由两道硬约束兜底:`timeout-minutes: 60` 的墙钟上限,以及标签门控(每次执行都经维护者手动授权,不存在被批量触发的路径)。

分诊层(15 轮)不变:它没有评论协议开销,从未用满。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iqDLfz5zspq1QBtp3CTmR