### PR TITLE
fix(github): @claude 交互层补齐 NER 模型环境

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,10 @@ permissions:
   actions: read
   id-token: write
 
+env:
+  # 与 ci.yml / claude-auto-fix.yml 保持一致;模型发新版时三处同步改
+  NER_MODEL_TAG: torrent-ner-v3
+
 jobs:
   claude:
     if: |
@@ -52,6 +56,25 @@ jobs:
 
       - name: 安装依赖（含 dev 工具链）
         run: pip install -e ".[dev]"
+
+      # NER 模型也必须就位:缺模型时季集/片名抽取的一批测试会稳定失败,
+      # Claude 跑 pytest 会撞上一堆与自己改动无关、又永远修不好的红,
+      # 在环境问题上空转烧轮数(实测 run 33323170428 百轮触顶的主因)
+      - name: 恢复 NER 模型缓存
+        id: ner-cache
+        uses: actions/cache@v4
+        with:
+          path: data/models/torrent-ner
+          key: ner-model-${{ env.NER_MODEL_TAG }}
+
+      - name: 下载 NER 模型（缓存未命中时）
+        if: steps.ner-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "$NER_MODEL_TAG" \
+            --repo "${{ github.repository }}" \
+            --dir data/models/torrent-ner
 
       - name: Claude 交互
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## 做了什么

`claude.yml` 补上 NER 模型的缓存与下载步骤(照抄 `ci.yml` / `claude-auto-fix.yml` 的同一套三步),`NER_MODEL_TAG` 三处保持同步。

## 为什么

交互层此前只 `pip install -e ".[dev]"`,没有 NER 模型;而缺模型时季集/片名抽取相关的一批测试**稳定失败**(CLAUDE.md 的已知事实,ci.yml 为此专门下载模型)。后果在 [run 33323170428](https://github.com/movieclaw/movieclaw/actions/runs/33323170428) 实测发生:@claude 在 #242 上做修复,改完代码跑 `pytest` 撞上一堆与自己改动无关、又永远修不好的红,在环境问题上空转,13.6 分钟、100 轮触顶,分支未推出,成果全部丢失。

补齐后交互层与 CI、auto-fix 层环境完全一致,"本地绿 = CI 绿"对三层同时成立。模型走 actions/cache,同 tag 只从 Release 下载一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iqDLfz5zspq1QBtp3CTmR

---
_Generated by [Claude Code](https://claude.ai/code/session_015iqDLfz5zspq1QBtp3CTmR)_