### PR TITLE
fix(web): 键盘收起后视口占位不再残留，界面不会一直矮一截

### DIFF
--- a/apps/web/components/modal.tsx
+++ b/apps/web/components/modal.tsx
@@ -23,6 +23,8 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
+import { softKeyboardPossible } from "@/lib/soft-keyboard";
+
 /**
  * 软键盘对视口底部的遮挡高度（px）。
  *
@@ -31,6 +33,11 @@ import { createPortal } from "react-dom";
  * 键盘底下。VisualViewport API 给出真实可见区域，据此算出底部被遮挡量，
  * 弹窗容器把 bottom 抬高同样的距离即可始终落在可见区内。
  * 桌面端与键盘收起时恒为 0，行为不变；不支持该 API 的环境静默退化。
+ *
+ * 只在焦点确实落在可输入元素上时才认这份遮挡（见 lib/soft-keyboard.ts）：
+ * iOS 收起键盘后可视视口常停在变矮的状态不恢复，照单全收会把弹窗凭空抬起
+ * ——底部抽屉比容器还高，从屏幕上沿溢出，标题与关闭按钮跑到状态栏外面。
+ * focusout 同样重算一次，弹窗里的输入框一失焦，抽屉立刻落回屏幕底边。
  */
 function useKeyboardInset(active: boolean): number {
   const [inset, setInset] = useState(0);
@@ -39,16 +46,20 @@ function useKeyboardInset(active: boolean): number {
     const vv = window.visualViewport;
     if (!vv) return;
     const update = () => {
-      const occluded = window.innerHeight - vv.height - vv.offsetTop;
+      const occluded = softKeyboardPossible() ? window.innerHeight - vv.height - vv.offsetTop : 0;
       setInset(Math.max(0, Math.round(occluded)));
     };
+    // 推迟一拍等焦点落定：focusout 触发时 activeElement 还没换过去
+    const onFocusOut = () => window.setTimeout(update, 0);
     update();
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
+    window.addEventListener("focusout", onFocusOut);
     return () => {
       setInset(0);
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
+      window.removeEventListener("focusout", onFocusOut);
     };
   }, [active]);
   return active ? inset : 0;
