### PR TITLE
test: 监听导入用例改合成事件注入，消除满载下 FSEvents 送达时序依赖

### DIFF
--- a/tests/api/test_library_watch_scope.py
+++ b/tests/api/test_library_watch_scope.py
@@ -606,7 +606,7 @@ async def test_schedule_failure_is_isolated_per_root(db, tmp_path, monkeypatch) 
 
 async def test_ingest_apply_watches_incremental_and_first_time_catchup(tmp_path) -> None:
     """监听导入差量重建：只有**初次**纳入的目录进补扫名单；未变目录零成本；
-    真实事件仍能送达（handler 挂接正确）。"""
+    事件经观察者分发线程仍能送达（handler 挂接正确）。"""
     pytest.importorskip("watchdog")
     d1 = tmp_path / "watch1"
     d2 = tmp_path / "watch2"
@@ -628,16 +628,15 @@ async def test_ingest_apply_watches_incremental_and_first_time_catchup(tmp_path)
         assert await asyncio.to_thread(watcher._apply_watches, [str(d2)]) == set()
         assert watcher.watched_keys() == {str(d2)}
 
-        # 真实事件送达：d2 里落文件 → 队列收到该源目录标识
-        (d2 / "Some.Movie.2020.mkv").write_bytes(b"x")
-        deadline = time_mod.monotonic() + 10
-        got = None
-        while time_mod.monotonic() < deadline:
-            try:
-                got = watcher._queue.get_nowait()
-                break
-            except asyncio.QueueEmpty:
-                await asyncio.sleep(0.05)
+        # 挂接验证：合成事件投进观察者的分发队列 → 仍走 watchdog 的
+        # dispatch 线程与 handler 注册表（拆 d1 时误拆 d2 的挂接会在此变红），
+        # 但不等真实 fs 事件——满载机器上 FSEvents 送达可超 10 秒，偶发超时
+        from watchdog.events import FileCreatedEvent
+
+        _handler, d2_watch = watcher._entries[str(d2)]
+        event = FileCreatedEvent(str(d2 / "Some.Movie.2020.mkv"))
+        watcher._observer.event_queue.put((event, d2_watch))
+        got = await asyncio.wait_for(watcher._queue.get(), timeout=10)
         assert got == str(d2)
     finally:
         await asyncio.to_thread(watcher._stop_observer)


### PR DESCRIPTION
## 变更内容

`tests/api/test_library_watch_scope.py::test_ingest_apply_watches_incremental_and_first_time_catchup` 的「真实事件送达」段不再写真实文件后限时 10 秒轮询队列等 FSEvents 送达，改为构造合成 `FileCreatedEvent`，连同 d2 的 watch 对象直接投进 watchdog 观察者的 `event_queue`。

## 为什么

本地满载并行（`pytest -m "not integration" -n auto --dist loadfile`）时，macOS FSEvents 的送达时延可能超过 10 秒 deadline，导致该用例偶发失败（单独运行稳定通过）。送达时延是操作系统行为，测试无法控制；而用例真正要守的是「差量重建（加 d2、拆 d1）后 d2 的 handler 挂接完好」。

合成事件注入仍走 watchdog 真实的 dispatch 线程与 handler 注册表，守卫强度不变：若挂接被误拆，`_handlers[watch]` 查不到、队列收不到事件，用例照样红（已模拟 `remove_handler_for_watch` 场景验证）。拿掉的只是「操作系统何时送信」这个不可控环节。

## 验证

- 改后用例单独连跑 10 次全绿；整个文件 19 个用例全绿
- 原始满载并行命令全量跑一遍，该用例通过
- 误拆挂接的负例场景确认收不到事件（守卫不是假绿）

## 审阅提示

- 同文件的 `test_shared_root_survives_sibling_removal` 与 `test_watcher_passes_scope_to_scan` 仍在等真实 fs 事件，有同样的偶发风险，已另开会话处理，不在本 PR 范围
- 全量并行验证中 `test_agent_sessions.py::test_fork_api_rejects_missing_running_and_empty_source` 偶发失败一次，是独立的既有竞态（fork 与后台 turn 赛跑），与本改动无关，也已另开会话处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)