### PR TITLE
瀑布流与海报墙加收藏标识，图廊灯箱可收藏；图片等待态与提前量一并收紧

### DIFF
--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -88,6 +88,7 @@ import {
   type ClaimSeed,
   searchSeedFromLabel,
 } from "@/components/claim-panels";
+import { setPlaybackMarks } from "@/lib/api/playback";
 import { listSubscriptions, type Subscription } from "@/lib/api/subscriptions";
 import { HttpError } from "@/lib/http";
 import { formatBytes } from "@/lib/format";
@@ -147,6 +148,24 @@ const WALL_PAGE_SIZE = 60;
 const WALL_API_PAGE_SIZE = 200;
 /** 图床浏览模式一页的作品数：一部作品十来张图，24 部约一屏半 */
 const GALLERY_PAGE_SIZE = 24;
+/**
+ * 图床浏览模式提前取下一页的距离：约一屏半，也就是当前这一页快滑完时就去要
+ * 下一页。图大、下载慢，等滑到底再发请求接上来的就是一屏空瓦片。
+ */
+const GALLERY_LOAD_MARGIN = "1200px 0px";
+
+/**
+ * 图廊分组上墙前的统一口径：没图的条目不占位（服务端按条目分页，空组只用来
+ * 数页），同一条目只留最前面那一组。追加下一页与整窗对账都过这一道。
+ */
+function dedupeGalleryGroups(groups: LibraryGalleryGroup[]): LibraryGalleryGroup[] {
+  const seen = new Set<number>();
+  return groups.filter((group) => {
+    if (group.images.length === 0 || seen.has(group.media_item_id)) return false;
+    seen.add(group.media_item_id);
+    return true;
+  });
+}
 
 /**
  * 列表拉取失败折成 ``null``（而不是空数组）。
@@ -164,8 +183,14 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   const initialSnapshot = getLibraryDetailSnapshot(libraryId);
   const { canManageLibraries } = usePermissions();
   const { activeJobs } = useJobs();
+  // 影视库 / 其他库的图床浏览模式（video-gallery.tsx）：海报墙换成每部作品的
+  // 海报 / 剧照 / 章节图瀑布流，点开灯箱能直接播放或进详情。偏好记在浏览器里；
+  // 图片库本身就是相册墙，这个开关对它没有意义
+  const [galleryPreferred, setGalleryMode] = useVideoGalleryMode();
+  // 两种墙的锚点属性不同：海报墙一格一个条目（data-library-item-id），图廊一部
+  // 作品十几张图，得按瓦片认（data-gallery-tile-id）。两者不会同时在 DOM 里
   const restoreScrollRef = useScrollRestoration(`library:${libraryId}`, {
-    anchorAttribute: "data-library-item-id",
+    anchorAttribute: galleryPreferred ? "data-gallery-tile-id" : "data-library-item-id",
   });
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   // 滚动位置恢复与字母索引联动共用同一个真实滚动容器，合并 callback ref
@@ -229,6 +254,15 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
     window.history.replaceState(null, "", `${window.location.pathname}${rest ? `?${rest}` : ""}`);
   }, []);
 
+  // 图床浏览模式已加载的窗口（用法见下面「图床浏览模式」一段）。与海报墙的
+  // 窗口一样随快照恢复，声明放在这里是因为下面的快照组装要读它们
+  const [galleryGroups, setGalleryGroups] = useState<LibraryGalleryGroup[]>(
+    initialSnapshot?.galleryGroups ?? [],
+  );
+  const [galleryHasMore, setGalleryHasMore] = useState(initialSnapshot?.galleryHasMore ?? false);
+  // 已请求到的条目数（按页长推进，不按拿到的组数——没图的条目也占一组）
+  const galleryLoaded = useRef(initialSnapshot?.galleryLoaded ?? 0);
+
   // 轮询乱序守卫：扫描期间后端响应时间抖动大，上一轮的慢响应可能晚于
   // 下一轮到达，不作废就会用旧快照覆盖新状态（进度回跳、胶囊闪烁）
   const reloadSeq = useRef(0);
@@ -258,6 +292,9 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
         wallLoaded: wallLoaded.current,
         wallSort: wallSort.current,
         wallOffset: wallOffset.current,
+        galleryGroups,
+        galleryHasMore,
+        galleryLoaded: galleryLoaded.current,
         stale: snapshotStale,
       }
     : null;
@@ -267,6 +304,8 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   useLayoutEffect(() => {
     if (snapshotRef.current) setLibraryDetailSnapshot(libraryId, snapshotRef.current);
   }, [
+    galleryGroups,
+    galleryHasMore,
     ignored,
     items,
     libraries,
@@ -582,17 +621,10 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   );
   // 灯箱翻到最后一张时：已加载列表被跳转替换过也无妨，loadMore 按当前窗口追加
   const closeLightbox = useCallback(() => setLightboxIndex(null), []);
-  // 影视库 / 其他库的图床浏览模式（video-gallery.tsx）：海报墙换成每部作品的
-  // 海报 / 剧照 / 章节图瀑布流，点开灯箱能直接播放或进详情。偏好记在浏览器里；
-  // 图片库本身就是相册墙，这个开关对它没有意义
-  const [galleryPreferred, setGalleryMode] = useVideoGalleryMode();
+  // 图床浏览模式的开关在文件上方（滚动恢复要先知道用哪个锚点属性）
   // 按作品分段，还是整库的图混成一条瀑布流（⋯ 菜单里切换）
   const [galleryGrouped, setGalleryGrouped] = useVideoGalleryGrouped();
   const gallery = galleryPreferred && Boolean(library?.capabilities.playable);
-  const [galleryGroups, setGalleryGroups] = useState<LibraryGalleryGroup[]>([]);
-  const [galleryHasMore, setGalleryHasMore] = useState(false);
-  // 已请求到的条目数（按页长推进，不按拿到的组数——没图的条目也占一组）
-  const galleryLoaded = useRef(0);
   const galleryLoading = useRef(false);
   const galleryEntries = useMemo(() => flattenGallery(galleryGroups), [galleryGroups]);
   const loadMoreGallery = useCallback(() => {
@@ -602,13 +634,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
     listLibraryGallery(libraryId, { limit: GALLERY_PAGE_SIZE, offset })
       .then((page) => {
         galleryLoaded.current = offset + page.length;
-        setGalleryGroups((current) => {
-          const seen = new Set(current.map((g) => g.media_item_id));
-          return [
-            ...current,
-            ...page.filter((g) => g.images.length > 0 && !seen.has(g.media_item_id)),
-          ];
-        });
+        setGalleryGroups((current) => dedupeGalleryGroups([...current, ...page]));
         setGalleryHasMore(page.length >= GALLERY_PAGE_SIZE);
       })
       .catch(() => setGalleryHasMore(false))
@@ -616,13 +642,81 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
         galleryLoading.current = false;
       });
   }, [libraryId]);
-  // 切进图廊（或换库）从第一页拉起；切回海报墙清空，别让旧图占着内存
+  /**
+   * 按已加载的页数重拉整个图廊窗口：从快照恢复出来的窗口是离开这一屏时的旧
+   * 数据（比如在详情页点了心，返回时角标要跟着变），拿到结果整体替换。
+   * 不缩窗口、不动滚动位置；失败就留着旧窗口，下次返回再对账。
+   */
+  const refreshGallery = useCallback(() => {
+    const loaded = galleryLoaded.current;
+    if (loaded <= 0 || galleryLoading.current) return;
+    galleryLoading.current = true; // 对账期间别让滚动哨兵同时追加下一页
+    Promise.all(
+      Array.from({ length: Math.ceil(loaded / GALLERY_PAGE_SIZE) }, (_, page) =>
+        listLibraryGallery(libraryId, {
+          limit: GALLERY_PAGE_SIZE,
+          offset: page * GALLERY_PAGE_SIZE,
+        }),
+      ),
+    )
+      .then((pages) => {
+        galleryLoaded.current = pages.reduce((sum, page) => sum + page.length, 0);
+        setGalleryGroups(dedupeGalleryGroups(pages.flat()));
+        setGalleryHasMore((pages.at(-1)?.length ?? 0) >= GALLERY_PAGE_SIZE);
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        galleryLoading.current = false;
+      });
+  }, [libraryId]);
+  /**
+   * 图廊里点心：收藏 / 取消收藏整部作品（与详情页那颗心同一落点）。
+   *
+   * 收藏态随图廊一起下发、挂在分组上，所以这里改的是 galleryGroups——灯箱的
+   * 心与墙上那几张瓦片的角标读同一份，翻一次全都跟着变。先翻本地再落库，
+   * 失败翻回来并提示。
+   */
+  const toggleGalleryFavorite = useCallback(
+    async (mediaItemId: number, next: boolean) => {
+      const patch = (value: boolean) =>
+        setGalleryGroups((current) =>
+          current.map((g) => (g.media_item_id === mediaItemId ? { ...g, is_favorite: value } : g)),
+        );
+      patch(next);
+      try {
+        const marks = await setPlaybackMarks({ media_item_id: mediaItemId }, { favorite: next });
+        patch(marks.is_favorite);
+      } catch (e) {
+        patch(!next);
+        toast.error(e instanceof Error ? e.message : "收藏失败，请稍后重试");
+      }
+    },
+    [toast],
+  );
+  // 当前这份图廊窗口属于哪个库：快照带回来的窗口一进来就算数
+  const galleryWindowLibrary = useRef<number | null>(
+    initialSnapshot?.galleryGroups.length ? libraryId : null,
+  );
+  /**
+   * 切进图廊：第一次（或换库）从第一页拉起；从条目详情页返回时窗口已经由快照
+   * 恢复，**不能**清空重拉——只补第一页的话容器矮到装不下离开时的滚动位置，
+   * 滚动恢复会等到超时后放弃，人被甩回墙首（用户反馈 2026-09-07）。
+   *
+   * 也不再于切回海报墙时清空：这份窗口本来就随快照留在会话里，清了只是让下次
+   * 切回图廊白拉一遍。
+   */
   useEffect(() => {
+    if (!gallery) return;
+    if (galleryWindowLibrary.current === libraryId) {
+      refreshGallery();
+      return;
+    }
+    galleryWindowLibrary.current = libraryId;
     galleryLoaded.current = 0;
     setGalleryGroups([]);
     setGalleryHasMore(false);
-    if (gallery) loadMoreGallery();
-  }, [gallery, loadMoreGallery]);
+    loadMoreGallery();
+  }, [gallery, libraryId, loadMoreGallery, refreshGallery]);
   const wideCards = Boolean(library && library.capabilities.default_aspect > 1);
   // 其他库的主图两种形态并存：刮削器放好 -poster 的是 2:3 竖版海报，只有 -thumb /
   // 抓帧的是横版缩略图。竖横混在一个网格里对不齐，按主图比例切成两区，各自用
