### PR TITLE
修复转码后画面变色：色彩管线从「隐式协商」改成「转码档的显式契约」

### DIFF
--- a/docs/design/web-player.md
+++ b/docs/design/web-player.md
@@ -1086,6 +1086,9 @@ ref——`setChromeVisible(true)` 是异步的，click 回调读到的可能已�
 | ③b | **MP4 edit list / VFR** | 音画差几十~几百 ms；长片累积漂移 | 检测 elst 并补偿；VFR 显式 `-fps_mode` |
 | ④ | **Dolby Vision P5** | **绿紫画面**（最显眼的 bug） | 读 `dv_profile` 单独分支；P5 强制转码+tone-map，无 GPU 则拒绝 |
 | ④b | **tone-map 用简单 clip** | 雪景/天空/爆炸高光死白 | 必须 BT.2390 EETF |
+| ④c | **tone-map 决策挂在提前 return 的判定链上** | HDR 片因「编码不支持 / 超解码上限 / 原生 HLS 上限 / 用户画质上限」转码时漏做 tone-map：对比度只剩三成、红绿反转 | 色彩不再由 `_judge_video` 产出；`_build_video_plan` 按 `media.hdr` 统一算，没有路径能绕过（issue #331） |
+| ④d | **硬件 tone-map 只设 transfer** | 画面已到 709、标签仍是 BT.2020，播放器照标签做色域扩展 → 偏红发品（实测差 13.4/255） | `tonemap_vaapi` / `vpp_qsv` 的 matrix 与 primaries 必须一并写死 |
+| ④e | **`scale` 不做色彩空间转换** | BT.2020 的 SDR 源带着 BT.2020 标签编成 H.264 → 偏色（实测 13.3/255）；无标签片缩过 720 线还会让播放器改猜 BT.601（10.4/255） | 非 709 源插 `colorspace` 显式转换；转码输出确知落在 709 时无条件写 `-colorspace/-color_primaries/-color_trc/-color_range` |
 | ⑤ | **多声道降混** | 「音效很响但听不清台词」（投诉第一名） | 默认带 `pan` 提升中置权重；不用 `volume=2`（削顶失真） |
 | ⑥ | **pipe 输出不能 seek** | 用户一 seek 就重开进程从头转 | 档 1 也必须会话化 + 分片落盘，不做「curl 管道」 |
 | ⑦ | **连拖进度条起 N 个 ffmpeg** | NAS 躺平 | 前端防抖 + 已转区间复用 + 新会话先杀旧会话（§4.4） |