@@ -110,6 +121,9 @@ export function Modal({
     // bottom 越出视口 --vp-overshoot：iOS 独立 App 的视口比屏幕矮一截（见
     // globals.css），不越出的话遮罩在屏幕底部留一条没压暗的缝、移动端 bottom
     // sheet 也会悬在物理底边上方。面板内容用加大的 pb 留在视口内（见下方）。
+    // 面板另有 max-md:!max-h-full 夹住高度：键盘抬起容器底边后容器会变矮，
+    // 调用方按视口给的 max-h-[N vh] 就可能超过容器，而 items-end 的溢出方向
+    // 是**上**，头部与关闭按钮会被顶出屏幕且无法滚回（! 压过调用方的 max-h）。
     <div
       className={`fixed inset-0 [bottom:calc(-1*var(--vp-overshoot))] ${topmost ? "z-[90]" : raised ? "z-[60]" : "z-50"} flex items-center justify-center p-6 max-md:items-end max-md:p-0`}
       // 键盘弹出时容器底边抬到键盘上沿（覆盖 className 里的 overshoot 负值）：
@@ -129,7 +143,7 @@ export function Modal({
         className="absolute inset-0 cursor-default bg-black/60 backdrop-blur-sm"
       />
       <div
-        className={`relative w-full ${WIDTH_CLS[width]} overflow-hidden rounded-2xl border border-white/10 bg-[rgba(16,18,26,0.92)] shadow-[0_32px_90px_rgba(0,0,0,0.7)] backdrop-blur-2xl max-md:!max-w-none max-md:rounded-b-none max-md:border-x-0 max-md:border-b-0 max-md:pb-[calc(var(--safe-bottom)+var(--vp-overshoot))] ${panelClassName}`}
+        className={`relative w-full ${WIDTH_CLS[width]} overflow-hidden rounded-2xl border border-white/10 bg-[rgba(16,18,26,0.92)] shadow-[0_32px_90px_rgba(0,0,0,0.7)] backdrop-blur-2xl max-md:!max-h-full max-md:!max-w-none max-md:rounded-b-none max-md:border-x-0 max-md:border-b-0 max-md:pb-[calc(var(--safe-bottom)+var(--vp-overshoot))] ${panelClassName}`}
       >
         {children}
       </div>

--- a/apps/web/components/viewport-keyboard.tsx
+++ b/apps/web/components/viewport-keyboard.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react";
 
+import { softKeyboardPossible } from "@/lib/soft-keyboard";
+
 /**
  * 软键盘适配的全站收口：撑出键盘占位 + 窗口滚动归位。两件事同源（都由
  * 可视视口的变化驱动），放在一个 effect 里，也保证「先改高度、再归位」的顺序。
@@ -21,6 +23,11 @@ import { useEffect } from "react";
  *
  * 这个式子在「键盘改的是布局视口」的浏览器上（部分 Android 形态）自动退化为
  * 0——innerHeight 跟着一起变矮，差值恒为 0，布局本就由 dvh 收好了，不重复让位。
+ *
+ * 差值只在**焦点确实落在可输入元素上**时才当作键盘（见 lib/soft-keyboard.ts）：
+ * iOS 上焦点元素随组件卸载消失时，可视视口经常停在变矮的状态不恢复，光凭差值
+ * 会把外壳永久缩着。除视口 resize 外，focusout 与 pointerdown 也重算一次，
+ * 保证键盘一收起（哪怕 WebKit 没补发 resize）高度立刻还原。
  *
  * —— 二、窗口滚动归位 ——
  *
@@ -49,7 +56,7 @@ export function ViewportKeyboard() {
     let applied = 0;
     const applyInset = () => {
       if (!vv) return;
-      const gap = zoomed() ? 0 : Math.round(window.innerHeight - vv.height);
+      const gap = zoomed() || !softKeyboardPossible() ? 0 : Math.round(window.innerHeight - vv.height);
       // 24px 以下按取整误差 / 浏览器自身工具条的收放处理，不当键盘
       const next = gap > 24 ? gap : 0;
       if (next === applied) return;
@@ -70,14 +77,24 @@ export function ViewportKeyboard() {
       applyInset();
       window.setTimeout(resetScroll, 0);
     };
-    const onFocusOut = () => window.setTimeout(resetScroll, 0);
+    // 推迟一拍等焦点落定（focusout 触发时 activeElement 还没换过去），
+    // 再按新焦点重算键盘占高并归位
+    const onFocusOut = () =>
+      window.setTimeout(() => {
+        applyInset();
+        resetScroll();
+      }, 0);
 
     window.addEventListener("scroll", resetScroll, { passive: true });
     window.addEventListener("focusout", onFocusOut);
+    // 兜底：焦点元素被卸载时 focusout 可能整个不发，界面会一直缩着；
+    // 用户下一次触屏就把它纠正回来（无键盘时这里恒等于把占位清零）
+    window.addEventListener("pointerdown", applyInset, { passive: true });
     vv?.addEventListener("resize", onResize);
     return () => {
       window.removeEventListener("scroll", resetScroll);
       window.removeEventListener("focusout", onFocusOut);
+      window.removeEventListener("pointerdown", applyInset);
       vv?.removeEventListener("resize", onResize);
       root.style.removeProperty("--keyboard-inset");
     };

--- a/apps/web/lib/soft-keyboard.ts
+++ b/apps/web/lib/soft-keyboard.ts
@@ -1,0 +1,23 @@
+/**
+ * 软键盘是否**可能**正立着——「可视视口变矮 == 键盘占高」这个推断的前置条件。
+ *
+ * iOS 只用 visualViewport 的高度差表达键盘占高（布局视口纹丝不动），但这个
+ * 差值**不保证归零**：焦点元素随组件卸载一起消失时（关掉搜索面板、关掉带
+ * 输入框的弹窗），WebKit 常常既不补发 focusout，也不把可视视口恢复到全高。
+ * 谁再拿这个差值当键盘高度用，谁就一直缩着不还原：
+ * - 外壳按 `100dvh - var(--keyboard-inset)` 缩短，屏幕底部空出一大条，
+ *   页面内容被拦腰截断（iOS 独立 App 实测，键盘收起后必现）；
+ * - 弹窗容器的 bottom 被抬起，移动端底部抽屉从屏幕**上沿**溢出，
+ *   面板标题和关闭按钮跑到状态栏外面，滚也滚不回来。
+ *
+ * 键盘只可能在可输入元素聚焦时立着（<select> 的滚轮选择器同理，它在 iOS 上
+ * 与键盘走同一套视口压缩），这是比事件更硬的判据：焦点不在这类元素上，
+ * 一律按「没有键盘」处理，高度差多半是 WebKit 还没恢复的残值。
+ *
+ * 两个使用方是一对，改动前先看另一处：components/viewport-keyboard.tsx
+ * （全站 --keyboard-inset）、components/modal.tsx（弹窗容器抬高）。
+ */
+export function softKeyboardPossible(): boolean {
+  const el = document.activeElement;
+  return el?.matches('input,textarea,select,[contenteditable]:not([contenteditable="false"])') ?? false;
+}

--- a/apps/web/test/soft-keyboard.test.mjs
+++ b/apps/web/test/soft-keyboard.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { softKeyboardPossible } from "../lib/soft-keyboard.ts";
+
+/**
+ * document.activeElement 的最小替身：只实现 matches，按「选择器里有没有点名自己」
+ * 作答。够验证「哪些元素算可输入」这条契约——名单少一类，就会在那类元素聚焦时
+ * 把真键盘误判成"没有键盘"，视口占高被清零，贴底的输入行重新沉到键盘底下。
+ */
+function focusOn(token) {
+  globalThis.document = {
+    activeElement:
+      token === null
+        ? null
+        : { matches: (selector) => selector.split(",").some((part) => part.trim().startsWith(token)) },
+  };
+}
+
+test("焦点不在可输入元素上时，一律按没有键盘处理", () => {
+  focusOn(null);
+  assert.equal(softKeyboardPossible(), false);
+
+  focusOn("div");
+  assert.equal(softKeyboardPossible(), false);
+});
+
+test("可输入元素聚焦时认键盘：input / textarea / select / contenteditable", () => {
+  for (const token of ["input", "textarea", "select", "[contenteditable]"]) {
+    focusOn(token);
+    assert.equal(softKeyboardPossible(), true, `${token} 聚焦时应认为键盘可能立着`);
+  }
+});


### PR DESCRIPTION
## 现象

iOS 独立 App（加到主屏打开）里，**只要用过一次输入框，整个界面就永久矮一截**，
换页、重开 App 都不还原：屏幕底部空出一大条背景，页面内容被拦腰截断。
实测 iPhone 16 Pro Max：内容只铺到 1785/2868px，约 62% 屏高。

此时再打开弹窗，第二个症状跟着出现：移动端的底部抽屉从屏幕**上沿**溢出，
面板标题和右上角关闭按钮跑到状态栏外面，而且滚不回来（`items-end` 的溢出方向
就是「上」）。发现页的组合筛选弹窗最明显——类型标签直接顶在状态栏时间底下。

## 根因

`--keyboard-inset` 表达键盘占高的式子是 `window.innerHeight - visualViewport.height`，
这个推断**缺一个前置条件**。

iOS 只用可视视口的高度差表达键盘（布局视口纹丝不动），但这个差值**不保证归零**：
焦点元素随组件卸载一起消失时（关掉搜索面板、关掉带输入框的弹窗），WebKit 既不
补发 `focusout`，也不把可视视口恢复到全高。差值就一直挂在那儿：

- `app-shell` 按 `100dvh - var(--keyboard-inset)` 一直缩着 → 底部空条；
- `Modal` 容器的 `bottom` 一直被抬起 → 抽屉溢出屏幕上沿。

`modal.tsx` 的 `useKeyboardInset` 是同一个式子的第二份拷贝，所以两处一起中招。

## 改动

- **新增 `apps/web/lib/soft-keyboard.ts`**：键盘只可能在可输入元素聚焦时立着，
  焦点不在 `input/textarea/select/[contenteditable]` 上就一律按「没有键盘」处理。
  焦点是比视口高度更硬的判据。`<select>` 的滚轮选择器在 iOS 上与键盘走同一套
  视口压缩，一并算进名单（Lexical 的输入框走 `contenteditable`，同样覆盖）。
- **`viewport-keyboard.tsx` / `modal.tsx`** 两处都套上这个前置条件，并在
  `focusout` 之后重算；前者再加 `pointerdown` 兜底——焦点元素被卸载时 `focusout`
  可能整个不发，此时用户下一次触屏就能把界面纠正回来（无键盘时它恒等于清零）。
- **`modal.tsx` 面板补 `max-md:!max-h-full`**：容器底边被键盘抬高后会变矮，而
  调用方按视口给的 `max-h-[N vh]` 不跟着变，面板一旦高过容器就从上沿溢出且无法
  滚回。**这条即使键盘是真的也会复现**（键盘高于 18vh 时，`max-h-[82vh]` 的
  筛选弹窗必中），属于独立的第二个缺陷。现有调用方清一色是
  `flex max-h-[N vh] flex-col` + 内层滚动区，夹住高度后内部滚动照常工作。

## 验证

- `node --test`（新增 `test/soft-keyboard.test.mjs`，覆盖名单少一类就会红）与
  `tsc --noEmit` 通过。
- 在 v0.21.0 的构建产物里确认了缺陷代码路径：
  `.next/static/chunks/app/layout-*.js` 里是
  `let r=n()?0:Math.round(window.innerHeight-t.height)`，`n()` 只有捏合缩放判断。
- 复现路径：iOS 加到主屏 → 打开搜索输入框 → 收起键盘/关掉搜索面板 → 界面矮一截；
  再打开发现页的组合筛选，抽屉顶出屏幕上沿。修复后随焦点离开立即还原。

## 兼容性

不涉及依赖、Node 大版本、Dockerfile 与 entrypoint 契约，`docker/runtime-version`
无需 bump。桌面端与 Android：`softKeyboardPossible()` 只是给原有式子加了个前置
条件，原本恒为 0 的场景仍恒为 0，行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
