### PR TITLE
修手机上灯箱底部缩略条看不见

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1278,6 +1278,24 @@ a {
   height: calc(100dvh - var(--keyboard-inset));
 }
 
+/*
+ * 全屏覆盖层（灯箱）的高度：与 .viewport-app-height 同一个理由，做法却必须
+ * 不同——覆盖层是 position: fixed，而 fixed 的包含块是**布局视口**，在移动
+ * 浏览器上等于「地址栏收起后」的大视口。于是 `inset: 0` 的覆盖层底边落在
+ * 屏幕之外，贴着 bottom:0 的那条缩略图整条被藏到地址栏 / 工具栏底下（手机上
+ * 实测：灯箱底部的小图预览一直看不见）。
+ *
+ * 改成 top:0 + 动态视口高度，底边就落在**可见**视口的底边上。再加
+ * --vp-overshoot：iOS 独立 App 形态下要向下多铺一截盖住底部黑条（见该变量
+ * 处的长注释），加进高度里与原来的负 bottom 等价。
+ *
+ * 不减 --keyboard-inset：灯箱上没有输入框，弹起软键盘时它该保持满屏。
+ */
+.viewport-overlay-height {
+  height: calc(100vh + var(--vp-overshoot));
+  height: calc(100dvh + var(--vp-overshoot));
+}
+
 body.cmdk-open .app-shell {
   transform: scale(0.978);
 }

