### PR TITLE
fix(sites): OurBits 分类筛选改用站点要求的重复 cat[] 参数

### DIFF
--- a/src/movieclaw_tracker/sites/configs/ourbits.yaml
+++ b/src/movieclaw_tracker/sites/configs/ourbits.yaml
@@ -1,10 +1,14 @@
 # OurBits（我堡）站点配置
 # 官网：https://ourbits.club/
+#
+# 分类筛选参数与标准 NexusPHP 不同：站点只认重复的 cat[]=401，忽略 cat401=1，
+# 由 sites/custom/ourbits.py 覆盖参数拼法；其余解析沿用框架默认实现。
 
 site_id: ourbits
 display_name: OurBits
 base_url: https://ourbits.club
 framework: nexusphp
+custom_class: movieclaw_tracker.sites.custom.ourbits.OurBitsSite
 
 selectors:
   # ── 种子列表 ─────────────────────────────────────────────────────
@@ -36,6 +40,11 @@ selectors:
   profile_downloaded_css: "font.color_downloaded::next_sibling_text"
   profile_seeding_css: "img[alt='Torrents seeding'] + *"
   profile_leeching_css: "img[alt='Torrents leeching'] + *"
+
+# ── 支持的授权类型 ────────────────────────────────────────────────
+# 登录页有 Cloudflare 人机挑战，账号密码模拟登录无法通过，仅支持粘贴 Cookie。
+auth:
+  supported: [cookie]
 
 # ── 分类映射 ──────────────────────────────────────────────────────
 categories:

--- a/src/movieclaw_tracker/sites/custom/ourbits.py
+++ b/src/movieclaw_tracker/sites/custom/ourbits.py
@@ -1,0 +1,41 @@
+"""OurBits（我堡 / ourbits.club）自定义站点适配器。
+
+OurBits 基于 NexusPHP 框架，列表解析、分页、用户资料全部沿用标准实现，
+只有一处与框架默认行为不同，需要覆盖：
+
+1. **分类筛选参数是重复的数组形式**
+   标准 NexusPHP 每个分类一个独立参数（``?cat401=1&cat402=1``），而
+   OurBits 只认重复的 ``cat[]``（``?cat[]=401&cat[]=402``）。站点对
+   ``cat401=1`` 这种写法直接忽略，带分类的搜索和列表会退化成全站结果。
+   因此重写 ``_apply_category_params``，把所有站点分类 ID 收进一个列表交给
+   ``cat[]``，由 HttpClient 展开为重复参数。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from movieclaw_tracker.frameworks.nexusphp import NexusPHPSite
+from movieclaw_tracker.models import TorrentCategory
+
+
+class OurBitsSite(NexusPHPSite):
+    """OurBits 站点：仅重写分类参数的拼法。
+
+    选择器、分类映射、分页偏移等仍由 ``sites/configs/ourbits.yaml`` 配置，
+    不在此重写。
+    """
+
+    def _apply_category_params(
+        self,
+        params: dict[str, Any],
+        categories: list[TorrentCategory] | None,
+    ) -> None:
+        if not categories or not self.category_map:
+            return
+
+        site_ids: list[str] = []
+        for category in categories:
+            site_ids.extend(self.category_map.get(category, []))
+        if site_ids:
+            params["cat[]"] = site_ids

--- a/tests/tracker/unit/test_ourbits_category_params.py
+++ b/tests/tracker/unit/test_ourbits_category_params.py
@@ -1,0 +1,74 @@
+"""OurBits 分类参数回归测试。
+
+OurBits 的分类筛选只认重复的 ``cat[]=401&cat[]=402``，标准 NexusPHP 发出的
+``cat401=1&cat402=1`` 会被站点忽略，带分类的搜索退化成全站结果。
+
+两层保障：
+1. 配置层：ourbits.yaml 绑定到 ``OurBitsSite``，且授权类型只声明 cookie。
+2. 行为层：用 Mock HttpClient 验证 ``search`` / ``list_torrents`` 最终发出的
+   请求参数是 ``cat[]`` 列表，且不再出现 ``cat4xx`` 这类键。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from movieclaw_tracker import load_all_sites
+from movieclaw_tracker.models import SearchQuery, TorrentCategory
+from movieclaw_tracker.registry import get_site_config
+from movieclaw_tracker.sites.custom.ourbits import OurBitsSite
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _load_configs() -> None:
+    load_all_sites()
+
+
+def test_ourbits_config_uses_custom_class() -> None:
+    config = get_site_config("ourbits")
+    assert config.site_class is OurBitsSite
+    assert config.supported_auth_types == ("cookie",)
+
+
+def _mock_site() -> tuple[OurBitsSite, AsyncMock]:
+    config = get_site_config("ourbits")
+    response = MagicMock()
+    response.text = "<html><body></body></html>"
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    site = OurBitsSite(
+        selectors=config.selectors,
+        category_map=config.category_map,
+        site_id=config.site_id,
+        base_url=config.base_url,
+        client=client,
+        auth_manager=MagicMock(),
+    )
+    return site, client.get
+
+
+async def test_search_sends_repeated_cat_array() -> None:
+    site, get = _mock_site()
+    await site.search(SearchQuery(keyword="test", categories=[TorrentCategory.MOVIE]))
+
+    params = get.call_args.kwargs["params"]
+    assert params["cat[]"] == ["401", "402"]
+    assert not any(key.startswith("cat4") for key in params)
+
+
+async def test_list_torrents_merges_multiple_categories() -> None:
+    site, get = _mock_site()
+    await site.list_torrents(categories=[TorrentCategory.MOVIE, TorrentCategory.DOCUMENTARY])
+
+    params = get.call_args.kwargs["params"]
+    assert params["cat[]"] == ["401", "402", "410"]
+
+
+async def test_no_categories_sends_no_cat_param() -> None:
+    site, get = _mock_site()
+    await site.search(SearchQuery(keyword="test"))
+
+    params = get.call_args.kwargs["params"]
+    assert "cat[]" not in params


