### PR TITLE
fix(更新): 检查更新与连通性测试口径对齐，不再把限流/抖动误报为网络不可达

### DIFF
--- a/src/movieclaw_api/services/app_update.py
+++ b/src/movieclaw_api/services/app_update.py
@@ -432,6 +432,18 @@ def reset_release_cache_for_tests() -> None:
 # 远低于给用户报一次假的「网络不可达」——原先零重试，一次抖动就报错。
 _RETRY_BACKOFF_SECONDS = (1.0, 3.0)
 
+# 值得重试的瞬时故障。**httpx.ProxyError 必须单列**：它不是 NetworkError 的
+# 子类，而是 TransportError 下与之平级的分支，只写 NetworkError 会把代理故障
+# 整类漏掉——而 SOCKS5 用户最常撞上的恰恰就是它（代理握手失败、Clash 回
+# 「host unreachable」、认证被拒都归到 ProxyError）。RemoteProtocolError
+# （代理未回响应就断开）同理，检查更新是幂等 GET，重试安全。
+_RETRYABLE_NETWORK_ERRORS = (
+    httpx.TimeoutException,
+    httpx.NetworkError,
+    httpx.ProxyError,
+    httpx.RemoteProtocolError,
+)
+
 
 def _proxy_hint() -> str:
     """当前 GitHub 出口的中文描述，拼进错误信息里。
@@ -474,6 +486,15 @@ def _describe_github_error(exc: httpx.HTTPError, what: str) -> str:
         return (
             f"GitHub 返回异常状态（HTTP {response.status_code}），无法检查{what}，"
             f"请稍后重试。{_proxy_hint()}"
+        )
+    if isinstance(exc, httpx.ProxyError):
+        # SOCKS5 用户最常撞上的一类：代理进程在线（所以「设置 → 网络」的测试
+        # 可能刚好赶上一次成功），但本次转发被拒——节点掉线、分流规则命中
+        # REJECT、认证失败都会走到这里。必须点名是代理拒绝而非 GitHub 不可达。
+        return (
+            f"代理拒绝了到 GitHub 的转发，无法检查{what}（{exc}）。{_proxy_hint()}；"
+            "请确认代理节点在线、认证信息正确，且 api.github.com 命中的分流规则"
+            "不是 REJECT/DIRECT"
         )
     if isinstance(exc, httpx.TimeoutException):
         return (
@@ -518,7 +539,7 @@ async def _fetch_releases(what: str) -> list[dict]:
                 if resp.status_code == 304 and _releases_cached is not None:
                     return _releases_cached
                 resp.raise_for_status()
-            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            except _RETRYABLE_NETWORK_ERRORS as exc:
                 if attempt == len(_RETRY_BACKOFF_SECONDS):
                     raise BadRequestException(_describe_github_error(exc, what)) from exc
                 delay = _RETRY_BACKOFF_SECONDS[attempt]

--- a/src/movieclaw_api/services/app_update.py
+++ b/src/movieclaw_api/services/app_update.py
@@ -427,32 +427,115 @@ def reset_release_cache_for_tests() -> None:
     _releases_cached = None
 
 
+# 网络级失败的退避重试节奏。只重试「线路抖动」：代理链路（尤其 socks5）
+# 偶发建连失败很常见，而检查更新是每小时一次的低频操作，多试两次的代价
+# 远低于给用户报一次假的「网络不可达」——原先零重试，一次抖动就报错。
+_RETRY_BACKOFF_SECONDS = (1.0, 3.0)
+
+
+def _proxy_hint() -> str:
+    """当前 GitHub 出口的中文描述，拼进错误信息里。
+
+    用户排查时的第一个疑问永远是「我配的代理到底生效了没」，把答案直接
+    写进报错，省掉一轮来回。
+    """
+    proxy = resolve_proxy_url("github")
+    return f"当前经代理 {proxy} 访问" if proxy else "当前为直连（未对 GitHub 启用代理）"
+
+
+def _describe_github_error(exc: httpx.HTTPError, what: str) -> str:
+    """把底层网络异常翻译成能直接指导下一步的中文说明。
+
+    原先这里不分青红皂白统一报「无法连接 GitHub，请确认网络可达」，把限流、
+    超时、连接被拒糊成同一句话，异常本身（``__cause__``）又从不外露——用户在
+    「设置 → 网络」测出绿灯后完全无从下手。而绿灯与红灯并存本就是常态：
+    连通性测试把 403 判为「网络连通，但限流中」，这里却当成连不上。错误分类
+    必须与连通性测试同口径，两处结论才不会互相打架。
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        response = exc.response
+        if response.status_code in (403, 429):
+            if response.headers.get("x-ratelimit-remaining") == "0":
+                reset = response.headers.get("x-ratelimit-reset", "")
+                recover = ""
+                if reset.isdigit():
+                    minutes = max(0, int((int(reset) - time.time()) // 60)) + 1
+                    recover = f"约 {minutes} 分钟后自动恢复，"
+                return (
+                    f"GitHub 接口配额已用尽，暂时无法检查{what}。未认证访问限 60 次/"
+                    f"小时/IP，走代理时该配额由出口节点的所有用户共享，"
+                    f"因此可能并非本机用量所致。{recover}期间不影响已装版本运行。"
+                    f"{_proxy_hint()}"
+                )
+            return (
+                f"GitHub 拒绝了本次请求（HTTP {response.status_code}），无法检查{what}。"
+                f"通常是出口 IP 触发了频率限制或风控，稍后会自动重试。{_proxy_hint()}"
+            )
+        return (
+            f"GitHub 返回异常状态（HTTP {response.status_code}），无法检查{what}，"
+            f"请稍后重试。{_proxy_hint()}"
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return (
+            f"连接 GitHub 超时，无法检查{what}。{_proxy_hint()}；"
+            "若代理按域名分流，请确认 api.github.com 走的是代理而非直连"
+        )
+    return (
+        f"无法连接 GitHub 检查{what}（{type(exc).__name__}：{exc}）。{_proxy_hint()}；"
+        "可在「设置 → 网络」调整代理，或用 UPDATE_API_BASE_URL 配置反代"
+    )
+
+
 async def _fetch_releases(what: str) -> list[dict]:
     """拉全部 Release 列表（应用与模型的 Release 混在同一个仓库里，
     必须列表过滤，绝不能用 /releases/latest——模型发布会把 latest 顶掉）。"""
     global _releases_etag, _releases_cached
     settings = get_settings()
-    api_url = f"{settings.update_api_base_url}/repos/{settings.update_repo}/releases?per_page=100"
+    # 反代地址常被写成带尾斜杠的形式，不去掉会拼出 //repos/... ——不少反代
+    # 对双斜杠直接 404，而「设置 → 网络」的连通性测试是 rstrip 过的，
+    # 于是测试通过、检查更新却失败，两处必须同口径
+    base_url = settings.update_api_base_url.rstrip("/")
+    api_url = f"{base_url}/repos/{settings.update_repo}/releases?per_page=100"
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "movieclaw-updater"}
     if _releases_etag and _releases_cached is not None:
         headers["If-None-Match"] = _releases_etag
     async with httpx.AsyncClient(
-        # 走统一网络出口（服务标签 github）：设置页可为更新流量单独开关代理
-        transport=egress_transport("github"),
+        # 走统一网络出口（服务标签 github）：设置页可为更新流量单独开关代理。
+        # 但**不上熔断**：熔断是为「用户正等着结果的高频请求」（发现页曾拖满
+        # 49 秒）设计的快速失败，而更新检查是每小时一次的后台任务加偶尔手动
+        # 点一次。熔断状态横跨这两个语境，只会让后台任务攒下的失败把用户手动
+        # 点的「检查更新」误伤成秒级失败——而同一时刻连通性测试（同样
+        # use_breaker=False，且成功后还会 reset）却是绿的，正是「测试可达但
+        # 检查更新报不可达」的成因之一。两条路径的出口口径就此对齐。
+        transport=egress_transport("github", use_breaker=False),
         timeout=_HTTP_TIMEOUT,
         follow_redirects=True,
         headers=headers,
     ) as client:
-        try:
-            resp = await client.get(api_url)
-            if resp.status_code == 304 and _releases_cached is not None:
-                return _releases_cached
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise BadRequestException(
-                f"无法连接 GitHub 检查{what}，"
-                "请确认网络可达（可配置代理或 UPDATE_API_BASE_URL 反代）"
-            ) from exc
+        for attempt in range(len(_RETRY_BACKOFF_SECONDS) + 1):
+            try:
+                resp = await client.get(api_url)
+                if resp.status_code == 304 and _releases_cached is not None:
+                    return _releases_cached
+                resp.raise_for_status()
+            except (httpx.TimeoutException, httpx.NetworkError) as exc:
+                if attempt == len(_RETRY_BACKOFF_SECONDS):
+                    raise BadRequestException(_describe_github_error(exc, what)) from exc
+                delay = _RETRY_BACKOFF_SECONDS[attempt]
+                logger.info(
+                    "检查%s时连接 GitHub 失败（第 %d 次：%s），%.0f 秒后重试",
+                    what,
+                    attempt + 1,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            except httpx.HTTPError as exc:
+                # HTTP 状态错误不重试：限流/风控下重试只会加速耗尽配额，
+                # 直接交给错误分类给出准确结论
+                raise BadRequestException(_describe_github_error(exc, what)) from exc
+            break
         releases = resp.json()
         etag = resp.headers.get("etag")
         if etag:
@@ -487,8 +570,8 @@ async def _fetch_latest_release() -> tuple[dict, dict]:
         raise BadRequestException("未找到任何应用发布（vX.Y.Z 的 Release），暂无可用更新")
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "movieclaw-updater"}
     async with httpx.AsyncClient(
-        # 走统一网络出口（服务标签 github）：设置页可为更新流量单独开关代理
-        transport=egress_transport("github"),
+        # 走统一网络出口（服务标签 github），同 _fetch_releases 不上熔断
+        transport=egress_transport("github", use_breaker=False),
         timeout=_HTTP_TIMEOUT,
         follow_redirects=True,
         headers=headers,
@@ -1127,7 +1210,7 @@ async def start_model_update() -> UpdateProgressView:
             )
         headers = {"User-Agent": "movieclaw-updater"}
         async with httpx.AsyncClient(
-            transport=egress_transport("github"),
+            transport=egress_transport("github", use_breaker=False),
             timeout=_HTTP_TIMEOUT,
             follow_redirects=True,
             headers=headers,

--- a/src/movieclaw_net/egress.py
+++ b/src/movieclaw_net/egress.py
@@ -38,11 +38,18 @@ from movieclaw_net.breaker import CircuitBreaker, get_breaker
 
 logger = logging.getLogger("movieclaw_net.egress")
 
-# 熔断器只统计这些"线路不通"级别的失败；HTTP 状态码错误不计入
-_NETWORK_FAILURES = (httpx.TimeoutException, httpx.NetworkError)
+# 熔断器只统计这些"线路不通"级别的失败；HTTP 状态码错误不计入。
+# ProxyError 必须单列：它不是 NetworkError 的子类，而是 TransportError 下与之
+# 平级的分支。漏掉它意味着**代理故障一次都不计数**——对走 SOCKS5 的用户
+# （节点掉线、分流规则 REJECT、认证失败全归 ProxyError）整个熔断形同虚设，
+# 每个请求都得等满超时，正是熔断本该消灭的那种体验。
+_NETWORK_FAILURES = (httpx.TimeoutException, httpx.NetworkError, httpx.ProxyError)
 
-# 允许的代理协议：http(s) 与 socks5（socks5h 表示由代理端解析域名，
-# 对被 DNS 污染的域名更稳，Clash/sing-box 均支持）
+# 允许的代理协议：http(s) 与 socks5。
+# 注意 socks5 与 socks5h 在 httpx 下**行为完全一致**：httpcore 把目标主机名
+# 原样以 ATYP=DOMAINNAME 发给代理（见 socksio.utils.encode_address），域名
+# 一律由代理端解析，本地不做 DNS。保留 socks5h 只为兼容用户从别处抄来的
+# 地址，改写成它并不会改变解析行为，不必拿它去试被污染的域名。
 PROXY_SCHEMES = ("http", "https", "socks5", "socks5h")
 
 

--- a/tests/api/test_app_update.py
+++ b/tests/api/test_app_update.py
@@ -2,7 +2,9 @@
 
 重点覆盖安全性质：sha256 不匹配/路径穿越/布局异常时绝不切换版本指针，
 切换与回退的符号链接操作正确且可互换，非 Docker 部署形态拒绝更新。
-网络部分（GitHub API）不在此测——那是薄封装，错误路径已转成中文提示。
+GitHub API 部分只测**失败路径的结论**（错误分类、退避重试、地址拼接、
+不上熔断）——这些口径必须与「设置 → 网络」的连通性测试一致，否则会出现
+「测试绿灯、检查更新报网络不可达」的割裂；成功路径是薄封装，不在此测。
 """
 
 from __future__ import annotations
@@ -857,6 +859,193 @@ async def test_fetch_releases_uses_etag_cache(updates_dir, monkeypatch):
     assert first == second == [{"tag_name": "v0.2.0"}]
     assert "if-none-match" not in calls[0]
     assert calls[1].get("if-none-match") == 'W/"abc"'
+
+
+# ---------------------------------------------------------------------------
+# 检查更新的失败路径：错误分类、退避重试、反代地址拼接
+#
+# 这一组的由来：用户在「设置 → 网络」测 GitHub 是绿的，点「检查更新」却
+# 偶发报「无法连接 GitHub」。根因是检查路径与连通性测试的口径不一致——
+# 测试绕过熔断、把 403 判为连通、且 rstrip 了反代地址，检查路径三样都没做，
+# 且异常原因被 BadRequestException 吞掉，日志与界面都查不出真凶。
+# ---------------------------------------------------------------------------
+
+
+def _mock_releases_client(monkeypatch, handler):
+    """把 _fetch_releases 用的 AsyncClient 换成 MockTransport 驱动的客户端。"""
+    import httpx
+
+    real_client = httpx.AsyncClient
+
+    def patched_client(**kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(**kwargs)
+
+    monkeypatch.setattr(app_update.httpx, "AsyncClient", patched_client)
+    app_update.reset_release_cache_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_reports_rate_limit_instead_of_unreachable(
+    updates_dir, monkeypatch
+):
+    """403 + 配额耗尽要说清是限流，不能糊成「网络不可达」。
+
+    连通性测试对同一个 403 判的是「网络连通，但限流中」，两处结论必须一致，
+    否则用户拿着绿灯的测试结果对着红色的「网络不可达」无从下手。
+    """
+    import httpx
+
+    reset_at = int(time.time()) + 15 * 60
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={"message": "API rate limit exceeded"},
+            headers={"x-ratelimit-remaining": "0", "x-ratelimit-reset": str(reset_at)},
+        )
+
+    _mock_releases_client(monkeypatch, handler)
+    try:
+        with pytest.raises(BadRequestException) as excinfo:
+            await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    message = excinfo.value.message
+    assert "配额" in message and "60 次" in message
+    assert "无法连接" not in message
+    assert "分钟后自动恢复" in message
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_rate_limit_is_not_retried(updates_dir, monkeypatch):
+    """限流不重试：重试只会加速耗尽配额。"""
+    import httpx
+
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        return httpx.Response(403, headers={"x-ratelimit-remaining": "0"})
+
+    _mock_releases_client(monkeypatch, handler)
+    try:
+        with pytest.raises(BadRequestException):
+            await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_retries_transient_network_failure(updates_dir, monkeypatch):
+    """线路抖动退避重试后成功：一次抖动不该报成「网络不可达」。"""
+    import httpx
+
+    attempts: list[int] = []
+    slept: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise httpx.ConnectError("connection reset by peer")
+        return httpx.Response(200, json=[{"tag_name": "v0.2.0"}])
+
+    _mock_releases_client(monkeypatch, handler)
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    monkeypatch.setattr(app_update.asyncio, "sleep", fake_sleep)
+    try:
+        releases = await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    assert releases == [{"tag_name": "v0.2.0"}]
+    assert len(attempts) == 2
+    assert slept == [app_update._RETRY_BACKOFF_SECONDS[0]]
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_gives_up_after_retries_with_proxy_hint(
+    updates_dir, monkeypatch
+):
+    """重试用尽后报错要带上「当前是直连还是走代理」——排查的第一个疑问。"""
+    import httpx
+
+    attempts: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        raise httpx.ConnectTimeout("timed out")
+
+    _mock_releases_client(monkeypatch, handler)
+
+    async def fake_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(app_update.asyncio, "sleep", fake_sleep)
+    try:
+        with pytest.raises(BadRequestException) as excinfo:
+            await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    assert len(attempts) == len(app_update._RETRY_BACKOFF_SECONDS) + 1
+    assert "超时" in excinfo.value.message
+    assert "直连" in excinfo.value.message or "代理" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_strips_trailing_slash_of_api_base(updates_dir, monkeypatch):
+    """反代地址带尾斜杠时不能拼出 //repos（不少反代对双斜杠直接 404）。"""
+    import httpx
+
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, json=[])
+
+    monkeypatch.setenv("UPDATE_API_BASE_URL", "https://gh.example.com/")
+    get_settings.cache_clear()
+    _mock_releases_client(monkeypatch, handler)
+    try:
+        await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+        get_settings.cache_clear()
+    assert seen[0].startswith("https://gh.example.com/repos/")
+    assert "//repos" not in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_github_egress_never_uses_breaker(updates_dir, monkeypatch):
+    """github 标签的出口一律不上熔断：后台任务攒下的失败不该让手动检查秒失败。
+
+    熔断是给「用户正等着结果的高频请求」用的快速失败；更新检查每小时一次，
+    熔断在这里只会误伤手动操作——而同一时刻连通性测试（同样 use_breaker=False，
+    且成功后还会 reset）却是绿的，正是「测试可达但检查更新报不可达」的成因。
+    """
+    import httpx
+
+    real_egress = app_update.egress_transport
+    kwargs_seen: list[dict] = []
+
+    def spy(service: str, **kwargs):
+        kwargs_seen.append({"service": service, **kwargs})
+        return real_egress(service, **kwargs)
+
+    monkeypatch.setattr(app_update, "egress_transport", spy)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"tag_name": "v0.2.0"}])
+
+    _mock_releases_client(monkeypatch, handler)
+    try:
+        await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    assert kwargs_seen == [{"service": "github", "use_breaker": False}]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_app_update.py
+++ b/tests/api/test_app_update.py
@@ -996,6 +996,61 @@ async def test_fetch_releases_gives_up_after_retries_with_proxy_hint(
 
 
 @pytest.mark.asyncio
+async def test_fetch_releases_retries_proxy_error(updates_dir, monkeypatch):
+    """代理故障也要重试。
+
+    httpx.ProxyError 不是 NetworkError 的子类而是它的兄弟，只捕获 NetworkError
+    会把代理故障整类漏掉——而 SOCKS5 用户最常撞上的恰恰就是它。
+    """
+    import httpx
+
+    assert not issubclass(httpx.ProxyError, httpx.NetworkError)  # 漏写的根源
+    attempts: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise httpx.ProxyError("proxy: host unreachable")
+        return httpx.Response(200, json=[{"tag_name": "v0.2.0"}])
+
+    _mock_releases_client(monkeypatch, handler)
+
+    async def fake_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(app_update.asyncio, "sleep", fake_sleep)
+    try:
+        releases = await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    assert releases == [{"tag_name": "v0.2.0"}]
+    assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_proxy_error_message_points_at_proxy(updates_dir, monkeypatch):
+    """代理拒绝转发时要点名是代理的问题，不能说成 GitHub 不可达。"""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ProxyError("host unreachable")
+
+    _mock_releases_client(monkeypatch, handler)
+
+    async def fake_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(app_update.asyncio, "sleep", fake_sleep)
+    try:
+        with pytest.raises(BadRequestException) as excinfo:
+            await app_update._fetch_releases("更新")
+    finally:
+        app_update.reset_release_cache_for_tests()
+    assert "代理拒绝" in excinfo.value.message
+    assert "REJECT" in excinfo.value.message
+
+
+@pytest.mark.asyncio
 async def test_fetch_releases_strips_trailing_slash_of_api_base(updates_dir, monkeypatch):
     """反代地址带尾斜杠时不能拼出 //repos（不少反代对双斜杠直接 404）。"""
     import httpx

--- a/tests/net/test_egress.py
+++ b/tests/net/test_egress.py
@@ -155,6 +155,36 @@ def test_transport_follows_breaker_registry_reset():
     fresh.before_request()  # 不抛 CircuitOpenError 即为通过
 
 
+@pytest.mark.asyncio
+async def test_breaker_counts_proxy_failures():
+    """回归：代理故障必须计入熔断。
+
+    httpx.ProxyError 不是 NetworkError 的子类，而是 TransportError 下与之平级的
+    分支。_NETWORK_FAILURES 漏掉它时，走 SOCKS5 的用户（节点掉线、分流规则
+    REJECT、认证失败全归 ProxyError）整个熔断形同虚设——每个请求都要等满超时，
+    正是熔断本该消灭的那种体验。
+    """
+    import httpx
+
+    from movieclaw_net import get_breaker
+    from movieclaw_net.egress import current_epoch
+
+    assert not issubclass(httpx.ProxyError, httpx.NetworkError)  # 漏写的根源
+
+    class _ProxyRefusing(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            raise httpx.ProxyError("host unreachable")
+
+    transport = egress_transport("tmdb")
+    transport._inner = _ProxyRefusing()
+    transport._inner_epoch = current_epoch()
+    request = httpx.Request("GET", "https://example.com/")
+    for _ in range(3):
+        with pytest.raises(httpx.ProxyError):
+            await transport.handle_async_request(request)
+    assert get_breaker("tmdb").is_open
+
+
 def test_transport_rebuilds_inner_on_config_change():
     transport = egress_transport("tmdb")
     inner_before = transport._ensure_inner()


### PR DESCRIPTION
用户在「设置 → 网络」把 GitHub 测成绿灯，点「检查更新」却偶发报
「无法连接 GitHub 检查更新」。根因是这两条路径的口径完全不一致，
而真实异常又被 BadRequestException 吞掉（__cause__ 从不外露），
界面和日志都查不出到底是超时、限流还是熔断。

四处对齐（均在 _fetch_releases）：

1. 错误分类：新增 _describe_github_error，把 403 + x-ratelimit-remaining=0
   说清为「配额已用尽，走代理时该配额由出口节点所有用户共享」并给出
   恢复时间，超时/连接失败各有专门文案，末尾统一附上当前是直连还是
   经哪个代理。连通性测试对同一个 403 判的是「网络连通，但限流中」，
   两处结论不能再打架。

2. 不上熔断：熔断是为「用户正等着结果的高频请求」设计的快速失败，
   而更新检查是每小时一次的后台任务加偶尔手动点一次。熔断状态横跨
   这两个语境，后台任务攒下的 3 次失败会让用户手动点的「检查更新」
   在 60 秒冷却期内秒失败——而同一时刻连通性测试（本就 use_breaker=False
   且成功后还会 reset）是绿的。github 标签的三处出口一律 use_breaker=False。

3. 退避重试：网络级失败退避重试两次（1s/3s）。代理链路尤其 socks5
   偶发建连失败很常见，原先零重试，一次抖动就报错。HTTP 状态错误
   不重试——限流下重试只会加速耗尽配额。

4. UPDATE_API_BASE_URL 尾斜杠：rstrip 后再拼，避免 //repos/...
   （不少反代对双斜杠直接 404）。连通性测试本就 rstrip 过。

未改：产物下载仍硬编码 github.com/releases/download（不走
UPDATE_API_BASE_URL），以及 manifest 经 objects.githubusercontent.com
回源——那是「立即更新」下载阶段的隐患，报错文案不同，另行处理。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015234vhrCaDHVH364wps7yb