### PR TITLE
fix(媒体库): ffprobe 探测失败补上退避重试与对账限量自愈

### DIFF
--- a/src/movieclaw_api/services/library/items.py
+++ b/src/movieclaw_api/services/library/items.py
@@ -57,7 +57,12 @@ from movieclaw_api.services.library.nfo import (
     read_episode_metadata,
 )
 from movieclaw_api.services.library.sort_key import title_initial, title_sort_key
-from movieclaw_api.services.media_probe import probe_media
+from movieclaw_api.services.media_probe import (
+    note_probe_failure,
+    note_probe_success,
+    probe_media,
+    probe_retry_due,
+)
 from movieclaw_api.services.media_scrape import asset_version, file_version
 from movieclaw_api.services.scrape_config import effective_language, scrape_setting_for_item
 from movieclaw_db.models import FileState, Library, LibraryFile, MediaItem, MediaSeason, utcnow
@@ -1097,6 +1102,8 @@ async def backfill_streams(
     就是流量与延迟），未探测的行由前端提示用户重新扫描补齐。
 
     探测失败的行保持原值、下次再试：失败常常是暂时的（挂载还没就绪）。
+    失败会记入 media_probe 的失败记忆（进程内、翻倍退避）：退避未到点的行
+    本轮直接跳过，坏文件不再让每轮手动扫描都全额付一次 30 秒超时。
     BDMV 已有流但缺 CLPI 版本戳时先读对应 CLPI；只有 CLPI 有效才重探 m2ts，
     随后用 PID 合并，避免缺失元数据导致无意义的大文件读取。
     """
@@ -1144,6 +1151,13 @@ async def backfill_streams(
             if not await keep_going():
                 break
             continue  # strm 占位文件没有媒体流，探了必失败，别每轮白试
+        if not probe_retry_due(row.file_path):
+            # 失败退避中（media_probe 的失败记忆）：上次探测失败且还没到
+            # 重试点，跳过省一次几乎必然的失败——坏文件一次就是 30 秒超时。
+            # 退避到点后自然回到这条链路。
+            if not await keep_going():
+                break
+            continue
         path = Path(row.file_path)
         target = disc_main_stream(path) if row.container in ("bluray", "dvd") else path
         if target is None or not await asyncio.to_thread(target.exists):
@@ -1161,6 +1175,10 @@ async def backfill_streams(
                 continue
         probed += 1
         spec = await asyncio.to_thread(probe_media, target)
+        if spec is None:
+            note_probe_failure(row.file_path)
+        else:
+            note_probe_success(row.file_path)
         if spec is not None:
             if languages is not None:
                 spec = enrich_spec_with_clpi(spec, languages)

--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -84,7 +84,13 @@ from movieclaw_api.services.library.subtitles import discover_external_subtitles
 from movieclaw_api.services.library.units import resolve_units
 from movieclaw_api.services.media_discover import get_tmdb_client
 from movieclaw_api.services.media_library import MediaLibraryService
-from movieclaw_api.services.media_probe import MediaSpec, probe_media
+from movieclaw_api.services.media_probe import (
+    MediaSpec,
+    note_probe_failure,
+    note_probe_success,
+    probe_media,
+    probe_retry_paths,
+)
 from movieclaw_api.services.task_state import TaskState
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import (
@@ -589,6 +595,7 @@ async def scan_library(
     library_id: int,
     *,
     backfill_existing_specs: bool = True,
+    probe_retry_limit: int | None = None,
     reprobe_paths: set[str] | None = None,
     scope_paths: set[str] | None = None,
     reconcile_root_change: bool = False,
@@ -605,11 +612,18 @@ async def scan_library(
     会让一次很小的目录事件演变为对整个机械盘媒体库的长时间读取。新入库文件
     仍在主流程中即时探测，不受此开关影响。
 
-    ``reprobe_paths``：watchdog 点名的"内容被修改过"的视频路径集合
-    （jellyfin-subtitle.md §2.4）。秒过时对名单内的行 stat 比对
-    (size, mtime)，确认变化才重探——视频原地替换（洗版/重灌同路径）后
-    介质规格与内封字幕轨不再永久陈旧。手动扫描（backfill_existing_specs
-    开启）则对全部在位行做该比对，无需点名。
+    ``probe_retry_limit``：定期对账传入的限量自愈补探——只重探「从未探测
+    成功且失败退避到点」的行（media_probe 的失败记忆），每轮最多 limit 个。
+    暂时性探测失败（挂载抖动/半截文件）由此自动到点重试，无 watch 的网络
+    挂载库不再只能靠用户手动扫描补救。与 backfill_existing_specs=True 同给
+    时后者优先（全量补探已覆盖）。
+
+    ``reprobe_paths``：需要重探的在位行点名集合，来自 watchdog 的"内容被
+    修改过"事件（jellyfin-subtitle.md §2.4）与定期对账的失败记忆到点名单
+    （probe_retry_paths）。秒过时对名单内的行 stat 比对 (size, mtime)，
+    确认变化才重探——视频原地替换（洗版/重灌同路径）后介质规格与内封
+    字幕轨不再永久陈旧。手动扫描（backfill_existing_specs 开启）则对全部
+    在位行做该比对，无需点名。
 
     ``scope_paths``：watch 事件限定的扫描范围（根下第一级条目的绝对路径
     集合，仅监听触发的扫描传入）。范围内的子树照常遍历入账、范围内的
@@ -685,6 +699,7 @@ async def scan_library(
             summary,
             state,
             backfill_existing_specs=backfill_existing_specs,
+            probe_retry_limit=probe_retry_limit,
             reprobe_paths=reprobe_paths or set(),
             scope_paths=scope_paths,
             reconcile_root_change=reconcile_root_change,
@@ -802,6 +817,7 @@ async def _scan(
     state: ScanState,
     *,
     backfill_existing_specs: bool,
+    probe_retry_limit: int | None,
     reprobe_paths: set[str],
     scope_paths: set[str] | None,
     reconcile_root_change: bool,
@@ -1195,6 +1211,12 @@ async def _scan(
         # 用户只能一个条目一个条目点开、靠详情页那点限量补探慢慢磨。
         if backfill_existing_specs:
             await _probe_backfill(session, library_id, summary, state, bridge=bridge)
+        elif probe_retry_limit:
+            # 定期对账的限量自愈：只补「从未探测成功且失败退避到点」的行，
+            # 上限 probe_retry_limit 个，见 _probe_backfill 的 limit 说明
+            await _probe_backfill(
+                session, library_id, summary, state, bridge=bridge, limit=probe_retry_limit
+            )
 
     # 文件台账已经收口就立刻发布统计，不等后续可能耗时数分钟的图片资产
     # 下载。扫描仍显示进行中，但首页的作品数与容量已经是本轮最新结果。
@@ -2296,7 +2318,13 @@ async def _refresh_known_row(
             return changed
         if (st.st_size, st.st_mtime_ns) != (row.size_bytes, row.file_mtime_ns):
             spec = await asyncio.to_thread(probe_media, file)
-            if spec is not None:
+            if spec is None:
+                # 重探失败（半截替换文件/挂载抖动）：保留旧值与旧新鲜度键，
+                # stat 差异仍在；记入失败记忆，定期对账退避到点会再点名重试
+                # （probe_retry_paths），不再陈旧到下次手动扫描
+                note_probe_failure(str(file))
+            else:
+                note_probe_success(str(file))
                 row.size_bytes = st.st_size
                 row.file_mtime_ns = st.st_mtime_ns
                 row.resolution = spec.resolution
@@ -2387,6 +2415,14 @@ async def _ingest_file(
         spec = await prefetched_probe
     else:
         spec = await asyncio.to_thread(probe_media, probe_target)
+    # 失败记忆（media_probe）：ffprobe 在位却探不出来（半截文件/挂载抖动/
+    # 坏文件）要记账，之后由定期对账带退避限量重试，不再只能等手动扫描；
+    # 成功则抹掉记录，退避从头起算
+    if probe_target is not None:
+        if spec is None:
+            note_probe_failure(str(file))
+        else:
+            note_probe_success(str(file))
     if spec is not None and is_disc and (file / "BDMV").is_dir():
         # m2ts 常常不带语言描述符；同编号 CLPI 用 PID 补齐，已有 ffprobe
         # 语言保持不动。缺失/损坏 CLPI 只降级，不影响原盘入账。
@@ -2623,8 +2659,14 @@ async def _probe_backfill(
     state: ScanState,
     *,
     bridge: _ScanJobBridge | None = None,
+    limit: int | None = None,
 ) -> None:
     """补齐未探测规格，并给存量 BDMV 回填 CLPI 语言。
+
+    ``limit`` 是定期对账的限量自愈模式：只挑「从未探测成功且失败退避到点」
+    的行，每轮最多 limit 个——瞬时探测失败不用等用户手动扫描，又不会让
+    后台周期演变成对整个媒体盘的长时间读取；BDMV 的 CLPI 历史回填仍只属
+    手动扫描。None = 手动扫描的全量补探。
 
     判据用 ``audio_streams IS NULL``：它是"这行从没探测成功过"的标记
     （空列表 = 探过、文件确实没有音轨，两者必须分开）。BDMV 另以流 JSON
@@ -2635,7 +2677,7 @@ async def _probe_backfill(
     否则每轮扫描都会白跑一遍必然失败的探测。
     """
     from movieclaw_api.services.library.items import backfill_streams
-    from movieclaw_api.services.media_probe import ffprobe_available
+    from movieclaw_api.services.media_probe import ffprobe_available, probe_retry_due
 
     if not ffprobe_available():
         return
@@ -2670,6 +2712,12 @@ async def _probe_backfill(
     # strm 占位文件永远探不出规格（本体没有媒体流），不进分母——否则
     # strm 库每轮扫描都会报"待补 N、探测 0"，像坏了一样
     rows = [row for row in rows if not row.file_path.lower().endswith(STRM_EXT)]
+    if limit is not None:
+        # 限量自愈：只挑从未探测成功且退避到点的行，取前 limit 个。ffprobe
+        # 后装的存量库也借此每轮慢慢补上一小批，而不是干等手动扫描
+        rows = [
+            row for row in rows if row.audio_streams is None and probe_retry_due(row.file_path)
+        ][:limit]
     if not rows:
         return
     state.phase = ScanPhase.PROBING
@@ -3721,6 +3769,11 @@ async def _reidentify(
 # 监听失效（如网络挂载不产生 fs 事件）的场景
 RECONCILE_INTERVAL_SECONDS = 6 * 3600
 
+# 对账顺带的限量自愈补探上限（每库每轮）：只重探失败退避到点/从未探测的
+# 行。取小值——对账是后台兜底，一轮十个足够让瞬时失败在几个周期内收敛，
+# 也保证最坏情况（全是坏文件、各吃 30 秒超时）只占用媒体盘几分钟
+_RECONCILE_PROBE_LIMIT = 10
+
 
 @register_task(
     "library_reconcile",
@@ -3739,9 +3792,16 @@ async def reconcile_libraries() -> None:
         libraries = list((await session.execute(select(Library))).scalars().all())
     for library in libraries:
         assert library.id is not None
-        # 对账负责让台账追上文件新增/删除；规格补探是可长达数小时的用户主动
-        # 维护任务，不能在空闲后台周期里抢占媒体盘。
-        summary = await scan_library(library.id, backfill_existing_specs=False)
+        # 对账负责让台账追上文件新增/删除；**全量**规格补探是可长达数小时的
+        # 用户主动维护任务，不能在空闲后台周期里抢占媒体盘。这里只做两件
+        # 有上限的自愈（media_probe 的失败记忆）：限量补探从未探测成功的行、
+        # 点名重探「上次点名重探失败、规格已陈旧」的行——都带退避且到点才做
+        summary = await scan_library(
+            library.id,
+            backfill_existing_specs=False,
+            probe_retry_limit=_RECONCILE_PROBE_LIMIT,
+            reprobe_paths=probe_retry_paths() or None,
+        )
         if summary.errors:
             logger.warning(
                 "媒体库「%s」对账补扫存在问题：%s", library.name, "；".join(summary.errors)

--- a/src/movieclaw_api/services/media_probe.py
+++ b/src/movieclaw_api/services/media_probe.py
@@ -19,6 +19,7 @@ import json
 import logging
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -98,6 +99,71 @@ def probe_media(path: str | Path) -> MediaSpec | None:
     except json.JSONDecodeError:
         return None
     return _parse_probe(payload, include_mpegts_pids=Path(path).suffix.lower() == ".m2ts")
+
+
+# --- 探测失败记忆（媒体库入库/补探/点名重探共用）---------------------------
+#
+# probe_media 失败分两类：瞬时环境故障（网络挂载抖动、文件还在写入）与
+# 确定性坏文件（损坏/截断，每探一次就是 30 秒超时）。台账侧只有
+# ``audio_streams IS NULL`` 一个「从未探测成功」标记，区分不了两者——没有
+# 这张表，坏文件每轮手动扫描都要全额付超时，瞬时失败又只能等用户手动扫描
+# 才有第二次机会（无 watch 的网络挂载库尤甚）。
+#
+# 进程内存表，不落库（同监听导入 ingest.py 的 _failed_retry 先例）：重启即
+# 清空，代价只是重启后的首轮补探把失败行都再试一遍——这本来就是期望行为，
+# 不值得为它做一次数据库迁移。键统一用**台账行路径**（原盘条目是目录而非
+# 其内的 m2ts），三处调用方（入库、补探、秒过行点名重探）以它查/记。
+
+_RETRY_BASE_SECONDS = 3600.0  # 首次失败后 1 小时可重试（对齐监听导入的小时级退避）
+_RETRY_MAX_SECONDS = 24 * 3600.0  # 连续失败翻倍退避，封顶一天
+_RETRY_STATE_MAX = 4096
+
+# 台账路径 -> (连续失败次数, 最近失败时刻 time.monotonic())
+_retry_state: dict[str, tuple[int, float]] = {}
+
+
+def note_probe_failure(path: str | Path) -> None:
+    """记一次探测失败；连续失败的重试间隔翻倍增长。
+
+    ffprobe 根本不在系统里时**不记**：那不是这个文件的问题，装好 ffmpeg 后
+    的首轮补探不该背着一张全库退避表起步。
+    """
+    if not ffprobe_available():
+        return
+    key = str(path)
+    if len(_retry_state) >= _RETRY_STATE_MAX and key not in _retry_state:
+        # 先清掉已到重试点的旧条目挪位置；仍然满（几千个坏文件，几乎不
+        # 可能）就整体放弃——重试提早无害，表无限膨胀才是问题
+        now = time.monotonic()
+        for stale in [p for p, s in _retry_state.items() if _retry_due(s, now)]:
+            _retry_state.pop(stale, None)
+        if len(_retry_state) >= _RETRY_STATE_MAX:
+            _retry_state.clear()
+    failures = _retry_state.get(key, (0, 0.0))[0] + 1
+    _retry_state[key] = (failures, time.monotonic())
+
+
+def note_probe_success(path: str | Path) -> None:
+    """探测成功即抹掉失败记忆，之后再失败从最短退避重新起算。"""
+    _retry_state.pop(str(path), None)
+
+
+def probe_retry_due(path: str | Path) -> bool:
+    """该路径现在值不值得再探：从没失败过，或退避已到点。"""
+    state = _retry_state.get(str(path))
+    return state is None or _retry_due(state, time.monotonic())
+
+
+def probe_retry_paths() -> set[str]:
+    """退避到点的失败路径集合（定期对账用它点名，重探规格陈旧的秒过行）。"""
+    now = time.monotonic()
+    return {p for p, s in _retry_state.items() if _retry_due(s, now)}
+
+
+def _retry_due(state: tuple[int, float], now: float) -> bool:
+    failures, last = state
+    delay = min(_RETRY_BASE_SECONDS * (2 ** (failures - 1)), _RETRY_MAX_SECONDS)
+    return now - last >= delay
 
 
 # --- 关键帧密度探测（docs/design/web-player.md §3.5 / §7-②）-----------------

--- a/tests/api/test_library_probe_backfill.py
+++ b/tests/api/test_library_probe_backfill.py
@@ -7,9 +7,11 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import httpx
+import pytest
 import pytest_asyncio
 from sqlmodel import select
 
@@ -62,6 +64,14 @@ def _body(tmdb_id: int) -> dict:
     }
 
 
+@pytest.fixture(autouse=True)
+def _fresh_probe_retry_state():
+    """探测失败记忆是进程级内存表，测试之间必须互不串味。"""
+    probe_mod._retry_state.clear()
+    yield
+    probe_mod._retry_state.clear()
+
+
 @pytest_asyncio.fixture
 async def db(tmp_path, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{tmp_path / 'probe.db'}")
@@ -102,6 +112,26 @@ def _with_ffprobe(monkeypatch, calls: list | None = None) -> None:
     monkeypatch.setattr(probe_mod, "ffprobe_available", lambda: True)
     monkeypatch.setattr(scan_mod, "probe_media", _probe)
     monkeypatch.setattr(items_mod, "probe_media", _probe)
+
+
+def _with_failing_ffprobe(monkeypatch, calls: list | None = None) -> None:
+    """模拟"ffmpeg 已装但探测失败"（半截文件/挂载抖动/坏文件）。"""
+
+    def _probe(path, *_a, **_k):
+        if calls is not None:
+            calls.append(str(path))
+        return None
+
+    monkeypatch.setattr(probe_mod, "ffprobe_available", lambda: True)
+    monkeypatch.setattr(scan_mod, "probe_media", _probe)
+    monkeypatch.setattr(items_mod, "probe_media", _probe)
+
+
+def _rewind_retry_state(seconds: float) -> None:
+    """把失败记忆的失败时刻拨到 seconds 秒之前，模拟退避到点。"""
+    now = time.monotonic()
+    for path, (failures, _last) in list(probe_mod._retry_state.items()):
+        probe_mod._retry_state[path] = (failures, now - seconds)
 
 
 async def _build(db, tmp_path, count: int = 3) -> int:
@@ -185,20 +215,23 @@ async def test_background_scan_skips_historical_spec_backfill(db, tmp_path, monk
 
 
 async def test_periodic_reconcile_skips_historical_spec_backfill(db, tmp_path, monkeypatch) -> None:
-    """定时对账传入关闭开关，避免后台周期扫到全库历史规格。"""
+    """定时对账关闭全量补探（避免后台周期扫到全库历史规格），
+    只带限量自愈参数与失败记忆的到点点名。"""
     library_id = await _build(db, tmp_path, count=1)
-    calls: list[tuple[int, bool]] = []
+    calls: list[dict] = []
 
-    async def fake_scan(
-        current_library_id: int, *, backfill_existing_specs: bool = True
-    ) -> ScanSummary:
-        calls.append((current_library_id, backfill_existing_specs))
+    async def fake_scan(current_library_id: int, **kwargs) -> ScanSummary:
+        calls.append({"library_id": current_library_id, **kwargs})
         return ScanSummary(library_id=current_library_id)
 
     monkeypatch.setattr(scan_mod, "scan_library", fake_scan)
     await scan_mod.reconcile_libraries()
 
-    assert calls == [(library_id, False)]
+    assert len(calls) == 1
+    assert calls[0]["library_id"] == library_id
+    assert calls[0]["backfill_existing_specs"] is False
+    assert calls[0]["probe_retry_limit"] == scan_mod._RECONCILE_PROBE_LIMIT
+    assert calls[0]["reprobe_paths"] is None  # 失败记忆为空时不点名
 
 
 async def test_backfill_skipped_when_ffprobe_missing(db, tmp_path, monkeypatch) -> None:
@@ -412,3 +445,77 @@ async def test_backfill_missing_clpi_still_completes_candidate_progress(
 
     assert summary.probed == 0
     assert state.processed == state.total == 1
+
+
+# ---------------------------------------------------------------------------
+# 探测失败记忆与退避重试（media_probe 的进程内失败表）
+# ---------------------------------------------------------------------------
+
+
+def test_retry_backoff_escalates() -> None:
+    """连续失败翻倍退避，封顶 24 小时——纯函数，直接验时间表。"""
+    hour = 3600.0
+    assert probe_mod._retry_due((1, 0.0), hour - 1) is False
+    assert probe_mod._retry_due((1, 0.0), hour) is True
+    assert probe_mod._retry_due((3, 0.0), 4 * hour - 1) is False
+    assert probe_mod._retry_due((3, 0.0), 4 * hour) is True
+    assert probe_mod._retry_due((10, 0.0), 24 * hour - 1) is False  # 封顶后不再翻倍
+    assert probe_mod._retry_due((10, 0.0), 24 * hour) is True
+
+
+async def test_manual_scan_backs_off_recent_probe_failures(db, tmp_path, monkeypatch) -> None:
+    """探测失败进退避：手动重扫不再每轮为同一个坏文件全额付一次超时。"""
+    calls: list[str] = []
+    _with_failing_ffprobe(monkeypatch, calls)
+    library_id = await _build(db, tmp_path, count=1)
+    await scan_library(library_id)  # 入库探测失败，进入失败记忆
+    assert len(calls) == 1
+    calls.clear()
+
+    summary = await scan_library(library_id)  # 退避未到点：补探阶段跳过该行
+    assert summary.probed == 0
+    assert calls == []
+
+    _rewind_retry_state(2 * 3600)  # 退避到点，且这次文件恢复可读
+    _with_ffprobe(monkeypatch, calls)
+    summary = await scan_library(library_id)
+    assert summary.probed == 1
+    row = (await _rows(db))[0]
+    assert row.audio_streams and row.resolution == "1080p"
+    assert row.file_path not in probe_mod._retry_state, "成功后失败记忆应被抹掉"
+
+
+async def test_reconcile_style_scan_heals_failed_probe_after_backoff(
+    db, tmp_path, monkeypatch
+) -> None:
+    """无 watch 库的自愈路径：对账限量补探到点重试，退避未到点不动媒体盘。"""
+    _with_failing_ffprobe(monkeypatch)
+    library_id = await _build(db, tmp_path, count=1)
+    await scan_library(library_id)
+
+    calls: list[str] = []
+    _with_ffprobe(monkeypatch, calls)
+    summary = await scan_library(library_id, backfill_existing_specs=False, probe_retry_limit=10)
+    assert summary.probed == 0 and calls == [], "退避未到点，对账不该重试"
+
+    _rewind_retry_state(2 * 3600)
+    summary = await scan_library(library_id, backfill_existing_specs=False, probe_retry_limit=10)
+    assert summary.probed == 1
+    assert (await _rows(db))[0].audio_streams is not None
+
+
+async def test_reconcile_budget_caps_probe_count(db, tmp_path, monkeypatch) -> None:
+    """ffprobe 后装的存量库：对账每轮只补一小批，绝不演变成整库读盘。"""
+    _no_ffprobe(monkeypatch)
+    library_id = await _build(db, tmp_path)  # 3 个文件，规格全 NULL 且无失败记录
+    await scan_library(library_id)
+
+    calls: list[str] = []
+    _with_ffprobe(monkeypatch, calls)
+    summary = await scan_library(library_id, backfill_existing_specs=False, probe_retry_limit=2)
+    assert summary.probed == 2 and len(calls) == 2
+
+    summary = await scan_library(library_id, backfill_existing_specs=False, probe_retry_limit=2)
+    assert summary.probed == 1, "下一轮接着补剩下的行"
+    rows = await _rows(db)
+    assert all(row.audio_streams is not None for row in rows)


### PR DESCRIPTION
## 问题

ffprobe 探测失败后，媒体库台账侧实际上只有「用户手动扫描」一条重试路径：

- 所有自动触发的扫描（watchdog 增量、6 小时对账、静默补扫）都以 `backfill_existing_specs=False` 运行——这是防止目录事件演变成整库长读取的刻意设计，但副作用是**无 watch 的网络挂载库**（SMB/NFS，恰是探测最易瞬时超时的场景）上，一次挂载抖动造成的探测失败会让规格列永远 NULL，除非用户手动扫描；
- 反过来，真损坏的文件没有任何失败记忆：`audio_streams IS NULL` 区分不了「没探过」和「探过 N 次都失败」，每轮手动扫描都要为每个坏文件全额付一次 30 秒超时。

## 修复

**失败记忆（media_probe.py）**：新增进程内失败表（同监听导入 `_failed_retry` 的先例，不落库、不加迁移）——按台账路径记连续失败次数，重试间隔从 1 小时起翻倍、封顶 24 小时，探测成功即抹掉。ffprobe 根本没装时不记账，装好后的首轮补探不背退避表。

**补探退避（items.py）**：`backfill_streams` 跳过退避未到点的行，坏文件不再拖慢每轮手动扫描；退避到点自然回到补探链路。

**对账限量自愈（scan.py）**：6 小时定期对账新增 `probe_retry_limit=10`——每库每轮最多重探 10 个「从未探测成功且退避到点」的行。瞬时失败几个周期内自动收敛，ffprobe 后装的存量库也每轮慢慢补一小批；上限保证最坏情况（全是坏文件）只占用媒体盘几分钟，不违背「后台不抢占媒体盘」的原则。对账同时把失败表中到点的路径作为 `reprobe_paths` 点名传入，点名重探失败导致的规格陈旧行（`_refresh_known_row`）也能到点自动重试。

入库、秒过行点名重探、补探三处探测统一记账（成功抹掉、失败进表）。

## 验证

- 新增 5 个测试：退避时间表纯函数验证、手动扫描跳过退避中的行并在到点后恢复、对账自愈路径、限量预算上限、对账入口参数；
- `tests/api/test_library_probe_backfill.py` 13 个全过；相邻 `test_library_scan` / `test_library_item_detail` / `test_library_l4` / `test_bluray_clpi` 套件全绿；全量 `-m "not integration"` 中剩余失败经 stash 对照确认为本地环境既有问题（缺 NER 模型、外网 DNS），与本改动无关；
- `ruff check .` 通过；
- 运行时依赖未动，无需 bump `docker/runtime-version`；无数据库迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEfXTir9FJfr52voc2YUWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEfXTir9FJfr52voc2YUWQ)_