### PR TITLE
fix(sites): 更新站点凭据时一并清掉旧的 cookie 会话快照

### DIFF
--- a/src/movieclaw_api/services/site_config.py
+++ b/src/movieclaw_api/services/site_config.py
@@ -127,6 +127,10 @@ class SiteConfigService:
             password=password,
             enabled=enabled,
         )
+        # 3.5 凭据已换，旧的 cookie 会话快照必须一并作废。否则 AuthManager 会先加载
+        #     快照并直接判定「已登录」（CookieAuthProvider.check 无法主动校验），
+        #     新凭据永远没有机会注入，验证会一直拿着过期 cookie 失败。
+        await self._cookies.delete(site_id)
         # 4. 建立同步游标：以「此刻」为跟踪起点 t0，next_sync_at 保持 NULL（立即到期），
         #    使站点通过验证后，下一个 tick 即触发首刷。幂等——已存在则不改动既有 t0。
         await self._torrents.ensure_cursor(site_id)

--- a/tests/api/test_sites.py
+++ b/tests/api/test_sites.py
@@ -19,6 +19,7 @@ from movieclaw_api.services import SiteConfigService
 from movieclaw_db.engine import dispose_db, get_database, init_db
 from movieclaw_db.migrations import run_migrations
 from movieclaw_db.models.site_credential import AuthType, ConfigStatus
+from movieclaw_db.repositories.cookie_repo import CookieRepository
 from movieclaw_db.repositories.credential_repo import CredentialRepository
 from movieclaw_db.repositories.profile_repo import ProfileRepository
 from movieclaw_tracker import load_all_sites
@@ -176,6 +177,37 @@ def test_update_credentials_resets_and_reverifies(client: TestClient) -> None:
     assert r.status_code == 200
     # 更新后重新验证，最终仍 active
     assert client.get("/api/v1/sites/mteam").json()["data"]["status"] == "active"
+
+
+def test_update_credentials_drops_stale_cookie_snapshot(client: TestClient) -> None:
+    """换凭据必须连带清掉旧的 cookie 会话快照。
+
+    AuthManager 认证时先加载快照，且 CookieAuthProvider.check 恒判「已登录」，
+    快照不清则新 cookie 永远不会被注入，验证会一直拿旧 cookie 失败。
+    """
+    client.post(
+        "/api/v1/sites",
+        json={"site_id": "ttg", "auth_type": "cookie", "cookie": "uid=1; pass=old"},
+    )
+
+    async def seed_snapshot() -> None:
+        async with get_database().session() as session:
+            await CookieRepository(session).upsert("ttg", {"uid": "1", "pass": "old"})
+
+    async def load_snapshot() -> dict[str, str] | None:
+        async with get_database().session() as session:
+            return await CookieRepository(session).get("ttg")
+
+    # TestClient 的 portal 在 app 的事件循环里执行，与请求共用同一个库连接池
+    client.portal.call(seed_snapshot)
+    assert client.portal.call(load_snapshot) == {"uid": "1", "pass": "old"}
+
+    r = client.put(
+        "/api/v1/sites/ttg",
+        json={"auth_type": "cookie", "cookie": "uid=1; pass=new", "enabled": True},
+    )
+    assert r.status_code == 200
+    assert client.portal.call(load_snapshot) is None
 
 
 def test_delete_removes_site(client: TestClient) -> None:


### PR DESCRIPTION
## 问题

给已配置的站点更新 cookie（浏览器扩展推送，或 `PUT /api/v1/sites/{site_id}`）之后，验证仍然失败，但 credential 已经被改掉了。反复换 cookie 结果一样。账号密码方式换密码同理。

## 根因

- `SiteConfigService.configure()`（`services/site_config.py`）写入新凭据后，没有作废 `site_cookie` 表里的旧会话快照。全仓只有 `delete()` 里清这张表。
- `AuthManager.authenticate()`（`movieclaw_tracker/auth.py`）先 `store.load()` 快照、再 `provider.check()`；`CookieAuthProvider.check()` 无法主动校验，恒返回 `AUTHENTICATED`，于是直接返回。新凭据所在的 `provider.authenticate()` 从不执行。
- 后续 `get_user_profile()` 拿着旧 cookie 请求失败 → 状态写回 FAILED。用户看到的就是"换了 cookie 还是失败"。

## 修复

`configure()` 落库新凭据后立刻 `await self._cookies.delete(site_id)`，与 `delete()` 里的处理一致。扩展推送和 `PUT` 两条路径都经过这里。

## 刻意收窄的地方

没有改 `CookieAuthProvider.check()` 的语义（让它真的去校验 cookie 有效性是另一种修法，但会给每次认证多一次站点请求，也会影响所有 cookie 站点），这里只在凭据变更这个明确的时点作废快照。

## 测试

`tests/api/test_sites.py` 新增 `test_update_credentials_drops_stale_cookie_snapshot`：预置快照 → `PUT` 新 cookie → 断言快照被清空。

本地跑了 `ruff check .`、`tests/api/test_sites.py`（38 passed）与 `tests/api/test_extension.py`（12 passed），全量测试交给 CI。未动运行时依赖，无需 bump `docker/runtime-version`。
