### PR TITLE
fix(刮削): 原声语言就是主语言时不许触发标题回落

### DIFF
--- a/src/movieclaw_media/library.py
+++ b/src/movieclaw_media/library.py
@@ -207,7 +207,19 @@ async def fetch_media_profile(
     # 判据要求 title 与原名相等——这才是"确实退回了原名"的证据。只看
     # translations 里有没有主语言条目不够：载荷里译名缺席、而顶层 title 已经
     # 是译名的情况存在，那时 title 是对的，任何回落都是把好数据换成差数据。
-    if title == original_title and not _translation_text(translations, primary, "title", "name"):
+    # 这个判据还有个前提：原声语言与主语言不是同一种语言。华语片配 zh-CN
+    # 时（原声语言就是主语言）title 与原名相等是**正确结果**而非退回，此时
+    # 回落只会把 TMDB 给的中文原名换成 CN 区别名里的拼音投稿（宝莲灯 →
+    # Băo lián dēng）或次位语言的英文译名（无名 → Hidden Blade）。原声语言
+    # 是回落链的隐含底座（TMDB 无译名时返回的就是它），它就是主语言时，
+    # 链条到此为止。
+    original_language = data.get("original_language") or None
+    primary_is_original = original_language == primary.split("-")[0]
+    if (
+        not primary_is_original
+        and title == original_title
+        and not _translation_text(translations, primary, "title", "name")
+    ):
         fallback_title = _alt_region_title(data, primary)
         for lang in languages[1:]:
             if fallback_title:
@@ -237,7 +249,6 @@ async def fetch_media_profile(
         overview = overview or _translation_text(translations, lang, "overview")
         tagline = tagline or _translation_text(translations, lang, "tagline")
 
-    original_language = data.get("original_language") or None
     poster_langs = resolve_image_languages(
         prefs.poster_langs, primary_language=primary, original_language=original_language
     )

--- a/tests/media/test_media_library.py
+++ b/tests/media/test_media_library.py
@@ -217,6 +217,70 @@ async def test_fetch_movie_title_falls_back_when_primary_untranslated() -> None:
     assert profile.title == "Dune: Part Two"
 
 
+# 结构照搬 TMDB /movie/331253?language=zh-CN 的真实响应（宝莲灯 1999）：
+# zh-CN 译名槽为空，顶层 title 就是中文原名，而 CN 区别名是网友投稿的拼音
+_CHINESE_MOVIE_DETAIL = {
+    **_MOVIE_DETAIL,
+    "id": 331253,
+    "title": "宝莲灯",
+    "original_title": "宝莲灯",
+    "original_language": "zh",
+    "alternative_titles": {
+        "titles": [
+            {"iso_3166_1": "CN", "title": "Băo lián dēng"},
+            {"iso_3166_1": "US", "title": "Lotus Lantern"},
+        ]
+    },
+    "translations": {
+        "translations": [
+            {"iso_639_1": "zh", "iso_3166_1": "CN", "data": {"title": ""}},
+            {"iso_639_1": "en", "iso_3166_1": "US", "data": {"title": "Lotus Lantern"}},
+        ]
+    },
+}
+
+
+async def test_fetch_movie_title_keeps_original_when_primary_is_original_language() -> None:
+    """原声语言 == 主语言时，title 与原名相等是正确结果，不许当成"退回原名"。
+
+    华语片配 zh-CN 的现实病例：TMDB 的 zh-CN 译名槽是空的，但顶层 title
+    给的就是中文原名「宝莲灯」；旧判据把它误判为退回，转手用 CN 区别名
+    里的拼音投稿覆盖成 Băo lián dēng。
+    """
+    client = _client({"/3/movie/331253": _CHINESE_MOVIE_DETAIL})
+    profile = await fetch_media_profile(
+        client, MediaKind.MOVIE, 331253, languages=["zh-CN", "en-US"]
+    )
+    assert profile.title == "宝莲灯"
+
+
+async def test_fetch_movie_title_original_language_guard_blocks_secondary_language() -> None:
+    """同一守卫也要挡住次位语言：CN 区无别名时不许跌到 en-US 的英文译名。
+
+    病例：无名 / 顽主 —— CN 区别名缺席，旧逻辑一路落到 en-US，中文库里
+    出现 Hidden Blade / The Troubleshooters。
+    """
+    detail = {
+        **_CHINESE_MOVIE_DETAIL,
+        "alternative_titles": {"titles": [{"iso_3166_1": "US", "title": "Lotus Lantern"}]},
+    }
+    client = _client({"/3/movie/331253": detail})
+    profile = await fetch_media_profile(
+        client, MediaKind.MOVIE, 331253, languages=["zh-CN", "en-US"]
+    )
+    assert profile.title == "宝莲灯"
+
+
+async def test_fetch_movie_title_falls_back_when_original_language_differs() -> None:
+    """守卫只在原声语言 == 主语言时生效：外语片的回落链一如既往。"""
+    detail = {**_CHINESE_MOVIE_DETAIL, "original_language": "en"}
+    client = _client({"/3/movie/331253": detail})
+    profile = await fetch_media_profile(
+        client, MediaKind.MOVIE, 331253, languages=["zh-CN", "en-US"]
+    )
+    assert profile.title == "Băo lián dēng"
+
+
 async def test_fetch_movie_title_keeps_translated_title_without_translations_payload() -> None:
     """顶层 title 已是译名（≠ 原名）时不许回落——回落会把好数据换成差数据。"""
     detail = {**_MOVIE_DETAIL, "translations": {"translations": []}}


### PR DESCRIPTION
## 问题

`fetch_media_profile` 的标题回落（#241）用 `title == original_title` 当作「TMDB 静默退回了原名」的证据，转而去 `alternative_titles` 的主语言同地区别名里补位。这个判据有个没写出来的前提：**原名与主语言不是同一种语言**。

华语片配 `zh-CN` 时前提不成立。TMDB 的 zh-CN 译名槽大量为空，顶层 `title` 返回的就是正确的中文原名，回落却把它当成"退回"，转手用 CN 区的用户投稿覆盖掉。

拿真实 TMDB 载荷重放线上库 857 部条目，**40 部被写坏**，且垃圾远不止拼音：

| 应为 | 被覆盖成 | 别名的性质 |
|---|---|---|
| 宝莲灯 | `Băo lián dēng` | 拼音投稿 |
| 流浪地球2 | `Liú Làng Dì Qiú 2` | 拼音投稿 |
| 无名 | `Hidden Blade` | CN 区无别名，一路落到次位语言 en-US |
| 寻龙诀 | `乌尔善版鬼吹灯` | 网友诨名 |
| 天盛长歌 | `凰权·弈天下` | 拍摄期工作名 |
| 琅琊榜 | `瑯琊榜` | 错别字投稿 |

**与语言无关**。同样拿真实载荷实测「主语言 == 条目原声语言」的其他语种，5/5 全部误触发：

| 主语言 | 条目 | 会被覆盖成 |
|---|---|---|
| ja-JP | 千と千尋の神隠し | `Sen to Chihiro no Kamikakushi` |
| ja-JP | 君の名は。 | `君の名は.` |
| en-US | Dune: Part Two | `Dune 2` |
| fr-FR | Le Fabuleux Destin d'Amélie Poulain | `Amélie Poulain` |
| ko-KR | 기생충 | `기생충`（碰巧无害） |

## 修法

把这条隐含前提写进代码：**原声语言是回落链的隐含底座**——TMDB 没有译名时返回的就是它，谁也掉不到它下面。它就是主语言时，链条到此为止。

守卫按 `original_language` 与主语言比对，不硬编码 `zh`，各语种一体适用。顺带把原本在下方的 `original_language` 取值提上来复用（选图那边本就要用），没有新增读取。

粤语（TMDB 用 `cn` 表示）**刻意不并入 `zh`**：对粤语条目而言 zh-CN 不是原声语言，"去找一个普通话/简体片名"是正当回落。实测 54 部粤语条目回落分支一次都不触发（zh-CN 译名槽都填着简体名），并入反而会挡掉正确行为。

## 影响面

全库 857 部重放，修复前后有差异的 40 部**全部是 `original_language=zh`**，其余 817 部（en 361 / ja 79 / ko 59 / cn 54 / fr 23 …）一字未动——既是修复覆盖面，也是守卫没有误伤正常回落链的证据。

`_alt_region_title` 本身没动，对外语片补中文译名这个原意完全保留。

## 测试

`tests/media/test_media_library.py` 新增 3 条，载荷结构照搬真实的 `/movie/331253?language=zh-CN` 响应：

1. 拼音别名不许覆盖中文原名；
2. CN 区无别名时也不许跌到次位语言的英文译名；
3. **原声语言不同时回落链必须原样保留**——把 `original_language` 改成 `en` 就应该照旧回落，守卫不能误伤沙丘那类正常场景。

```
tests/media  106 passed
```

## 存量数据

本 PR 只改刮削逻辑，不动存量。已被写坏的条目需要触发一次重刮才会纠正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
