### PR TITLE
Remove settings header section from sidebar

### DIFF
--- a/apps/web/components/settings-view.tsx
+++ b/apps/web/components/settings-view.tsx
@@ -80,7 +80,7 @@ export function SettingsSidebar({ active, onSelect, onBack }: SettingsSidebarPro
       fallbackAlpha={glass.fallbackAlpha}
     >
       {/* 顶部：返回按钮（玻璃胶囊，轮廓明确的「可点」入口） */}
-      <div className="px-3 pb-1 pt-3.5">
+      <div className="px-3 pb-3 pt-3.5">
         <button
           type="button"
           onClick={onBack}
@@ -89,11 +89,6 @@ export function SettingsSidebar({ active, onSelect, onBack }: SettingsSidebarPro
           <ArrowLeftIcon className="size-4" />
           <span>返回工作台</span>
         </button>
-      </div>
-
-      <div className="px-4 pb-4 pt-4">
-        <h2 className="text-sheen text-title-lg font-semibold tracking-tight">设置</h2>
-        <p className="mt-1 text-sub text-[var(--text-muted)]">管理账号与工作台偏好</p>
       </div>
 
       {/* 分区列表：标准 SaaS 设置菜单——紧凑单行（小图标内联 + 标签），


### PR DESCRIPTION
## Summary
Removed the redundant "设置" (Settings) header section from the SettingsSidebar component and adjusted padding on the back button container.

## Changes
- Removed the header div containing the "设置" title and description text ("管理账号与工作台偏好")
- Adjusted bottom padding on the back button container from `pb-1` to `pb-3` to maintain visual spacing

## Rationale
The header section appears to be redundant given the sidebar's purpose is already clear from context. The padding adjustment compensates for the removed section to maintain consistent spacing between the back button and the navigation menu below.

https://claude.ai/code/session_013LKhTJ9k5HCjW8h3ukyYgH