### PR TITLE
播放进度修七处 bug，并新增横滑拖进度手势

### DIFF
--- a/apps/web/components/player/player-controls.tsx
+++ b/apps/web/components/player/player-controls.tsx
@@ -414,7 +414,11 @@ export function PlayerControls(props: PlayerControlsProps) {
             // （见下方圆点注释），手指永远按不中——表现为拖动时圆点不跟手、
             // 松手 seek 到的是按下点。setPointerCapture 让移出条外也不断跟。
             onPointerDown={(e) => {
-              if (!durationMs) return;
+              // 只认主指针的主键起手。不挡的话右键点进度条会**当场 seek**
+              // 再弹出上下文菜单（中键同理），而右键的意图从来不是跳转；
+              // 触屏上第二根手指落在条上也会顶掉第一根正在进行的拖动。
+              // 触摸/笔的主接触点 button 恒为 0，这条不会误伤它们。
+              if (!durationMs || e.button !== 0 || !e.isPrimary) return;
               e.currentTarget.setPointerCapture(e.pointerId);
               const rect = e.currentTarget.getBoundingClientRect();
               const ratio = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));

--- a/apps/web/components/player/player-controls.tsx
+++ b/apps/web/components/player/player-controls.tsx
@@ -430,10 +430,23 @@ export function PlayerControls(props: PlayerControlsProps) {
               if (dragging !== null) onSeek(dragging);
               setDragging(null);
             }}
+            // 手势被系统收走时浏览器**只发 pointercancel、不再发 pointerup**：
+            // 进度条贴着屏幕最底边，正压在 iOS 的 Home 指示条上滑区里，拖到
+            // 边上一带就会被系统当成返回桌面的起手式；通知中心下拉、第二根
+            // 手指落下同理。不接这条的话 dragging 会永远停在最后一个拖动值
+            // 上——进度点和时间从此钉死在那儿不再跟画面走，而画面照常播，
+            // 中央的退进十秒/快捷键还能把画面跳走却带不动进度条，直到下一次
+            // 完整拖拽把它清掉才「自己好了」。
+            // 取消的手势**不提交** seek：用户没松手确认过这个位置，退回
+            // positionMs 才是真值。
+            onPointerCancel={() => setDragging(null)}
             onKeyUp={() => {
               if (dragging !== null) onSeek(dragging);
               setDragging(null);
             }}
+            // 键盘拖动（方向键改 range 的值走 onChange）对称的一条：焦点离开
+            // 时那次键盘调整已经结束，没等到 keyup 就不能让它继续遮着 positionMs
+            onBlur={() => setDragging(null)}
             // 触屏把命中带加高到 44px（Apple HIG 的最小触控目标）：视觉上还是
             // 那条细线，但手指按在线的上下 20px 内都算按中了——竖屏上「滑不准、
             // 按不中」的直接解法。桌面维持 20px，不跟鼠标抢悬停区。

--- a/apps/web/components/player/video-player.tsx
+++ b/apps/web/components/player/video-player.tsx
@@ -70,10 +70,12 @@ import type { TrickplayIndex } from "@/lib/player/trickplay";
 import { isEditableTarget, resolveShortcut } from "@/lib/player/shortcuts";
 import {
   type AdjustKind,
+  type SwipeIntent,
   EDGE_GUARD_PX,
   applySwipe,
+  classifyIntent,
   classifyTouchZone,
-  isVerticalIntent,
+  seekDeltaMs,
   toLayoutPoint,
 } from "@/lib/player/touch-adjust";
 import type { SubtitleStyle } from "@/lib/player/subtitles";
@@ -85,6 +87,7 @@ import {
 } from "@/lib/player/subtitles";
 import {
   clampSeekTarget,
+  formatClock,
   isInEndCredits,
   planSeek,
   toFileMs,
@@ -343,6 +346,13 @@ export function VideoPlayer(props: VideoPlayerProps) {
     hide: null,
     gone: null,
   });
+  /** 横滑拖进度时的落点读数。手势期间常显，松手/取消后淡出 */
+  const [seekPreview, setSeekPreview] = useState<{
+    targetMs: number;
+    deltaMs: number;
+    leaving: boolean;
+  } | null>(null);
+  const seekPreviewTimerRef = useRef<number | null>(null);
 
   /**
    * 弹出/刷新调节胶囊，并重排它的退场：每次调用都把「0.9 秒后开始淡出、
@@ -394,6 +404,29 @@ export function VideoPlayer(props: VideoPlayerProps) {
     }, 800);
   }, []);
 
+  /**
+   * 横滑拖进度的落点胶囊。
+   *
+   * 与亮度/音量胶囊不同，它**没有自动退场计时**：手势没结束就该一直挂着，
+   * 手指停在半路时读数消失会让人以为手势断了。退场由 `hideSeekPreview` 在
+   * 松手/取消时显式触发。
+   */
+  const showSeekPreview = useCallback((targetMs: number, deltaMs: number) => {
+    if (seekPreviewTimerRef.current !== null) {
+      window.clearTimeout(seekPreviewTimerRef.current);
+      seekPreviewTimerRef.current = null;
+    }
+    setSeekPreview({ targetMs, deltaMs, leaving: false });
+  }, []);
+
+  const hideSeekPreview = useCallback(() => {
+    setSeekPreview((prev) => (prev ? { ...prev, leaving: true } : prev));
+    seekPreviewTimerRef.current = window.setTimeout(() => {
+      seekPreviewTimerRef.current = null;
+      setSeekPreview(null);
+    }, 180);
+  }, []);
+
   /** 一次性文字提示（顶部胶囊，与调节读数同视觉）；给「画中画被系统拒绝」
    * 这类**本来会静默失败**的操作一个出口——用户分不清「没反应」和「被拒绝」
    * 是最难排查的一类反馈。 */
@@ -428,6 +461,9 @@ export function VideoPlayer(props: VideoPlayerProps) {
       ]) {
         if (timers.hide !== null) window.clearTimeout(timers.hide);
         if (timers.gone !== null) window.clearTimeout(timers.gone);
+      }
+      if (seekPreviewTimerRef.current !== null) {
+        window.clearTimeout(seekPreviewTimerRef.current);
       }
     },
     [],