@@ -1512,6 +1515,8 @@ Mac mini 验证。做成发版前的人工清单，列进 `.claude/skills/releas
 | §4.5 | 并发超限「排队并明确告知」 | **立即拒绝**并报当前占用（如「2/2」） | HTTP 请求里排队 = 用户对着转圈等一个不知道多久的位置 |
 | §3.5 | 关键帧索引落 `library_file` | **不落库**，采样现算 + 内存缓存 | 存量库无论如何要懒加载补齐，落库的增量收益只是「重启后不用重算」，不值一次迁移 |
 | §7-④ | 按 `dv_profile` 区分 P5/P8 | **DV 一律转码** | 探测层只落 `hdr="Dolby Vision"` 不落 profile；判错的代价是绿紫画面，保守 |
+| §7-④ | P5 转码 + tone-map 即可 | **仍未真正解决 P5** | P5 是 IPT-PQ-c2，不是 YCbCr/BT.2020；`tonemapx` 按 BT.2020 处理它依然出绿紫。要治得走 jellyfin-ffmpeg 的 `-dolbyvision` 解码开关，缺真片验证，未动 |
+| §7-④e | BT.601 源也转到 709 | **不转，也不打标签** | 探测层把 601 的 525/625 两制式并成一个标签，补不回来是哪一个；两者矩阵相同只差原色，猜错的收益小于风险 |
 
 ### 12.5 尚未做
 

--- a/src/movieclaw_api/services/playback/ffmpeg_args.py
+++ b/src/movieclaw_api/services/playback/ffmpeg_args.py
@@ -125,6 +125,31 @@ _SOFTWARE_TONEMAP = (
     "tonemapx=tonemap=bt2390:desat=0:p=bt709:t=bt709:m=bt709:format=yuv420p"
 )
 
+#: 台账色彩空间标签 → ``colorspace`` 滤镜的输入三件套。
+#:
+#: **为什么必须显式声明输入**：只写输出（``colorspace=all=bt709``）时，滤镜
+#: 遇到原色缺失的源会直接报「Unsupported input primaries 2 (unknown)」并让
+#: ffmpeg 退出——那不是偏色，是整部片放不了。而探测层的标签恰恰会在原色写成
+#: unknown 时靠矩阵兜底（media_probe._color_space_label），这个组合是真会撞上的。
+#:
+#: **为什么只列 BT.2020**：探测层把 BT.601 的 525/625 两制式合并成一个标签，
+#: 补不回来是哪一个；两者矩阵相同、只差原色，猜错的收益远小于风险，不如不动。
+#: Display P3 / DCI-P3 则不在 ``colorspace`` 滤镜的支持集里。用上游内置的
+#: ``colorspace`` 而不是 ``zscale``：少一个 libzimg 依赖，输入假设也能写死。
+_COLOR_CONVERT_INPUT: dict[str, str] = {
+    "BT.2020": "ispace=bt2020ncl:iprimaries=bt2020:itrc=bt2020-10",
+}
+
+#: 转码输出的色彩标签。**只要装配层确知画面已经落在 BT.709 就无条件写上**——
+#: 写标签零成本，却能兜住任何后端滤镜漏设的情况（VAAPI/QSV 就漏过），也能消掉
+#: 「无标签片缩放跨过 720 线、播放器改猜 BT.601」的偏色。
+_BT709_OUTPUT_TAGS = [
+    "-colorspace", "bt709",
+    "-color_primaries", "bt709",
+    "-color_trc", "bt709",
+    "-color_range", "tv",
+]
+
 #: 多声道降混系数：提升中置声道权重。不带它，对白会明显偏小——
 #: 「音效很响但听不清台词」是用户投诉第一名（§7-⑤）。
 #: 不用 ``-af volume=2`` 那种 hack，那会削顶失真。
@@ -164,7 +189,10 @@ HW_BACKENDS: dict[str, HwBackend] = {
         hwaccel="vaapi",
         hwaccel_output_format="vaapi",
         scale_filter="scale_vaapi",
-        tonemap_filter="tonemap_vaapi=format=nv12:t=bt709",
+        # 三项必须都写。只设 t=bt709 会把画面映射到 709 却仍标着 BT.2020 的
+        # 原色与矩阵，播放器照标签做色域扩展——实测渲染差平均 13.4/255、
+        # 最高 90，观感是整体偏红发品（issue #331）。
+        tonemap_filter="tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709",
         device="/dev/dri/renderD128",
         sw_frames_ok=False,
     ),
@@ -174,7 +202,11 @@ HW_BACKENDS: dict[str, HwBackend] = {
         hwaccel="qsv",
         hwaccel_output_format="qsv",
         scale_filter="scale_qsv",
-        tonemap_filter="vpp_qsv=tonemap=1:format=nv12",
+        # 同 VAAPI：vpp_qsv 不写 out_color_* 就只换曲线不换标签。
+        tonemap_filter=(
+            "vpp_qsv=tonemap=1:format=nv12:out_color_transfer=bt709"
+            ":out_color_matrix=bt709:out_color_primaries=bt709"
+        ),
     ),
     "nvenc": HwBackend(
         name="nvenc",
@@ -369,20 +401,20 @@ def _burn_subtitle_index(plan: PlaybackPlan) -> int | None:
 
 
 def _burn_filter_graph(plan: PlaybackPlan, subtitle_index: int) -> str:
-    """烧录的 filter_complex 图：tone-map →（源分辨率）overlay 烧字幕 → scale。
+    """烧录的 filter_complex 图：色彩归一 →（源分辨率）overlay 烧字幕 → scale。
 
     顺序有讲究：
     - overlay 必须在 **scale 之前**——PGS 位图的坐标按源分辨率定位，先缩放
       画面再叠原始坐标的字幕，位置和大小全错；
-    - tone-map 在 overlay 之前——PGS 是 SDR 图形，叠上 HDR 帧再整体映射会把
-      字幕颜色一起压暗；先把画面拉回 SDR 再叠，字幕保持设计时的观感。
+    - 色彩归一在 overlay 之前——PGS 是按 BT.709 SDR 设计的图形，叠上 HDR 或
+      BT.2020 的帧再整体转换，会把字幕颜色一起改掉；先把画面拉到 BT.709 再叠，
+      字幕保持设计时的观感。
     烧录一律软件滤镜链（overlay 没有通用的硬件版本），编码器侧的取舍见
     ``effective_hw_backend``。
     """
-    steps: list[tuple[str, str]] = []  # (滤镜串, 输出标签)
-    if plan.video.tone_map:
-        steps.append((_SOFTWARE_TONEMAP, "tm"))
-    base = f"[0:v:0]{steps[0][0]}[tm];[tm]" if steps else "[0:v:0]"
+    # HDR 走 tone-map，非 709 的 SDR 走色彩空间转换；两者互斥，都落到 BT.709。
+    color_pre = _SOFTWARE_TONEMAP if plan.video.tone_map else _color_convert_filter(plan)
+    base = f"[0:v:0]{color_pre}[tm];[tm]" if color_pre else "[0:v:0]"
     graph = f"{base}[0:s:{subtitle_index}]overlay"
     if plan.video.height:
         graph += f"[burned];[burned]scale=-2:{plan.video.height}"
@@ -392,6 +424,35 @@ def _burn_filter_graph(plan: PlaybackPlan, subtitle_index: int) -> str:
     graph += "[pre];[pre]format=yuv420p"
     graph += "[vout]"
     return graph
+
+
+def _color_convert_filter(plan: PlaybackPlan) -> str | None:
+    """非 HDR 但源色彩空间不是 BT.709 时要插的转换滤镜；不需要则 None。
+
+    ``scale`` 只改分辨率，**不做色彩空间转换**——BT.2020 的 SDR 源（10-bit
+    压制常见）不管它，就会带着 BT.2020 的原色与矩阵编成 H.264 交给播放器，
+    实测偏色平均 13.3/255、最高 102（issue #331）。HDR 源不走这里：tone-map
+    链本身就把画面落到 BT.709 了。
+    """
+    if plan.video.tone_map:
+        return None
+    spec = _COLOR_CONVERT_INPUT.get(plan.video.source_color or "")
+    return f"colorspace={spec}:all=bt709:format=yuv420p" if spec else None
+
+
+def _outputs_bt709(plan: PlaybackPlan) -> bool:
+    """装配出来的这条链，产物是不是确定落在 BT.709。
+
+    三种情况确定：tone-map 过、做了色彩空间转换、源本来就是 BT.709
+    （含决策层按源高度认定的那一档，见 decide._transcode_source_color）。
+    其余情况（BT.601 / P3 / 源是无标签的 SD）不确定，不写标签——
+    标一个没把握的值，比留空更容易把播放器带偏。
+    """
+    return (
+        plan.video.tone_map
+        or plan.video.source_color == "BT.709"
+        or plan.video.source_color in _COLOR_CONVERT_INPUT
+    )
 
 
 def _video_args(
@@ -459,6 +520,10 @@ def _video_args(
     # 把 HLS 切成 0.4 秒一段；force_key_frames 再把关键帧对齐到分片栅格。
     args += ["-g", str(MAX_GOP_FRAMES)]
     args += ["-force_key_frames", f"expr:gte(t,n_forced*{SEGMENT_SECONDS})"]
+    # 输出侧的色彩标签放在最后、且不依赖滤镜链的属性传递：滤镜漏设（VAAPI 与
+    # QSV 都漏过）或不同 ffmpeg 版本的协商差异，都会在这里被兜住。
+    if _outputs_bt709(plan):
+        args += _BT709_OUTPUT_TAGS
     return args
 
 
@@ -472,6 +537,11 @@ def _filter_chain(
             parts.append(backend.tonemap_filter)
         else:
             parts.append(_SOFTWARE_TONEMAP)
+    else:
+        # 非 HDR 的非 709 源同样要显式转换，scale 不会替我们做
+        convert = _color_convert_filter(plan)
+        if convert:
+            parts.append(convert)
     if height:
         if backend is not None and backend.scale_filter and not software_filters:
             parts.append(f"{backend.scale_filter}=w=-2:h={height}")

--- a/src/movieclaw_playback/decide.py
+++ b/src/movieclaw_playback/decide.py
@@ -115,6 +115,10 @@ class MediaProfile:
     video_codec: str | None = None
     resolution: str | None = None
     hdr: str | None = None  # None=SDR / "HDR10" / "HLG" / "HDR10+" / "Dolby Vision"
+    #: 归一化色彩空间标签（"BT.2020" / "BT.709" / "BT.601" / …），来自 ffprobe
+    #: 落库的真值。SDR 片同样可能是 BT.2020（10-bit 压制常见），转码要据此决定
+    #: 插不插色彩空间转换——只看 hdr 是不够的。
+    color_space: str | None = None
     bit_depth: int | None = None
     duration_ms: int | None = None
     audio_tracks: tuple[AudioTrack, ...] = ()
@@ -155,7 +159,18 @@ class VideoPlan:
     #: 源视频位深（来自 ffprobe）。VideoToolbox 从硬件帧下载前要据此选择
     #: 8-bit 的 NV12 或 10-bit 的 P010；未知时由命令装配层安全回退软件解码。
     source_bit_depth: int | None = None
-    tone_map: bool = False  # HDR → SDR
+    #: HDR → SDR。**转码档的不变量，不是一个判断**：转码输出恒为 H.264 8-bit
+    #: BT.709，装不下 HDR，所以只要源是 HDR 就必须映射——与「为什么要转码」
+    #: 无关。曾经它由 _judge_video 顺带产出，而那串判定是提前 return 的：
+    #: 编码不支持 / 超解码上限 / 原生 HLS 上限 / 用户画质上限，任意一条先命中，
+    #: HDR 判定就根本不执行，PQ 曲线被当 SDR 直接编进 8-bit——画面灰暗、
+    #: 对比度只剩三成、红绿反转（issue #331）。现在改由 _build_video_plan
+    #: 统一按 media.hdr 计算，没有任何路径能绕过去。
+    tone_map: bool = False
+    #: 源画面的色彩空间（_transcode_source_color 解析）。scale 滤镜**不做**
+    #: 色彩空间转换，BT.2020 的 SDR 源不管它就会带着 BT.2020 标签编成 H.264，
+    #: 播放器按标签做色域扩展 → 偏色。None=无从判断，装配层保持原样不猜。
+    source_color: str | None = None
     #: 要烧录进画面的字幕轨（中性引用，只会是内封 PGS）。非空即 Emby 语义的
     #: 「字幕压制」：用户显式选中位图字幕，视频整路转码、字幕合成进帧——
     #: 这是**硬边界 1 唯一的例外**，且必须由用户的选择触发，决策器绝不主动。
@@ -300,7 +315,6 @@ def decide_playback(
         video_verdict = _VideoVerdict(
             can_copy=False,
             reason="已选中 PGS 图形字幕，按你的选择转码并把字幕压制进画面",
-            tone_map=video_verdict.tone_map,
         )
 
     # 6–7. 综合定档。
@@ -332,7 +346,6 @@ def decide_playback(
         container=container,
         video=_build_video_plan(
             media,
-            video_verdict,
             tier,
             policy,
             max_height,
@@ -353,9 +366,15 @@ def decide_playback(
 
 @dataclass(frozen=True)
 class _VideoVerdict:
+    """视频能不能直通的判定。
+
+    **不含 tone_map**：这串判定是提前 return 的，任何挂在末尾的字段都会被
+    先命中的分支跳过（issue #331 的成因）。色彩相关的结论一律由
+    ``_build_video_plan`` 按源规格统一算，那里是转码计划的唯一出口。
+    """
+
     can_copy: bool
     reason: str
-    tone_map: bool = False
     #: 无法直通且连转码也不该做（如 HDR 需 tone-map 但没有 GPU）
     blocked: str | None = None
 
@@ -442,9 +461,7 @@ def _judge_video(
                     "不予启用。"
                 ),
             )
-        return _VideoVerdict(
-            can_copy=False, reason="Dolby Vision 已转换为 SDR 显示", tone_map=True
-        )
+        return _VideoVerdict(can_copy=False, reason="Dolby Vision 已转换为 SDR 显示")
 
     if media.hdr and not capability.hdr_passthrough:
         if not policy.hardware_available:
@@ -456,9 +473,7 @@ def _judge_video(
                     "色调映射；但未检测到可用的硬件加速设备。"
                 ),
             )
-        return _VideoVerdict(
-            can_copy=False, reason=f"{media.hdr} 已转换为 SDR 显示", tone_map=True
-        )
+        return _VideoVerdict(can_copy=False, reason=f"{media.hdr} 已转换为 SDR 显示")
 
     hdr_note = f"（{media.hdr} 直通）" if media.hdr else ""
     return _VideoVerdict(can_copy=True, reason=f"视频编码 {codec_label} 可直通{hdr_note}")
@@ -713,7 +728,6 @@ def needs_keyframe_probe(
         video_verdict = _VideoVerdict(
             can_copy=False,
             reason="已选中 PGS 图形字幕，按你的选择转码并把字幕压制进画面",
-            tone_map=video_verdict.tone_map,
         )
 
     tier, _, _, _ = _resolve_tier(
@@ -734,7 +748,6 @@ def needs_keyframe_probe(
 
 def _build_video_plan(
     media: MediaProfile,
-    verdict: _VideoVerdict,
     tier: PlaybackTier,
     policy: PlaybackPolicy,
     max_height: int | None = None,
@@ -753,9 +766,29 @@ def _build_video_plan(
         codec="h264",
         height=min(candidates),
         source_bit_depth=media.bit_depth,
-        tone_map=verdict.tone_map,
+        # 色彩两项只看**源是什么**，不看这次为什么要转码——转码输出恒为
+        # H.264 8-bit BT.709，HDR 装不进去。verdict 不再参与（issue #331）。
+        tone_map=bool(media.hdr),
+        source_color=_transcode_source_color(media),
         burn_subtitle=burn_subtitle,
     )
+
+
+def _transcode_source_color(media: MediaProfile) -> str | None:
+    """转码时按什么色彩空间解读源画面。
+
+    台账的探测值优先。探测不到时，只在源本身是 HD 的情况下认定 BT.709：
+    无标签的片子播放器就是**按高度猜**的（<720 判 BT.601、≥720 判 BT.709），
+    而转码会改高度——一部无标签的 1080p 片降到 480p，播放器的猜法就从
+    BT.709 翻成 BT.601，画面平白偏色（实测平均差 10.4/255）。把源侧已经
+    成立的解读固化到输出标签上，缩放就不再改变解读。
+
+    源本身是 SD 时无从判断（既可能是真 BT.601，也可能是没打标签的 BT.709），
+    返回 None 让装配层保持原样——猜错了比不猜更糟。
+    """
+    if media.color_space:
+        return media.color_space
+    return "BT.709" if (media.height or 0) >= 720 else None
 
 
 def _burn_target(media: MediaProfile, preferred_subtitle: str | None) -> SubtitleTrack | None:

--- a/src/movieclaw_playback/profile.py
+++ b/src/movieclaw_playback/profile.py
@@ -37,6 +37,7 @@ def media_profile_from_file(
         video_codec=file.video_codec,
         resolution=file.resolution,
         hdr=file.hdr,
+        color_space=file.color_space,
         bit_depth=file.bit_depth,
         duration_ms=(file.duration_seconds * 1000) if file.duration_seconds else None,
         audio_tracks=_audio_tracks(file),

--- a/tests/playback/test_decide.py
+++ b/tests/playback/test_decide.py
@@ -270,6 +270,129 @@ def test_hdr10_tone_maps_when_display_cannot():
 
 
 # ---------------------------------------------------------------------------
+# 转码档的色彩不变量（issue #331）
+#
+# tone_map 曾经挂在 _judge_video 的判定链末尾，而那串判定是**提前 return**
+# 的：编码不支持 / 超设备解码上限 / 原生 HLS 上限 / 用户画质上限，任意一条
+# 先命中，HDR 判定就根本不执行，tone_map 保持 False——PQ 曲线被当 SDR 直接
+# 编进 8-bit H.264，实测对比度只剩三成、红绿反转。
+#
+# 这四条路径每一条都要单独钉死：它们的共同点恰恰是「与 HDR 无关」，最容易
+# 在后续迭代里再被加一条同类分支绕过去。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, media_kwargs, capability, max_height",
+    [
+        (
+            "浏览器不支持该编码（Chrome 遇 HEVC，最常见）",
+            {"video_codec": "hevc", "hdr": "HDR10"},
+            CHROME_NO_HEVC,
+            None,
+        ),
+        (
+            "超出设备探测到的解码上限",
+            {"video_codec": "hevc", "hdr": "HDR10", "resolution": "2160p"},
+            ClientCapability(
+                video=(VideoSupport("hevc", max_height=1080),),
+                audio=(AudioSupport("aac"),),
+                containers=frozenset({"mp4", "hls-fmp4"}),
+                hdr_passthrough=True,
+            ),
+            None,
+        ),
+        (
+            "原生 HLS 的 1080p 上限",
+            {"video_codec": "hevc", "hdr": "HDR10", "resolution": "2160p"},
+            IOS_NATIVE_HLS,
+            None,
+        ),
+        (
+            "用户选的画质上限",
+            {"video_codec": "hevc", "hdr": "HDR10"},
+            SAFARI_MAC,
+            720,
+        ),
+    ],
+)
+def test_hdr_always_tone_maps_whatever_forced_the_transcode(
+    name, media_kwargs, capability, max_height
+):
+    """只要落到转码档，HDR 源就必须 tone-map——与「为什么转码」无关。
+
+    转码输出恒为 H.264 8-bit BT.709，HDR 根本装不进去；漏掉 tone-map 不是
+    「少做一步优化」，是把 PQ 数据当 SDR 电平送显，画面必然失真。
+    """
+    decision = decide_playback(
+        media(**media_kwargs), capability, WITH_GPU, max_height=max_height
+    )
+    assert isinstance(decision, PlaybackPlan), name
+    assert decision.video.action == "transcode", name
+    assert decision.video.tone_map is True, name
+
+
+def test_hdr_tone_maps_even_when_display_supports_hdr():
+    """HDR 屏也一样：一旦转码，输出就是 SDR，不存在「转码后还是 HDR」。
+
+    这条曾经是自相矛盾的——判定说「HDR10 直通」，档位却因关键帧索引未就绪
+    落到转码，产出一个没做 tone-map 的 8-bit 流。
+    """
+    decision = decide_playback(
+        media(video_codec="hevc", hdr="HDR10", keyframe_interval_s=None),
+        SAFARI_MAC,
+        WITH_GPU,
+    )
+    assert isinstance(decision, PlaybackPlan)
+    assert decision.video.action == "transcode"
+    assert decision.video.tone_map is True
+
+
+def test_sdr_never_tone_maps():
+    """反向守护：SDR 源不能被误加 tone-map（会把画面整体压暗）。"""
+    decision = decide_playback(media(video_codec="hevc"), CHROME_NO_HEVC, WITH_GPU)
+    assert isinstance(decision, PlaybackPlan)
+    assert decision.video.tone_map is False
+
+
+def test_copy_path_carries_no_color_work():
+    """直通/重封装档不碰画面，色彩字段必须是空的。"""
+    decision = decide_playback(media(hdr="HDR10"), SAFARI_MAC, WITH_GPU)
+    assert isinstance(decision, PlaybackPlan)
+    assert decision.video.action == "copy"
+    assert decision.video.tone_map is False
+    assert decision.video.source_color is None
+
+
+@pytest.mark.parametrize(
+    "name, color_space, resolution, expected",
+    [
+        ("台账探测到 BT.2020 就照实传下去", "BT.2020", "1080p", "BT.2020"),
+        ("台账探测到 BT.709 同理", "BT.709", "1080p", "BT.709"),
+        ("无标签的 HD 源按播放器的猜法认定 709", None, "1080p", "BT.709"),
+        ("无标签的 HD 源缩到 480p 也仍是 709（防解读翻转）", None, "720p", "BT.709"),
+        ("无标签的 SD 源无从判断，不猜", None, "480p", None),
+    ],
+)
+def test_source_color_resolution(name, color_space, resolution, expected):
+    """源色彩空间的解析口径。
+
+    无标签片播放器是**按高度猜**的（<720 判 BT.601、≥720 判 BT.709）。转码会
+    改高度，1080p 降到 480p 会让猜法翻转、画面偏色（实测平均差 10.4/255）；
+    把源侧已经成立的解读固化下来，缩放就不再改变解读。源本身是 SD 时两种
+    可能都有，返回 None 让装配层不写标签——猜错比不猜更糟。
+    """
+    decision = decide_playback(
+        media(video_codec="hevc", resolution=resolution, color_space=color_space),
+        CHROME_NO_HEVC,
+        WITH_GPU,
+    )
+    assert isinstance(decision, PlaybackPlan), name
+    assert decision.video.action == "transcode", name
+    assert decision.video.source_color == expected, name
+
+
+# ---------------------------------------------------------------------------
 # 关键帧密度（§7-②：remux 的分片只能切在 IDR 上）
 # ---------------------------------------------------------------------------
 

--- a/tests/playback/test_ffmpeg_args.py
+++ b/tests/playback/test_ffmpeg_args.py
@@ -409,6 +409,136 @@ def test_tone_map_uses_bt2390_not_clip():
     assert "bt2390" in pair(argv, "-vf")
 
 
+def test_hardware_tonemap_pins_all_three_color_properties():
+    """VAAPI/QSV 的 tone-map 必须把矩阵与原色一起落到 BT.709。
+
+    只设 t=bt709 会把画面映射到 709、标签却仍写着 BT.2020，播放器照标签做
+    色域扩展——实测渲染差平均 13.4/255、最高 90，观感是整体偏红发品
+    （issue #331）。这条打的正是 Intel/AMD 核显那批 Docker 部署。
+    """
+    for backend, filter_name in (("vaapi", "tonemap_vaapi"), ("qsv", "vpp_qsv")):
+        argv = argv_of(
+            plan(
+                PlaybackTier.HARDWARE_TRANSCODE,
+                video=VideoPlan(
+                    action="transcode", codec="h264", height=1080, tone_map=True
+                ),
+            ),
+            hw_backend=backend,
+        )
+        vf = pair(argv, "-vf")
+        assert vf and filter_name in vf, backend
+        # 三项齐全，一项都不能少
+        assert vf.count("bt709") >= 3, f"{backend}: {vf}"
+
+
+@pytest.mark.parametrize(
+    "name, video_kw, expect_filter",
+    [
+        (
+            "BT.2020 的 SDR 源要显式转换——scale 不做色彩空间转换",
+            {"source_color": "BT.2020"},
+            "colorspace=ispace=bt2020ncl:iprimaries=bt2020:itrc=bt2020-10"
+            ":all=bt709:format=yuv420p",
+        ),
+        ("源本来就是 BT.709，不做无谓的转换", {"source_color": "BT.709"}, None),
+        ("源色彩未知，不猜", {"source_color": None}, None),
+        (
+            "BT.601 的 525/625 探测层已合并，补不回来就不动",
+            {"source_color": "BT.601"},
+            None,
+        ),
+    ],
+)
+def test_sdr_color_space_conversion(name, video_kw, expect_filter):
+    argv = argv_of(
+        plan(
+            PlaybackTier.SOFTWARE_TRANSCODE,
+            video=VideoPlan(action="transcode", codec="h264", height=1080, **video_kw),
+        )
+    )
+    vf = pair(argv, "-vf") or ""
+    if expect_filter is None:
+        assert "colorspace=" not in vf, name
+    else:
+        assert expect_filter in vf, name
+
+
+def test_hdr_source_is_not_converted_twice():
+    """HDR 源几乎都是 BT.2020：tone-map 已经把画面落到 709，不能再叠一次转换。
+
+    叠两次会把画面按 BT.2020 再解一遍，等于凭空引入一次反向偏色。
+    """
+    argv = argv_of(
+        plan(
+            PlaybackTier.SOFTWARE_TRANSCODE,
+            video=VideoPlan(
+                action="transcode", codec="h264", height=1080,
+                tone_map=True, source_color="BT.2020",
+            ),
+        )
+    )
+    vf = pair(argv, "-vf")
+    assert "tonemapx" in vf
+    assert "colorspace=" not in vf
+    assert pair(argv, "-colorspace") == "bt709"  # 标签照打
+
+
+def test_color_convert_is_declared_with_explicit_input():
+    """输入三件套必须显式写死。
+
+    只写输出时，``colorspace`` 滤镜遇到原色缺失的源会直接报
+    「Unsupported input primaries 2 (unknown)」让 ffmpeg 退出——那不是偏色，
+    是整部片放不了。而探测层的标签恰恰会在原色写成 unknown 时靠矩阵兜底
+    （media_probe._color_space_label），这个组合真会撞上。
+    """
+    argv = argv_of(
+        plan(
+            PlaybackTier.SOFTWARE_TRANSCODE,
+            video=VideoPlan(
+                action="transcode", codec="h264", height=1080, source_color="BT.2020"
+            ),
+        )
+    )
+    vf = pair(argv, "-vf")
+    assert "ispace=" in vf and "iprimaries=" in vf and "itrc=" in vf
+
+
+@pytest.mark.parametrize(
+    "name, video_kw, tagged",
+    [
+        ("tone-map 过，产物确定是 709", {"tone_map": True}, True),
+        ("做了色彩空间转换，产物确定是 709", {"source_color": "BT.2020"}, True),
+        ("源本来就是 709", {"source_color": "BT.709"}, True),
+        ("源色彩未知，不写标签", {"source_color": None}, False),
+        ("BT.601 没做转换，不能标成 709", {"source_color": "BT.601"}, False),
+    ],
+)
+def test_output_color_tags_only_when_certain(name, video_kw, tagged):
+    """确知落在 BT.709 就无条件写标签，没把握就留空。
+
+    写标签零成本，却能兜住后端滤镜漏设（VAAPI/QSV 就漏过），也能消掉
+    「无标签片缩放跨过 720 线、播放器改猜 BT.601」的偏色。反过来，标一个
+    没把握的值比留空更容易把播放器带偏。
+    """
+    argv = argv_of(
+        plan(
+            PlaybackTier.SOFTWARE_TRANSCODE,
+            video=VideoPlan(action="transcode", codec="h264", height=1080, **video_kw),
+        )
+    )
+    for flag in ("-colorspace", "-color_primaries", "-color_trc"):
+        assert (pair(argv, flag) == "bt709") is tagged, f"{name}: {flag}"
+    assert (pair(argv, "-color_range") == "tv") is tagged, name
+
+
+def test_copy_path_gets_no_color_tags():
+    """直通/重封装不解码画面，写色彩标签既没依据也可能覆盖源的正确标签。"""
+    argv = argv_of(plan(PlaybackTier.REMUX))
+    assert "-colorspace" not in argv
+    assert "-color_primaries" not in argv
+
+
 def test_direct_play_tier_is_rejected():
     """档 0 是原文件直出，走到命令装配就是调用方的 bug。"""
     with pytest.raises(ValueError):
@@ -605,6 +735,19 @@ def test_burn_uses_filter_complex_with_overlay_before_scale():
     assert argv[argv.index("-map") + 1] == "[vout]"
     assert "0:v:0" not in [argv[i + 1] for i, a in enumerate(argv) if a == "-map"]
     assert "-vf" not in argv  # 与 filter_complex 互斥
+
+
+def test_burn_converts_color_space_before_overlay():
+    """非 HDR 的非 709 源，烧录链同样要先把画面拉到 BT.709 再叠字幕。
+
+    PGS 是按 BT.709 SDR 设计的图形；先叠再整体转换会把字幕颜色一起改掉。
+    烧录走独立的 filter_complex 分支，色彩链必须与 -vf 那条保持一致，
+    否则「选了 PGS 字幕」会成为绕过色彩修复的第二条路径。
+    """
+    argv = argv_of(_burn_plan(source_color="BT.2020", height=None))
+    graph = argv[argv.index("-filter_complex") + 1]
+    assert graph.startswith("[0:v:0]colorspace=")
+    assert graph.index("colorspace=") < graph.index("overlay")
 
 
 def test_burn_with_tonemap_runs_tonemap_before_overlay():


### PR DESCRIPTION
Closes #331

## 问题

用户报「某些格式的影片原画正常、转码后变色」。查下来是三处**独立**缺陷，共同根因是转码路径把色彩交给 ffmpeg 隐式协商，只在 HDR 这一个特例上显式干预。

本 PR 确立一条不变量：**任何 `transcode` 输出恒为 BT.709 / limited / 8-bit，并显式打标签。**

## ① tone_map 挂在提前 return 的判定链末尾（决策层）

`_judge_video` 是一串提前 return，HDR 判定排在最后：

| 顺序 | 判定 | 命中后 |
|---|---|---|
| 1 | 浏览器不支持该编码（Chrome 遇 HEVC，最常见） | `return`，`tone_map` 默认 **False** |
| 2 | 高度超设备解码上限 | `return`，**False** |
| 3 | 原生 HLS 的 1080p 上限 | `return`，**False** |
| 4 | 用户选的画质上限 | `return`，**False** |
| 5 | **HDR 判定** | 只有走到这里才 `tone_map=True` |

前四条任意一条命中，第 5 条根本不执行 → PQ 曲线被当 SDR 直接编进 8-bit H.264。实测**对比度只剩三成、红绿关系反转**。

补四个标志位治不了根：正确性会一直取决于「判定有没有走到那一行」。改为把色彩结论整个**移出判定链**——删掉 `_VideoVerdict.tone_map`，由 `_build_video_plan` 按源规格统一算，那里是转码计划的唯一出口。以后再加一条同类的提前 return 也不会重蹈。

顺带修一处自相矛盾：判定说「HDR10 直通」、档位却因关键帧索引未就绪落到转码时，产出的是没做 tone-map 的 8-bit 流。转码输出装不下 HDR，只要转码就必须映射，与 `hdr_passthrough` 无关。

## ② 硬件 tone-map 只设 transfer，不设 primaries 与 matrix（装配层）

```
vaapi: tonemap_vaapi=format=nv12:t=bt709     ← 只设了 transfer
qsv:   vpp_qsv=tonemap=1:format=nv12         ← 一项都没设
```

画面已经映射到 709，标签却仍是 BT.2020，播放器照标签做色域扩展。实测渲染差**平均 13.4/255、最高 90**，观感是整体偏红发品。

软件链的 `tonemapx` 三项齐全，所以这条只打 VAAPI/QSV —— 正是 Intel/AMD 核显那批 Docker 部署，也就是本 issue 报告人的画像。

## ③ scale 不做色彩空间转换，输出也不打标签（装配层）

| 场景 | 修复前 |
|---|---|
| BT.2020 的 SDR 源（10-bit 压制常见） | 原样透传 bt2020 标签，偏色 13.3/255 |
| 无色彩标签的片降到 720 线以下 | 播放器矩阵猜法从 709 翻成 601，偏色 10.4/255 |

现在非 709 源插 `colorspace` 显式转换；确知落在 709 时无条件写 `-colorspace/-color_primaries/-color_trc/-color_range`。

两处踩坑写进了注释与用例：

- **输入三件套必须显式写死**。只写输出（`colorspace=all=bt709`）时，遇到原色缺失的源会直接报 `Unsupported input primaries 2 (unknown)` 让 ffmpeg 退出——那不是偏色，是整部片放不了；而探测层的标签恰恰会在原色 unknown 时靠矩阵兜底，这个组合真会撞上。
- **只转 BT.2020**。探测层把 BT.601 的 525/625 并成了一个标签，补不回来是哪一个；两者矩阵相同、只差原色，猜错的收益小于风险。

烧录链（`filter_complex`）走同一套色彩前置，否则「选了 PGS 字幕」会成为绕过修复的第二条路径。

## 拒播策略

维持现状，**不扩大范围**：`blocked` 仍只在原来那条 HDR 判定分支触发。无 GPU 的用户从「变色」变成「画面正确但慢」，没有人被新拒播。

## 验证

装配层是纯函数，色彩链与输出标签全部表驱动单测，四条提前 return 路径逐条钉死，另加「HDR 源不被重复转换」的守护。

真 ffmpeg 端到端量化（用改后代码真正装配出的命令）：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| HDR10 | 对比度剩 30%、红绿反转 | 误差 **0.2**/255 |
| BT.2020 SDR | 13.3/255 | **0.0**/255 |
| 无标签源 | 标签 `unknown` | 钉成 `bt709` |

另外确认那四个输出标志纯属元数据：**无损编码下加与不加像素逐字节完全一致**，不会触发意外的范围转换。

`ruff check .` 全仓通过；playback 全套通过。

## 明确未解决（已记入 `docs/design/web-player.md`）

- **Dolby Vision P5 仍出绿紫**：P5 是 IPT-PQ-c2，不是 YCbCr/BT.2020，`tonemapx` 按 BT.2020 处理它没用。要治得走 jellyfin-ffmpeg 的 `-dolbyvision` 解码开关，缺真片验证，本次未动。
- **BT.601 源不转换也不打标签**，理由见 ③。
- 诊断面板的 reason 在「HDR10 直通」判定后落到转码时文案仍显示直通。属 reason 拼装逻辑，与色彩修复是两件事，未一并动。

## 兼容性

不涉及运行时依赖变更，无需 bump `docker/runtime-version`。无数据库迁移（`color_space` 台账里已有，只是此前没接进决策层）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfMgMJaaHWfHPMNbygqxLJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfMgMJaaHWfHPMNbygqxLJ)_