### PR TITLE
fix(release): 手动触发通道补一个本地 tag，解除 v0.22.0 发版的 goreleaser 阻塞

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,16 +158,36 @@ jobs:
       - name: 导出内嵌基线 spec
         run: scripts/export-spec.sh
 
+      # 手动触发通道里 tag 要等 draft 转正才真正创建，checkout 里没有它。
+      # goreleaser 不只是「校验」tag，它还要读 tag 的内容（annotation）来填
+      # 发布元数据：--skip=validate 关不掉这一步。2.18.0 读不到时只是警告
+      # 「couldn't find any tags before ...」后继续，2.18.1 起改成硬失败
+      # （couldn't get tag contents: unexpected git tag output for "vX.Y.Z": ""），
+      # v0.22.0 的发版就是这么红的——version: "~> v2" 是浮动的，同一份工作流
+      # 换个月跑就换了行为。这里补一个只存在于 runner 本地、绝不推送的
+      # annotated tag，让两条通道对 goreleaser 呈现同一个 git 状态：不再依赖
+      # goreleaser 对「tag 不存在」的容忍度。tag 推送通道里 tag 已存在，
+      # 这步自然跳过。
+      - name: 补一个本地 tag（手动触发通道里 tag 尚未创建）
+        run: |
+          if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" > /dev/null; then
+            echo "tag $RELEASE_TAG 已存在（tag 推送通道），无需补"
+          else
+            echo "在 $GITHUB_SHA 上补本地 tag $RELEASE_TAG（不推送）"
+            git -c user.email=actions@github.com -c user.name=github-actions \
+              tag -a "$RELEASE_TAG" -m "$RELEASE_TAG" "$GITHUB_SHA"
+          fi
+
       - name: 构建六平台产物
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
           workdir: cli
-          # --skip=validate：手动触发通道里 tag 要等 draft 转正才真正创建，
-          # goreleaser 的 tag/HEAD 校验必挂；脏区与版本一致性已由上一步和
-          # build-release-artifacts.sh 显式把关。上传不走 goreleaser
-          # （GitHub API 按 tag 查不到 draft，goreleaser 会另建一个 Release），
-          # 由下一步用 gh 上传——gh 能按 tag 名找到草稿。
+          # --skip=validate：手动触发通道里 HEAD 与 tag 的关系不满足 goreleaser
+          # 的期待，脏区与版本一致性已由上一步和 build-release-artifacts.sh
+          # 显式把关。上传不走 goreleaser（GitHub API 按 tag 查不到 draft，
+          # goreleaser 会另建一个 Release），由下一步用 gh 上传——gh 能按
+          # tag 名找到草稿。
           args: release --clean --skip=validate
         env:
           GORELEASER_CURRENT_TAG: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
## 现象

v0.22.0 的发版（[release run #25](https://github.com/movieclaw/movieclaw/actions/runs/34103580906)）在 `cli` 作业红了，Release 停在 draft：

```
⨯ release failed after 0s
  error=couldn't get tag contents: unexpected git tag output for "v0.22.0": ""
```

失败在 goreleaser 的 **getting and validating git state**，`--skip=validate` 之后。

## 根因：goreleaser 版本漂移

手动触发通道（`release-kick` → `workflow_dispatch`）里 tag 要等 draft 转正才真正创建，所以 checkout 里根本没有 `v0.22.0`。goreleaser 不只是「校验」tag，它还要**读 tag 的内容（annotation）**来填发布元数据 —— 这一步 `--skip=validate` 关不掉。

| | v0.21.0（成功） | v0.22.0（失败） |
|---|---|---|
| goreleaser | **2.18.0** | **2.18.1** |
| tag 缺席时 | 警告 `couldn't find any tags before "v0.21.0"` 后继续 | 硬失败 `couldn't get tag contents` |

`version: "~> v2"` 是浮动的 —— 同一份工作流换个月跑就换了行为。所以这不是 flake，重跑必然同样红。

## 改法

与其去追 goreleaser 对「tag 不存在」的容忍度，不如**让两条通道对它呈现同一个 git 状态**：跑 goreleaser 之前，若 tag 不存在就在 `GITHUB_SHA` 上补一个 annotated tag。

- 只存在于 runner 本地，**绝不推送**；与 draft 转正时创建的那个 tag 同名、同提交
- tag 推送通道里 tag 本就存在，这步自然跳过（幂等，重跑安全）
- 不动 `version: "~> v2"`：钉版本只是把问题推到下一次升级

顺带把 `--skip=validate` 那段注释改准 —— 它此前写的是「tag/HEAD 校验必挂」，而真正关不掉的恰恰是读 tag 内容这一步。

## 验证

本地用**真实的 goreleaser 2.18.1** + main HEAD `d3948a63`（无 `v0.22.0` tag，与 CI 处境一致）：

**修复前 —— 原样复现：**
```
• getting and validating git state
⨯ release failed after 0s   error=couldn't get tag contents: unexpected git tag output for "v0.22.0": ""
```

**补上本地 tag 后 —— 越过该步进入 before hooks：**
```
• getting and validating git state
  • using tags        previous=<unknown> current=v0.22.0
  • pipe skipped or partially skipped   reason=validation is disabled
• parsing tag
• setting defaults
• running before hooks
```
（本地跑到 before hook 就停了，因为沙箱没装 FastAPI 依赖；CI 的上一步会装。`previous=<unknown>` 是我这份 clone 是 shallow、tag 不可达导致的，与本改动无关。）

另外：新增那一步的 shell 逻辑两条分支（tag 缺席 / 已存在）各演练一次，结果符合预期；`release.yml` 的 YAML 解析通过。

## 硬约束核对

- 版本号未动（`0.22.0` 已在 main 上，本 PR 不碰）
- 只改 `.github/workflows/release.yml`，不触碰运行时依赖，**不需要 bump `docker/runtime-version`**
- 无迁移、无 `data/` 新目录

## 合入后

到 Actions → release 重跑整个 [run #25](https://github.com/movieclaw/movieclaw/actions/runs/34103580906) 即可 —— 所有上传都带 `--clobber`，安全重入；`release-artifacts` 会把 draft 的 target 校正到新的 main HEAD。docker 镜像那两个作业上一轮已经成功推送，重跑会用同一批标签覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7D3sFAnAaeFrdcfauFxtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7D3sFAnAaeFrdcfauFxtX)_