### PR TITLE
test(agent): 用事件闸门消除 fork 运行中断言的时序竞态

### DIFF
--- a/tests/api/test_agent_sessions.py
+++ b/tests/api/test_agent_sessions.py
@@ -624,12 +624,13 @@ def test_fork_api_creates_independent_session_and_resumes_snapshot(client, monke
     assert captured[-1][1:] == ["第一轮", "已找到资源", "从这里继续"]
 
 
-def test_fork_api_rejects_missing_running_and_empty_source(client) -> None:
+def test_fork_api_rejects_missing_running_and_empty_source(client, monkeypatch) -> None:
     configure_provider(client)
     assert client.post("/api/v1/sessions/missing/fork").status_code == 404
 
     # 存储层空会话虽然不会由普通 UI 产生，但 Fork 仍需给出明确业务错误。
     import asyncio
+    import threading
 
     from movieclaw_api.services.agent_sessions import get_agent_session_store
     from movieclaw_db.engine import get_database
@@ -645,9 +646,32 @@ def test_fork_api_rejects_missing_running_and_empty_source(client) -> None:
     asyncio.run(create_index())
     assert client.post(f"/api/v1/sessions/{empty_id}/fork").status_code == 400
 
+    # 「运行中拒绝分叉」不能依赖调度时序：mock LLM 即时返回时，后台运行可能
+    # 在 fork 请求发出前就已结束（会话不再运行中，fork 被合法接受）。用事件
+    # 闸门扣住流式返回，保证断言窗口内会话必然运行中，断言后放行正常收尾。
+    gate = threading.Event()
+
+    class _GatedProtocol(_StreamProtocol):
+        async def chat_stream(self, request, model_id):
+            # 超时兜底：断言失败提前退出时闸门不会 set，避免工作线程悬死
+            await asyncio.to_thread(gate.wait, 30)
+            async for event in super().chat_stream(request, model_id):
+                yield event
+
+    monkeypatch.setitem(PROTOCOLS, "openai_chat", _GatedProtocol)
+    # 进程级 _runtime_router 按配置指纹缓存协议客户端；换一个 Key 强制重建
+    client.put(
+        "/api/v1/llm/provider",
+        json={
+            "provider_type": "bailian",
+            "api_key": "sk-fork-running",
+            "default_model": "qwen3.7-max",
+        },
+    )
     started = client.post("/api/v1/sessions", json={"content": "仍在执行"})
     running_id = started.json()["data"]["session_id"]
     assert client.post(f"/api/v1/sessions/{running_id}/fork").status_code == 400
+    gate.set()
     with client.stream("GET", f"/api/v1/sessions/{running_id}/events") as response:
         response.read()
 


### PR DESCRIPTION
## 问题

CI（run 33322107549）中 `test_fork_api_rejects_missing_running_and_empty_source` 偶发失败：期望「对运行中的会话发起 fork 返回 400」，实际返回 201。

## 根因

mock LLM 即时返回，后台 Agent 运行在测试发出 fork 请求**之前**就已进入终态并清掉运行标记（`active_run_id`），此时会话不再运行中，fork 被合法接受。这是测试自身的时序竞态，#253 引入 pytest-xdist 并行化改变调度时序后开始显现。

## 修复

只改测试，不动被测接口语义：

- 用 `threading.Event` 闸门扣住 mock 协议的 `chat_stream`（`asyncio.to_thread(gate.wait, 30)`，30 秒超时兜底避免断言失败时工作线程悬死）；
- 由于 `POST /sessions` 返回 202 前 `recorder.begin` 已完成 `mark_running` 落库，而后台运行被闸住无法终结，断言窗口内会话**必然**处于运行中，fork 确定返回 400；
- 断言后 `gate.set()` 放行，运行以 agent_done 正常收尾；
- 按既有做法换一个 provider api_key，强制进程级 `_runtime_router` 用替换后的协议类重建客户端。

## 验证

- 该用例单独跑 10 次、`-n 4 --dist loadfile` 跑 5 次、所在文件 `-n auto --dist loadfile` 跑 3 次：全部通过；
- `ruff check .` 全绿；
- 全量 `pytest -q -m "not integration" -n auto --dist loadfile`：agent 会话相关全部通过。本机满载下 `test_library_watch_scope.py::test_ingest_apply_watches_incremental_and_first_time_catchup` 偶发超时（依赖 watchdog 真实 FS 事件 10 秒内送达，单独跑稳定通过），与本改动无关，已另开任务跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)