### PR DESCRIPTION
## 问题

OurBits 的分类筛选参数是重复的数组形式 `cat[]=401&cat[]=402`，站点会忽略标准 NexusPHP 的 `cat401=1`。`ourbits.yaml` 目前走通用 `NexusPHPSite`，`_apply_category_params` 拼出来的是后者，于是带分类的 `search` / `list_torrents` 退化成全站结果——分类映射本身是对的，只是参数没被站点识别。

## 修复

参照 mteam / ttg 的 `custom_class` 做法：

- 新增 `sites/custom/ourbits.py`，继承 `NexusPHPSite`，只重写 `_apply_category_params`，把所有站点分类 ID 收进 `params["cat[]"]` 列表，由 HttpClient 展开为重复参数。选择器、分类映射、分页仍由 YAML 配置。
- `ourbits.yaml` 挂上 `custom_class`；同时声明 `auth.supported: [cookie]`——登录页有 Cloudflare 人机挑战，账号密码模拟登录无法通过，只有粘贴 Cookie 可用。

## 刻意收窄的地方

只改 OurBits 一个站点，没有给 `NexusPHPSite` 基类加"分类参数风格"之类的通用配置项。如果之后还有别的站点也用 `cat[]`，再抽到框架层更合适，这里先不替框架做决定。

`auth.supported: [cookie]` 如果与你对该站点的规划不一致，去掉这一段不影响分类修复。

## 测试

新增 `tests/tracker/unit/test_ourbits_category_params.py`：配置层断言绑定到 `OurBitsSite` 且只支持 cookie；行为层用 Mock HttpClient 断言 `search` / `list_torrents` 最终请求参数是 `cat[]` 列表、不再出现 `cat4xx` 键。

本地跑了 `ruff check .` 与 `tests/tracker/unit/`（18 passed），全量测试交给 CI。未动运行时依赖，无需 bump `docker/runtime-version`。