@@ -1204,6 +1298,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
                   start={gallery ? 0 : wallStart}
                   total={library.stats.item_count}
                   onReach={gallery ? loadMoreGallery : loadMore}
+                  rootMargin={gallery ? GALLERY_LOAD_MARGIN : undefined}
                 />
 
                 {/* —— 未识别分区（只有影视库会有）：认不出的文件按文件名/目录名
@@ -1275,6 +1370,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
               hasMore={galleryHasMore}
               onIndexChange={setLightboxIndex}
               onReachEnd={loadMoreGallery}
+              onToggleFavorite={toggleGalleryFavorite}
               onClose={closeLightbox}
             />
           )}
@@ -1616,6 +1712,7 @@ export const InventoryCell = memo(function InventoryCell({
     aspect: item.primary_aspect >= 1 ? 16 / 9 : 2 / 3,
     imageAspect: item.primary_aspect,
     overlayDetails: inventoryLabel ? { primary: inventoryLabel } : undefined,
+    favorite: item.is_favorite,
     // 海报可能是本地刮削资产的相对路径（断网可用），也可能是 TMDB 图床地址。
     // 与首页海报墙同样取派生图（竖版 poster-card / 横版 landscape-card）：海报墙
     // 是全站最大的一张图片网格，直出原图等于每屏多拉三倍字节（见 library-view.tsx
@@ -1686,6 +1783,7 @@ export function WallLoadMore({
   start,
   total,
   onReach,
+  rootMargin = "600px 0px",
 }: {
   hasMore: boolean;
   loaded: number;
@@ -1693,6 +1791,12 @@ export function WallLoadMore({
   start: number;
   total: number;
   onReach: () => void;
+  /**
+   * 提前多远开始取下一页。海报墙 600px（约半屏）够用：格子小、图也小，到底
+   * 那一下基本无感。图床浏览模式要给得更宽——一页只有二十几部作品但每张图
+   * 都大，等滑到底再发请求，接上来的一屏全是还在下载的空瓦片。
+   */
+  rootMargin?: string;
 }) {
   const sentinel = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -1702,11 +1806,11 @@ export function WallLoadMore({
       ([entry]) => {
         if (entry.isIntersecting) onReach();
       },
-      { rootMargin: "600px 0px" },
+      { rootMargin },
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [hasMore, loaded, onReach]);
+  }, [hasMore, loaded, onReach, rootMargin]);
 
   return (
     <div
@@ -1714,9 +1818,16 @@ export function WallLoadMore({
       className="mt-8 flex h-10 items-center justify-center text-sub text-[var(--text-muted)]"
       aria-live="polite"
     >
-      {hasMore
-        ? `加载中…（第 ${start + 1}–${start + loaded} 部 / 共 ${Math.max(total, start + loaded)}）`
-        : null}
+      {hasMore ? (
+        <>
+          {/* 转圈：这一条原先只有一行字，静止不动时看着像卡住了 */}
+          <span
+            aria-hidden="true"
+            className="mr-2 size-3.5 animate-spin rounded-full border-2 border-white/15 border-t-white/60 motion-reduce:animate-none"
+          />
+          {`加载中…（第 ${start + 1}–${start + loaded} 部 / 共 ${Math.max(total, start + loaded)}）`}
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/poster-card.tsx
+++ b/apps/web/components/poster-card.tsx
@@ -5,7 +5,14 @@ import { useEffect, useRef, useState, type MouseEvent } from "react";
 import type { Route } from "next";
 import Link from "next/link";
 
-import { BellIcon, CheckIcon, DownloadIcon, PlusIcon, StarIcon } from "@/components/icons";
+import {
+  BellIcon,
+  CheckIcon,
+  DownloadIcon,
+  HeartIcon,
+  PlusIcon,
+  StarIcon,
+} from "@/components/icons";
 import { PosterImage } from "@/components/poster-image";
 import { useSubscribeEntry } from "@/components/subscribe-entry";
 import { useMediaDetail } from "@/lib/media-detail";
@@ -105,6 +112,8 @@ export interface PosterVisualItem {
     upgrading?: boolean;
     upgradingCount?: number;
   };
+  /** 已被当前观看者收藏：海报右上角点一颗实心红心（只是标识，点收藏在详情页 / 图廊灯箱） */
+  favorite?: boolean;
   /** 悬浮层的一行紧凑元信息；长内容截断，完整值保留在 title 中。 */
   overlayMeta?: string;
   /** 悬浮层的两行紧凑上下文；不占用海报下方的常显元信息。 */
@@ -385,14 +394,28 @@ function PosterCardContent({
             洗版 {item.posterFooter.upgradingCount}
           </span>
         )}
-        {/* 右上：评分徽章（暂无评分时不渲染，避免展示 0.0） */}
-        {item.rating > 0 && (
-          <span
-            className={`tnum absolute right-2 flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-caption font-semibold text-white ${ribbon && !ribbon.compactLeft ? "top-12" : "top-2"}`}
+        {/* 右上角状态位：收藏的心 + 评分徽章（评分为 0 不渲染，避免展示 0.0）。
+            两者排一行，谁都没有就不占位——库存墙不给评分、只可能有心，发现页
+            只可能有评分，订阅墙两者都没有（右上角让给上面的洗版徽标） */}
+        {(item.favorite || item.rating > 0) && (
+          <div
+            className={`absolute right-2 flex items-center gap-1 ${ribbon && !ribbon.compactLeft ? "top-12" : "top-2"}`}
           >
-            <StarIcon className="size-3 text-[var(--warn)]" />
-            {item.rating.toFixed(1)}
-          </span>
+            {item.favorite && (
+              <span
+                aria-label="已收藏"
+                className="flex items-center rounded-md bg-black/70 px-1 py-0.5 text-[var(--danger)]"
+              >
+                <HeartIcon className="size-3.5" fill="currentColor" />
+              </span>
+            )}
+            {item.rating > 0 && (
+              <span className="tnum flex items-center gap-1 rounded-md bg-black/70 px-1.5 py-0.5 text-caption font-semibold text-white">
+                <StarIcon className="size-3 text-[var(--warn)]" />
+                {item.rating.toFixed(1)}
+              </span>
+            )}
+          </div>
         )}
 
         {/* 订阅墙的剧集收录摘要常驻海报内部，利用底部暗部承载一眼可扫的

--- a/apps/web/components/poster-image.tsx
+++ b/apps/web/components/poster-image.tsx
@@ -9,7 +9,9 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
  *   1. loading="lazy" —— 海报墙一页几十张图，懒加载是默认约定；
  *   2. referrerPolicy="no-referrer" —— 豆瓣等图床按 Referer 拒绝外链，不带即可正常加载；
  *   3. 加载失败回退 —— 防盗链 / 图床失效时渲染深色占位（或调用方自定义的 fallback），
- *      卡片不塌陷、不出裂图图标。
+ *      卡片不塌陷、不出裂图图标；
+ *   4. 等待态占位（``pulseWhileLoading``，按需开）—— 图没到之前盖一层脉冲，
+ *      大图墙上滑到哪儿黑一块的观感由它兜住。
  *
  * 定位、圆角、hover 缩放等布局差异全部通过 className 由调用方传入；
  * 占位符会套用同一份 className，保证与图片占据完全相同的盒子。
@@ -20,6 +22,8 @@ export function PosterImage({
   alt,
   className = "",
   fallback,
+  pulseWhileLoading = false,
+  preload = false,
 }: {
   /** 图片地址；为空时直接渲染占位 */
   src?: string | null;
@@ -28,8 +32,22 @@ export function PosterImage({
   className?: string;
   /** 自定义占位内容；不传则渲染深色渐变底 */
   fallback?: ReactNode;
+  /**
+   * 图片就位前盖一层脉冲占位（默认不开）。大图墙需要它：瀑布流的瓦片底色是
+   * 深色，滑到哪儿黑一块，看着像坏了而不是在加载。占位与图片是重叠的两层，
+   * 只有 className 本身是绝对定位（absolute inset-0 这类）时才对得上。
+   */
+  pulseWhileLoading?: boolean;
+  /**
+   * 外部已判定这张图快进视口了（大图墙用一个共享的 IntersectionObserver 提前
+   * 判，见 video-gallery.tsx），直接 eager 取图，不等原生懒加载——瓦片带
+   * content-visibility 时原生懒加载要等瓦片解除跳过（约半屏前）才发请求，
+   * 滑快一点图就一路追在人后面。详见下面「懒加载失灵兜底」的注释。
+   */
+  preload?: boolean;
 }) {
   const [broken, setBroken] = useState(false);
+  const [loaded, setLoaded] = useState(false);
   // 懒加载失灵兜底：海报常被包在 content-visibility:auto 的格子/行里（海报墙、
   // 横滚行），Chromium 对「被跳过渲染的子树」里的懒加载图片不做视口相交判定，
   // 而页面打开瞬间所有格子都处于跳过态，首屏图片可能永远不发请求——表现为
@@ -45,6 +63,11 @@ export function PosterImage({
   // 标签页天然挂起，也顺带保证了「后台打开、切回前台才开始取图」的正确时序。
   const imgRef = useRef<HTMLImageElement | null>(null);
   const [eager, setEager] = useState(false);
+  // 换图时复位「已就位」：缓存直出的图 load 事件可能早于本组件挂载，
+  // 那种情况下 img.complete 已经是 true，不补这一下占位就撤不掉
+  useEffect(() => {
+    setLoaded(imgRef.current?.complete ?? false);
+  }, [src]);
   useEffect(() => {
     let raf = 0;
     const kickOrRetry = () => {
@@ -90,19 +113,29 @@ export function PosterImage({
     );
   }
   return (
-    <img
-      ref={imgRef}
-      src={src}
-      alt={alt}
-      loading={eager ? "eager" : "lazy"}
-      // 必须同步解码：async 解码的「完成→重绘」通知在 content-visibility 格子里
-      // 会被 Chromium 丢弃，海报停在占位直到 hover 强制重排（实测定位的根因）。
-      // sync 让任何一次绘制都当场解码带图，不依赖那条会丢的通知；单张海报解码
-      // 只有几毫秒，且只有真正被绘制的格子才会解码，无首屏卡顿之虞。
-      decoding="sync"
-      referrerPolicy="no-referrer"
-      onError={() => setBroken(true)}
-      className={`bg-[#141824] object-cover ${className}`}
-    />
+    <>
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        loading={eager || preload ? "eager" : "lazy"}
+        // 必须同步解码：async 解码的「完成→重绘」通知在 content-visibility 格子里
+        // 会被 Chromium 丢弃，海报停在占位直到 hover 强制重排（实测定位的根因）。
+        // sync 让任何一次绘制都当场解码带图，不依赖那条会丢的通知；单张海报解码
+        // 只有几毫秒，且只有真正被绘制的格子才会解码，无首屏卡顿之虞。
+        decoding="sync"
+        referrerPolicy="no-referrer"
+        onError={() => setBroken(true)}
+        onLoad={() => setLoaded(true)}
+        className={`bg-[#141824] object-cover ${className}`}
+      />
+      {/* 脉冲占位盖在图片**之上**：<img> 自带不透明深色底，垫在下面看不见 */}
+      {pulseWhileLoading && !loaded && (
+        <span
+          aria-hidden="true"
+          className={`pointer-events-none animate-pulse bg-white/[0.07] motion-reduce:animate-none ${className}`}
+        />
+      )}
+    </>
   );
 }

--- a/apps/web/components/video-gallery.tsx
+++ b/apps/web/components/video-gallery.tsx
@@ -6,7 +6,7 @@ import type { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
-import { OpenIcon, PlayIcon } from "@/components/icons";
+import { HeartIcon, OpenIcon, PlayIcon } from "@/components/icons";
 import {
   DENSITY,
   layoutMasonry,
@@ -27,9 +27,9 @@ import { playHref, rememberPlayerReturnPath } from "@/lib/player/play-links";
  *   - 分组按**作品**而不是按月：一部作品一段标题 + 一面墙，标题可点进详情。
  *     分组可以在 ⋯ 菜单里关掉——关掉之后整库的图混成一条瀑布流，谁也不分段，
  *     纯看图时最沉浸（用户决策 2026-09-07）；
- *   - 灯箱顶栏右侧不是「下载 / 拍摄信息」，而是「播放 / 详情」：章节场景图的
+ *   - 灯箱顶栏右侧不是「下载 / 拍摄信息」，而是「播放 / 收藏 / 详情」：章节场景图的
  *     播放就是从那一帧起播（服务端给了 t_seconds），分集剧照带季集号进详情页
- *     直接落到那一集。
+ *     直接落到那一集；心与详情页那颗是同一颗（收藏整部作品，见 playback marks）。
  *
  * 数据来自 /libraries/{id}/gallery，按作品分页（与海报墙同一份标题序）；
  * 灯箱翻的是铺平后的整份图列表（GalleryEntry），翻到末尾向外要下一页。
@@ -91,6 +91,16 @@ function groupTitle(group: LibraryGalleryGroup): string {
   return group.year ? `${group.title} (${group.year})` : group.title;
 }
 
+/**
+ * 一张瓦片的稳定标识：React key 与滚动恢复的锚点共用同一串。
+ *
+ * 不能只用条目 id——同一部作品在墙上有十几张图；也不能只用 url——不分组时
+ * 整库的图排在一面墙上，不同条目的图床地址理论上可能撞。
+ */
+function tileKey(group: LibraryGalleryGroup, image: LibraryGalleryImage): string {
+  return `${group.media_item_id}:${image.kind}:${image.url}`;
+}
+
 /** 条目详情页地址：分集剧照 / 剧集章节图带季集号，详情页直接落到那一集 */
 function detailHref(libraryId: number, entry: GalleryEntry): Route {
   const { group, image } = entry;
@@ -100,6 +110,78 @@ function detailHref(libraryId: number, entry: GalleryEntry): Route {
       ? `?season=${image.season}&episode=${image.episode}`
       : "";
   return `${base}${unit}` as Route;
+}
+
+/**
+ * 提前取图的距离：约一屏半。
+ *
+ * 瓦片带 ``content-visibility:auto``，子树被跳过时 ``<img loading="lazy">`` 不做
+ * 相交判定（根因见 poster-image.tsx 顶部的长注释），实际要等瓦片自己解除跳过
+ * ——大约只提前半屏——才发第一个请求。图廊的图又比海报大，滑快一点就是一路
+ * 黑格，图追在人后面。这里提前一屏半开始取，滑到时基本已经就位。
+ */
+const PREFETCH_MARGIN = "1200px 0px";
+
+/**
+ * 一面墙一个 IntersectionObserver，观察**瓦片本体**：瓦片有显式宽高、自己不被
+ * 跳过，相交判定照常工作（被跳过的是它的子树）。进入提前量的瓦片切成 eager。
+ *
+ * 标记只加不减——图取过就不必再管，命中即 ``unobserve``；一次滑动会连着命中
+ * 几十张，合并到下一帧统一提交，不一张一次 setState。分组模式下每段墙各持
+ * 一个观察器：段与段互不影响，某一段有图进场时不必惊动整墙重渲染。
+ */
+function useTilePrefetch() {
+  const [near, setNear] = useState<ReadonlySet<string>>(() => new Set());
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const pending = useRef<Set<string>>(new Set());
+  const flush = useRef(0);
+
+  const getObserver = useCallback(() => {
+    if (observerRef.current || typeof IntersectionObserver === "undefined") {
+      return observerRef.current;
+    }
+    observerRef.current = new IntersectionObserver(
+      (records) => {
+        for (const record of records) {
+          if (!record.isIntersecting) continue;
+          const key = (record.target as HTMLElement).dataset.galleryTileId;
+          if (key) pending.current.add(key);
+          observerRef.current?.unobserve(record.target);
+        }
+        if (pending.current.size > 0 && !flush.current) {
+          flush.current = requestAnimationFrame(() => {
+            flush.current = 0;
+            setNear((current) => new Set([...current, ...pending.current]));
+            pending.current.clear();
+          });
+        }
+      },
+      { rootMargin: PREFETCH_MARGIN },
+    );
+    return observerRef.current;
+  }, []);
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (flush.current) cancelAnimationFrame(flush.current);
+    },
+    [],
+  );
+
+  // 瓦片的 ref：挂上即观察，卸载时（React 19 的 ref 清理）取消观察
+  const observe = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) return;
+      const observer = getObserver();
+      observer?.observe(node);
+      return () => observer?.unobserve(node);
+    },
+    [getObserver],
+  );
+
+  return { near, observe };
 }
 
 export function VideoGalleryWall({
@@ -187,6 +269,7 @@ const GalleryTiles = memo(function GalleryTiles({
   spec: DensitySpec;
   onOpen: (index: number) => void;
 }) {
+  const { near, observe } = useTilePrefetch();
   const layout = useMemo(() => {
     const aspects = entries.map((entry) => entry.image.aspect);
     const masonry = layoutMasonry(aspects, width, spec.column, spec.gap, spec.minColumns);
@@ -197,17 +280,26 @@ const GalleryTiles = memo(function GalleryTiles({
   }, [entries, width, spec]);
   return (
     <div className="relative" style={{ height: layout.height }}>
-      {entries.map(({ group, image }, i) => (
-        // key 带上条目 id：不分组时整库的图排在一面墙上，光靠 url 不保证唯一
-        <GalleryTile
-          key={`${group.media_item_id}:${image.kind}:${image.url}`}
-          group={group}
-          image={image}
-          placement={layout.placements[i]}
-          spec={spec}
-          onOpen={() => onOpen(start + i)}
-        />
-      ))}
+      {entries.map(({ group, image }, i) => {
+        const placement = layout.placements[i];
+        const key = tileKey(group, image);
+        return (
+          <GalleryTile
+            key={key}
+            group={group}
+            image={image}
+            index={start + i}
+            preload={near.has(key)}
+            observe={observe}
+            x={placement.x}
+            y={placement.y}
+            width={placement.width}
+            height={placement.height}
+            spec={spec}
+            onOpen={onOpen}
+          />
+        );
+      })}
     </div>
   );
 });
@@ -250,39 +342,84 @@ const GalleryGroupSection = memo(function GalleryGroupSection({
   );
 });
 
+/**
+ * 一张瓦片。
+ *
+ * 位置拆成四个数字、点击给稳定的 ``onOpen`` + 自己的下标，都是为了让 ``memo``
+ * 真的生效：不分组时整墙共用一份铺平列表，追加一页或翻一次收藏都会重算
+ * layout，传对象（每次新引用）或内联箭头（每次新函数）会让几千个瓦片跟着
+ * 全量重渲染。分组模式下每组各算各的，本来就不受影响。
+ */
 const GalleryTile = memo(function GalleryTile({
   group,
   image,
-  placement,
+  index,
+  preload,
+  observe,
+  x,
+  y,
+  width,
+  height,
   spec,
   onOpen,
 }: {
   group: LibraryGalleryGroup;
   image: LibraryGalleryImage;
-  placement: { x: number; y: number; width: number; height: number };
+  /** 本瓦片在铺平列表里的全局下标：灯箱按同一列表翻页 */
+  index: number;
+  /** 已进入提前量，图直接取（见 useTilePrefetch） */
+  preload: boolean;
+  /** 把瓦片交给墙上那个共享观察器 */
+  observe: (node: HTMLElement | null) => (() => void) | void;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
   spec: DensitySpec;
-  onOpen: () => void;
+  onOpen: (index: number) => void;
 }) {
   return (
     // 与相册墙的瓦片同一套：绝对定位 + transform 重排走过渡，content-visibility
     // 让视口外的瓦片跳过绘制
     <button
       type="button"
-      aria-label={`查看 ${group.title} · ${image.label}`}
-      onClick={onOpen}
+      ref={observe}
+      // 滚动恢复的锚点（见 lib/use-scroll-restoration.ts）：离开这一屏时记下
+      // 首个可见瓦片，返回时按它回位。纯像素位在窗口宽度变过（转屏、缩窗口）
+      // 之后会错行——masonry 重排后同一个 y 已经不是同一批图了
+      data-gallery-tile-id={tileKey(group, image)}
+      aria-label={`查看 ${group.title} · ${image.label}${group.is_favorite ? "（已收藏）" : ""}`}
+      onClick={() => onOpen(index)}
       className="group/tile absolute left-0 top-0 block overflow-hidden rounded-xl bg-[#141824] text-left shadow-[0_8px_22px_rgba(0,0,0,0.35)] ring-1 ring-white/[0.07] transition-[transform,width,height,box-shadow] duration-300 ease-out [content-visibility:auto] hover:z-[2] hover:shadow-[0_18px_44px_rgba(0,0,0,0.6)] hover:ring-white/25 focus-visible:z-[2] focus-visible:ring-2 focus-visible:ring-[var(--accent)] motion-reduce:transition-none"
       style={{
-        transform: `translate(${Math.round(placement.x)}px, ${Math.round(placement.y)}px)`,
-        width: Math.round(placement.width),
-        height: Math.round(placement.height),
+        transform: `translate(${Math.round(x)}px, ${Math.round(y)}px)`,
+        width: Math.round(width),
+        height: Math.round(height),
       }}
     >
+      {/* 图廊的图比海报大得多（剧照 w1280、本地资产是原件），滑过去经常要等上
+          一会儿；开脉冲占位，等待期看着是"在加载"而不是一块黑。
+          取图一律走派生：相册墙的宽松密度（spec.variant 为 undefined）直接吃原图，
+          那是因为图片库的墙图本来就是 720 缩略图——图廊没这层，得自己要一张 */}
       <PosterImage
-        src={imageUrl(image.url, spec.variant)}
+        src={imageUrl(image.url, spec.variant ?? "gallery-tile")}
         alt={`${group.title} · ${image.label}`}
+        pulseWhileLoading
+        preload={preload}
         className="absolute inset-0 size-full object-cover transition-transform duration-500 ease-out group-hover/tile:scale-[1.04] motion-reduce:transition-none"
       />
-      {/* 不给常驻角标（用户决策 2026-09-07）：几百个「海报 / 剧照 / 第 3 集」浮在
+      {/* 收藏是唯一的常驻角标：它是**状态**不是分类文案，不认标签也认得这颗心，
+          而且只有被收藏的那几张才有，不会像「海报 / 剧照 / 第 3 集」那样满墙都是。
+          aria 走瓦片自己的 label（上面带了「已收藏」），这里纯装饰 */}
+      {group.is_favorite && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-2 text-[var(--danger)] drop-shadow-[0_1px_3px_rgba(0,0,0,0.75)]"
+        >
+          <HeartIcon className="size-4" fill="currentColor" />
+        </span>
+      )}
+      {/* 除上面那颗心外不给分类角标（用户决策 2026-09-07）：几百个「海报 / 剧照 / 第 3 集」浮在
           墙上，视线全被标签牵走，瀑布流就不是一面图墙了。是哪一类图移到下面的
           悬停层里说——真要分辨时鼠标一停就有，平时画面干净。
           悬停信息层：作品名 + 图的说明。不用 backdrop-blur（几百张瓦片叠加会拖慢滚动） */}
@@ -313,6 +450,7 @@ export function VideoGalleryLightbox({
   hasMore,
   onIndexChange,
   onReachEnd,
+  onToggleFavorite,
   onClose,
 }: {
   libraryId: number;
@@ -322,6 +460,8 @@ export function VideoGalleryLightbox({
   hasMore: boolean;
   onIndexChange: (index: number) => void;
   onReachEnd: () => void;
+  /** 收藏 / 取消收藏这部作品：状态挂在分组上（墙上的角标读同一份），由外层落库与回滚 */
+  onToggleFavorite: (mediaItemId: number, favorite: boolean) => void;
   onClose: () => void;
 }) {
   const router = useRouter();
@@ -331,10 +471,11 @@ export function VideoGalleryLightbox({
       entries.map(({ group, image }, i) => ({
         key: i,
         title: `${groupTitle(group)} · ${image.label}`,
-        // 墙上的派生图先铺底，主图直接是服务端给的这张（海报 w780 / 剧照 w1280 /
-        // 本地资产原件），没有再高一级的原图
+        // 墙上的派生图先铺底，主图走屏幕适配派生（长边 2048，不放大）：源本身
+        // 就没有比 w1280 剧照 / 本地资产更高一级的原图，这一层不为缩小尺寸，
+        // 而是转成 WebP——同样的画质少三到五成字节，翻页跟手（图片库灯箱同款口径）
         thumbUrl: imageUrl(image.url, "photo-tile"),
-        screenUrl: imageUrl(image.url),
+        screenUrl: imageUrl(image.url, "photo-screen"),
         aspect: image.aspect,
       })),
     [entries],
@@ -357,6 +498,9 @@ export function VideoGalleryLightbox({
 
   if (!entry) return null;
   const playLabel = entry.image.t_seconds !== null ? "从此处播放" : "播放";
+  // 收藏的是整部作品（与详情页那颗心同一落点），不是当前这张图或这一集
+  const favorite = entry.group.is_favorite;
+  const favoriteLabel = favorite ? "取消收藏" : "收藏";
   const buttonClass =
     "rounded-full p-2 text-white/70 transition-colors hover:bg-white/[0.12] hover:text-white";
 
@@ -379,6 +523,19 @@ export function VideoGalleryLightbox({
             className={buttonClass}
           >
             <PlayIcon className="size-[18px]" />
+          </button>
+          <button
+            type="button"
+            title={`${favoriteLabel}《${entry.group.title}》`}
+            aria-label={favoriteLabel}
+            aria-pressed={favorite}
+            onClick={() => onToggleFavorite(entry.group.media_item_id, !favorite)}
+            className={buttonClass}
+          >
+            <HeartIcon
+              className={favorite ? "size-[18px] text-[var(--danger)]" : "size-[18px]"}
+              fill={favorite ? "currentColor" : "none"}
+            />
           </button>
           <Link
             href={detailHref(libraryId, entry)}

--- a/apps/web/lib/api/libraries.ts
+++ b/apps/web/lib/api/libraries.ts
@@ -286,6 +286,8 @@ export interface LibraryItem {
   missing_episode_count: number;
   /** 最近一次文件入账时间（ISO 字符串），首页「最近添加」排序依据 */
   added_at: string | null;
+  /** 当前观看者是否收藏了这部作品（海报右上角那颗心）；不认人的接口恒 false */
+  is_favorite: boolean;
   /** 最近一次可追溯入库批次；旧台账和电影为 null */
   recent_addition: {
     season_count: number;
@@ -586,6 +588,8 @@ export interface LibraryGalleryGroup {
   kind: LibraryKind;
   title: string;
   year: number | null;
+  /** 当前观看者是否收藏了这部作品（瓦片角标与灯箱那颗心的初始态） */
+  is_favorite: boolean;
   images: LibraryGalleryImage[];
 }
 

--- a/apps/web/lib/image-proxy.ts
+++ b/apps/web/lib/image-proxy.ts
@@ -1,7 +1,12 @@
 import { resolveRequestUrl } from "@/lib/http";
 
 /** 后端允许的固定图片派生预设；固定枚举避免调用方制造任意尺寸缓存。 */
-export type ImageVariant = "landscape-card" | "poster-card" | "photo-tile";
+export type ImageVariant =
+  | "landscape-card"
+  | "poster-card"
+  | "photo-tile"
+  | "gallery-tile"
+  | "photo-screen";
 
 /**
  * 海报墙格子按主图比例挑派生预设：预设是等比缩放的外接框，横版封面（其他库

--- a/apps/web/lib/library-detail-snapshot.ts
+++ b/apps/web/lib/library-detail-snapshot.ts
@@ -1,4 +1,5 @@
 import type {
+  LibraryGalleryGroup,
   LibraryIndexEntry,
   LibraryItem,
   LibraryItemSort,
@@ -32,6 +33,15 @@ export interface LibraryDetailSnapshot {
   wallLoaded: number;
   wallSort: LibraryItemSort;
   wallOffset: number;
+  /**
+   * 图床浏览模式已加载的整份窗口。它必须跟着快照一起回来：图廊只按条目分页，
+   * 只补第一页的话容器会矮到装不下离开时的滚动位置，人就被甩回墙首。
+   * 空数组 = 这一次浏览没进过图廊。
+   */
+  galleryGroups: LibraryGalleryGroup[];
+  galleryHasMore: boolean;
+  /** 已向服务端请求到第几个条目（图廊按条目分页），返回后按同样的页数对账 */
+  galleryLoaded: number;
   /** 删除或转移等操作后标记为过期；保留旧窗口只为让滚动恢复有落脚点。 */
   stale: boolean;
 }

--- a/src/movieclaw_api/api/routes/libraries.py
+++ b/src/movieclaw_api/api/routes/libraries.py
@@ -1848,7 +1848,6 @@ async def start_organize(
     response_model=ApiResponse[list[LibraryItemView]],
     summary="库内媒体条目的库存聚合（单库海报墙数据源）",
     operation_id="library.items.list",
-    dependencies=[Depends(require_library_visible)],
 )
 async def list_library_items(
     library_id: int,
@@ -1877,12 +1876,21 @@ async def list_library_items(
         ),
     ] = "confirmed",
     session: AsyncSession = Depends(get_session),
+    principal: Principal = Depends(require_library_visible),
 ) -> ApiResponse[list[LibraryItemView]]:
 
     await LibraryConfigService(session).get(library_id)  # 404 检查
+    # 收藏态按人算（海报右上角那颗心），所以这条路由要认人
+    member_id = principal.member_id if principal.member_id is not None else 0
     return ok(
         await build_library_wall(
-            session, library_id, sort=sort, limit=limit, offset=offset, identity=identity
+            session,
+            library_id,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            identity=identity,
+            member_id=member_id,
         )
     )
 
@@ -1952,7 +1960,6 @@ async def list_library_item_index(
     summary="库内条目的图廊：海报 / 剧照 / 章节场景图按条目分组铺平（图床浏览模式数据源）",
     operation_id="ui.library.gallery",
     openapi_extra={"x-cli-hidden": True},
-    dependencies=[Depends(require_library_visible)],
 )
 async def list_library_gallery(
     library_id: int,
@@ -1961,13 +1968,20 @@ async def list_library_gallery(
     ] = None,
     offset: Annotated[int, Query(ge=0, description="跳过的条目数（滚动加载翻页用）")] = 0,
     session: AsyncSession = Depends(get_session),
+    principal: Principal = Depends(require_library_visible),
 ) -> ApiResponse[list[LibraryGalleryGroupView]]:
     """影视库 / 其他库的图床浏览模式：与 ``/items?sort=title`` 同一份排序与
     分页口径，一组就是一部作品的全部图（海报 → 剧照 → 逐集剧照与章节图）。
-    没有任何图的条目也占一组（images 为空），一页的组数恒等于条目数。"""
+    没有任何图的条目也占一组（images 为空），一页的组数恒等于条目数。
+    每组带当前观看者的收藏态（瓦片角标与灯箱的心）。"""
 
     await LibraryConfigService(session).get(library_id)  # 404 检查
-    return ok(await build_library_gallery(session, library_id, limit=limit, offset=offset))
+    member_id = principal.member_id if principal.member_id is not None else 0
+    return ok(
+        await build_library_gallery(
+            session, library_id, member_id=member_id, limit=limit, offset=offset
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/movieclaw_api/schemas/library.py
+++ b/src/movieclaw_api/schemas/library.py
@@ -428,6 +428,10 @@ class LibraryGalleryGroupView(BaseModel):
     kind: MediaKind
     title: str
     year: int | None = None
+    is_favorite: bool = Field(
+        default=False,
+        description="当前观看者是否收藏了这部作品：瓦片右上角的心形角标与灯箱里那颗心的初始态",
+    )
     images: list[LibraryGalleryImageView]
 
 
@@ -502,6 +506,10 @@ class LibraryItemView(BaseModel):
     )
     added_at: datetime | None = Field(
         default=None, description="最近一次文件入账时间（首页「最近添加」排序依据）"
+    )
+    is_favorite: bool = Field(
+        default=False,
+        description="当前观看者是否收藏了这部作品（海报右上角那颗心）；不认人的调用恒 False",
     )
     recent_addition: LibraryRecentAdditionView | None = Field(
         default=None,

--- a/src/movieclaw_api/services/image_variants.py
+++ b/src/movieclaw_api/services/image_variants.py
@@ -34,6 +34,10 @@ class ImageVariant(StrEnum):
     # 屏幕适配图。两者都是「装进盒子、不裁切」——照片的比例本身就是内容
     PHOTO_TILE = "photo-tile"
     PHOTO_SCREEN = "photo-screen"
+    # 影视库 / 其他库的图床浏览模式（瀑布流墙）在宽松密度下的瓦片。相册墙同一档
+    # 直接用原图是因为图片库的墙图本来就是 720 缩略图；图廊的源却是 TMDB w1280
+    # 剧照与本地刮削原件，一张几百 KB 到几 MB，滑过去就是一片黑等着下载
+    GALLERY_TILE = "gallery-tile"
 
 
 @dataclass(frozen=True)
@@ -56,6 +60,8 @@ _PRESETS = {
     ImageVariant.PHOTO_TILE: VariantPreset(width=480, height=480, quality=78),
     # 灯箱屏幕适配图：长边 2048 覆盖 4K 以下全屏，几百 KB 而不是原图的几 MB；放大才拉原图
     ImageVariant.PHOTO_SCREEN: VariantPreset(width=2048, height=2048, quality=82),
+    # 图廊宽松密度：列宽 340 CSS px，720px 覆盖 2x 屏
+    ImageVariant.GALLERY_TILE: VariantPreset(width=720, height=720, quality=78),
 }
 
 

--- a/src/movieclaw_api/services/library/items.py
+++ b/src/movieclaw_api/services/library/items.py
@@ -419,6 +419,49 @@ async def _wall_page_ids(
     return ids if limit is None else ids[offset : offset + limit]
 
 
+async def favorite_item_ids(
+    session: AsyncSession, media_item_ids: list[int], *, member_id: int
+) -> set[int]:
+    """这批条目里当前观看者收藏了哪几部（条目级收藏，不含单季 / 单集）。
+
+    收藏落在条目级哨兵单元上（剧 ``(-1,-1)``、电影 ``(0,0)``，见
+    ``services/playback/marks.py``），这里只捞已收藏的行再按哨兵过滤——一页
+    几十部，命中的通常是个位数，比给每部作品单独问一次 ``/playback/marks``
+    便宜得多。海报墙与图廊共用这一份口径。
+    """
+    from movieclaw_api.services.playback.marks import item_favorite_unit
+    from movieclaw_db.models import PlaybackState
+
+    if not media_item_ids:
+        return set()
+    kinds = {
+        item_id: kind
+        for item_id, kind in (
+            await session.execute(
+                select(MediaItem.id, MediaItem.kind).where(MediaItem.id.in_(media_item_ids))  # type: ignore[attr-defined]
+            )
+        ).all()
+    }
+    return {
+        item_id
+        for item_id, season, episode in (
+            await session.execute(
+                select(
+                    PlaybackState.media_item_id,
+                    PlaybackState.season_number,
+                    PlaybackState.episode_number,
+                ).where(
+                    PlaybackState.member_id == member_id,
+                    PlaybackState.media_item_id.in_(media_item_ids),  # type: ignore[attr-defined]
+                    PlaybackState.is_favorite.is_(True),  # type: ignore[union-attr]
+                )
+            )
+        ).all()
+        if item_id in kinds
+        and (item_id, season, episode) == item_favorite_unit(item_id, kinds[item_id])
+    }
+
+
 async def build_library_wall(
     session: AsyncSession,
     library_id: int,
@@ -427,6 +470,7 @@ async def build_library_wall(
     limit: int | None = None,
     offset: int = 0,
     identity: WallIdentity = "confirmed",
+    member_id: int | None = None,
 ) -> list[LibraryItemView]:
     """库内媒体条目的库存聚合（单库海报墙数据源）。
 
@@ -436,6 +480,9 @@ async def build_library_wall(
     ``limit`` 给定时只聚合这一页的条目——首页「最近添加」只要 20 格，
     海报墙滚动加载一次要一屏，都不该为此把整库的台账行捞出来算一遍。
     不给 limit 则是全库（保留给一次性拿完整库存的调用方）。
+
+    给了 ``member_id`` 才带这位观看者的收藏态（海报右上角那颗心）；不给就一律
+    ``False``——内部调用与不认人的场景不必为此多查一次。
 
     调用方需自行完成库存在性检查（404）。
     """
@@ -452,7 +499,12 @@ async def build_library_wall(
         if limit is None
         else page_ids
     )
-    return await _aggregate_wall_views(session, library_id, in_page, page_ids)
+    views = await _aggregate_wall_views(session, library_id, in_page, page_ids)
+    if member_id is not None:
+        favorites = await favorite_item_ids(session, page_ids, member_id=member_id)
+        for view in views:
+            view.is_favorite = view.media_item_id in favorites
+    return views
 
 
 async def _aggregate_wall_views(
@@ -670,6 +722,7 @@ async def build_library_gallery(
     session: AsyncSession,
     library_id: int,
     *,
+    member_id: int,
     limit: int | None = None,
     offset: int = 0,
 ) -> list[LibraryGalleryGroupView]:
@@ -680,7 +733,9 @@ async def build_library_gallery(
     海报 → 横幅剧照 → 逐集（分集剧照 → 该集章节图）。只取库里**在位**文件
     名下的章节图与分集剧照：图廊看的是"我库里有的"，缺集的剧照不混进来。
     没有任何图的条目也占一组（``images`` 为空）——一页的组数恒等于条目数，
-    前端据此判断还有没有下一页。
+    前端据此判断还有没有下一页。每组还带上 ``member_id`` 这位观看者有没有
+    收藏这部作品，供瓦片角标与灯箱里的心一次拿齐（详情页那样逐条目问
+    ``/playback/marks``，一屏几十张图就是几十个请求）。
 
     图片来源与海报墙、详情页同一优先级：本地刮削资产（断网可用，带
     ``?v=`` 版本戳）优先，其次 TMDB 图床——但海报取 w780、剧照取 w1280
@@ -704,6 +759,7 @@ async def build_library_gallery(
         .all()
         if item.id is not None
     }
+    favorite_ids = await favorite_item_ids(session, page_ids, member_id=member_id)
     meta_by_id: dict[int, tuple[str | None, int | None, int | None, str | None]] = {
         item_id: (poster_file, width, height, backdrop_file)
         for item_id, poster_file, width, height, backdrop_file in (
@@ -849,6 +905,7 @@ async def build_library_gallery(
                 kind=MediaKind(item.kind),
                 title=item.title,
                 year=item.year,
+                is_favorite=item_id in favorite_ids,
                 images=images,
             )
         )

--- a/src/movieclaw_api/services/playback/marks.py
+++ b/src/movieclaw_api/services/playback/marks.py
@@ -112,6 +112,15 @@ async def resolve_played_units(session: AsyncSession, target: MarkTarget) -> lis
     return units or [(target.media_item_id, 0, 0)]
 
 
+def item_favorite_unit(media_item_id: int, kind: str | None) -> Unit:
+    """条目级收藏的落点单元（已知 kind 时的同步版）。
+
+    批量场景（图廊一页几十部作品要知道各自收藏没有）用它，免得为每部作品
+    回查一次 ``MediaItem``；哨兵的取值只在这里定义一次，读写两侧共用。
+    """
+    return (media_item_id, -1, -1) if kind == "tv" else (media_item_id, 0, 0)
+
+
 async def favorite_unit(session: AsyncSession, target: MarkTarget) -> Unit:
     """收藏的落点单元：叶子用真实单元；整季/整剧用哨兵 ``(s,-1)`` / ``(-1,-1)``
     ——与 Jellyfin 兼容层 ``catalog._folder_user_data`` 的读取侧约定一致。"""
@@ -122,9 +131,7 @@ async def favorite_unit(session: AsyncSession, target: MarkTarget) -> Unit:
         assert target.season is not None
         return (target.media_item_id, target.season, -1)
     item = await session.get(MediaItem, target.media_item_id)
-    if item is not None and item.kind == "tv":
-        return (target.media_item_id, -1, -1)
-    return (target.media_item_id, 0, 0)
+    return item_favorite_unit(target.media_item_id, item.kind if item is not None else None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_library_item_detail.py
+++ b/tests/api/test_library_item_detail.py
@@ -1786,8 +1786,11 @@ async def test_library_refresh_targets_include_fileless_tracked_items(db, tmp_pa
 
 async def test_library_gallery_flattens_posters_stills_and_chapters(db, tmp_path) -> None:
     """图廊按条目分组铺平：海报 → 剧照 → 逐集（分集剧照 → 该集章节图），
-    章节图带起播秒数与季集号；分页按条目数走，与海报墙同口径。"""
+    章节图带起播秒数与季集号；分页按条目数走，与海报墙同口径；每组还带
+    当前观看者的收藏态（瀑布流角标与灯箱的心）。"""
     from movieclaw_api.api.routes.libraries import list_library_gallery
+    from movieclaw_api.services.playback import marks as playback_marks
+    from movieclaw_playback import state as playback_state
 
     root = tmp_path / "media" / "tv"
     show = root / "测试剧集 (2024)" / "Season 01"
@@ -1823,7 +1826,7 @@ async def test_library_gallery_flattens_posters_stills_and_chapters(db, tmp_path
         await session.commit()
 
     async with db.session() as session:
-        groups = (await list_library_gallery(library.id, None, 0, session)).data
+        groups = (await list_library_gallery(library.id, None, 0, session, _ADMIN)).data
         assert [g.title for g in groups] == ["测试剧集"]
         images = groups[0].images
         # 剧集条目在假 TMDB 里没有海报/横幅，图只来自分集剧照与章节图：
@@ -1839,5 +1842,18 @@ async def test_library_gallery_flattens_posters_stills_and_chapters(db, tmp_path
         assert chapter.url.startswith("/images/assets/chapters/1/1/0.jpg?v=")
         assert abs(chapter.aspect - 16 / 9) < 1e-6
 
+        # 收藏态随图廊一起下发（瀑布流的心形角标与灯箱那颗心的初始态）：
+        # 读的是条目级哨兵单元，与详情页 / Jellyfin 点的心是同一份数据
+        assert groups[0].is_favorite is False
+
         # 分页按条目数：跳过唯一的条目就什么都没有
-        assert (await list_library_gallery(library.id, 1, 1, session)).data == []
+        assert (await list_library_gallery(library.id, 1, 1, session, _ADMIN)).data == []
+
+    async with db.session() as session:
+        item_id = groups[0].media_item_id
+        unit = await playback_marks.favorite_unit(session, playback_marks.MarkTarget(item_id))
+        await playback_state.set_favorite(session, unit, member_id=0, favorite=True)
+        await session.commit()
+    async with db.session() as session:
+        groups = (await list_library_gallery(library.id, None, 0, session, _ADMIN)).data
+        assert groups[0].is_favorite is True

--- a/tests/api/test_library_items.py
+++ b/tests/api/test_library_items.py
@@ -10,6 +10,7 @@ from sqlmodel import select
 from movieclaw_api.api.routes.libraries import list_library_items
 from movieclaw_api.core.config import get_settings
 from movieclaw_api.schemas.library import derive_air_status
+from movieclaw_api.services.auth import Principal
 from movieclaw_db.engine import dispose_db, get_database, init_db
 from movieclaw_db.migrations import run_migrations
 from movieclaw_db.models import (
@@ -22,6 +23,9 @@ from movieclaw_db.models import (
     utcnow,
 )
 from movieclaw_db.repositories.library_repo import LibraryRepository
+
+#: 直接调路由函数时的主体（海报墙的收藏态按人算，必须显式给）
+_ADMIN = Principal(kind="admin", name="tester")
 
 
 @pytest_asyncio.fixture
@@ -116,7 +120,7 @@ async def test_items_air_status_and_missing_episodes(db) -> None:
         )
         await session.flush()
 
-        resp = await list_library_items(library.id, session=session)
+        resp = await list_library_items(library.id, session=session, principal=_ADMIN)
         rows = {r.media_item_id: r for r in resp.data}
 
         assert rows[airing.id].air_status == "airing"
@@ -155,7 +159,7 @@ async def test_items_missing_episodes_counts_across_libraries(db) -> None:
         )
         await session.flush()
 
-        resp = await list_library_items(main.id, session=session)
+        resp = await list_library_items(main.id, session=session, principal=_ADMIN)
         row = {r.media_item_id: r for r in resp.data}[item.id]
 
         # 本库库存仍按本库口径展示（海报墙显示的是这个库里有什么）
@@ -196,12 +200,64 @@ async def test_items_movie_and_unknown_status(db) -> None:
         )
         await session.flush()
 
-        resp = await list_library_items(library.id, session=session)
+        resp = await list_library_items(library.id, session=session, principal=_ADMIN)
         rows = {r.media_item_id: r for r in resp.data}
 
         assert rows[movie.id].air_status is None
         assert rows[movie.id].missing_episode_count == 0
         assert rows[unknown.id].air_status is None
+
+
+async def test_items_carry_viewer_favorite(db) -> None:
+    """海报墙带当前观看者的收藏态（右上角那颗心），且各人看各人的。
+
+    收藏落在条目级哨兵单元上（电影 (0,0)、剧 (-1,-1)），与详情页 / 图廊 /
+    Jellyfin 点的是同一份数据，所以这里按哨兵写库、从墙上读回。
+    """
+    from movieclaw_api.services.playback import marks as playback_marks
+    from movieclaw_playback import state as playback_state
+
+    async with db.session() as session:
+        library = await LibraryRepository(session).create(
+            name="电影库", kind="movie", root_paths=["/movies"]
+        )
+        loved = MediaItem(kind="movie", tmdb_id=501, title="心头好", original_title="L")
+        plain = MediaItem(kind="movie", tmdb_id=502, title="路人甲", original_title="P")
+        session.add_all([loved, plain])
+        await session.flush()
+        assert library.id and loved.id and plain.id
+        session.add_all(
+            [
+                LibraryFile(
+                    library_id=library.id,
+                    media_item_id=item_id,
+                    season_number=0,
+                    episode_number=0,
+                    file_path=f"/movies/{item_id}/m.mkv",
+                    size_bytes=1,
+                    source=FileSource.SCANNED,
+                )
+                for item_id in (loved.id, plain.id)
+            ]
+        )
+        await session.flush()
+
+        # 超管（member_id 缺省视为 0）收藏其中一部
+        unit = await playback_marks.favorite_unit(session, playback_marks.MarkTarget(loved.id))
+        await playback_state.set_favorite(session, unit, member_id=0, favorite=True)
+        await session.flush()
+
+        rows = {
+            r.media_item_id: r
+            for r in (await list_library_items(library.id, session=session, principal=_ADMIN)).data
+        }
+        assert rows[loved.id].is_favorite is True
+        assert rows[plain.id].is_favorite is False
+
+        # 换个成员看同一面墙：收藏是各人各的，不该跟着亮
+        member = Principal(kind="member", name="别人", member_id=7, is_admin=False)
+        others = (await list_library_items(library.id, session=session, principal=member)).data
+        assert [r.is_favorite for r in others] == [False, False]
 
 
 async def test_items_sort_and_paging(db) -> None:
@@ -237,14 +293,18 @@ async def test_items_sort_and_paging(db) -> None:
             )
         await session.flush()
 
-        by_title = await list_library_items(library.id, session=session)
+        by_title = await list_library_items(library.id, session=session, principal=_ADMIN)
         assert [r.title for r in by_title.data] == titles
 
-        recent = await list_library_items(library.id, sort="added_at", limit=2, session=session)
+        recent = await list_library_items(
+            library.id, sort="added_at", limit=2, session=session, principal=_ADMIN
+        )
         assert [r.title for r in recent.data] == ["A片", "B片"]
 
-        page1 = await list_library_items(library.id, limit=2, session=session)
-        page2 = await list_library_items(library.id, limit=2, offset=2, session=session)
+        page1 = await list_library_items(library.id, limit=2, session=session, principal=_ADMIN)
+        page2 = await list_library_items(
+            library.id, limit=2, offset=2, session=session, principal=_ADMIN
+        )
         assert [r.title for r in page1.data] + [r.title for r in page2.data] == titles
 
         # 补探优先：给 A 片探出音轨后它就不再是"待处理"，让位给尚未探测的 B 片
@@ -254,10 +314,14 @@ async def test_items_sort_and_paging(db) -> None:
         a_file.audio_streams = []
         session.add(a_file)
         await session.flush()
-        probing = await list_library_items(library.id, sort="probing", limit=2, session=session)
+        probing = await list_library_items(
+            library.id, sort="probing", limit=2, session=session, principal=_ADMIN
+        )
         assert [r.title for r in probing.data] == ["B片", "C片"]
 
-        empty = await list_library_items(library.id, limit=2, offset=4, session=session)
+        empty = await list_library_items(
+            library.id, limit=2, offset=4, session=session, principal=_ADMIN
+        )
         assert empty.data == []
 
         id_resp = await list_library_item_ids(library.id, session=session)
@@ -315,7 +379,9 @@ async def test_items_recent_addition_uses_latest_ingest_batch(db) -> None:
         )
         await session.flush()
 
-        response = await list_library_items(library.id, sort="added_at", session=session)
+        response = await list_library_items(
+            library.id, sort="added_at", session=session, principal=_ADMIN
+        )
         rows = {row.media_item_id: row for row in response.data}
         recent = rows[current.id]
 
@@ -392,7 +458,7 @@ async def test_items_inventory_summary_uses_in_place_files_and_known_structure(d
         )
         await session.flush()
 
-        response = await list_library_items(library.id, session=session)
+        response = await list_library_items(library.id, session=session, principal=_ADMIN)
         rows = {row.media_item_id: row for row in response.data}
 
         full = rows[full_seasons.id].inventory_summary
@@ -441,7 +507,7 @@ async def test_items_pinyin_order_and_index(db) -> None:
             session.add(_file(library.id, item.id, 1, 1))
         await session.flush()
 
-        rows = await list_library_items(library.id, session=session)
+        rows = await list_library_items(library.id, session=session, principal=_ADMIN)
         assert [r.title for r in rows.data] == [
             "爱很美味",  # a
             "重庆森林",  # chongqing——多音字，码点序绝排不到这
@@ -459,7 +525,9 @@ async def test_items_pinyin_order_and_index(db) -> None:
             ("#", 1, 4),
         ]
         # 索引条给的 offset 直接可用：点「M」拿到的就是该档第一格
-        jumped = await list_library_items(library.id, limit=1, offset=2, session=session)
+        jumped = await list_library_items(
+            library.id, limit=1, offset=2, session=session, principal=_ADMIN
+        )
         assert [r.title for r in jumped.data] == ["漫长的季节"]
 
 

--- a/tests/api/test_library_photo_kind.py
+++ b/tests/api/test_library_photo_kind.py
@@ -437,6 +437,11 @@ def test_photo_variants_fit_without_cropping(tmp_path) -> None:
     # 卡片预设同样是等比装框：竖版照片以 492 高为界、宽按原比例算，不裁成 2:3
     card = Image.open(BytesIO(_render_webp(photo, _PRESETS[ImageVariant.POSTER_CARD])))
     assert card.size == (308, 492)
+    # 图廊瓦片（图床浏览模式的宽松密度）走同一套规则，长边 720
+    gallery = Image.open(BytesIO(_render_webp(photo, _PRESETS[ImageVariant.GALLERY_TILE])))
+    assert gallery.size == (450, 720)
+    # 新增预设漏配尺寸会在请求时 KeyError 500，这里一次挡住
+    assert set(_PRESETS) == set(ImageVariant)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_library_scan_perf.py
+++ b/tests/api/test_library_scan_perf.py
@@ -16,12 +16,15 @@ from sqlmodel import select
 import movieclaw_api.services.library.scan as scan_mod
 import movieclaw_api.services.media_discover as discover_mod
 from movieclaw_api.core.config import get_settings
+from movieclaw_api.services.auth import Principal
 from movieclaw_api.services.library.scan import scan_library
 from movieclaw_db.engine import dispose_db, get_database, init_db
 from movieclaw_db.migrations import run_migrations
 from movieclaw_db.models import LibraryFile, MediaItem, MediaItemPerson
 from movieclaw_db.repositories.library_repo import LibraryRepository
 from movieclaw_media.tmdb import TmdbClient
+
+_ADMIN = Principal(kind="admin", name="tester")
 
 _KEY = "0123456789abcdef0123456789abcdef"
 _MOVIES = 5
@@ -197,7 +200,7 @@ async def test_library_wall_query_count_is_flat(db, tmp_path) -> None:
             _sink.append(stmt)
 
         async with db.session() as session:
-            resp = await list_library_items(library_id, session=session)
+            resp = await list_library_items(library_id, session=session, principal=_ADMIN)
         event.remove(engine, "before_cursor_execute", _tally)
 
         assert len(resp.data) == count


### PR DESCRIPTION
## 收藏

- 图廊灯箱顶栏加了心：**收藏整部作品**，与详情页那颗心、Jellyfin 客户端是同一个落点（`playback_state` 的条目级哨兵单元）。
- 瓦片右上角、海报墙卡片右上角显示已收藏标识（**只是标识，不可点** —— 卡片本身是通往详情页的链接，塞可点热区容易误触）。
- 收藏态随列表接口批量下发（`LibraryGalleryGroupView.is_favorite` / `LibraryItemView.is_favorite`），不给每部作品单独问一次 `/playback/marks`。抽出 `favorite_item_ids()`，海报墙与图廊共用同一份哨兵口径。
- `/libraries/{id}/items` 与 `/libraries/{id}/gallery` 因此要认人：`require_library_visible` 从 `dependencies=[]` 改成 `principal` 参数（鉴权行为不变）。

## 滚动恢复（用户反馈：从图片点进影片页再返回，停不回原位置）

图廊窗口没进会话快照，每次进图廊都清空重拉第一页；容器矮到装不下离开时的滚动位置，恢复逻辑等 5 秒后放弃，人被甩回墙首。

- 已加载窗口（分组 / 页数 / 还有没有下一页）进 `LibraryDetailSnapshot`，返回时直接沿用；
- 返回时按已加载页数并行重拉一次对账（在详情页点了心，回来角标要跟着变），不缩窗口、不动滚动位置；
- 瓦片带 `data-gallery-tile-id` 锚点，窗口宽度变过（转屏、缩窗口）导致 masonry 重排后也能停在原来那批图上。

## 加载体验（用户反馈：滑到底有黑屏等图）

- `PosterImage` 新增按需开启的脉冲占位，图廊瓦片开启；底部加载条加转圈。
- 图廊提前一屏半取下一页（`WallLoadMore` 的 `rootMargin` 可配，海报墙维持 600px）。
- 一面墙一个共享 `IntersectionObserver` 观察瓦片本体，提前一屏半把图切 `eager` —— 瓦片带 `content-visibility:auto` 时原生懒加载要等瓦片解除跳过（约半屏前）才发第一个请求，这是"黑一块"的根因。
- 新增 `gallery-tile` 派生预设（长边 720）：图廊宽松密度原先直吃原图，相册墙敢这么做是因为图片库的墙图本来就是 720 缩略图，图廊的源却是 w1280 剧照与本地刮削原件。
- 灯箱主图改走 `photo-screen`（2048、不放大），不再直出原件 —— 与图片库灯箱同一口径。

## 性能

瓦片位置拆成基本类型、点击回调收敛到稳定引用，`memo` 才真的生效：关闭分组时，追加一页或翻一次收藏不再让整墙几千个瓦片重渲染。

## 测试

- `tests/api/test_library_items.py::test_items_carry_viewer_favorite`：按哨兵单元写库、从墙上读回，并验证换个成员看同一面墙不亮心；
- 图廊接口测试补收藏态断言；派生预设测试补 720 档（不裁切、不放大）与 `set(_PRESETS) == set(ImageVariant)` 守卫（以后加枚举漏配尺寸会在这里挡下，而不是线上 KeyError 500）；
- `list_library_items` 现在要主体，15 处直接调用的测试补 `principal=_ADMIN`（沿用 `test_chapter_images.py` 的写法）。

本地：相关后端测试、`tsc --noEmit`、eslint、`node --test`（379）全绿。`test_library_item_detail.py` 有两个失败（`probe_pending_count` 与本地刮削），干净 worktree 上同样失败，本机缺 ffprobe 所致，与本次改动无关。

## 没做的

界面上的心只在图廊灯箱可点；海报墙和瓦片上是纯标识。派生图预热（扫描后后台预生成缩略图）另议 —— 先看图片缓存的实际占用与 `IMAGE_CACHE_MAX_MB` 是否需要调大，否则热完就被 LRU 淘汰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