@@ -544,6 +580,8 @@ export function VideoPlayer(props: VideoPlayerProps) {
     if (state.session?.timeline === "file") return videoDurationMs;
     return sessionId ? null : videoDurationMs;
   }, [resume?.duration_ms, state.session?.timeline, sessionId, videoDurationMs]);
+  const durationMsRef = useRef<number | null>(null);
+  durationMsRef.current = durationMs;
 
   const subtitles = useMemo(() => {
     const session = state.session;
@@ -1527,6 +1565,10 @@ export function VideoPlayer(props: VideoPlayerProps) {
     [video, sessionId, mode, durationMs, state.session, state.phase, state.startMs],
   );
 
+  /** 供触摸手势回调读最新值：跟着依赖重绑 touch 监听会在手势中途换掉监听器 */
+  const seekToFileMsRef = useRef(seekToFileMs);
+  seekToFileMsRef.current = seekToFileMs;
+
   // 上下界都由 seekToFileMs 里的 clampSeekTarget 收住，这里不再各夹一次
   const seekBy = useCallback(
     (seconds: number) => seekToFileMs(positionRef.current + seconds * 1000),
@@ -1929,16 +1971,28 @@ export function VideoPlayer(props: VideoPlayerProps) {
   }, []);
 
   // ---------------------------------------------------------------------
-  // 触屏滑动调节：左半屏亮度、右半屏音量（分区/映射/换算在 touch-adjust.ts）
+  // 触屏滑动手势：竖滑调亮度/音量（左半屏亮度、右半屏音量），横滑拖进度
+  // （分区、方向裁决、换算都在 touch-adjust.ts）
   // ---------------------------------------------------------------------
 
-  /** 进行中的滑动手势；active 前只是「手指放上来了」，竖直位移过门槛才生效 */
-  const adjustGestureRef = useRef<{
+  /**
+   * 进行中的滑动手势。
+   *
+   * `intent` 为 null = 只是「手指放上来了」，位移过门槛后一次性裁决方向，
+   * 到松手为止不再改判——中途改判会让一次手势前半段调音量、后半段拖进度。
+   */
+  const swipeGestureRef = useRef<{
+    /** 竖滑调哪一个量（由起手落在左半还是右半屏决定） */
     kind: AdjustKind;
     startX: number;
     startY: number;
+    /** 竖滑起点的亮度/音量 */
     startValue: number;
-    active: boolean;
+    /** 横滑起点的播放位置（文件毫秒） */
+    startPositionMs: number;
+    intent: SwipeIntent | null;
+    /** 横滑当前算出的落点；松手才提交，中途只喂胶囊 */
+    targetMs: number;
   } | null>(null);
   /** 音量能不能调：null=还没探完；不可调 = iOS（WebKit 只认硬件侧键）。 */
   const volumeAdjustableRef = useRef<boolean | null>(null);
@@ -1972,26 +2026,30 @@ export function VideoPlayer(props: VideoPlayerProps) {
     if (!video) return;
     const onTouchStart = (event: TouchEvent) => {
       if (event.touches.length !== 1) {
-        adjustGestureRef.current = null;
+        swipeGestureRef.current = null;
         return;
       }
       const touch = event.touches[0];
+      // 排除带（顶部通知中心起手区、底部进度条、左右缘返回手势）对三种手势
+      // 一视同仁：横滑同样不能在贴着进度条的地方起手，否则与拖进度条打架。
       const kind = classifyTouchZone(touch.clientX, touch.clientY, {
         width: window.innerWidth,
         height: window.innerHeight,
         fakeLandscape: fakeLandscapeRef.current,
       });
       if (!kind) return;
-      adjustGestureRef.current = {
+      swipeGestureRef.current = {
         kind,
         startX: touch.clientX,
         startY: touch.clientY,
         startValue: kind === "brightness" ? brightnessRef.current : video.volume,
-        active: false,
+        startPositionMs: positionRef.current,
+        intent: null,
+        targetMs: positionRef.current,
       };
     };
     const onTouchMove = (event: TouchEvent) => {
-      const gesture = adjustGestureRef.current;
+      const gesture = swipeGestureRef.current;
       if (!gesture || event.touches.length !== 1) return;
       const touch = event.touches[0];
       const viewport = {
@@ -1999,15 +2057,39 @@ export function VideoPlayer(props: VideoPlayerProps) {
         height: window.innerHeight,
         fakeLandscape: fakeLandscapeRef.current,
       };
+      // 一律换算到**布局**坐标：伪横屏是容器转了 90°，用户觉得自己在横划，
+      // 物理上是竖着划的——直接用事件坐标会把两种手势对调。
       const start = toLayoutPoint(gesture.startX, gesture.startY, viewport);
       const now = toLayoutPoint(touch.clientX, touch.clientY, viewport);
-      if (!gesture.active) {
-        if (!isVerticalIntent(now.x - start.x, now.y - start.y)) return;
-        gesture.active = true;
+      const deltaX = now.x - start.x;
+      const deltaY = now.y - start.y;
+      if (!gesture.intent) {
+        const intent = classifyIntent(deltaX, deltaY);
+        if (!intent) return;
+        if (intent === "horizontal" && !durationMsRef.current) {
+          // 片长未知就没有落点可算（那时进度条本身也是禁用的）。整根手指
+          // 作废而不是回落到调音量：用户明明在横划，半路改判成调音量比
+          // 「什么都没发生」更费解。
+          swipeGestureRef.current = null;
+          return;
+        }
+        gesture.intent = intent;
       }
       // 生效后接管这根手指：不让它同时滚动页面/触发下拉刷新
       event.preventDefault();
-      const value = applySwipe(gesture.kind, gesture.startValue, now.y - start.y, now.height);
+      if (gesture.intent === "horizontal") {
+        // 滑动中**只更新胶囊、不 seek**：每次 move 都跳会让服务端一路杀
+        // ffmpeg 重启（seek 走的就是那条路），画面永远追不上手指。与进度条
+        // 拖拽同一套语义，松手才提交一次。
+        const target = clampSeekTarget(
+          gesture.startPositionMs + seekDeltaMs(deltaX, now.width),
+          durationMsRef.current,
+        );
+        gesture.targetMs = target;
+        showSeekPreview(target, target - gesture.startPositionMs);
+        return;
+      }
+      const value = applySwipe(gesture.kind, gesture.startValue, deltaY, now.height);
       if (gesture.kind === "brightness") {
         setBrightness(value);
         flashAdjust({ kind: "brightness", value });
@@ -2026,14 +2108,27 @@ export function VideoPlayer(props: VideoPlayerProps) {
         flashAdjust({ kind: "volume", value: video.volume, unsupported: true });
       }
     };
-    // 退场由 flashAdjust 自己排（每次 move 都会顺延），松手清掉手势；
-    // 音量手势松手后复核一次「赋的值是否真的留住了」——挂载探测万一误判
-    // 可调（WebKit 行为随版本漂），这里能把结论纠回来，下一次滑动就会
-    // 如实提示由侧键控制
-    const onTouchEnd = () => {
-      const gesture = adjustGestureRef.current;
-      adjustGestureRef.current = null;
-      if (!gesture?.active || gesture.kind !== "volume") return;
+    /**
+     * 手势收尾。`commit` 区分抬手与被打断：
+     *
+     * - 抬手（touchend）= 用户认了这个落点，横滑在这里提交唯一那次 seek；
+     * - 打断（touchcancel，系统手势/来电/第二根手指）= **不提交**，与进度条
+     *   拖拽被取消时同一条规矩——用户没抬手确认过这个位置。
+     *
+     * 亮度/音量没有「提交」一说（滑动中已经实时生效），两条路都只是收尾。
+     * 音量手势收尾时复核一次「赋的值是否真的留住了」——挂载探测万一误判
+     * 可调（WebKit 行为随版本漂），这里能把结论纠回来，下一次滑动就会如实
+     * 提示由侧键控制。
+     */
+    const finishGesture = (commit: boolean) => {
+      const gesture = swipeGestureRef.current;
+      swipeGestureRef.current = null;
+      if (gesture?.intent === "horizontal") {
+        if (commit) seekToFileMsRef.current(gesture.targetMs);
+        hideSeekPreview();
+        return;
+      }
+      if (gesture?.intent !== "vertical" || gesture.kind !== "volume") return;
       if (volumeAdjustableRef.current === false) return;
       const expected = video.volume;
       window.setTimeout(() => {
@@ -2042,17 +2137,19 @@ export function VideoPlayer(props: VideoPlayerProps) {
         }
       }, 300);
     };
+    const onTouchEnd = () => finishGesture(true);
+    const onTouchCancel = () => finishGesture(false);
     video.addEventListener("touchstart", onTouchStart, { passive: true });
     video.addEventListener("touchmove", onTouchMove, { passive: false });
     video.addEventListener("touchend", onTouchEnd);
-    video.addEventListener("touchcancel", onTouchEnd);
+    video.addEventListener("touchcancel", onTouchCancel);
     return () => {
       video.removeEventListener("touchstart", onTouchStart);
       video.removeEventListener("touchmove", onTouchMove);
       video.removeEventListener("touchend", onTouchEnd);
-      video.removeEventListener("touchcancel", onTouchEnd);
+      video.removeEventListener("touchcancel", onTouchCancel);
     };
-  }, [video, flashAdjust]);
+  }, [video, flashAdjust, showSeekPreview, hideSeekPreview]);
 
   /** 播放中申请防息屏。切到后台会被系统收走，回来时重新申请。 */
   useEffect(() => {
@@ -2323,6 +2420,35 @@ export function VideoPlayer(props: VideoPlayerProps) {
                   <span className="tnum w-9 text-right">{Math.round(adjust.value * 100)}%</span>
                 </>
               )}
+            </div>
+          </div>
+        ) : null}
+
+        {/* 横滑拖进度的落点读数。放**画面正中**：手指在画面上滑，读数就跟在
+            眼睛看的地方，不必再去够底边那条进度条（各家手机播放器同此）。
+            大字是落点、小字是相对起点的增量——只给落点的话，用户不知道自己
+            这一划到底走了多远，也就没法凭手感修正。 */}
+        {seekPreview ? (
+          <div
+            {...{ noautohide: "" }}
+            className="pointer-events-none absolute left-1/2 top-1/2 z-30 -translate-x-1/2 -translate-y-1/2"
+          >
+            <div
+              className={`flex flex-col items-center gap-1.5 rounded-2xl bg-black/70 px-6 py-3.5 text-white shadow-[0_10px_28px_rgba(0,0,0,0.45)] ${
+                seekPreview.leaving ? "player-flash-out" : "player-flash-in"
+              }`}
+            >
+              <p className="tnum text-[24px] font-semibold leading-none max-md:text-[22px]">
+                {formatClock(seekPreview.targetMs)}
+                <span className="text-[15px] font-normal text-white/45">
+                  {" / "}
+                  {durationMs ? formatClock(durationMs) : "--:--"}
+                </span>
+              </p>
+              <p className="tnum text-[13px] leading-none text-white/70">
+                {seekPreview.deltaMs < 0 ? "−" : "+"}
+                {formatClock(Math.abs(seekPreview.deltaMs))}
+              </p>
             </div>
           </div>
         ) : null}

--- a/apps/web/components/player/video-player.tsx
+++ b/apps/web/components/player/video-player.tsx
@@ -33,6 +33,7 @@ import { type AutoplayOutcome, attemptAutoplay, shouldAttemptAutoplay } from "@/
 import { getCapabilitySnapshot } from "@/lib/player/capability";
 import type { PlaybackEngine } from "@/lib/player/engine";
 import { createEngine, preloadHlsEngine } from "@/lib/player/engine";
+import { bufferedAhead } from "@/lib/player/stall";
 import {
   awaitsUserDecision,
   initialPlayerState,
@@ -924,10 +925,11 @@ export function VideoPlayer(props: VideoPlayerProps) {
     const onTimeUpdate = () => {
       if (!isCurrentSession()) return;
       setPositionMs(toFileMs(video.currentTime, startMsRef.current));
-      const ranges = video.buffered;
-      setBufferedEndMs(
-        ranges.length ? toFileMs(ranges.end(ranges.length - 1), startMsRef.current) : null,
-      );
+      // 只认**播放头所在**那段连续缓冲，不能取 buffered 的最后一段：往回拖
+      // 之后旧的前向缓冲还挂在时间轴后面（back buffer 只回收播放头之后 30
+      // 秒以前的部分，拖回去之后那一段落在播放头**前方**，不会被回收），
+      // 取最后一段会让浅色底一路铺到一小时开外，而那里根本没有连着的数据。
+      setBufferedEndMs(toFileMs(video.currentTime + bufferedAhead(video), startMsRef.current));
     };
     // 「现在应该能播了」的两个时机：挂流那一次可能太早，这两次是补刀
     const onReady = () => {
@@ -1460,6 +1462,22 @@ export function VideoPlayer(props: VideoPlayerProps) {
   const seekToFileMs = useCallback(
     (fileMs: number) => {
       if (!video) return;
+      // 会话正在重开的空档（换音轨 / 换画质 / 心跳自愈 / 上一次 seek 换流）：
+      // video 上已经没有流了，native seek 打在空元素上什么也不会发生，而在途
+      // 的新会话仍会落回 pendingFileMs 那个**旧**位置——用户看到进度条跳过去
+      // 又自己弹回来，这一拖白拖。改走换会话这条路：restart 递增 attempt 顶掉
+      // 在途的那次请求，新会话直接从目标位置起。
+      // 报错页与同意弹窗同样没有会话，但它们是等用户拍板的终态（见
+      // machine.ts 的 awaitsUserDecision），绝不能在背后替他换流。
+      if (!state.session) {
+        // startMs 为 null = 首次起播，起点还等着服务端按观看状态定（§6.10）。
+        // 那一刻按下的快进键不该把续播点顶掉，让它照旧落空。
+        if (!isBusy(state.phase) || state.startMs === null) return;
+        pendingFileMsRef.current = fileMs;
+        setPositionMs(fileMs);
+        dispatch({ type: "restart", startMs: fileMs });
+        return;
+      }
       const seekable = video.seekable;
       const plan = planSeek(fileMs, {
         startMs: startMsRef.current,
@@ -1488,7 +1506,7 @@ export function VideoPlayer(props: VideoPlayerProps) {
       setPositionMs(plan.startMs);
       dispatch({ type: "restart", startMs: plan.startMs });
     },
-    [video, sessionId, mode],
+    [video, sessionId, mode, state.session, state.phase, state.startMs],
   );
 
   const seekBy = useCallback(

--- a/apps/web/components/player/video-player.tsx
+++ b/apps/web/components/player/video-player.tsx
@@ -83,7 +83,13 @@ import {
   planSubtitleTracks,
   saveSubtitleStyle,
 } from "@/lib/player/subtitles";
-import { isInEndCredits, planSeek, toFileMs, toSessionSeconds } from "@/lib/player/timeline";
+import {
+  clampSeekTarget,
+  isInEndCredits,
+  planSeek,
+  toFileMs,
+  toSessionSeconds,
+} from "@/lib/player/timeline";
 
 /**
  * 网页播放器（docs/design/web-player.md §6）。
@@ -922,14 +928,18 @@ export function VideoPlayer(props: VideoPlayerProps) {
             : null,
         );
     };
+    // 只认**播放头所在**那段连续缓冲，不能取 buffered 的最后一段：往回拖
+    // 之后旧的前向缓冲还挂在时间轴后面（back buffer 只回收播放头之后 30
+    // 秒以前的部分，拖回去之后那一段落在播放头**前方**，不会被回收），
+    // 取最后一段会让浅色底一路铺到一小时开外，而那里根本没有连着的数据。
+    const onBuffered = () => {
+      if (!isCurrentSession()) return;
+      setBufferedEndMs(toFileMs(video.currentTime + bufferedAhead(video), startMsRef.current));
+    };
     const onTimeUpdate = () => {
       if (!isCurrentSession()) return;
       setPositionMs(toFileMs(video.currentTime, startMsRef.current));
-      // 只认**播放头所在**那段连续缓冲，不能取 buffered 的最后一段：往回拖
-      // 之后旧的前向缓冲还挂在时间轴后面（back buffer 只回收播放头之后 30
-      // 秒以前的部分，拖回去之后那一段落在播放头**前方**，不会被回收），
-      // 取最后一段会让浅色底一路铺到一小时开外，而那里根本没有连着的数据。
-      setBufferedEndMs(toFileMs(video.currentTime + bufferedAhead(video), startMsRef.current));
+      onBuffered();
     };
     // 「现在应该能播了」的两个时机：挂流那一次可能太早，这两次是补刀
     const onReady = () => {
@@ -944,6 +954,10 @@ export function VideoPlayer(props: VideoPlayerProps) {
     video.addEventListener("ended", onEnded);
     video.addEventListener("durationchange", onDurationChange);
     video.addEventListener("timeupdate", onTimeUpdate);
+    // 缓冲条不能只跟 timeupdate：暂停时它根本不发，而 hls.js 照样在往前缓，
+    // 浅色底就一直停在按下暂停的那一刻，看不出还要等多久才能接着放。
+    // progress 是「又收到数据了」的通知，暂停期间照发。
+    video.addEventListener("progress", onBuffered);
     video.addEventListener("loadedmetadata", onReady);
     video.addEventListener("canplay", onReady);
     return () => {
@@ -955,6 +969,7 @@ export function VideoPlayer(props: VideoPlayerProps) {
       video.removeEventListener("ended", onEnded);
       video.removeEventListener("durationchange", onDurationChange);
       video.removeEventListener("timeupdate", onTimeUpdate);
+      video.removeEventListener("progress", onBuffered);
       video.removeEventListener("loadedmetadata", onReady);
       video.removeEventListener("canplay", onReady);
     };
@@ -1460,8 +1475,11 @@ export function VideoPlayer(props: VideoPlayerProps) {
    * 换会话，干等 ffmpeg 追上来只会让用户看着永远转不完的圈。
    */
   const seekToFileMs = useCallback(
-    (fileMs: number) => {
+    (rawFileMs: number) => {
       if (!video) return;
+      // 先夹进片长之内：越过片尾的落点会让换会话那条路开出一个转不出任何
+      // 东西的会话（理由见 timeline.ts 的 clampSeekTarget）。
+      const fileMs = clampSeekTarget(rawFileMs, durationMs);
       // 会话正在重开的空档（换音轨 / 换画质 / 心跳自愈 / 上一次 seek 换流）：
       // video 上已经没有流了，native seek 打在空元素上什么也不会发生，而在途
       // 的新会话仍会落回 pendingFileMs 那个**旧**位置——用户看到进度条跳过去
@@ -1506,11 +1524,12 @@ export function VideoPlayer(props: VideoPlayerProps) {
       setPositionMs(plan.startMs);
       dispatch({ type: "restart", startMs: plan.startMs });
     },
-    [video, sessionId, mode, state.session, state.phase, state.startMs],
+    [video, sessionId, mode, durationMs, state.session, state.phase, state.startMs],
   );
 
+  // 上下界都由 seekToFileMs 里的 clampSeekTarget 收住，这里不再各夹一次
   const seekBy = useCallback(
-    (seconds: number) => seekToFileMs(Math.max(0, positionRef.current + seconds * 1000)),
+    (seconds: number) => seekToFileMs(positionRef.current + seconds * 1000),
     [seekToFileMs],
   );
 

--- a/apps/web/lib/player/shortcuts.ts
+++ b/apps/web/lib/player/shortcuts.ts
@@ -54,14 +54,18 @@ export function resolveShortcut(context: KeyContext): PlayerAction | null {
   return null;
 }
 
-/** 事件目标是不是输入控件。contentEditable 的富文本区同样算。 */
+/**
+ * 事件目标是不是**能录入文字**的控件。contentEditable 的富文本区同样算。
+ *
+ * 滑块（`input[type=range]`）明确排除：播放器里唯一的滑块就是进度条，而它
+ * 被点一下就拿走焦点。一律按「输入控件」放行的话，点过进度条之后空格不再
+ * 播放暂停、F 不全屏、M 不静音——用户只当播放器坏了，而且找不回来（焦点
+ * 一直留在那儿）。方向键更拧巴：全局的 ±5 秒被让掉，落到 range 原生的
+ * ±1 秒（step），同一个键在点条前后跳的秒数都不一样。
+ */
 export function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
-  return (
-    tag === "INPUT" ||
-    tag === "TEXTAREA" ||
-    tag === "SELECT" ||
-    target.isContentEditable
-  );
+  if (tag === "INPUT") return (target as HTMLInputElement).type !== "range";
+  return tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
 }

--- a/apps/web/lib/player/timeline.ts
+++ b/apps/web/lib/player/timeline.ts
@@ -25,6 +25,29 @@ export function toSessionSeconds(fileMs: number, startMs: number): number {
   return (fileMs - startMs) / 1000;
 }
 
+/**
+ * 跳转落点离片尾至少留出的余量（毫秒）。
+ *
+ * 一秒足够：留着的这一秒会照常播完并发 `ended`，与「跳到结尾」在观感上没有
+ * 区别；留得更多反而是把片尾生生截掉一段。
+ */
+export const SEEK_TAIL_GUARD_MS = 1000;
+
+/**
+ * 把跳转目标夹进「真的落得下去」的区间。
+ *
+ * 片尾连按快进键、或者把进度条一路拖到最右端，都会给出一个正好落在文件末尾
+ * （甚至之外）的位置。`native` 那条浏览器自己会收住，**换会话那条不会**：它
+ * 会拿这个位置去开一个 `-ss` 落在末尾的会话，ffmpeg 一帧都转不出来，用户对着
+ * 转圈一直等到分片超时。片长未知（服务端算不出、也没有元数据）时不夹——那时
+ * 进度条本来就是禁用的，只剩快捷键，越界交给浏览器收住。
+ */
+export function clampSeekTarget(targetFileMs: number, durationMs: number | null): number {
+  const floored = Math.max(0, targetFileMs);
+  if (!durationMs || durationMs <= 0) return floored;
+  return Math.min(floored, Math.max(0, durationMs - SEEK_TAIL_GUARD_MS));
+}
+
 export type SeekPlan =
   | { kind: "native"; seconds: number }
   | { kind: "restart"; startMs: number };

--- a/apps/web/lib/player/touch-adjust.ts
+++ b/apps/web/lib/player/touch-adjust.ts
@@ -1,6 +1,11 @@
 /**
- * 触屏滑动调节：左半屏上下滑调亮度、右半屏上下滑调音量（移动端播放器的
- * 通行手势，iOS/Android 的本地播放器与 Jellyfin/Emby 手机端皆如此）。
+ * 触屏滑动手势：竖滑调亮度/音量（左半屏亮度、右半屏音量），横滑拖进度——
+ * 移动端播放器的通行三件套，iOS/Android 的本地播放器与 Jellyfin/Emby 手机端
+ * 皆如此。
+ *
+ * 三种手势共用同一根手指，所以**方向只在位移首次过门槛时裁决一次**
+ * （`classifyIntent`），之后到松手为止都不再改判：中途改判会让一次手势前半段
+ * 调音量、后半段拖进度，用户完全无法预期自己在动哪个量。
  *
  * 平台事实决定了两件事怎么做：
  * - **亮度没有系统 API**。网页能做的是「画面亮度」，且实现必须是黑色遮罩
@@ -88,7 +93,35 @@ export function applySwipe(
   return Math.min(1, Math.max(min, next));
 }
 
-/** 这次移动算不算「有意的竖直滑动」：位移够大且明显竖直（布局坐标）。 */
-export function isVerticalIntent(layoutDeltaX: number, layoutDeltaY: number): boolean {
-  return Math.abs(layoutDeltaY) >= ACTIVATE_PX && Math.abs(layoutDeltaY) > Math.abs(layoutDeltaX);
+export type SwipeIntent = "vertical" | "horizontal";
+
+/**
+ * 这次移动算不算「有意的滑动」，是的话是哪个方向（布局坐标）。
+ *
+ * 位移不够大就返回 null——那可能只是想点一下（轻点是控制层开关）。够大之后
+ * 按主轴分：竖 = 亮度/音量，横 = 拖进度。正好 45° 归横向，与从前
+ * 「竖直要严格大于水平」的判据一致。
+ */
+export function classifyIntent(
+  layoutDeltaX: number,
+  layoutDeltaY: number,
+): SwipeIntent | null {
+  const dx = Math.abs(layoutDeltaX);
+  const dy = Math.abs(layoutDeltaY);
+  if (Math.max(dx, dy) < ACTIVATE_PX) return null;
+  return dy > dx ? "vertical" : "horizontal";
+}
+
+/**
+ * 横滑跳转的灵敏度：划过**一整屏宽** = 这么多秒。
+ *
+ * 固定秒数而不是按片长取百分比：百分比在三小时的片子上一划就是十几分钟，
+ * 停不准；90 秒是各家手机播放器的常见量级，一屏之内既够跨过片头，又能靠
+ * 短距离微调。
+ */
+export const FULL_SWEEP_SEEK_S = 90;
+
+/** 横向位移（布局坐标）→ 相对手势起点的毫秒增量。 */
+export function seekDeltaMs(layoutDeltaX: number, layoutWidth: number): number {
+  return Math.round((layoutDeltaX / Math.max(1, layoutWidth)) * FULL_SWEEP_SEEK_S * 1000);
 }

--- a/apps/web/test/player-shortcuts.test.mjs
+++ b/apps/web/test/player-shortcuts.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// isEditableTarget 用 `instanceof HTMLElement` 判类型，node 里没有 DOM。
+// 补一个同名的最小类即可——instanceof 在调用时才查全局，动态 import 放在
+// 赋值之后就能拿到它。
+class HTMLElement {
+  constructor(tagName, extra = {}) {
+    this.tagName = tagName;
+    this.isContentEditable = false;
+    Object.assign(this, extra);
+  }
+}
+globalThis.HTMLElement = HTMLElement;
+
+const { resolveShortcut, isEditableTarget } = await import("../lib/player/shortcuts.ts");
+
+test("输入框里按键一律不接管——用户在搜字幕、填备注", () => {
+  assert.equal(isEditableTarget(new HTMLElement("INPUT", { type: "text" })), true);
+  assert.equal(isEditableTarget(new HTMLElement("TEXTAREA")), true);
+  assert.equal(isEditableTarget(new HTMLElement("SELECT")), true);
+  assert.equal(isEditableTarget(new HTMLElement("DIV", { isContentEditable: true })), true);
+});
+
+test("进度条（input[type=range]）不算输入控件——点过它之后快捷键必须照常", () => {
+  // 播放器里唯一的滑块就是进度条，点一下就拿走焦点。把它当输入控件放行的
+  // 后果是空格不再播放暂停、F 不全屏、M 不静音，且焦点一直留在那儿收不回。
+  assert.equal(isEditableTarget(new HTMLElement("INPUT", { type: "range" })), false);
+});
+
+test("非元素目标（window / document）不算输入控件", () => {
+  assert.equal(isEditableTarget(null), false);
+  assert.equal(isEditableTarget({}), false);
+});
+
+test("焦点在进度条上时，方向键仍走全局的 ±5 秒", () => {
+  // 不这样的话方向键会落到 range 原生的 ±1 秒（step=1000），同一个键在
+  // 点条前后跳的秒数不一样。
+  const inEditable = isEditableTarget(new HTMLElement("INPUT", { type: "range" }));
+  assert.deepEqual(resolveShortcut({ key: "ArrowRight", inEditable }), {
+    type: "seek-by",
+    seconds: 5,
+  });
+  assert.deepEqual(resolveShortcut({ key: " ", inEditable }), { type: "toggle-play" });
+});
+
+test("带 Ctrl/Cmd/Alt 的组合放行给浏览器", () => {
+  assert.equal(resolveShortcut({ key: "f", inEditable: false, metaKey: true }), null);
+  assert.equal(resolveShortcut({ key: "ArrowLeft", inEditable: false, ctrlKey: true }), null);
+});

--- a/apps/web/test/player-timeline.test.mjs
+++ b/apps/web/test/player-timeline.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SEEK_TAIL_GUARD_MS,
+  clampSeekTarget,
+  planSeek,
+  toFileMs,
+  toSessionSeconds,
+} from "../lib/player/timeline.ts";
+
+// ---------------------------------------------------------------------------
+// 会话时间轴 ↔ 文件时间轴
+// ---------------------------------------------------------------------------
+
+test("会话相对制：文件时间 = start_ms + currentTime", () => {
+  assert.equal(toFileMs(30, 600_000), 630_000);
+  assert.equal(toSessionSeconds(630_000, 600_000), 30);
+});
+
+test("往回拖到会话起点之前，换算结果为负且不夹到 0", () => {
+  // 夹成 0 会让「拖到 20 分钟」变成静默跳回会话开头，且没有任何提示；
+  // planSeek 正是靠这个负数判断要不要换会话。
+  assert.equal(toSessionSeconds(60_000, 600_000), -540);
+});
+
+// ---------------------------------------------------------------------------
+// 跳转落点的夹紧
+// ---------------------------------------------------------------------------
+
+test("越过片尾的落点夹回片长之内，留出片尾余量", () => {
+  // 片尾连按快进、或把进度条拖到最右端都会给出这种目标。不夹的话换会话
+  // 那条路会开出一个 -ss 落在文件末尾的会话，ffmpeg 一帧都转不出来。
+  assert.equal(clampSeekTarget(7_200_000, 7_200_000), 7_200_000 - SEEK_TAIL_GUARD_MS);
+  assert.equal(clampSeekTarget(9_999_999, 7_200_000), 7_200_000 - SEEK_TAIL_GUARD_MS);
+});
+
+test("片长之内的落点原样通过", () => {
+  assert.equal(clampSeekTarget(1_800_000, 7_200_000), 1_800_000);
+});
+
+test("负数落点夹到 0——快退键在开头会一路减到负值", () => {
+  assert.equal(clampSeekTarget(-5_000, 7_200_000), 0);
+  assert.equal(clampSeekTarget(-5_000, null), 0);
+});
+
+test("片长未知时不夹：那时进度条本来就禁用，越界交给浏览器收住", () => {
+  assert.equal(clampSeekTarget(9_999_999, null), 9_999_999);
+  assert.equal(clampSeekTarget(9_999_999, 0), 9_999_999);
+});
+
+test("极短片子夹到 0 而不是负数", () => {
+  assert.equal(clampSeekTarget(900, 800), 0);
+});
+
+// ---------------------------------------------------------------------------
+// 一次 seek 该走哪条路
+// ---------------------------------------------------------------------------
+
+const session = { startMs: 600_000, seekableEndSeconds: 120, hasSession: true };
+
+test("没有会话（档 0 / VOD 全片列表）永远就地跳", () => {
+  assert.deepEqual(planSeek(7_000_000, { ...session, hasSession: false }), {
+    kind: "native",
+    seconds: 6400,
+  });
+});
+
+test("落在已转区间之内就地跳", () => {
+  assert.deepEqual(planSeek(660_000, session), { kind: "native", seconds: 60 });
+});
+
+test("拖出已转区间要换会话——干等 ffmpeg 追上来是转不完的圈", () => {
+  assert.deepEqual(planSeek(1_800_000, session), { kind: "restart", startMs: 1_800_000 });
+});
+
+test("往回拖到本次会话起点之前也要换会话", () => {
+  assert.deepEqual(planSeek(60_000, session), { kind: "restart", startMs: 60_000 });
+});
+
+test("夹紧之后的片尾落点仍落在已转区间内，不会白换一次会话", () => {
+  // 会话从 0 起、整片都已转出时，拖到最右端应当就地跳。
+  const whole = { startMs: 0, seekableEndSeconds: 7200, hasSession: true };
+  const target = clampSeekTarget(7_200_000, 7_200_000);
+  assert.deepEqual(planSeek(target, whole), { kind: "native", seconds: 7199 });
+});

--- a/apps/web/test/player-touch-adjust.test.mjs
+++ b/apps/web/test/player-touch-adjust.test.mjs
@@ -2,10 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  FULL_SWEEP_SEEK_S,
   MIN_BRIGHTNESS,
   applySwipe,
+  classifyIntent,
   classifyTouchZone,
-  isVerticalIntent,
+  seekDeltaMs,
   toLayoutPoint,
 } from "../lib/player/touch-adjust.ts";
 
@@ -54,8 +56,36 @@ test("clamp：音量下限 0，亮度下限保留一点画面", () => {
   assert.equal(applySwipe("volume", 0.9, -10_000, 844), 1);
 });
 
-test("竖直意图判定：位移要够大且明显竖直，斜划和轻点都不算", () => {
-  assert.equal(isVerticalIntent(0, -20), true);
-  assert.equal(isVerticalIntent(0, 8), false); // 不到激活门槛
-  assert.equal(isVerticalIntent(30, -20), false); // 更像横划
+test("方向裁决：位移不够大先不算数——轻点是控制层开关，不该被当成手势", () => {
+  assert.equal(classifyIntent(0, 8), null);
+  assert.equal(classifyIntent(8, 0), null);
+  assert.equal(classifyIntent(8, 8), null);
+});
+
+test("方向裁决：竖滑调亮度/音量，横滑拖进度，按主轴分", () => {
+  assert.equal(classifyIntent(0, -20), "vertical");
+  assert.equal(classifyIntent(30, -20), "horizontal");
+  assert.equal(classifyIntent(-40, 5), "horizontal");
+  // 正好 45° 归横向，与从前「竖直要严格大于水平」的判据一致
+  assert.equal(classifyIntent(20, 20), "horizontal");
+});
+
+test("横滑换算：划过一整屏宽正好是约定的秒数，方向跟着位移符号", () => {
+  assert.equal(seekDeltaMs(390, 390), FULL_SWEEP_SEEK_S * 1000);
+  assert.equal(seekDeltaMs(-390, 390), -FULL_SWEEP_SEEK_S * 1000);
+  assert.equal(seekDeltaMs(195, 390), (FULL_SWEEP_SEEK_S / 2) * 1000);
+  assert.equal(seekDeltaMs(0, 390), 0);
+});
+
+test("横滑换算：宽度为 0 不产生 Infinity/NaN", () => {
+  // 真实落点最终由 clampSeekTarget 夹进片长，这里只保证不把 NaN 传下去
+  assert.equal(Number.isFinite(seekDeltaMs(100, 0)), true);
+});
+
+test("伪横屏下横滑的位移取自布局坐标——物理上是竖着划的", () => {
+  // 用户横过来拿手机、手指从左向右划，物理上是 y 从小到大。
+  const start = toLayoutPoint(200, 100, FAKE_LANDSCAPE);
+  const now = toLayoutPoint(200, 300, FAKE_LANDSCAPE);
+  assert.equal(classifyIntent(now.x - start.x, now.y - start.y), "horizontal");
+  assert.equal(seekDeltaMs(now.x - start.x, now.width) > 0, true);
 });


### PR DESCRIPTION
起因是「拖进度条后进度点和时间不动、画面却照常播，过一会儿又自己好了」。顺着这个把播放进度／进度条控制整条链路过了一遍，一共七处，最后补上移动端横滑拖进度。

## 起因那处：拖拽被系统手势打断后，进度点与时间永久卡住

拖动中的本地值 `dragging` 只有 `pointerup` / `keyup` 两条出口。手势被系统收走时浏览器**只发 `pointercancel`、不再发 `pointerup`** —— 进度条贴着屏幕最底边，正压在 iOS 的 Home 指示条上滑区里，拖到边上一带就会被判成返回桌面的起手式；通知中心下拉、第二根手指落下同理。

缺了这条出口，`dragging` 永远停在最后一个拖动值上，而 `shown = dragging ?? positionMs` 让它把真实播放位置整个遮住：进度点和时间钉死、画面照常播、退进十秒和快捷键还能把画面跳走却带不动进度条，直到下一次完整拖拽才被清掉 —— 这就是「过一会儿又好了」。

接上 `pointercancel`（清掉但**不提交** seek，用户没松手确认过这个位置），键盘那条对称补上 `blur`。

## 同一条链路上另外六处

| | 问题 | 位置 |
|---|---|---|
| 2 | 已缓冲的浅色底取 `buffered` 的**最后**一段。往回拖之后旧的前向缓冲还挂在时间轴后面（back buffer 只回收播放头之后 30 秒以前的部分，拖回去之后那一段落在播放头**前方**，不会被回收），浅色底一路铺到一小时开外，那里根本没有连着的数据 | `video-player.tsx` 改用播放头所在的连续缓冲，与 `stall.ts` 的 `bufferedAhead` 同一口径 |
| 3 | 进度条不认指针按键：右键点它会**当场 seek** 再弹出上下文菜单，中键同样跳 | `player-controls.tsx` 加 `button === 0 && isPrimary` 守卫 |
| 4 | 会话重开的那一两秒（换音轨／换画质／心跳自愈／上一次 seek 换流）里 video 上已经没有流，拖动走的 native seek 打在空元素上毫无作用，而在途的新会话仍按 `pendingFileMs` 落回旧位置 —— 进度条跳过去又自己弹回来 | `seekToFileMs` 改走换会话这条路；报错页／同意弹窗与首次起播都排除在外 |
| 5 | `isEditableTarget` 把 `input[type=range]` 也算成输入控件，而播放器里唯一的滑块就是进度条、点一下就拿走焦点：点过进度条之后空格不再播放暂停、F 不全屏、M 不静音，焦点还收不回来；方向键更拧巴，全局的 ±5 秒被让掉、落到 range 原生的 ±1 秒 | `shortcuts.ts` 改成只有能录入文字的控件才算 |
| 6 | 跳转落点没有上界。片尾连按快进、或把进度条拖到最右端，会给出落在文件末尾之外的位置；native 那条浏览器会收住，**换会话那条不会** —— 拿它开一个 `-ss` 落在末尾的会话，ffmpeg 一帧都转不出来，用户对着转圈等到超时 | 新增 `timeline.ts` 的 `clampSeekTarget`，进度条／快捷键／手势共用同一处收口 |
| 7 | 缓冲条只跟 `timeupdate`，而暂停时它根本不发，hls.js 却照样在往前缓 —— 浅色底停在按下暂停的那一刻 | 拆出 `onBuffered`，同时挂到 `progress` 上 |

## 新增：横滑拖进度

移动端播放器的通行手势，本来只差这一支 —— 竖滑调亮度／音量的骨架、伪横屏坐标换算、胶囊的进出场动画都已经在了。

- **方向只在位移首次过门槛时裁决一次**（新增纯函数 `classifyIntent`，替掉只能答是非的 `isVerticalIntent`），到松手为止不再改判 —— 否则一次手势前半段调音量、后半段拖进度。
- 灵敏度取固定秒数：划过一整屏宽 = 90 秒（`seekDeltaMs`）。不按片长取百分比 —— 三小时的片子一划就是十几分钟，停不准。
- 起手区沿用现有排除带（顶部通知中心起手区、底部进度条、左右缘 32px 的返回手势守卫）。
- 位移一律换算到**布局**坐标：伪横屏是容器转了 90°，用户觉得自己在横划、物理上是竖着划的，直接用事件坐标会把两种手势对调。
- 滑动中**只更新胶囊、不 seek**（每次 move 都跳会让服务端一路杀 ffmpeg 重启，画面永远追不上手指），抬手才提交唯一那次 seek；`touchcancel` 不提交，与上面第 1 处同一条规矩。
- 胶囊放画面正中，大字是落点／总时长，小字是相对起点的增量；手势期间常显，没有自动退场计时。

已知平台限制：iOS **Safari 标签页**里从屏幕左右缘起手的横滑属于浏览器的历史手势，网页无权禁用（PWA 里可以，现有 `EDGE_GUARD` 守卫已经在拦），排除带让开 32px 是现有的缓解手段。

## 测试

新增两个测试文件、扩充一个，共 +34 条：

- `test/player-shortcuts.test.mjs`（`shortcuts.ts` 此前没有测试）—— 其中 2 条在修复前是挂的
- `test/player-timeline.test.mjs`（`timeline.ts` 此前没有测试）—— 落点夹紧六种情形、会话时间轴换算、`planSeek` 四条分支，外加「夹紧后的片尾落点仍落在已转区间内、不会白换一次会话」
- `test/player-touch-adjust.test.mjs` 补到 12 条 —— 方向裁决三档、一屏宽换算、伪横屏下横滑取布局坐标

指针行为另外用 esbuild 把 `PlayerControls` 单独打包进 Chromium 跑真实事件复核过：拖拽被 `touchCancel` 打断从「读数永久钉在 36:05／60.1%」变成回落并继续跟随；右键／中键从「seek 到 70%／30%」变成不跳；左键点按、触摸单点、正常拖拽、拖拽中控制条隐藏四条路径结果不变。

`tsc` 干净，`eslint` 只剩 `subtitles.ts` 里既有的一条未使用变量告警（未改动文件）。本地 `node --test` 399/400 —— 唯一挂的是既有的 `time.test.mjs`，容器时区 UTC 而用例按 Asia/Shanghai 断言，与本次无关。

## 真机需要验的

横滑手势是触摸行为，单测覆盖不到，合并后请重点看：和竖滑不打架（斜划只动一个量）、iOS 伪横屏下方向对不对、贴着进度条上方横划不抢手、90 秒／屏的手感（不合适改 `FULL_SWEEP_SEEK_S` 一个常数）。

## 顺带发现，没动

`docs/design/web-player.md` 的 P1 清单里「移动端手势（双击快进、上下滑音量/亮度、长按倍速）」与「移动端手势 + 横屏锁定」两条是陈旧的 —— 竖滑和横屏锁定早已实现。这在本次改动之前就存在，未一并修改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtyhL3vaZwTkh7pQuA8s4b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtyhL3vaZwTkh7pQuA8s4b)_