### PR TITLE
修复服务重启后 Infuse 正在播放的会话从活动页消失

### DIFF
--- a/src/movieclaw_api/services/playback/watch.py
+++ b/src/movieclaw_api/services/playback/watch.py
@@ -284,6 +284,38 @@ def report_heartbeat(
     )
 
 
+async def restore_session_from_stream(
+    session: AsyncSession, unit: Unit, *, member_id: int, client: ClientInfo
+) -> None:
+    """取流到达但设备没有实时会话：从库里补位置与开始时间，把会话重建回来。
+
+    典型场景是服务重启：Infuse 正常播放阶段不发心跳，重启后只有源源不断的
+    Range 取流，活动页却看不到它。同设备同单元尚未收口的 ``playback_log``
+    行是本场播放的记录（开始时间、最近上报位置），优先用它；没有就退回
+    ``playback_state`` 的续播点；再没有就留空，等下一次上报补齐。
+    调用方只在 :func:`activity.has_session` 为假时进来，Range 连接很密，
+    不能每条都查库。
+    """
+    position_ms: int | None = None
+    started_at = None
+    row = await _open_log(session, unit, member_id=member_id, device_id=client.device_id)
+    if row is not None:
+        position_ms = row.end_position_ms
+        started_at = row.started_at
+    else:
+        state = (await playback_state.get_states(session, [unit[0]], member_id=member_id)).get(unit)
+        if state is not None:
+            position_ms = state.position_ms
+    activity.restore_session(
+        client.device_id,
+        member_id=member_id,
+        client=client,
+        unit=unit,
+        position_ms=position_ms,
+        started_at=started_at,
+    )
+
+
 async def record_start(
     session: AsyncSession,
     unit: Unit,

--- a/src/movieclaw_jellyfin/routes/playback.py
+++ b/src/movieclaw_jellyfin/routes/playback.py
@@ -23,6 +23,7 @@ from fastapi.responses import JSONResponse, RedirectResponse, Response
 from sqlalchemy import select
 
 from movieclaw_api.services.library.access import member_visible_ids
+from movieclaw_api.services.playback import watch as playback_watch
 from movieclaw_db.engine import get_database
 from movieclaw_db.models import LibraryFile
 from movieclaw_jellyfin.catalog import (
@@ -298,13 +299,22 @@ async def video_stream(
     # 停止播放并不保证客户端立刻关闭 Range 连接。按已认证设备登记这条流，
     # 让 /Sessions/Playing/Stopped 能主动停止读盘；TCP 断连仍是第二道兜底。
     device_id = identity.device.device_id
+    unit = _stream_unit(ref)
+    if request.method == "GET" and not activity.has_session(device_id):
+        # 服务重启后注册表已清空，而 Infuse 一类直连播放器正常播放阶段不发
+        # 心跳，只会一直拉字节：把取流当作播放仍在进行的证据把会话建回来，
+        # 否则活动页要等用户暂停再播才看得到。HEAD 只是探测，不算播放。
+        async with get_database().session() as db:
+            await playback_watch.restore_session_from_stream(
+                db, unit, member_id=identity.device.member_id, client=_identity_client(identity)
+            )
     session_stopped = register_device_stream(device_id)
     # 顺带登记到播放活动注册表：活动页「观看」视角据此展示实时传输速率
     meter = activity.register_stream(
         device_id=device_id,
         kind=activity.STREAM_KIND_PLAY,
         member_id=identity.device.member_id,
-        unit=_stream_unit(ref),
+        unit=unit,
         file_id=f.id,
         file_name=path.name,
         size_bytes=f.size_bytes,

--- a/src/movieclaw_playback/activity.py
+++ b/src/movieclaw_playback/activity.py
@@ -197,6 +197,45 @@ def report_progress(
     session.last_activity_mono = time.monotonic()
 
 
+def has_session(device_id: str) -> bool:
+    """设备当前是否有实时会话（取流路由据此决定要不要查库重建）。"""
+    return device_id in _sessions
+
+
+def restore_session(
+    device_id: str,
+    *,
+    member_id: int,
+    client: ClientInfo,
+    unit: Unit,
+    position_ms: int | None,
+    started_at: datetime | None,
+) -> None:
+    """按取流证据重建会话：设备没有会话时，把「正在拉字节」视同「正在播放」。
+
+    Infuse 一类直连播放器正常播放阶段几乎不发进度心跳，只在开始、暂停、
+    seek、停止时上报；服务重启后注册表清空，靠上报重建要等用户暂停再播。
+    但播放器一直在换 Range 连接拉字节，这本身就是播放仍在进行的证据，
+    据此把会话建回来，位置与开始时间由调用方从库里补（没有就留空）。
+
+    只在设备**没有**会话时重建：已有会话（哪怕单元不同）交给上报路径维护，
+    避免播放器对另一条目的探测请求把正在展示的会话顶掉。
+    """
+    if not device_id or device_id in _sessions or device_ended(device_id):
+        return
+    session = PlaySession(
+        device_id=device_id,
+        member_id=member_id,
+        client=client,
+        unit=unit,
+        position_ms=position_ms,
+        local_streamed=True,
+    )
+    if started_at is not None:
+        session.started_at = started_at
+    _sessions[device_id] = session
+
+
 def report_stop(device_id: str) -> None:
     """停止上报（含播放失败）：会话立即结束并从实时视图消失。"""
     _sessions.pop(device_id, None)

--- a/tests/jellyfin/test_http_flow.py
+++ b/tests/jellyfin/test_http_flow.py
@@ -798,6 +798,51 @@ def test_admin_end_playback_blocks_stream_until_device_restarts(
     activity.reset()
 
 
+def test_stream_rebuilds_session_after_restart(client: TestClient, seeded: dict) -> None:
+    """服务重启（注册表清空）后 Infuse 不发心跳只拉字节：取流即重建实时会话，
+    位置与开始时间取自本场尚未收口的播放日志；HEAD 探测不算播放。"""
+    from movieclaw_playback import activity
+
+    activity.reset()
+    token = jf_login(client)
+    auth = {"ApiKey": token}
+    guid = item_guid(seeded["movie"])
+    info = client.post(f"/Items/{guid}/PlaybackInfo", params=auth).json()
+    local = next(s for s in info["MediaSources"] if s["Protocol"] == "File")
+    stream = {"ApiKey": token, "static": "true", "mediaSourceId": local["Id"]}
+
+    client.post("/Sessions/Playing", params=auth, json={"ItemId": guid})
+    client.post(
+        "/Sessions/Playing/Progress",
+        params=auth,
+        json={"ItemId": guid, "PositionTicks": 90_000 * TICKS_PER_MS, "IsPaused": False},
+    )
+    before, _ = activity.snapshot()
+    started_at = before[0].started_at
+
+    activity.reset()  # 模拟进程重启
+    assert activity.snapshot()[0] == []
+
+    assert client.head(f"/Videos/{guid}/stream", params=stream).status_code == 200
+    assert activity.snapshot()[0] == []
+
+    assert client.get(f"/Videos/{guid}/stream", params=stream).status_code == 200
+    sessions, _ = activity.snapshot()
+    assert len(sessions) == 1
+    restored = sessions[0]
+    assert restored.device_id == "test-device-1"
+    assert restored.unit == (seeded["movie"], 0, 0)
+    assert restored.position_ms == 90_000
+    # 开始时间来自播放日志行，与注册表里的开始时间是两次 utcnow()，只差毫秒
+    assert abs((restored.started_at - started_at).total_seconds()) < 1
+    assert restored.local_streamed is True
+
+    # 活动页据此能看到它
+    data = client.get("/api/v1/playback/activity").json()["data"]
+    assert [s["device_id"] for s in data["sessions"]] == ["test-device-1"]
+    activity.reset()
+
+
 def test_stopped_failed_skips_persistence(client: TestClient, seeded: dict) -> None:
     token = jf_login(client)
     auth = {"ApiKey": token}

--- a/tests/playback/test_activity.py
+++ b/tests/playback/test_activity.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
 
 import pytest
 
@@ -219,3 +220,33 @@ def test_finished_connection_bytes_do_not_leak_to_next_unit() -> None:
     sessions, _ = activity.snapshot()
     assert sessions[0].unit == next_unit
     assert sessions[0].bytes_transferred == 0
+
+
+def test_restore_session_only_when_device_has_none() -> None:
+    """取流证据重建会话：设备无会话时建（带库里补的位置/开始时间、标本地直连），
+    已有会话时不动，拒绝窗口内不建。"""
+    started = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
+    activity.restore_session(
+        "dev-1", member_id=3, client=CLIENT, unit=UNIT, position_ms=42_000, started_at=started
+    )
+    sessions, _ = activity.snapshot()
+    assert len(sessions) == 1
+    restored = sessions[0]
+    assert restored.member_id == 3
+    assert restored.position_ms == 42_000
+    assert restored.started_at == started
+    assert restored.local_streamed is True
+
+    # 已有会话（哪怕单元不同）不被顶掉
+    activity.restore_session(
+        "dev-1", member_id=3, client=CLIENT, unit=(2, 1, 1), position_ms=None, started_at=None
+    )
+    sessions, _ = activity.snapshot()
+    assert sessions[0].unit == UNIT
+
+    # 管理员刚结束的设备不能靠取流建回来
+    activity.end_device("dev-1")
+    activity.restore_session(
+        "dev-1", member_id=3, client=CLIENT, unit=UNIT, position_ms=None, started_at=None
+    )
+    assert activity.snapshot()[0] == []


### PR DESCRIPTION
## 问题

在 Infuse 里播放时服务器重启，恢复后活动页「正在播放」看不到这台设备，实际上还在播，直到用户暂停再播放才重新出现。

## 根因

活动页的数据源是 `movieclaw_playback.activity` 的进程内注册表，重启即清空，靠播放器下一次 `/Sessions/Playing/Progress` 上报就地重建。Infuse 一类直连播放器正常播放阶段不发进度心跳，只在开始、暂停、seek、停止时上报，所以重启后没有任何上报能把会话建回来。期间播放器一直在换 Range 连接向 `/Videos/{id}/stream` 拉字节，每条连接都登记了计量器，但活动页只遍历会话，有计量器没会话的设备完全不显示。

## 改动

- `movieclaw_playback/activity.py`：新增 `has_session` 与 `restore_session`。后者只在设备没有会话时按取流证据重建会话并标记本地直连；已有会话（哪怕单元不同）不动，避免对另一条目的探测请求顶掉正在展示的会话；管理员刚结束的设备在拒绝窗口内不建。
- `movieclaw_api/services/playback/watch.py`：新增 `restore_session_from_stream`。位置与开始时间优先取同设备同单元尚未收口的 `playback_log` 行，没有就退回 `playback_state` 的续播点，再没有留空等下一次上报补齐。
- `movieclaw_jellyfin/routes/playback.py`：取流路由在 GET 且设备无会话时调用重建。只在无会话时查库，Range 连接很密不能每条都查；HEAD 视为探测不建会话。

不涉及运行时依赖与数据库迁移。

## 测试

- 新增注册表单元测试：无会话时重建并带位置/开始时间，已有会话不动，拒绝窗口内不建。
- 新增 HTTP 流程测试：开始播放并上报进度 → 清空注册表模拟重启 → HEAD 不重建 → GET 重建且位置、开始时间与本场日志一致 → `/api/v1/playback/activity` 可见。
- 本地跑通 `tests/playback/test_activity.py`、`tests/jellyfin/test_http_flow.py`、`tests/api/test_playback_activity.py`、`tests/jellyfin/test_member_multiuser.py`、`tests/jellyfin/test_audit_regressions.py`，ruff 通过。

## 未覆盖

strm 网盘条目走 302 直链，字节不经过服务器，重启后仍要等下一次暂停或 seek 才能重新出现。要补这条需先确认 Infuse 是否周期性发 `/Sessions/Playing/Ping`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DShv4FgQdLWykdEdRhZ6Wq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DShv4FgQdLWykdEdRhZ6Wq)_