### PR TITLE
test(library): watch 用例改合成事件注入，消除满载并行下的偶发超时

### DIFF
--- a/tests/api/test_library_watch_scope.py
+++ b/tests/api/test_library_watch_scope.py
@@ -432,10 +432,15 @@ async def test_watcher_passes_scope_to_scan(db, tmp_path, monkeypatch) -> None:
         assert watcher._startup is not None
         await watcher._startup
         entry = root / "影片X (2020)"
-        entry.mkdir()
-        (entry / "X.2020.mkv").write_bytes(b"x")
+        # 合成事件直投观察者分发队列：仍走 dispatch 线程与 handler 注册表
+        # （挂接被误拆时收不到），但不依赖真实文件系统送信时延——满载并行
+        # 跑测试时 FSEvents 送达可超限时，是偶发超时的根源
+        from watchdog.events import FileCreatedEvent
+
+        watch = next(iter(watcher._entries.values()))[1]
+        watcher._observer.event_queue.put((FileCreatedEvent(str(entry / "X.2020.mkv")), watch))
         for _ in range(100):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.05)
             if calls:
                 break
         assert calls, "监控未触发扫描"
@@ -559,8 +564,12 @@ async def test_shared_root_survives_sibling_removal(db, tmp_path, monkeypatch) -
         assert set(watcher._entries) == {(lib_a.id, str(root))}
 
         entry = root / "影片Y (2020)"
-        entry.mkdir()
-        (entry / "Y.mkv").write_bytes(b"x")
+        # 合成事件直投观察者分发队列（不依赖真实文件系统送信时延）：事件仍
+        # 按 handler 注册表分发，lib_a 的挂接若被误拆则收不到
+        from watchdog.events import FileCreatedEvent
+
+        watch = watcher._entries[(lib_a.id, str(root))][1]
+        watcher._observer.event_queue.put((FileCreatedEvent(str(entry / "Y.mkv")), watch))
         deadline = time_mod.monotonic() + 10
         got = None
         while time_mod.monotonic() < deadline:


### PR DESCRIPTION
## 改了什么

`tests/api/test_library_watch_scope.py` 里最后两个依赖真实文件系统事件的用例改为合成事件注入：

- **test_watcher_passes_scope_to_scan**：原先写真实文件后 100×0.1s 轮询 `calls`，等 FSEvents 送达；
- **test_shared_root_survives_sibling_removal**：原先写真实文件后 10 秒 deadline 轮询 `watcher._queue`。

两处均改为从 `watcher._entries` 取 watch 对象，把 `FileCreatedEvent` 直投 `watcher._observer.event_queue`，与已采用同方案的做法一致。

## 为什么

`pytest -n auto --dist loadfile` 满载并行时，macOS FSEvents 送信可超过用例限时，这两个用例有偶发超时风险（与此前修过的 `test_ingest_apply_watches_incremental_and_first_time_catchup` 同根因）。

## 回归保护没有削弱

合成事件仍从 `observer.event_queue` 走 watchdog dispatch 线程、按 `_handlers[watch]` 注册表分发：

- 「差量重建误拆挂接」时 handler 不在注册表 → 收不到事件 → 用例红。已临时在注入前加 `remove_handler_for_watch` 模拟验证，两用例均如期失败；
- watch 被误 `unschedule` 时 `_handlers` 条目整个消失，同样拦得住；
- `FileCreatedEvent` 带 `.mkv` 后缀，正常通过 `_is_relevant_event` 相关性过滤。

## 验证

- 两用例连跑 10 次全绿；
- 整文件 19 个用例一次通过（2.6 秒，不再有等真实事件的秒级等待）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)