### PR TITLE
fix: 订阅追踪中（无库存文件）条目的元数据/选图入口不再被库存文件前置挡住

### DIFF
--- a/src/movieclaw_api/api/routes/libraries.py
+++ b/src/movieclaw_api/api/routes/libraries.py
@@ -1411,7 +1411,7 @@ async def refresh_item_metadata(
 ) -> ApiResponse[dict]:
 
     await LibraryConfigService(session).get(library_id)  # 404 检查
-    item, _rows = await _item_rows(session, library_id, media_item_id)  # 404 检查
+    item = await _metadata_item(session, library_id, media_item_id)  # 404 检查（不要求文件）
     created = await media_scrape.enqueue_item_metadata_refresh_job(
         session,
         library_id=library_id,
@@ -1445,7 +1445,7 @@ async def list_artwork_candidates_route(
     海报中文优先），首张即当前自动策略会选的那张。"""
 
     await LibraryConfigService(session).get(library_id)  # 404 检查
-    await _item_rows(session, library_id, media_item_id)  # 404 检查
+    await _metadata_item(session, library_id, media_item_id)  # 404 检查（不要求文件）
     (
         posters,
         backdrops,
@@ -1482,7 +1482,7 @@ async def select_artwork_route(
     ``file_path=null`` 解锁恢复自动选图。同步执行（单张图，秒级）。"""
 
     await LibraryConfigService(session).get(library_id)  # 404 检查
-    await _item_rows(session, library_id, media_item_id)  # 404 检查
+    await _metadata_item(session, library_id, media_item_id)  # 404 检查（不要求文件）
     await media_scrape.select_artwork(media_item_id, kind=payload.kind, file_path=payload.file_path)
     label = "海报" if payload.kind == "poster" else "背景图"
     message = (
@@ -1514,10 +1514,7 @@ async def set_item_scrape_library(
     按的按钮（详情页的「刷新元数据」），这里只返回提示。
     """
     await LibraryConfigService(session).get(library_id)  # 404 检查
-    await _item_rows(session, library_id, media_item_id)  # 404 检查
-    item = await session.get(MediaItem, media_item_id)
-    if item is None:
-        raise NotFoundException(f"媒体条目不存在：id={media_item_id}")
+    item = await _metadata_item(session, library_id, media_item_id)  # 404 检查（不要求文件）
 
     if payload.target_library_id is None:
         item.scrape_library_id = None
@@ -1736,6 +1733,40 @@ def _trash_note(row: LibraryFile) -> str | None:
     if note and label:
         return f"{note}（{label}）"
     return note or label or None
+
+
+async def _metadata_item(
+    session: AsyncSession, library_id: int, media_item_id: int
+) -> MediaItem:
+    """纯元数据操作（重刮/选图/改刮削归属）的条目校验：**不要求库存文件**。
+
+    订阅追踪中的条目（已订阅、下载尚未入库）在库页「追踪中」区块展示的
+    就是 ``media_item`` 的图片字段。这类操作的数据源是 TMDB、产物挂在
+    ``media_item`` 上，与磁盘上有没有媒体文件无关——若沿用「有台账行」
+    前置，改选图偏好对它们会静默失效，且没有任何手动出口（#278）。
+    无台账行时按刮削归属库（docs/design/scrape-customization.md §14）
+    判定条目与库的关联。
+    """
+    item = await session.get(MediaItem, media_item_id)
+    if item is None:
+        raise NotFoundException("媒体条目不存在（可能已被删除）")
+    has_row = (
+        await session.execute(
+            select(LibraryFile.id)
+            .where(
+                LibraryFile.library_id == library_id,
+                LibraryFile.media_item_id == media_item_id,
+            )
+            .limit(1)
+        )
+    ).first() is not None
+    if has_row:
+        return item
+    resolved = await resolve_scrape_library(session, item)
+    if resolved is None or resolved.id != library_id:
+        raise NotFoundException(f"「{item.title}」不在该媒体库中（无库存文件，刮削归属也不是该库）")
+    await session.commit()  # resolve 可能刚推断并固化了归属，落库保持口径稳定
+    return item
 
 
 async def _item_rows(

--- a/src/movieclaw_api/services/media_scrape.py
+++ b/src/movieclaw_api/services/media_scrape.py
@@ -46,6 +46,7 @@ from movieclaw_api.services.scrape_config import (
     effective_language,
     effective_mirror_flags,
     profile_fetch_kwargs,
+    resolve_scrape_library,
     scrape_setting_for_item,
 )
 from movieclaw_api.services.task_state import TaskState
@@ -264,6 +265,54 @@ def request_stop_library_refresh(library_id: int) -> bool:
     return True
 
 
+async def _library_refresh_targets(session: AsyncSession, library_id: int) -> list[tuple[int, str]]:
+    """整库刷新的目标条目：库内有台账行的 ∪ 刮削归属到该库的无文件条目。
+
+    第二类是订阅追踪中的条目（已订阅、尚无任何库存文件）：它们在库页
+    「追踪中」区块带海报展示，若只按台账行取目标，改选图偏好后整库刷新
+    对它们会静默失效——进度显示全量成功，用户无从察觉有条目不在范围内
+    （#278）。候选面很小（有订阅或显式归属的无文件条目），逐个按
+    docs/design/scrape-customization.md §14 的规则解析归属即可。
+    """
+    result = await session.execute(
+        select(LibraryFile.media_item_id, MediaItem.title)
+        .join(MediaItem, MediaItem.id == LibraryFile.media_item_id)  # type: ignore[arg-type]
+        .where(LibraryFile.library_id == library_id)
+        .distinct()
+        .order_by(LibraryFile.media_item_id)
+    )
+    targets = [(i, t) for i, t in result.all() if i is not None]
+
+    library = await session.get(Library, library_id)
+    if library is None:
+        return targets
+    any_file = select(LibraryFile.media_item_id).where(
+        LibraryFile.media_item_id.is_not(None)  # type: ignore[union-attr]
+    )
+    subscribed = select(Subscription.media_item_id)
+    candidates = (
+        (
+            await session.execute(
+                select(MediaItem)
+                .where(
+                    MediaItem.kind == library.kind,
+                    MediaItem.id.not_in(any_file),  # type: ignore[union-attr]
+                    (MediaItem.scrape_library_id == library_id)
+                    | MediaItem.id.in_(subscribed),  # type: ignore[union-attr]
+                )
+                .order_by(MediaItem.id)  # type: ignore[arg-type]
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for item in candidates:
+        resolved = await resolve_scrape_library(session, item)
+        if resolved is not None and resolved.id == library_id and item.id is not None:
+            targets.append((item.id, item.title))
+    return targets
+
+
 async def refresh_library_metadata(library_id: int) -> None:
     """整库刷新（后台任务入口）：库内全部已识别条目**全量重刮**。
 
@@ -281,13 +330,7 @@ async def refresh_library_metadata(library_id: int) -> None:
     try:
         db = get_database()
         async with db.session() as session:
-            result = await session.execute(
-                select(LibraryFile.media_item_id, MediaItem.title)
-                .join(MediaItem, MediaItem.id == LibraryFile.media_item_id)  # type: ignore[arg-type]
-                .where(LibraryFile.library_id == library_id)
-                .distinct()
-            )
-            targets = [(i, t) for i, t in result.all() if i is not None]
+            targets = await _library_refresh_targets(session, library_id)
         state.total = len(targets)
 
         queue: asyncio.Queue = asyncio.Queue()
@@ -349,17 +392,9 @@ async def enqueue_library_metadata_refresh_job(
     origin: str = "web",
 ) -> jobs.CreateJobResult:
     """把整库刷新固化成可恢复 Job；目标快照保证更新前后处理口径一致。"""
-    result = await session.execute(
-        select(LibraryFile.media_item_id, MediaItem.title)
-        .join(MediaItem, MediaItem.id == LibraryFile.media_item_id)  # type: ignore[arg-type]
-        .where(LibraryFile.library_id == library_id)
-        .distinct()
-        .order_by(LibraryFile.media_item_id)
-    )
     targets = [
         {"media_item_id": item_id, "title": title}
-        for item_id, title in result.all()
-        if item_id is not None
+        for item_id, title in await _library_refresh_targets(session, library_id)
     ]
     return await jobs.create_job(
         session,

--- a/tests/api/test_library_item_detail.py
+++ b/tests/api/test_library_item_detail.py
@@ -1653,3 +1653,126 @@ async def test_set_item_scrape_library_switches_and_resets(db, tmp_path) -> None
         assert (await session.get(MediaItem, item_id)).scrape_library_id is None
         view = (await get_library_item(library.id, item_id, _ADMIN, session)).data
     assert view.scrape_library_id == library.id
+
+
+# ---------------------------------------------------------------------------
+# 订阅追踪中（无库存文件）的条目：纯元数据入口不再被"没有库存文件"挡住（#278）
+# ---------------------------------------------------------------------------
+
+
+async def _make_tracked_fileless_item(db, library_id: int, *, tmdb_id: int = 300) -> int:
+    """建一个"已订阅、尚无任何库存文件"的条目（媒体库页「追踪中」区块的形态）。"""
+    from movieclaw_db.models import RuleSet, Subscription
+
+    async with db.session() as session:
+        item = MediaItem(
+            kind="movie", tmdb_id=tmdb_id, title="某电影", original_title="Some Movie", year=2020
+        )
+        session.add(item)
+        rule_set = RuleSet(name="默认规则组", is_default=True, spec={})
+        session.add(rule_set)
+        await session.commit()
+        await session.refresh(item)
+        await session.refresh(rule_set)
+        session.add(
+            Subscription(
+                media_item_id=item.id,
+                kind="movie",
+                rule_set_id=rule_set.id,
+                library_id=library_id,
+            )
+        )
+        await session.commit()
+        return item.id
+
+
+async def test_fileless_tracked_item_opens_metadata_routes(db, tmp_path) -> None:
+    """无库存文件的追踪中条目：重刮 / 候选图 / 选图三个入口都能用，选图不因
+    没有条目目录而失败；刮削归属不是该库的照旧 404（#278）。"""
+    from movieclaw_api.api.routes.libraries import (
+        list_artwork_candidates_route,
+        refresh_item_metadata,
+        select_artwork_route,
+    )
+    from movieclaw_api.schemas.library import ArtworkSelectPayload
+    from movieclaw_db.repositories import MediaItemRepository
+
+    async with db.session() as session:
+        library = await LibraryRepository(session).create(
+            name="电影库", kind="movie", root_paths=[str(tmp_path / "movies")]
+        )
+        other = await LibraryRepository(session).create(
+            name="4K 电影库", kind="movie", root_paths=[str(tmp_path / "uhd")]
+        )
+    item_id = await _make_tracked_fileless_item(db, library.id)
+
+    # 候选图：TMDB 候选照常返回
+    async with db.session() as session:
+        resp = await list_artwork_candidates_route(library.id, item_id, session)
+        assert "/poster.jpg" in [p.file_path for p in resp.data.posters]
+
+    # 重刮：能正常入队后台作业
+    async with db.session() as session:
+        resp = await refresh_item_metadata(library.id, item_id, client_name=None, session=session)
+        assert resp.data["started"] is True
+
+    # 选图：更新条目图片字段并加锁；镜像落盘对无文件条目是安全 no-op
+    async with db.session() as session:
+        await select_artwork_route(
+            library.id,
+            item_id,
+            ArtworkSelectPayload(kind="poster", file_path="/poster.jpg"),
+            session,
+        )
+    async with db.session() as session:
+        refreshed = await session.get(MediaItem, item_id)
+        assert refreshed.poster_path == "/poster.jpg"
+        meta = await MediaItemRepository(session).get_metadata(item_id)
+        assert meta.poster_locked is True
+        # 校验时按订阅目标库推断出的归属已固化
+        assert refreshed.scrape_library_id == library.id
+
+    # 刮削归属不是该库 → 条目不属于那个库，仍然 404
+    async with db.session() as session:
+        with pytest.raises(NotFoundException):
+            await list_artwork_candidates_route(other.id, item_id, session)
+
+
+async def test_library_refresh_targets_include_fileless_tracked_items(db, tmp_path) -> None:
+    """整库刷新的目标 = 有台账行的条目 ∪ 刮削归属到该库的无文件条目——
+    追踪中条目从此进刷新范围，改选图偏好后不再静默失效（#278）。"""
+    from movieclaw_api.services import media_scrape
+
+    root, _entry, _video = _make_movie_entry(tmp_path)
+    async with db.session() as session:
+        library = await LibraryRepository(session).create(
+            name="电影库", kind="movie", root_paths=[str(root)]
+        )
+    assert (await scan_library(library.id)).identified == 1
+    tracked_id = await _make_tracked_fileless_item(db, library.id, tmdb_id=969681)
+
+    async with db.session() as session:
+        # 无订阅也无归属的纯浏览条目不进名单（它不在任何库的界面上展示）
+        stray = MediaItem(
+            kind="movie", tmdb_id=301, title="路过的电影", original_title="Passerby", year=2021
+        )
+        session.add(stray)
+        await session.commit()
+        await session.refresh(stray)
+        stray_id = stray.id
+
+        created = await media_scrape.enqueue_library_metadata_refresh_job(
+            session, library.id, "电影库"
+        )
+        target_ids = {t["media_item_id"] for t in created.job.input_data["targets"]}
+
+    async with db.session() as session:
+        scanned = (
+            (await session.execute(select(MediaItem).where(MediaItem.tmdb_id == 300)))
+            .scalars()
+            .all()
+        )
+    scanned_ids = {i.id for i in scanned}
+    assert tracked_id in target_ids
+    assert scanned_ids & target_ids  # 有文件的条目照旧在名单里
+    assert stray_id not in target_ids


### PR DESCRIPTION
Fixes #278

## 问题

订阅追踪中（已订阅、下载尚未入库）的条目在媒体库页「追踪中」区块带海报展示，海报来源就是 `media_item.poster_path`——与刮削管线写的是同一个字段。但这类条目被「有库存文件」这一前置条件卡死在所有入口之外：

- `items.refresh-metadata`、`artwork.list-candidates`、`artwork.select`、`items.set-scrape-library` 四个纯元数据路由复用 `_item_rows`，无台账行直接 404；
- 整库刷新的 targets 从 `LibraryFile join MediaItem` 取，无文件条目天生不在名单里，而进度分母就是 targets 数——用户看到「918/918 成功」，无从察觉有条目被静默排除。

结果是：界面上显示着这张海报，改选图偏好对它完全无效，也没有任何手动出口能换掉它。

## 修复

对应 issue 的建议 1、2、3（做了 3 之后不再有被排除的条目，建议 4 的提示不再需要）：

1. **四个纯元数据路由改用不要求库存文件的校验 `_metadata_item`**（`api/routes/libraries.py`）：有台账行照旧通过；无台账行时按刮削归属库（docs/design/scrape-customization.md §14 的解析规则，含「订阅目标库 → 默认库」推断）判定条目与库的关联，归属不是该库仍 404。服务层一行未动——`scrape_media_item` / `list_artwork_candidates` / `select_artwork` 本就只按 `media_item_id` 干活，唯一碰媒体目录的 `mirror_media_dir_assets` 对无文件条目已是安全 no-op。
2. **整库刷新的目标并入追踪中条目**（`services/media_scrape.py`）：抽出 `_library_refresh_targets` 供后台任务与 Job 快照两条路径共用，目标 = 库内有台账行的条目 ∪ 刮削归属解析到该库的无文件条目。候选面只限「有订阅或显式归属」的无文件条目（个位数规模），无归属的纯发现页浏览条目仍不进名单。

不动运行时依赖，无需 bump `docker/runtime-version`；接口契约不变（只放宽前置条件），前端无需改动。

## 测试

新增两个用例（`tests/api/test_library_item_detail.py`）：

- `test_fileless_tracked_item_opens_metadata_routes`：无文件追踪中条目走通重刮（成功入队）、候选图（TMDB 候选正常返回）、选图（字段更新 + 加锁，不因缺条目目录失败，归属固化到订阅目标库）；用另一个库调用仍 404。
- `test_library_refresh_targets_include_fileless_tracked_items`：整库刷新 Job 的目标快照同时含有文件条目与追踪中条目，不含无归属条目。

验证：新用例与 `test_library_item_detail.py` / `test_scrape_config_e2e.py` / `test_p0_persistent_jobs.py` 全部通过，`ruff check .` 干净。全量 `pytest -m "not integration"` 中 `tests/enrich`（缺 NER 模型文件）与 `tests/net/test_egress.py`（沙箱预设 `HTTPS_PROXY`）的失败在 main 上原样复现，属既有环境问题，与本次改动无关。

## 备注

issue 讨论中发现的第二个疑点（定时刷新 `REFRESH_PER_TICK=5` × 900s tick 可能积压，导致 24 小时档的追踪中条目实际刷不到）是独立问题，等报告者提供 `metadata_refreshed_at` 数据后建议另开 issue 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eXki8FtoRF2LwyzRo9bF9

---
_Generated by [Claude Code](https://claude.ai/code/session_016eXki8FtoRF2LwyzRo9bF9)_