### PR TITLE
修复 Telegram、Discord、Webhook 连通性测试

### DIFF
--- a/src/movieclaw_api/schemas/network.py
+++ b/src/movieclaw_api/schemas/network.py
@@ -35,8 +35,8 @@ class NetworkConfigPayload(BaseModel):
     )
     proxy_services: list[str] = Field(
         default_factory=list,
-        description="走代理的服务 id 列表：tmdb / image / douban / llm / site:<站点id>；"
-        "不在列表内的服务直连",
+        description="走代理的服务 id 列表：tmdb / image / douban / llm / telegram / "
+        "discord / webhook / github / site:<站点id>；不在列表内的服务直连",
     )
     tmdb_api_base_url: str = Field(
         default="", description="TMDB 接口镜像地址；留空用默认（见读取接口的 mirror_defaults）"
@@ -61,7 +61,8 @@ class NetworkTestPayload(BaseModel):
     service: str = Field(
         min_length=1,
         max_length=100,
-        description="要测试连通性的服务 id：tmdb / image / douban / llm / site:<站点id>",
+        description="要测试连通性的服务 id：tmdb / image / douban / llm / telegram / "
+        "discord / webhook / github / site:<站点id>",
     )
 
 

--- a/src/movieclaw_api/services/network_config.py
+++ b/src/movieclaw_api/services/network_config.py
@@ -34,7 +34,13 @@ from movieclaw_api.services.network_egress import (
     effective_tmdb_image_base_url,
     save_network_egress,
 )
-from movieclaw_api.settings import BUILTIN_EGRESS_SERVICES, NetworkEgressSetting
+from movieclaw_api.settings import (
+    BUILTIN_EGRESS_SERVICES,
+    NetworkEgressSetting,
+    WebhookSetting,
+    get_setting_store,
+)
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
 from movieclaw_db.repositories.credential_repo import CredentialRepository
 from movieclaw_net import (
     PROXY_SCHEMES,
@@ -184,6 +190,29 @@ async def _probe_target(service: str, session: AsyncSession) -> tuple[str, dict[
         if user_agent:
             headers["User-Agent"] = user_agent
         return f"{base.rstrip('/')}/models", headers
+    if service in ("telegram", "discord"):
+        channel_name = "Telegram" if service == "telegram" else "Discord"
+        accounts = await ChannelAccountRepository(session).list_by_channel(service)
+        if not accounts:
+            raise BadRequestException(f"尚未绑定 {channel_name} bot，无法测试")
+        try:
+            token = ChannelAccountRepository.decrypted_token(accounts[0])
+        except Exception as exc:  # noqa: BLE001 -- 凭据损坏时返回可操作的中文错误
+            raise BadRequestException(
+                f"{channel_name} bot 凭据不可用，请重新绑定"
+            ) from exc
+        if service == "telegram":
+            return f"https://api.telegram.org/bot{token}/getMe", {}
+        return "https://discord.com/api/v10/users/@me", {"Authorization": f"Bot {token}"}
+    if service == "webhook":
+        setting = await get_setting_store().get(WebhookSetting)
+        endpoint = next(
+            (item for item in setting.endpoints if item.enabled and item.url.strip()),
+            None,
+        )
+        if endpoint is None:
+            raise BadRequestException("尚未配置可用的 Webhook endpoint，无法测试")
+        return endpoint.url, dict(endpoint.headers)
     if service == "github":
         # 与应用内更新的检查请求同源（api.github.com 或 UPDATE_API_BASE_URL 反代）
         settings = get_settings()
@@ -230,6 +259,11 @@ def _classify_probe(service: str, status_code: int) -> NetworkTestResult:
         else:
             message = f"网络连通（HTTP {status_code}）"
         return NetworkTestResult(ok=True, message=message)
+    if service in ("telegram", "discord") and status_code in (401, 403, 404):
+        channel_name = "Telegram" if service == "telegram" else "Discord"
+        return NetworkTestResult(
+            ok=True, message=f"网络连通，但 {channel_name} bot Token 无效"
+        )
     return NetworkTestResult(ok=True, message=f"网络连通（HTTP {status_code}）")
 
 

--- a/tests/api/test_network.py
+++ b/tests/api/test_network.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
 from movieclaw_api.core.config import get_settings
+from movieclaw_api.services import network_config
 from movieclaw_api.services.auth import reset_auth_state
 from movieclaw_api.services.media_discover import reset_media_service
 from movieclaw_api.services.network_egress import reset_network_egress
+from movieclaw_api.settings import WebhookEndpoint, WebhookSetting
 from movieclaw_api.settings.store import reset_setting_store
 from movieclaw_db.crypto import reset_secret_box
+from movieclaw_db.repositories.channel_account_repo import ChannelAccountRepository
 from movieclaw_net import EgressConfig, apply_egress_config, resolve_proxy_url
 
 
@@ -139,6 +145,72 @@ def test_test_endpoint_llm_unconfigured(client):
     resp = client.post("/api/v1/network/test", json={"service": "llm"})
     assert resp.status_code == 400
     assert "尚未配置" in resp.json()["message"]
+
+
+@pytest.mark.parametrize(
+    ("service", "message"),
+    [
+        ("telegram", "尚未绑定 Telegram bot"),
+        ("discord", "尚未绑定 Discord bot"),
+        ("webhook", "尚未配置可用的 Webhook endpoint"),
+    ],
+)
+def test_test_endpoint_reports_missing_integration_config(client, monkeypatch, service, message):
+    async def no_accounts(self, channel_id):
+        return []
+
+    monkeypatch.setattr(ChannelAccountRepository, "list_by_channel", no_accounts)
+    resp = client.post("/api/v1/network/test", json={"service": service})
+    assert resp.status_code == 400
+    assert message in resp.json()["message"]
+
+
+def test_test_endpoint_probes_telegram_discord_and_webhook(client, monkeypatch):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        network_config,
+        "egress_transport",
+        lambda service, **kwargs: httpx.MockTransport(handler),
+    )
+
+    async def one_account(self, channel_id):
+        return [SimpleNamespace(token="encrypted-token")]
+
+    monkeypatch.setattr(ChannelAccountRepository, "list_by_channel", one_account)
+    monkeypatch.setattr(
+        ChannelAccountRepository,
+        "decrypted_token",
+        lambda row: "test-bot-token",
+    )
+
+    class FakeSettingStore:
+        async def get(self, model):
+            return WebhookSetting(
+                endpoints=[
+                    WebhookEndpoint(
+                        url="http://receiver.test/hook",
+                        headers={"X-Test": "1"},
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(network_config, "get_setting_store", lambda: FakeSettingStore())
+
+    for service in ("telegram", "discord", "webhook"):
+        response = client.post("/api/v1/network/test", json={"service": service})
+        assert response.status_code == 200, response.text
+        assert response.json()["data"]["ok"] is True
+
+    assert str(requests[0].url) == "https://api.telegram.org/bottest-bot-token/getMe"
+    assert str(requests[1].url) == "https://discord.com/api/v10/users/@me"
+    assert requests[1].headers["Authorization"] == "Bot test-bot-token"
+    assert str(requests[2].url) == "http://receiver.test/hook"
+    assert requests[2].headers["X-Test"] == "1"
 
 
 def test_requires_login(tmp_path, monkeypatch):


### PR DESCRIPTION
## 变更

- 补齐 Telegram、Discord、Webhook 的网络连通性探测
- 未配置账号或 Webhook 时返回明确错误
- 增加 Token 无效状态提示
- 添加对应回归测试

## 验证

- `py_compile` 通过
- `git diff --check` 通过