--- a/apps/web/components/image-lightbox.tsx
+++ b/apps/web/components/image-lightbox.tsx
@@ -136,14 +136,16 @@ export function ImageLightbox({
 
   return createPortal(
     // 点击空白处关闭；内容区各元素自行 stopPropagation。
-    // bottom 越出视口 --vp-overshoot：黑底铺到屏幕物理底边（iOS 独立 App
-    // 的视口矮一截，见 globals.css）；底部缩略图条用加大的 pb 留在视口内
+    // 高度走 viewport-overlay-height 而不是 inset-0：fixed 贴的是布局视口，
+    // 在移动浏览器上等于「地址栏收起后」的大视口，贴底的缩略图条会被地址栏 /
+    // 工具栏盖住（见 globals.css 那条注释）。黑底仍向下多铺 --vp-overshoot
+    // 盖住 iOS 独立 App 的底部黑条，缩略条自己用加大的 pb 留在视口内
     <div
       role="dialog"
       aria-modal="true"
       aria-label={heading ? `图片浏览：${heading}` : "图片浏览"}
       onClick={onClose}
-      className="fixed inset-0 z-[70] flex flex-col bg-black/85 backdrop-blur-md [bottom:calc(-1*var(--vp-overshoot))]"
+      className="viewport-overlay-height fixed inset-x-0 top-0 z-[70] flex flex-col bg-black/85 backdrop-blur-md"
     >
       {/* 顶栏：计数 + 标题 + 关闭 */}
       <div className="flex shrink-0 flex-wrap items-center gap-3 px-4 py-3 text-white/85 [padding-top:calc(0.75rem+var(--safe-top))] max-md:gap-2 max-md:px-3">
@@ -268,7 +270,10 @@ export function ImageLightbox({
       {images.length > 1 && (
         <div
           onClick={(e) => e.stopPropagation()}
-          className="scroll-none shrink-0 overflow-x-auto px-4 py-3 [padding-bottom:calc(0.75rem+var(--safe-bottom)+var(--vp-overshoot))] max-md:px-3"
+          // 底边内距只由这一条任意值给：py-3 会一并设 padding-bottom，两条规则
+          // 撞车时谁生效取决于 Tailwind 生成的先后，实测 py-3 会赢、overshoot
+          // 的补偿失效。改成只写 pt-3，0.75rem 的底距已算在下面那条里
+          className="scroll-none shrink-0 overflow-x-auto px-4 pt-3 [padding-bottom:calc(0.75rem+var(--safe-bottom)+var(--vp-overshoot))] max-md:px-3"
         >
           <div className="mx-auto flex w-max gap-2">
             {images.map((url, i) => (

--- a/apps/web/components/zoom-lightbox.tsx
+++ b/apps/web/components/zoom-lightbox.tsx
@@ -495,7 +495,9 @@ export function ZoomLightbox({
       role="dialog"
       aria-modal="true"
       aria-label={label}
-      className="fixed inset-0 z-[70] overflow-hidden bg-[rgba(4,5,9,0.94)] backdrop-blur-md [bottom:calc(-1*var(--vp-overshoot))]"
+      // 高度走 viewport-overlay-height 而不是 inset-0：fixed 贴的是布局视口，
+      // 手机上底部的缩略条会被浏览器工具栏盖住（见 globals.css 那条注释）
+      className="viewport-overlay-height fixed inset-x-0 top-0 z-[70] overflow-hidden bg-[rgba(4,5,9,0.94)] backdrop-blur-md"
     >
       {/* 舞台：铺满整个对话框（控件浮在它上面）。点画面收放控件、点画面外的
           空白关闭（未缩放时），滚轮 / 捏合 / 双击缩放，放大后拖拽平移、
@@ -650,7 +652,12 @@ export function ZoomLightbox({
         )}
 
         {/* 缩略条：只渲染当前位置前后各 30 张 */}
-        <div className="scroll-none pointer-events-auto overflow-x-auto px-4 pb-2.5 [padding-bottom:calc(0.625rem+var(--safe-bottom)+var(--vp-overshoot))] max-md:px-3">
+        {/* 底边内距只由这一条任意值给：再挂一个 pb-2.5 的话两条规则都设
+            padding-bottom，谁生效取决于 Tailwind 生成的先后而不是这里的书写
+            顺序——实测 pb-2.5 赢了，--vp-overshoot 的补偿整个失效，iOS 独立
+            App 里缩略条被推到可见区域之外（这正是「手机上看不到底部小图」的
+            成因之一）。0.625rem 就是 pb-2.5，已经算在里面 */}
+        <div className="scroll-none pointer-events-auto overflow-x-auto px-4 [padding-bottom:calc(0.625rem+var(--safe-bottom)+var(--vp-overshoot))] max-md:px-3">
           <div className="mx-auto flex w-max gap-1.5">
             {slides.slice(stripRange.start, stripRange.end).map((entry, offset) => {
               const i = stripRange.start + offset;


### PR DESCRIPTION
用户反馈手机上看不到灯箱底部的小图预览。查下来是两个互相独立的成因叠在一起，各修一处。

## 成因一：`fixed inset-0` 贴的是布局视口

覆盖层用 `fixed inset-0` 定高。`position: fixed` 的包含块是**布局视口**，而移动浏览器的布局视口等于「地址栏收起后」的大视口。于是 `bottom: 0` 落在屏幕之外，贴底的缩略条被地址栏或底部工具栏整条盖住。

改成 `top: 0` + 动态视口高度。新增的 `.viewport-overlay-height` 与 AppShell 早就在用的 `.viewport-app-height` 是同一个理由、同一套 `vh → dvh` 回退——那条工具类的注释里写的就是「100vh 取的是地址栏收起后的大视口，底部输入区会被推到屏幕外」，同一个坑。差别只有两点：覆盖层要**加上** `--vp-overshoot`（iOS 独立 App 形态下向下多铺一截盖住底部黑条，与原来的负 `bottom` 等价），且不减 `--keyboard-inset`（灯箱上没有输入框）。

## 成因二：两条 padding-bottom 打架

缩略条同时挂着 `pb-2.5` 和一条带 `--vp-overshoot` 的任意值 `padding-bottom`。两条规则设的是同一个属性，谁生效取决于 Tailwind 生成的先后而不是 `className` 里的书写顺序——实测短类名赢了，overshoot 的补偿整个失效。

iOS 独立 App 形态下 `--vp-overshoot` 等于状态栏高度（iPhone 上约 47px），缩略条正好被推到可见区域之外。**如果用户是把网页加到主屏幕当 App 用，这一条就是主因。**

去掉短类名，底距只由那条任意值给（`0.625rem` 本来就算在里面）。

## 一并修了旧的 ImageLightbox

`ImageLightbox`（发现页详情、搜索结果的站点截图、助手对话）两处成因完全相同，且它在手机上同样显示底部缩略条。同一个 bug 只修一半，用户换个入口还是看不到，所以一起修掉。

## 测试

390×844 的触屏视口下实测缩略图底边坐标：

| 场景 | 改前 | 改后 | 视口高 |
|---|---|---|---|
| 常规移动浏览器（overshoot 0） | 834 | 834 | 844 |
| 模拟 iOS 独立 App（overshoot 47px） | 874 ❌ | 834 ✅ | 844 |

补偿失效那条也直接量了计算值：改前 `padding-bottom` 是 10px，改后 50px（= 10 + safe-bottom + overshoot 40 的验证例）。

触屏轻点收起 / 展开控件仍正常。桌面端灯箱的收放、双击缩放、拖拽与方向键翻页、点空白关闭、放大后点空白不误关，以及章节横排灯箱，全部回归通过，无页面报错。`tsc` 与 `eslint` 干净。

**一处坦白**：无头 Chromium 造不出真实的浏览器地址栏收放，所以成因一的效果我只能通过「高度公式确实按动态视口计算」来间接验证，没法在这里端到端复现真机上的工具栏遮挡。成因二是直接量到并修复的。建议在真机上确认一次。

## 顺带发现，未改动

`components/modal.tsx` 的移动端底部抽屉也是 `fixed inset-0` + `items-end`，同一个成因下面板底部会被浏览器工具栏盖住。它的调用点很多，改动需要逐个验证，本 PR 没碰。要处理的话可以另开一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br3scbToJDijSUgXNFWutS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br3scbToJDijSUgXNFWutS)_