### PR TITLE
灯箱两侧补一对翻页键，只给有鼠标的设备

### DIFF
--- a/apps/web/components/zoom-lightbox.tsx
+++ b/apps/web/components/zoom-lightbox.tsx
@@ -3,7 +3,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
-import { MinusIcon, PlusIcon, XIcon } from "@/components/icons";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MinusIcon,
+  PlusIcon,
+  XIcon,
+} from "@/components/icons";
 
 /**
  * 可缩放的全屏灯箱内核（docs/design/library-photo-kind.md 3.3）。
@@ -28,8 +34,11 @@ import { MinusIcon, PlusIcon, XIcon } from "@/components/icons";
  *     iOS 不派发 dblclick，舞台又必须 touch-action:none 挡住系统的整页缩放，
  *     交给浏览器的话手机上放大缩小就全无反应；
  *   - 翻页：未放大时左右拖拽 / 滑动，画面跟手移动，松手超过阈值翻页、不够弹回，
- *     鼠标与手指同一套；触控板横向两指滑同样翻页；键盘 ←→。舞台两侧不放
- *     箭头按钮——常驻的控件叠在画面上打破沉浸感，翻页动作本身已经够直觉。
+ *     鼠标与手指同一套；触控板横向两指滑同样翻页；键盘 ←→。舞台两侧另有一对
+ *     箭头按钮，**只给有鼠标的设备**：手指滑动是连续、跟手的，鼠标拖拽翻页却
+ *     要按住横拖 70px，远不如点一下直接（用户反馈 2026-09-07）；触屏上照旧
+ *     不摆，滑动已经是全部手势。箭头跟顶栏底栏同进同退（点画面收起控件后
+ *     画面仍独占整个视口），到头的那一侧不渲染——按不动的按钮不如不摆。
  *     翻到已加载列表末尾且服务端还有下一页时向外要一页（onReachEnd），
  *     拿到后继续翻；
  *   - 缩略条只渲染当前位置前后各 30 张：万张库不铺满 DOM。
@@ -588,6 +597,43 @@ export function ZoomLightbox({
         {/* 浮层跟着控件一起收放：只剩一块信息面板浮在画面上很怪 */}
         {chromeShown && overlay}
       </div>
+
+      {/* 舞台两侧的翻页键：只给有鼠标的设备（触屏上左右滑动就是全部手势），
+          与顶栏底栏同进同退。放在舞台之外，点它不会被当成舞台上的点按；
+          到头的那一侧不渲染 */}
+      {[
+        {
+          delta: -1,
+          enabled: index > 0,
+          label: "上一张 (←)",
+          Icon: ChevronLeftIcon,
+          side: "left-[max(0.75rem,var(--safe-left))]",
+        },
+        {
+          delta: 1,
+          enabled: index < slides.length - 1 || hasMore,
+          label: "下一张 (→)",
+          Icon: ChevronRightIcon,
+          side: "right-[max(0.75rem,var(--safe-right))]",
+        },
+      ].map(({ delta, enabled, label, Icon, side }) =>
+        enabled ? (
+          <div
+            key={delta}
+            className={`absolute top-1/2 z-20 -translate-y-1/2 [@media(hover:none)]:hidden ${side} ${chromeClass}`}
+          >
+            <button
+              type="button"
+              title={label}
+              aria-label={label}
+              onClick={() => step(delta)}
+              className="grid place-items-center rounded-full bg-white/[0.08] p-2.5 text-white/80 backdrop-blur transition-colors hover:bg-white/[0.18] hover:text-white"
+            >
+              <Icon className="size-6" />
+            </button>
+          </div>
+        ) : null,
+      )}
 
       {/* 顶栏：计数 + 标题 + 工具。渐变垫底让白字压在亮图上也读得清；
           容器不吃指针事件，只有右侧那组按钮吃 */}


### PR DESCRIPTION
## 为什么

移动端左右滑动翻页跟手、连续，鼠标上却要按住横拖 70px（`SWIPE_THRESHOLD`）才翻一页，比点一下麻烦得多。文件头注释里原来那条「舞台两侧不放箭头按钮」的决策只在触屏上成立，桌面端需要一个直接的前后切换。

## 改了什么

只动灯箱内核 `apps/web/components/zoom-lightbox.tsx`，图片库瀑布流灯箱（`PhotoLightbox`）、影视库图廊灯箱（`VideoGallery`）、章节图灯箱（`ChapterStrip`）三处共用它，一起生效。

- **只给有鼠标的设备**：`[@media(hover:none)]:hidden`，与底栏那组缩放控件同一条规矩——触屏上滑动已是全部手势，摆常驻按钮只占画面。
- **「如有」才出现**：左键 `index > 0`，右键 `index < slides.length - 1 || hasMore`；到头的那一侧不渲染，不摆按不动的灰按钮。末尾还有下一页时保留，点它照旧走 `onReachEnd` 要下一页再翻。
- **跟顶栏底栏同进同退**：复用 `chromeClass`，点画面收起控件后箭头一起淡出，收起后画面仍独占整个视口。
- **放在舞台元素之外**：不经过舞台的 pointer 判定，点箭头不会被当成「点画面收放控件」，也不会掺进单击 / 双击那套判定。
- 样式与位置沿用搜索页 `ImageLightbox` 已有的两侧箭头（半透明圆钮 + backdrop-blur，垂直居中，左右留 `max(0.75rem, safe-area)`），`title` / `aria-label` 标了「上一张 (←)」「下一张 (→)」。

顺带把文件头注释里那条旧决策记录改成现在的做法与理由。

## 验证

- `npx tsc --noEmit`：无错误
- `pnpm lint`：0 error（两条 warning 在 `library-item-detail-view.tsx`、`lib/player/subtitles.ts`，本次未触及）
- `pnpm test`：378/379 通过；唯一失败的 `test/time.test.mjs` 是既有的时区依赖（用例假定 UTC+8，容器是 UTC，`TZ=Asia/Shanghai` 下全绿），与本次改动无关

纯前端展示层改动，不涉及运行时依赖、数据库迁移与 `data/` 目录，无需 bump `docker/runtime-version`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2jAQzNEDp2j9DSN5Pkiyi


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2jAQzNEDp2j9DSN5Pkiyi)_