### PR TITLE
test(agent): 修复 fork 拦截用例的时序竞态

### DIFF
--- a/tests/api/test_agent_sessions.py
+++ b/tests/api/test_agent_sessions.py
@@ -645,11 +645,18 @@ def test_fork_api_rejects_missing_running_and_empty_source(client) -> None:
     asyncio.run(create_index())
     assert client.post(f"/api/v1/sessions/{empty_id}/fork").status_code == 400
 
-    started = client.post("/api/v1/sessions", json={"content": "仍在执行"})
-    running_id = started.json()["data"]["session_id"]
+    # 「运行中不可 fork」：不与真实后台执行赛跑（机器满载时后台 turn 可能在
+    # fork 请求前就结束），而是等会话跑完后按 is_running 的心跳定义直接构造
+    # 运行状态，让断言窗口完全可控。
+    running_id, _ = _send_message_and_wait(client, {"content": "仍在执行"})
+    _wait_not_running(client, running_id)
+
+    async def mark_running() -> None:
+        async with get_database().session() as db_session:
+            await AgentSessionRepository(db_session).mark_running(running_id, "run-fork-guard")
+
+    asyncio.run(mark_running())
     assert client.post(f"/api/v1/sessions/{running_id}/fork").status_code == 400
-    with client.stream("GET", f"/api/v1/sessions/{running_id}/events") as response:
-        response.read()
 
 
 def test_send_message_to_unknown_session_returns_404(client) -> None:


### PR DESCRIPTION
## 问题

`tests/api/test_agent_sessions.py::test_fork_api_rejects_missing_running_and_empty_source` 在满载并行（`-n auto --dist loadfile`）下偶发失败，单独运行稳定通过。

## 根因

用例原来通过 `POST /api/v1/sessions` 启动会话后立刻 `POST fork`，指望赶在后台 turn 结束前命中「运行中不可 fork」的 400 拦截。但测试用的 `_StreamProtocol` mock 流瞬间完成，后台任务一结束就 `finish_run` 清空 `active_run_id` 与心跳，`is_running` 变 False；机器满载时 fork 请求可能排在后台 turn 完成之后，fork 走「已结束会话」路径成功返回 201，断言 `400` 失败。已用临时用例确定性复现：等会话结束后 fork 返回的正是 201。

## 修复

不再与真实后台执行赛跑：先用 `_send_message_and_wait` + `_wait_not_running` 等会话完全跑完，再通过 `AgentSessionRepository.mark_running()` 按心跳判定的定义直接构造运行状态（30 秒超时窗内 `is_running` 必然为 True），然后断言 fork 返回 400。断言窗口完全可控，生产代码零改动。

## 验证

- 目标测试单独运行通过
- 在 12 个 xdist worker 满载并行制造的高负载背景下连续重复运行 16 次全部通过（原偶发失败的负载条件）
- `test_agent_sessions.py` + `test_agent.py` 完整回归：40 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)