### PR TITLE
收藏页：竖横封面对齐 + 补上图床浏览切换

### DIFF
--- a/apps/web/components/favorites-view.tsx
+++ b/apps/web/components/favorites-view.tsx
@@ -1,17 +1,43 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import type { Route } from "next";
 
+import { useToast } from "@/components/feedback";
+import { MasonryIcon, MoreIcon, PosterGridIcon } from "@/components/icons";
 import { InventoryCell, WALL_GRID_POSTER, WallLoadMore } from "@/components/library-detail-view";
-import { PageNav } from "@/components/page-nav";
-import { type FavoriteItem, listFavorites } from "@/lib/api/playback";
+import { PAGE_NAV_BUTTON_CLASS, PageNav } from "@/components/page-nav";
+import { usePhotoWallDensity } from "@/components/photo-wall";
+import {
+  GALLERY_LOAD_MARGIN,
+  GALLERY_PAGE_SIZE,
+  VideoGalleryLightbox,
+  VideoGalleryWall,
+  WallPrefItems,
+  dedupeGalleryGroups,
+  flattenGallery,
+  useVideoGalleryGrouped,
+  useVideoGalleryMode,
+} from "@/components/video-gallery";
+import type { LibraryGalleryGroup } from "@/lib/api/libraries";
+import {
+  type FavoriteItem,
+  listFavorites,
+  listFavoritesGallery,
+  setPlaybackMarks,
+} from "@/lib/api/playback";
 import { usePageTitle } from "@/lib/use-page-title";
 import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /** 每次向服务端要的格数，与单库海报墙同一页长。 */
 const PAGE_SIZE = 60;
+
+/** 本页 ⋯ 菜单的行样式（与全站各处菜单同一副长相）。 */
+const ITEM_CLASS =
+  "glass-row nav-item cursor-pointer px-3 py-2 text-ui font-medium outline-none " +
+  "data-[highlighted]:!bg-[var(--glass-fill-hover)] data-[highlighted]:!text-[var(--text)]";
 
 /**
  * 整面墙钉死的框比例：2:3 竖版海报。
@@ -28,15 +54,30 @@ const PAGE_SIZE = 60;
 const FAVORITES_FRAME_ASPECT = 2 / 3;
 
 /**
- * 「全部收藏」页（/library/favorites）：当前账号收藏的全部作品，海报墙形态
- * 与单库页一致——同一套格子（InventoryCell）、同一种滚动加载，区别只在框比例
- * 统一钉死（见 FAVORITES_FRAME_ASPECT）。数据是
+ * 「全部收藏」页（/library/favorites）：当前账号收藏的全部作品。数据是
  * playback_state 里的收藏列，与 Jellyfin 客户端点的心同一份；每格的详情落点
  * 是服务端解析好的可见库。首页只横滚最近 20 部，多的到这里看。
+ *
+ * 与单库页一样有两种浏览形态，顶栏那颗键来回切（偏好与单库页共用一份，
+ * 见 useVideoGalleryMode）：
+ *   - 海报墙：同一套格子（InventoryCell）、同一种滚动加载，区别只在框比例
+ *     统一钉死（见 FAVORITES_FRAME_ASPECT）；
+ *   - 图床浏览：同一套瀑布流与灯箱（video-gallery），数据换成
+ *     /playback/favorites/gallery——收藏作品的海报 / 剧照 / 章节场景图。
+ *
+ * 两种形态各自分页、互不干扰；海报墙那一份始终会拉（页头的总数与切回来时的
+ * 首屏都靠它），与单库页同一处理。
  */
 export function FavoritesView() {
   usePageTitle("我的收藏");
-  const scrollRef = useScrollRestoration("library:favorites");
+  const toast = useToast();
+  const [galleryPreferred, setGalleryMode] = useVideoGalleryMode();
+  const [galleryGrouped, setGalleryGrouped] = useVideoGalleryGrouped();
+  const [density, setDensity] = usePhotoWallDensity();
+  // 两种墙的滚动锚点不同：海报墙一格一个条目，图廊一部作品十几张图按瓦片认
+  const scrollRef = useScrollRestoration("library:favorites", {
+    anchorAttribute: galleryPreferred ? "data-gallery-tile-id" : "data-library-item-id",
+  });
   const [items, setItems] = useState<FavoriteItem[] | null>(null);
   const [total, setTotal] = useState(0);
   const [failed, setFailed] = useState(false);
@@ -68,9 +109,125 @@ export function FavoritesView() {
     void load(loaded);
   }, [load, loaded]);
 
+  // —— 图床浏览模式 —— //
+  const [galleryGroups, setGalleryGroups] = useState<LibraryGalleryGroup[]>([]);
+  const [galleryHasMore, setGalleryHasMore] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  // 已请求到的作品数（按页长推进，不按拿到的组数——没图的作品也占一组）
+  const galleryLoaded = useRef(0);
+  const galleryLoading = useRef(false);
+  const galleryEntries = useMemo(() => flattenGallery(galleryGroups), [galleryGroups]);
+
+  const loadMoreGallery = useCallback(() => {
+    if (galleryLoading.current) return;
+    galleryLoading.current = true;
+    const offset = galleryLoaded.current;
+    listFavoritesGallery({ limit: GALLERY_PAGE_SIZE, offset })
+      .then((page) => {
+        galleryLoaded.current = offset + page.length;
+        setGalleryGroups((current) => dedupeGalleryGroups([...current, ...page]));
+        setGalleryHasMore(page.length >= GALLERY_PAGE_SIZE);
+      })
+      .catch(() => setGalleryHasMore(false))
+      .finally(() => {
+        galleryLoading.current = false;
+      });
+  }, []);
+
+  // 切进图廊（或进页面时偏好就在图廊）：拉第一页。海报墙那一份照常自己拉，
+  // 切回去时首屏已经在手上
+  useEffect(() => {
+    if (!galleryPreferred || galleryLoaded.current > 0) return;
+    loadMoreGallery();
+  }, [galleryPreferred, loadMoreGallery]);
+
+  /**
+   * 灯箱里点心：取消收藏后**不把瓦片抽走**——正在看的这张图连同它所在的那一段
+   * 会当场消失，翻页下标全乱。墙上的心跟着灭掉即可，下次进这一页时它自然不在了。
+   */
+  const toggleGalleryFavorite = useCallback(
+    async (mediaItemId: number, next: boolean) => {
+      const patch = (value: boolean) =>
+        setGalleryGroups((current) =>
+          current.map((g) => (g.media_item_id === mediaItemId ? { ...g, is_favorite: value } : g)),
+        );
+      patch(next);
+      try {
+        const marks = await setPlaybackMarks({ media_item_id: mediaItemId }, { favorite: next });
+        patch(marks.is_favorite);
+      } catch (e) {
+        patch(!next);
+        toast.error(e instanceof Error ? e.message : "收藏失败，请稍后重试");
+      }
+    },
+    [toast],
+  );
+
+  // 收藏一部都没有时不给切换键：两种形态都是空页，多一颗键只会让人以为点了没反应
+  const empty = items !== null && items.length === 0;
+  const gallery = galleryPreferred && !empty;
+
   return (
     <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
-      <PageNav title="我的收藏" fallback={{ label: "媒体库", href: "/library" as Route }} />
+      <PageNav
+        title="我的收藏"
+        fallback={{ label: "媒体库", href: "/library" as Route }}
+        actions={
+          empty ? undefined : (
+            <>
+              {/* 与单库页顶栏同一颗键、同一副图标：画的是**点过去会变成的那面墙** */}
+              <button
+                type="button"
+                title={gallery ? "回到海报墙" : "图床浏览"}
+                aria-label={gallery ? "回到海报墙" : "图床浏览"}
+                aria-pressed={gallery}
+                onClick={() => {
+                  // 两种模式的灯箱翻的不是同一份列表，下标不能沿用
+                  setLightboxIndex(null);
+                  setGalleryMode(!gallery);
+                }}
+                className={`${PAGE_NAV_BUTTON_CLASS} ${gallery ? "bg-black/55 text-white" : ""}`}
+              >
+                {gallery ? (
+                  <PosterGridIcon className="size-[18px] max-md:size-[22px]" />
+                ) : (
+                  <MasonryIcon className="size-[18px] max-md:size-[22px]" />
+                )}
+              </button>
+              {/* 看图的两个偏好；海报墙上没有可调的，整个菜单也就不出现 */}
+              {gallery && (
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger asChild>
+                    <button
+                      type="button"
+                      aria-label="浏览设置"
+                      className={`${PAGE_NAV_BUTTON_CLASS} data-[state=open]:bg-black/55 data-[state=open]:text-white`}
+                    >
+                      <MoreIcon className="size-[18px] max-md:size-[22px]" />
+                    </button>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content
+                      align="end"
+                      sideOffset={6}
+                      collisionPadding={12}
+                      className="menu-surface z-50 min-w-[11rem] p-1"
+                    >
+                      <WallPrefItems
+                        grouped={galleryGrouped}
+                        onGroupedChange={setGalleryGrouped}
+                        density={density}
+                        onDensityChange={setDensity}
+                        itemClass={ITEM_CLASS}
+                      />
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
+              )}
+            </>
+          )
+        }
+      />
       <div className="px-6 max-md:px-4">
         <h2 className="text-on-image truncate text-[26px] font-bold leading-tight tracking-[-0.02em] text-white max-md:text-[20px]">
           我的收藏
@@ -98,26 +255,50 @@ export function FavoritesView() {
 
         {items !== null && items.length > 0 && (
           <>
-            <div className={`mt-6 ${WALL_GRID_POSTER}`}>
-              {items.map((item) => (
-                <InventoryCell
-                  key={item.media_item_id}
-                  item={item}
-                  libraryId={item.library_id}
-                  frameAspect={FAVORITES_FRAME_ASPECT}
+            {gallery ? (
+              <div className="mt-6">
+                <VideoGalleryWall
+                  groups={galleryGroups}
+                  density={density}
+                  grouped={galleryGrouped}
+                  onOpen={setLightboxIndex}
                 />
-              ))}
-            </div>
+              </div>
+            ) : (
+              <div className={`mt-6 ${WALL_GRID_POSTER}`}>
+                {items.map((item) => (
+                  <InventoryCell
+                    key={item.media_item_id}
+                    item={item}
+                    libraryId={item.library_id}
+                    frameAspect={FAVORITES_FRAME_ASPECT}
+                  />
+                ))}
+              </div>
+            )}
+            {/* 两种形态各自分页，哨兵按当前模式接线（图廊按作品数计） */}
             <WallLoadMore
-              hasMore={hasMore}
-              loaded={loaded}
+              hasMore={gallery ? galleryHasMore : hasMore}
+              loaded={gallery ? galleryLoaded.current : loaded}
               start={0}
               total={total}
-              onReach={loadMore}
+              onReach={gallery ? loadMoreGallery : loadMore}
+              rootMargin={gallery ? GALLERY_LOAD_MARGIN : undefined}
             />
           </>
         )}
       </div>
+      {gallery && lightboxIndex !== null && galleryEntries[lightboxIndex] && (
+        <VideoGalleryLightbox
+          entries={galleryEntries}
+          index={lightboxIndex}
+          hasMore={galleryHasMore}
+          onIndexChange={setLightboxIndex}
+          onReachEnd={loadMoreGallery}
+          onToggleFavorite={toggleGalleryFavorite}
+          onClose={() => setLightboxIndex(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/components/favorites-view.tsx
+++ b/apps/web/components/favorites-view.tsx
@@ -14,8 +14,23 @@ import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 const PAGE_SIZE = 60;
 
 /**
+ * 整面墙钉死的框比例：2:3 竖版海报。
+ *
+ * 收藏是跨库的一面墙，横版封面（其他库的 16:9 抓帧）和竖版海报必然混在一起。
+ * 单库页遇到这种情况会把墙切成竖横两区各自对齐，但收藏页排的是「最近收藏的
+ * 在前」——按比例分区等于把收藏顺序打散，人再也找不到刚点的那部。
+ *
+ * 所以这里照搬最近观看那一行的做法：**框比例固定，主图按真实比例居中完整显示、
+ * 同图放大模糊铺底**（PosterCardVisual 的 letterbox 分支）。每格等高、片名落在
+ * 一条线上，横版封面也不会被裁掉两边。首页横滚的「我的收藏」本来就是这么排的，
+ * 点「查看全部」进来的这面墙从此与它同一形态。
+ */
+const FAVORITES_FRAME_ASPECT = 2 / 3;
+
+/**
  * 「全部收藏」页（/library/favorites）：当前账号收藏的全部作品，海报墙形态
- * 与单库页完全一致——同一套格子（InventoryCell）、同一种滚动加载。数据是
+ * 与单库页一致——同一套格子（InventoryCell）、同一种滚动加载，区别只在框比例
+ * 统一钉死（见 FAVORITES_FRAME_ASPECT）。数据是
  * playback_state 里的收藏列，与 Jellyfin 客户端点的心同一份；每格的详情落点
  * 是服务端解析好的可见库。首页只横滚最近 20 部，多的到这里看。
  */
@@ -89,6 +104,7 @@ export function FavoritesView() {
                   key={item.media_item_id}
                   item={item}
                   libraryId={item.library_id}
+                  frameAspect={FAVORITES_FRAME_ASPECT}
                 />
               ))}
             </div>

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/lib/library-confirm";
 import { chapterJobLabel } from "@/lib/library-manage";
 import {
-  CheckIcon,
   LockIcon,
   MasonryIcon,
   MoreIcon,
@@ -37,8 +36,12 @@ import {
 } from "@/components/photo-wall";
 import { PosterCardVisual, type PosterVisualItem } from "@/components/poster-card";
 import {
+  GALLERY_LOAD_MARGIN,
+  GALLERY_PAGE_SIZE,
+  dedupeGalleryGroups,
   VideoGalleryLightbox,
   VideoGalleryWall,
+  WallPrefItems,
   flattenGallery,
   useVideoGalleryGrouped,
   useVideoGalleryMode,
@@ -146,26 +149,6 @@ const PROVISIONAL_LIMIT = 200;
 const WALL_PAGE_SIZE = 60;
 /** 后端单次分页的硬上限；轮询已加载窗口时按此上限分块请求。 */
 const WALL_API_PAGE_SIZE = 200;
-/** 图床浏览模式一页的作品数：一部作品十来张图，24 部约一屏半 */
-const GALLERY_PAGE_SIZE = 24;
-/**
- * 图床浏览模式提前取下一页的距离：约一屏半，也就是当前这一页快滑完时就去要
- * 下一页。图大、下载慢，等滑到底再发请求接上来的就是一屏空瓦片。
- */
-const GALLERY_LOAD_MARGIN = "1200px 0px";
-
-/**
- * 图廊分组上墙前的统一口径：没图的条目不占位（服务端按条目分页，空组只用来
- * 数页），同一条目只留最前面那一组。追加下一页与整窗对账都过这一道。
- */
-function dedupeGalleryGroups(groups: LibraryGalleryGroup[]): LibraryGalleryGroup[] {
-  const seen = new Set<number>();
-  return groups.filter((group) => {
-    if (group.images.length === 0 || seen.has(group.media_item_id)) return false;
-    seen.add(group.media_item_id);
-    return true;
-  });
-}
 
 /**
  * 列表拉取失败折成 ``null``（而不是空数组）。
@@ -1236,7 +1219,6 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
                     density={photoDensity}
                     grouped={galleryGrouped}
                     onOpen={setLightboxIndex}
-                    libraryId={libraryId}
                   />
                 ) : photoWall ? (
                   <div ref={wallGrid}>
@@ -1364,7 +1346,6 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
           </div>
           {gallery && lightboxIndex !== null && galleryEntries[lightboxIndex] && (
             <VideoGalleryLightbox
-              libraryId={libraryId}
               entries={galleryEntries}
               index={lightboxIndex}
               hasMore={galleryHasMore}
@@ -1569,45 +1550,15 @@ function LibraryActionsMenu({
           {canManage && (grouped !== undefined || density) && (
             <DropdownMenu.Separator className="my-1 h-px bg-white/[0.07]" />
           )}
-          {/* 图床浏览：关掉分组，整库的图就混成一条瀑布流 */}
-          {grouped !== undefined && onGroupedChange && (
-            <DropdownMenu.CheckboxItem
-              checked={grouped}
-              onCheckedChange={onGroupedChange}
-              className={`${itemClass} flex items-center justify-between`}
-            >
-              按作品分组
-              <DropdownMenu.ItemIndicator>
-                <CheckIcon className="size-3.5 text-[var(--accent)]" />
-              </DropdownMenu.ItemIndicator>
-            </DropdownMenu.CheckboxItem>
-          )}
-          {density && onDensityChange && (
-            <>
-              <DropdownMenu.Label className="px-3 pb-1 pt-1.5 text-caption text-[var(--text-faint)]">
-                瀑布流密度
-              </DropdownMenu.Label>
-              <DropdownMenu.RadioGroup
-                value={density}
-                onValueChange={(next) => onDensityChange(next as PhotoWallDensity)}
-              >
-                {(
-                  [
-                    ["compact", "紧凑"],
-                    ["standard", "标准"],
-                    ["loose", "宽松"],
-                  ] as [PhotoWallDensity, string][]
-                ).map(([key, label]) => (
-                  <DropdownMenu.RadioItem key={key} value={key} className={`${itemClass} flex items-center justify-between`}>
-                    {label}
-                    <DropdownMenu.ItemIndicator>
-                      <CheckIcon className="size-3.5 text-[var(--accent)]" />
-                    </DropdownMenu.ItemIndicator>
-                  </DropdownMenu.RadioItem>
-                ))}
-              </DropdownMenu.RadioGroup>
-            </>
-          )}
+          {/* 与「全部收藏」页的图廊菜单是同一组（见 video-gallery.tsx）：
+              图片库只传密度，图床浏览模式两项都传 */}
+          <WallPrefItems
+            grouped={grouped}
+            onGroupedChange={onGroupedChange}
+            density={density}
+            onDensityChange={onDensityChange}
+            itemClass={itemClass}
+          />
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -1686,6 +1686,7 @@ export const InventoryCell = memo(function InventoryCell({
   libraryId,
   wallInitial,
   workingLabel,
+  frameAspect,
 }: {
   item: LibraryItem;
   libraryId: number;
@@ -1693,6 +1694,12 @@ export const InventoryCell = memo(function InventoryCell({
   wallInitial?: string;
   /** 这一格正被后台处理（整库刷新的阶段 / 扫描补探）时的文案；不在处理为 undefined */
   workingLabel?: string;
+  /**
+   * 强制锁定框比例。单库页的墙已按主图比例切成竖横两区，每区内比例天然一致，
+   * 不传即按本格主图自选（竖 2:3 / 横 16:9）；而「全部收藏」是跨库按时间排的
+   * 一面墙，不能为了对齐去打散收藏顺序，只能由调用方把整面墙钉死在一个比例上。
+   */
+  frameAspect?: number;
 }) {
   const inventoryLabel =
     item.kind === "tv" && item.inventory_summary
@@ -1708,8 +1715,9 @@ export const InventoryCell = memo(function InventoryCell({
     rating: 0,
     // 框比例按分区锁死（竖版 2:3 / 横版 16:9），同一分区里每格等高、片名一条线；
     // 主图真实比例另传，和框不一致的（4:3 封面、1.5 的横版海报）模糊铺底居中完整显示，
-    // 不按各自真实比例撑格——那样一行里 1.5 与 1.78 的封面高度不一，片名参差
-    aspect: item.primary_aspect >= 1 ? 16 / 9 : 2 / 3,
+    // 不按各自真实比例撑格——那样一行里 1.5 与 1.78 的封面高度不一，片名参差。
+    // 调用方给了 frameAspect 就一切照它来（竖横混排的墙，见上面参数注释）
+    aspect: frameAspect ?? (item.primary_aspect >= 1 ? 16 / 9 : 2 / 3),
     imageAspect: item.primary_aspect,
     overlayDetails: inventoryLabel ? { primary: inventoryLabel } : undefined,
     favorite: item.is_favorite,

--- a/apps/web/components/video-gallery.tsx
+++ b/apps/web/components/video-gallery.tsx
@@ -6,7 +6,9 @@ import type { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
-import { HeartIcon, OpenIcon, PlayIcon } from "@/components/icons";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+
+import { CheckIcon, HeartIcon, OpenIcon, PlayIcon } from "@/components/icons";
 import {
   DENSITY,
   layoutMasonry,
@@ -33,7 +35,19 @@ import { playHref, rememberPlayerReturnPath } from "@/lib/player/play-links";
  *
  * 数据来自 /libraries/{id}/gallery，按作品分页（与海报墙同一份标题序）；
  * 灯箱翻的是铺平后的整份图列表（GalleryEntry），翻到末尾向外要下一页。
+ *
+ * 「全部收藏」页复用同一套墙与灯箱，数据换成 /playback/favorites/gallery
+ * （跨库、最近收藏在前）。因此详情落点库不是整墙一个，而是每组自带
+ * （LibraryGalleryGroup.library_id）。
  */
+
+/** 图床浏览模式一页的作品数：一部作品十来张图，24 部约一屏半 */
+export const GALLERY_PAGE_SIZE = 24;
+/**
+ * 图床浏览模式提前取下一页的距离：约一屏半，也就是当前这一页快滑完时就去要
+ * 下一页。图大、下载慢，等滑到底再发请求接上来的就是一屏空瓦片。
+ */
+export const GALLERY_LOAD_MARGIN = "1200px 0px";
 
 const MODE_STORAGE_KEY = "movieclaw.library.gallery-mode";
 const GROUPED_STORAGE_KEY = "movieclaw.library.gallery-grouped";
@@ -77,10 +91,95 @@ export function useVideoGalleryGrouped(): [boolean, (next: boolean) => void] {
   return useStoredFlag(GROUPED_STORAGE_KEY, true);
 }
 
+/**
+ * 看图的两个偏好（按作品分组 / 瀑布流密度），作为菜单项交给调用方的 ⋯ 菜单。
+ *
+ * 三处菜单要用到它：单库页的图床浏览（两项都有）、图片库的相册墙（只有密度，
+ * 它没有分组一说）、「全部收藏」页的图廊（两项都有，且整个菜单只有这一组）。
+ * 每一半都可以不给——不给就不渲染那一半。菜单外壳（触发键、Content）留在各自
+ * 的调用方：全站惯例是每个菜单自带外壳与行样式（itemClass 因此由调用方传入），
+ * 这里只共享真正相同的那部分——项目本身。
+ */
+export function WallPrefItems({
+  grouped,
+  onGroupedChange,
+  density,
+  onDensityChange,
+  itemClass,
+}: {
+  grouped?: boolean;
+  onGroupedChange?: (next: boolean) => void;
+  density?: PhotoWallDensity;
+  onDensityChange?: (next: PhotoWallDensity) => void;
+  /** 调用方菜单的行样式：同一个菜单里各项长相必须一致 */
+  itemClass: string;
+}) {
+  return (
+    <>
+      {/* 图床浏览：关掉分组，整墙的图就混成一条瀑布流 */}
+      {grouped !== undefined && onGroupedChange && (
+        <DropdownMenu.CheckboxItem
+          checked={grouped}
+          onCheckedChange={onGroupedChange}
+          className={`${itemClass} flex items-center justify-between`}
+        >
+          按作品分组
+          <DropdownMenu.ItemIndicator>
+            <CheckIcon className="size-3.5 text-[var(--accent)]" />
+          </DropdownMenu.ItemIndicator>
+        </DropdownMenu.CheckboxItem>
+      )}
+      {density && onDensityChange && (
+        <>
+          <DropdownMenu.Label className="px-3 pb-1 pt-1.5 text-caption text-[var(--text-faint)]">
+            瀑布流密度
+          </DropdownMenu.Label>
+          <DropdownMenu.RadioGroup
+            value={density}
+            onValueChange={(next) => onDensityChange(next as PhotoWallDensity)}
+          >
+            {(
+              [
+                ["compact", "紧凑"],
+                ["standard", "标准"],
+                ["loose", "宽松"],
+              ] as [PhotoWallDensity, string][]
+            ).map(([key, label]) => (
+              <DropdownMenu.RadioItem
+                key={key}
+                value={key}
+                className={`${itemClass} flex items-center justify-between`}
+              >
+                {label}
+                <DropdownMenu.ItemIndicator>
+                  <CheckIcon className="size-3.5 text-[var(--accent)]" />
+                </DropdownMenu.ItemIndicator>
+              </DropdownMenu.RadioItem>
+            ))}
+          </DropdownMenu.RadioGroup>
+        </>
+      )}
+    </>
+  );
+}
+
 /** 铺平后的一张图：知道自己属于哪部作品，播放 / 详情按钮据此拼地址 */
 export interface GalleryEntry {
   group: LibraryGalleryGroup;
   image: LibraryGalleryImage;
+}
+
+/**
+ * 图廊分组上墙前的统一口径：没图的作品不占位（服务端按作品分页，空组只用来
+ * 数页），同一部作品只留最前面那一组。追加下一页与整窗对账都过这一道。
+ */
+export function dedupeGalleryGroups(groups: LibraryGalleryGroup[]): LibraryGalleryGroup[] {
+  const seen = new Set<number>();
+  return groups.filter((group) => {
+    if (group.images.length === 0 || seen.has(group.media_item_id)) return false;
+    seen.add(group.media_item_id);
+    return true;
+  });
 }
 
 export function flattenGallery(groups: readonly LibraryGalleryGroup[]): GalleryEntry[] {
@@ -101,10 +200,13 @@ function tileKey(group: LibraryGalleryGroup, image: LibraryGalleryImage): string
   return `${group.media_item_id}:${image.kind}:${image.url}`;
 }
 
-/** 条目详情页地址：分集剧照 / 剧集章节图带季集号，详情页直接落到那一集 */
-function detailHref(libraryId: number, entry: GalleryEntry): Route {
+/**
+ * 条目详情页地址：分集剧照 / 剧集章节图带季集号，详情页直接落到那一集。
+ * 落点库取分组自己带的那个——收藏图廊是跨库的一面墙，同一面墙上各组不同库。
+ */
+function detailHref(entry: GalleryEntry): Route {
   const { group, image } = entry;
-  const base = `/library/${libraryId}/item/${group.media_item_id}`;
+  const base = `/library/${group.library_id}/item/${group.media_item_id}`;
   const unit =
     image.season !== null && image.episode !== null
       ? `?season=${image.season}&episode=${image.episode}`
@@ -189,16 +291,14 @@ export function VideoGalleryWall({
   density,
   grouped,
   onOpen,
-  libraryId,
 }: {
-  /** 已加载的作品分组（服务端标题序） */
+  /** 已加载的作品分组（服务端给的顺序：单库按标题，收藏按最近收藏） */
   groups: LibraryGalleryGroup[];
   density: PhotoWallDensity;
-  /** 按作品分段；false = 整库的图混成一条瀑布流，没有段标题 */
+  /** 按作品分段；false = 整墙的图混成一条瀑布流，没有段标题 */
   grouped: boolean;
   /** 点击某张：传的是它在铺平列表（flattenGallery）里的下标，灯箱按同一列表翻页 */
   onOpen: (index: number) => void;
-  libraryId: number;
 }) {
   // 铺平的整份列表：不分组时直接排它；分组时用来算每段的起始下标
   // （灯箱按整份列表翻页，瓦片点击要给全局下标）
@@ -241,7 +341,6 @@ export function VideoGalleryWall({
               width={width}
               spec={spec}
               onOpen={onOpen}
-              libraryId={libraryId}
             />
           ))
         ) : (
@@ -310,7 +409,6 @@ const GalleryGroupSection = memo(function GalleryGroupSection({
   width,
   spec,
   onOpen,
-  libraryId,
 }: {
   group: LibraryGalleryGroup;
   /** 本组第一张在铺平列表里的下标 */
@@ -318,7 +416,6 @@ const GalleryGroupSection = memo(function GalleryGroupSection({
   width: number;
   spec: DensitySpec;
   onOpen: (index: number) => void;
-  libraryId: number;
 }) {
   const entries = useMemo(
     () => group.images.map((image) => ({ group, image })),
@@ -328,7 +425,7 @@ const GalleryGroupSection = memo(function GalleryGroupSection({
     <section className="mb-8 last:mb-0">
       <div className="mb-3 flex items-baseline gap-2.5">
         <Link
-          href={`/library/${libraryId}/item/${group.media_item_id}` as Route}
+          href={`/library/${group.library_id}/item/${group.media_item_id}` as Route}
           className="text-on-image truncate text-body-lg font-semibold text-white/85 transition-colors hover:text-white"
         >
           {groupTitle(group)}
@@ -444,7 +541,6 @@ function formatSeconds(total: number): string {
 }
 
 export function VideoGalleryLightbox({
-  libraryId,
   entries,
   index,
   hasMore,
@@ -453,7 +549,6 @@ export function VideoGalleryLightbox({
   onToggleFavorite,
   onClose,
 }: {
-  libraryId: number;
   /** 铺平后的整份已加载图列表（与墙同一顺序） */
   entries: GalleryEntry[];
   index: number;
@@ -538,7 +633,7 @@ export function VideoGalleryLightbox({
             />
           </button>
           <Link
-            href={detailHref(libraryId, entry)}
+            href={detailHref(entry)}
             title="前往影片详情"
             aria-label="前往影片详情"
             className={buttonClass}

--- a/apps/web/lib/api/libraries.ts
+++ b/apps/web/lib/api/libraries.ts
@@ -585,6 +585,11 @@ export interface LibraryGalleryImage {
 /** 图廊按条目分的一组：一部作品的全部图，墙上是一段标题 + 一面瀑布流。 */
 export interface LibraryGalleryGroup {
   media_item_id: number;
+  /**
+   * 这一组的详情落点库：段标题与灯箱「前往详情」的地址按它拼。单库图廊恒等于
+   * 本库；「我的收藏」的图廊是跨库的一面墙，每组各带自己的落点库。
+   */
+  library_id: number;
   kind: LibraryKind;
   title: string;
   year: number | null;

--- a/apps/web/lib/api/playback.ts
+++ b/apps/web/lib/api/playback.ts
@@ -2,7 +2,7 @@ import { publicEnv } from "@/lib/env";
 import { getPlayerDeviceId } from "@/lib/player/device";
 import type { TrickplayIndex } from "@/lib/player/trickplay";
 import { HttpError, request, resolveRequestUrl } from "@/lib/http";
-import type { LibraryEpisode, LibraryItem } from "@/lib/api/libraries";
+import type { LibraryEpisode, LibraryGalleryGroup, LibraryItem } from "@/lib/api/libraries";
 import type { LibraryKind, MediaType } from "@/lib/media-types";
 import { readLocalProgress, writeLocalProgress } from "@/lib/player/local-progress";
 
@@ -119,6 +119,22 @@ export interface FavoritesPage {
 export async function listFavorites(limit = 20, offset = 0): Promise<FavoritesPage> {
   const response = await request<ApiEnvelope<FavoritesPage>>(
     `/playback/favorites?limit=${limit}&offset=${offset}`,
+  );
+  return response.data;
+}
+
+/**
+ * 「全部收藏」页图床浏览模式的数据源：与 listFavorites 同一份名单与顺序，
+ * 一组是一部作品的全部图（海报 / 剧照 / 分集剧照 / 章节场景图）。分页口径同
+ * 单库图廊——offset / limit 都按作品数，没有图的作品也占一组，拿满一页就还有
+ * 下一页；收藏跨库，每组自带详情落点库。
+ */
+export async function listFavoritesGallery(params: {
+  limit: number;
+  offset: number;
+}): Promise<LibraryGalleryGroup[]> {
+  const response = await request<ApiEnvelope<LibraryGalleryGroup[]>>(
+    `/playback/favorites/gallery?limit=${params.limit}&offset=${params.offset}`,
   );
   return response.data;
 }

--- a/cli/internal/tree/guards_test.go
+++ b/cli/internal/tree/guards_test.go
@@ -69,10 +69,12 @@ var knownNonGenerated = []string{
 	"transcode.artifact.put",
 	"playback.progress",
 	"playback.resume",
-	// 已看 / 收藏标记与首页「我的收藏」：详情页与首页的 Web 动作，命令行无消费方
+	// 已看 / 收藏标记与「我的收藏」（含收藏页图床浏览的图廊）：详情页与收藏页的
+	// Web 动作，命令行无消费方
 	"playback.marks.get",
 	"playback.marks.set",
 	"playback.favorites",
+	"playback.favorites.gallery",
 	"playback.policy.show",
 	"playback.policy.set",
 	"workflow.library.organize-files.preview",

--- a/src/movieclaw_api/api/routes/playback.py
+++ b/src/movieclaw_api/api/routes/playback.py
@@ -26,7 +26,7 @@ from movieclaw_api.exceptions import (
     ServiceUnavailableException,
 )
 from movieclaw_api.schemas.base import utc_isoformat
-from movieclaw_api.schemas.library import SeasonEpisodesView
+from movieclaw_api.schemas.library import LibraryGalleryGroupView, SeasonEpisodesView
 from movieclaw_api.schemas.playback import (
     FavoritesView,
     HwBackendStatusView,
@@ -118,7 +118,7 @@ from movieclaw_api.services.playback_activity import (
     media_activity_overview,
     revoke_device,
 )
-from movieclaw_api.services.playback_favorites import favorite_items
+from movieclaw_api.services.playback_favorites import favorite_gallery, favorite_items
 from movieclaw_api.services.playback_recent import recent_watch_items
 from movieclaw_api.services.playback_stats import playback_history, playback_stats
 from movieclaw_api.settings import PlaybackPolicySetting
@@ -385,6 +385,37 @@ async def list_favorites(
         offset=offset,
     )
     return ok(FavoritesView(items=items, total=total))
+
+
+@router.get(
+    "/favorites/gallery",
+    response_model=ApiResponse[list[LibraryGalleryGroupView]],
+    summary="我的收藏 · 图廊：收藏作品的海报 / 剧照 / 章节场景图按作品分组铺平",
+    operation_id="playback.favorites.gallery",
+    openapi_extra={"x-cli-hidden": True},
+)
+async def list_favorites_gallery(
+    limit: Annotated[
+        int, Query(ge=1, le=100, description="本页作品数（按作品分页，不按图）")
+    ] = 24,
+    offset: Annotated[int, Query(ge=0, description="跳过的作品数（滚动加载翻页用）")] = 0,
+    principal: Principal = Depends(require_login),
+    session: AsyncSession = Depends(get_session),
+) -> ApiResponse[list[LibraryGalleryGroupView]]:
+    """「全部收藏」页的图床浏览模式：与 ``/playback/favorites`` 同一份名单与顺序
+    （最近收藏在前），一组就是一部作品的全部图。收藏跨库，每组带自己的详情
+    落点库。没有任何图的作品也占一组，一页的组数恒等于作品数。"""
+    visible_ids = await visible_library_ids(session, principal)
+    member_id = principal.member_id if principal.member_id is not None else 0
+    return ok(
+        await favorite_gallery(
+            session,
+            member_id=member_id,
+            visible_library_ids=visible_ids,
+            limit=limit,
+            offset=offset,
+        )
+    )
 
 
 @router.get(

--- a/src/movieclaw_api/schemas/library.py
+++ b/src/movieclaw_api/schemas/library.py
@@ -425,6 +425,12 @@ class LibraryGalleryGroupView(BaseModel):
     """图廊按条目分的一组（一部作品的全部图），墙上是一段标题 + 一面瀑布流。"""
 
     media_item_id: int
+    library_id: int = Field(
+        description=(
+            "这一组的详情落点库：段标题与灯箱「前往详情」的地址按它拼。"
+            "单库图廊恒等于本库；「我的收藏」的图廊跨库，每组各带自己的落点库"
+        )
+    )
     kind: MediaKind
     title: str
     year: int | None = None

--- a/src/movieclaw_api/services/library/items.py
+++ b/src/movieclaw_api/services/library/items.py
@@ -29,7 +29,7 @@ import logging
 import os
 import re
 import shutil
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
@@ -729,9 +729,32 @@ async def build_library_gallery(
     """影视库 / 其他库的「图床浏览模式」数据源：条目的图铺平成组。
 
     与海报墙共用同一份按标题排好的正式条目名单与分页口径（``offset`` /
-    ``limit`` 都按**条目**数），一组就是一部作品的全部图，顺序固定为
-    海报 → 横幅剧照 → 逐集（分集剧照 → 该集章节图）。只取库里**在位**文件
-    名下的章节图与分集剧照：图廊看的是"我库里有的"，缺集的剧照不混进来。
+    ``limit`` 都按**条目**数），本页条目定下来之后交给
+    :func:`build_gallery_groups` 组图。
+    """
+    page_ids = await _wall_page_ids(session, library_id, "title", limit, offset)
+    return await build_gallery_groups(
+        session, [(item_id, library_id) for item_id in page_ids], member_id=member_id
+    )
+
+
+async def build_gallery_groups(
+    session: AsyncSession,
+    page: Sequence[tuple[int, int]],
+    *,
+    member_id: int,
+) -> list[LibraryGalleryGroupView]:
+    """把「本页条目」铺平成图廊分组，顺序与 ``page`` 一致。
+
+    ``page`` 的每一项是 ``(条目 id, 落点库 id)``：单库图廊里落点库恒等于本库，
+    「我的收藏」的图廊是跨库的一面墙，每部作品各带自己的落点库（同收藏海报墙
+    的口径，见 services/playback_favorites.py）。落点库决定两件事——组标题和
+    灯箱里「前往详情」的地址，以及**取哪些文件**的章节图与分集剧照：同一部
+    作品可能在多个库里各有一份文件，只认落点库那一份，图廊看的是"这一格点
+    进去的那个库里有的"。
+
+    一组就是一部作品的全部图，顺序固定为海报 → 横幅剧照 → 逐集（分集剧照 →
+    该集章节图）。只取**在位**文件名下的章节图与分集剧照，缺集的剧照不混进来。
     没有任何图的条目也占一组（``images`` 为空）——一页的组数恒等于条目数，
     前端据此判断还有没有下一页。每组还带上 ``member_id`` 这位观看者有没有
     收藏这部作品，供瓦片角标与灯箱里的心一次拿齐（详情页那样逐条目问
@@ -747,9 +770,10 @@ async def build_library_gallery(
     from movieclaw_api.services.library import chapters as chapters_mod
     from movieclaw_db.models import MediaEpisode
 
-    page_ids = await _wall_page_ids(session, library_id, "title", limit, offset)
-    if not page_ids:
+    if not page:
         return []
+    page_ids = [item_id for item_id, _ in page]
+    library_of = dict(page)
     items_by_id: dict[int, MediaItem] = {
         item.id: item
         for item in (
@@ -774,11 +798,13 @@ async def build_library_gallery(
             )
         ).all()
     }
-    # 在位文件：只取章节相关的几列，不整行取（音轨/字幕 JSON 用不上）
+    # 在位文件：只取章节相关的几列，不整行取（音轨/字幕 JSON 用不上）。
+    # 库集合先粗筛（跨库时是这一页涉及的几个库），再按 (条目, 落点库) 精确留下
     file_rows = (
         await session.execute(
             select(
                 LibraryFile.media_item_id,
+                LibraryFile.library_id,
                 LibraryFile.id,
                 LibraryFile.season_number,
                 LibraryFile.episode_number,
@@ -787,7 +813,7 @@ async def build_library_gallery(
                 LibraryFile.chapter_images,
             )
             .where(
-                LibraryFile.library_id == library_id,
+                LibraryFile.library_id.in_(sorted(set(library_of.values()))),  # type: ignore[attr-defined]
                 LibraryFile.media_item_id.in_(page_ids),  # type: ignore[union-attr]
                 LibraryFile.in_place(),
             )
@@ -795,7 +821,9 @@ async def build_library_gallery(
         )
     ).all()
     files_by_item: dict[int, list[tuple]] = {}
-    for media_item_id, *facts in file_rows:
+    for media_item_id, file_library_id, *facts in file_rows:
+        if library_of.get(media_item_id) != file_library_id:
+            continue
         files_by_item.setdefault(media_item_id, []).append(tuple(facts))
     tv_ids = [i for i in page_ids if (item := items_by_id.get(i)) and item.kind == "tv"]
     stills_by_unit: dict[tuple[int, int, int], tuple[str, str]] = {}
@@ -902,6 +930,7 @@ async def build_library_gallery(
         groups.append(
             LibraryGalleryGroupView(
                 media_item_id=item_id,
+                library_id=library_of[item_id],
                 kind=MediaKind(item.kind),
                 title=item.title,
                 year=item.year,

--- a/src/movieclaw_api/services/playback_favorites.py
+++ b/src/movieclaw_api/services/playback_favorites.py
@@ -1,4 +1,4 @@
-"""媒体库首页「我的收藏」的业务查询。
+"""媒体库首页与「全部收藏」页「我的收藏」的业务查询。
 
 收藏事实只有一处：``playback_state.is_favorite``（网页详情页的心与 Jellyfin
 客户端的心写的是同一列，见 services/playback/marks.py）。首页直接读这张领域表，
@@ -7,6 +7,10 @@
 一部作品只出一格：Jellyfin 客户端可以分别收藏整剧、某一季、某一集，同一部剧
 可能有多行收藏，首页按作品去重，取最近一次收藏的那一行说明收藏的层级。
 卡片本体复用单库海报墙的聚合视图（海报、库存概况、缺集数同一口径）。
+
+「全部收藏」页与单库页一样有两种浏览形态，两者共用 :func:`_favorite_page`
+定下的同一份名单：海报墙走 :func:`favorite_items`，图床浏览（瀑布流）走
+:func:`favorite_gallery`。
 """
 
 from __future__ import annotations
@@ -14,28 +18,31 @@ from __future__ import annotations
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from movieclaw_api.schemas.library import LibraryGalleryGroupView
 from movieclaw_api.schemas.playback import FavoriteItemView
-from movieclaw_api.services.library.items import _aggregate_wall_views
+from movieclaw_api.services.library.items import _aggregate_wall_views, build_gallery_groups
 from movieclaw_db.models import Library, LibraryFile, PlaybackState
 from movieclaw_media.models import MediaKind
 
 
-async def favorite_items(
+async def _favorite_page(
     session: AsyncSession,
     *,
     member_id: int,
     visible_library_ids: set[int] | None,
     limit: int,
-    offset: int = 0,
-) -> tuple[list[FavoriteItemView], int]:
-    """返回一个账号收藏的作品（最近收藏的在前）与去重后的总数。
+    offset: int,
+) -> tuple[list[tuple[int, int]], int, dict[int, PlaybackState]]:
+    """收藏墙与收藏图廊共用的一页名单：``[(条目 id, 落点库 id)]`` + 去重总数 +
+    每部作品最近那一行收藏状态（层级文案要用）。
 
-    ``offset`` / ``limit`` 是「全部收藏」海报墙的滚动分页窗口；首页横滚行只取
-    最前面一页。同一作品跨库存在时按媒体库首页的展示顺序选择第一个可见库，
-    保证卡片有稳定、可访问的详情落点；没有任何可见在位文件的收藏不计入总数。
+    最近收藏的在前；同一作品跨库存在时按媒体库首页的展示顺序选择第一个可见库，
+    保证这一格有稳定、可访问的详情落点；没有任何可见在位文件的收藏不计入总数。
+    海报墙与图廊必须走同一份名单——两种视图翻的是同一批作品、同一个顺序，
+    切换视图时看到的不能是两份内容。
     """
     if visible_library_ids == set():
-        return [], 0
+        return [], 0, {}
 
     rows = (
         (
@@ -59,7 +66,7 @@ async def favorite_items(
     for row in rows:
         latest.setdefault(row.media_item_id, row)
     if not latest:
-        return [], 0
+        return [], 0, {}
 
     # 落点库：作品有在位文件的可见库，按首页库排序取第一个
     library_query = (
@@ -81,18 +88,44 @@ async def favorite_items(
 
     ordered = [item_id for item_id in latest if item_id in library_of]
     total = len(ordered)
-    ordered = ordered[offset : offset + limit]
+    page = [(item_id, library_of[item_id]) for item_id in ordered[offset : offset + limit]]
+    return page, total, latest
+
+
+async def favorite_items(
+    session: AsyncSession,
+    *,
+    member_id: int,
+    visible_library_ids: set[int] | None,
+    limit: int,
+    offset: int = 0,
+) -> tuple[list[FavoriteItemView], int]:
+    """返回一个账号收藏的作品（最近收藏的在前）与去重后的总数。
+
+    ``offset`` / ``limit`` 是「全部收藏」海报墙的滚动分页窗口；首页横滚行只取
+    最前面一页。卡片本体复用单库海报墙的聚合视图，因此按落点库分组聚合、
+    再按名单顺序拼回来。
+    """
+    page, total, latest = await _favorite_page(
+        session,
+        member_id=member_id,
+        visible_library_ids=visible_library_ids,
+        limit=limit,
+        offset=offset,
+    )
+    if not page:
+        return [], total
 
     by_library: dict[int, list[int]] = {}
-    for item_id in ordered:
-        by_library.setdefault(library_of[item_id], []).append(item_id)
+    for item_id, library_id in page:
+        by_library.setdefault(library_id, []).append(item_id)
     views = {}
     for library_id, ids in by_library.items():
         for view in await _aggregate_wall_views(session, library_id, ids, ids):
             views[view.media_item_id] = view
 
     result: list[FavoriteItemView] = []
-    for item_id in ordered:
+    for item_id, landing_library_id in page:
         view = views.get(item_id)
         if view is None:
             continue
@@ -103,7 +136,7 @@ async def favorite_items(
         result.append(
             FavoriteItemView(
                 **view.model_dump(),
-                library_id=library_of[item_id],
+                library_id=landing_library_id,
                 favorite_season_number=(
                     state.season_number if is_tv and state.season_number >= 0 else None
                 ),
@@ -113,3 +146,28 @@ async def favorite_items(
             )
         )
     return result, total
+
+
+async def favorite_gallery(
+    session: AsyncSession,
+    *,
+    member_id: int,
+    visible_library_ids: set[int] | None,
+    limit: int,
+    offset: int = 0,
+) -> list[LibraryGalleryGroupView]:
+    """「我的收藏」的图床浏览模式数据源：与收藏海报墙同一份名单、同一个顺序。
+
+    单库图廊是 ``/libraries/{id}/gallery``，一面墙只有一个库；收藏是跨库的一面
+    墙，所以每组各带自己的落点库（``library_id``），段标题与灯箱的「前往详情」
+    据此拼地址。分页口径与单库图廊一致：``offset`` / ``limit`` 都按**作品**数，
+    没有图的作品也占一组，前端靠"拿到的组数是否满一页"判断还有没有下一页。
+    """
+    page, _total, _latest = await _favorite_page(
+        session,
+        member_id=member_id,
+        visible_library_ids=visible_library_ids,
+        limit=limit,
+        offset=offset,
+    )
+    return await build_gallery_groups(session, page, member_id=member_id)

--- a/tests/api/test_member_auth.py
+++ b/tests/api/test_member_auth.py
@@ -604,8 +604,10 @@ _MEMBER_ALLOWLIST = {
     # 同一张表），目标条目不可见一律 404
     ("GET", "/api/v1/playback/marks"),
     ("POST", "/api/v1/playback/marks"),
-    # 首页「我的收藏」：个人数据，且只列可见库里有在位文件的作品
+    # 首页「我的收藏」：个人数据，且只列可见库里有在位文件的作品。
+    # 图廊是同一份名单的另一种铺法（「全部收藏」页的图床浏览模式），同一口径
     ("GET", "/api/v1/playback/favorites"),
+    ("GET", "/api/v1/playback/favorites/gallery"),
     # 搜索历史：个人数据；统一结果端点再按记录类型检查对应能力。
     ("GET", "/api/v1/search/history"),
     ("GET", "/api/v1/search/history/{history_id}/results"),

--- a/tests/api/test_playback_favorites.py
+++ b/tests/api/test_playback_favorites.py
@@ -211,3 +211,65 @@ def test_favorites_are_per_member_and_hidden_library_excluded(client, tmp_path):
     client.post("/api/v1/auth/logout")
     assert client.post("/api/v1/auth/login", json=_ADMIN).status_code == 200
     assert [i["media_item_id"] for i in favorites(client)["items"]] == [ids["movie_a"]]
+
+
+# ---------------------------------------------------------------------------
+# 图床浏览模式（``/playback/favorites/gallery``）
+# ---------------------------------------------------------------------------
+
+
+async def _set_poster_paths(item_ids: list[int]) -> None:
+    """给条目挂上 TMDB 海报路径，让图廊有图可铺（扫描出来的假条目本来没有）。"""
+    async with get_database().session() as session:
+        for item_id in item_ids:
+            item = await session.get(MediaItem, item_id)
+            assert item is not None
+            item.poster_path = f"/p{item_id}.jpg"
+            session.add(item)
+        await session.commit()
+
+
+def set_posters(client: TestClient, item_ids: list[int]) -> None:
+    client.portal.call(partial(_set_poster_paths, item_ids))  # type: ignore[attr-defined]
+
+
+def gallery(client: TestClient, **params) -> list[dict]:
+    resp = client.get(f"{_PB}/favorites/gallery", params=params)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["data"]
+
+
+def test_favorites_gallery_shares_the_wall_order_and_carries_landing_library(client, tmp_path):
+    """图廊与收藏海报墙是同一份名单、同一个顺序（最近收藏在前）；收藏跨库，
+    每组带自己的详情落点库——单库图廊整墙一个库，这里一组一个。"""
+    ids = seed(client, tmp_path)
+    set_posters(client, [ids["movie_a"], ids["show"]])
+    web_favorite(client, media_item_id=ids["movie_a"])
+    web_favorite(client, media_item_id=ids["show"])
+
+    groups = gallery(client)
+    assert [g["media_item_id"] for g in groups] == [ids["show"], ids["movie_a"]]
+    assert [i["media_item_id"] for i in favorites(client)["items"]] == [
+        g["media_item_id"] for g in groups
+    ]
+    assert [g["library_id"] for g in groups] == [ids["shows_library"], ids["movies_library"]]
+    assert all(g["is_favorite"] for g in groups)
+    assert [i["kind"] for i in groups[0]["images"]] == ["poster"]
+    assert groups[0]["images"][0]["url"].endswith(f"/w780/p{ids['show']}.jpg")
+
+
+def test_favorites_gallery_pages_by_work(client, tmp_path):
+    """分页口径与单库图廊一致：offset / limit 都按作品数，没图的作品也占一组
+    （前端靠"拿到的组数是否满一页"判断还有没有下一页）。"""
+    ids = seed(client, tmp_path)
+    set_posters(client, [ids["show"]])
+    for key in ("movie_a", "movie_b", "show"):
+        web_favorite(client, media_item_id=ids[key])
+
+    first = gallery(client, limit=1, offset=0)
+    assert [g["media_item_id"] for g in first] == [ids["show"]]
+    rest = gallery(client, limit=2, offset=1)
+    assert [g["media_item_id"] for g in rest] == [ids["movie_b"], ids["movie_a"]]
+    # 没有海报的两部电影仍各占一组，只是 images 为空
+    assert [g["images"] for g in rest] == [[], []]
+    assert gallery(client, limit=2, offset=3) == []

--- a/tests/e2e/test_favorites_browser.py
+++ b/tests/e2e/test_favorites_browser.py
@@ -10,7 +10,8 @@ SQLite 播种：二十五部电影 + 一部三集剧，各有在位文件。覆�
   分集卡右上角出现对勾、Jellyfin 的 ``UnplayedItemCount`` 减一；
 - 首页「我的收藏」跟在最近观看之下，横滚最近收藏的 20 部（26 个收藏时最早的
   被挤出）；「查看全部」进 /library/favorites，与单库页同一套海报墙、全部换行
-  铺开，顶栏返回键回首页；
+  铺开，顶栏那颗键能切进图床浏览（跨库图廊，与海报墙同一份名单）再切回来，
+  顶栏返回键回首页；
 - Infuse 取消收藏电影 → 详情页的心翻回未收藏、全部收藏页里也没有了。
 
 标 integration：要 pnpm（apps/web 已 install）与 Playwright Chromium，CI 不跑。
@@ -462,6 +463,23 @@ def test_favorites_and_played_end_to_end(stack) -> None:  # noqa: PLR0915
         assert wall.last.bounding_box()["y"] > wall.first.bounding_box()["y"]  # 网格换行
         expect(wall.last.get_by_role("link", name=re.compile("《电影 01》"))).to_be_visible()
         page.screenshot(path=str(shots / "06-favorites-page.png"), full_page=True)
+
+        # ---- 图床浏览：与单库页同一颗切换键，数据是跨库的收藏图廊 ----
+        # 名单与顺序跟海报墙同一份，每组带自己的详情落点库（收藏跨库）
+        groups = api(page, "get", "/playback/favorites/gallery?limit=100&offset=0")["data"]
+        assert [g["title"] for g in groups] == favorite_titles(page)
+        assert {g["library_id"] for g in groups} <= set(library_ids.values())
+        page.get_by_role("button", name="图床浏览").click()
+        expect(page.get_by_role("button", name="回到海报墙")).to_be_visible()
+        expect(page.locator("[data-library-item-id]")).to_have_count(0)
+        # 看图的两个偏好收在这一页自己的 ⋯ 里（海报墙上没有可调的，键也不出现）
+        page.get_by_role("button", name="浏览设置").click()
+        expect(page.get_by_role("menuitemcheckbox", name="按作品分组")).to_be_visible()
+        page.keyboard.press("Escape")
+        page.screenshot(path=str(shots / "06b-favorites-gallery.png"), full_page=True)
+        page.get_by_role("button", name="回到海报墙").click()
+        expect(page.locator("[data-library-item-id]")).to_have_count(total)
+
         # 顶栏返回键回到媒体库首页
         page.get_by_role("button", name=re.compile("^返回上一页")).click()
         page.wait_for_url(re.compile(r"/library$"))


### PR DESCRIPTION
「全部收藏」页的两处问题，来自用户反馈。

## 1. 竖横封面混排时格子高矮不一

`InventoryCell` 的框比例是**逐格**按自己主图选的（竖 2:3 / 横 16:9）。单库页能这么干，是因为它先把墙按比例切成竖横两区，每区内比例天然一致；而收藏是跨库混排的一面墙，于是同一行里 16:9 抓帧封面和 2:3 海报高矮不一、片名错位。

改成最近观看那一行的做法：整面墙钉死 2:3 竖框，横版封面走 `PosterCardVisual` 已有的 letterbox 分支——按真实比例居中完整显示、同图放大模糊铺底，不裁切也不撑格。首页横滚的「我的收藏」本来就是这么排的，两处从此同一形态。

没有采用「按比例分区」：收藏页排的是「最近收藏的在前」，分区会打散收藏顺序。

`InventoryCell` 为此加了可选 `frameAspect`，不传保持原行为。

## 2. 顶栏没有「海报墙 ⇄ 图床浏览」的切换键

图廊原来的数据源 `/libraries/{id}/gallery` 整面墙绑定一个库，收藏是跨库的墙，没有对应接口，所以这一页一直只有海报墙。

新增 `GET /playback/favorites/gallery`：与 `/playback/favorites` 共用同一份名单与顺序（最近收藏在前），一组是一部作品的全部图。两处共用的部分抽出来，不另起一套：

- `build_library_gallery` 拆出 `build_gallery_groups(page=[(条目, 落点库)])`，章节图与分集剧照按各自落点库那一份文件取；
- 收藏墙与收藏图廊共用 `_favorite_page` 定下的名单——两种视图翻的是同一批作品；
- 图廊分组新增 `library_id`：段标题与灯箱「前往详情」按每组自己的落点库拼地址，单库图廊里它恒等于本库；
- 前端复用 `VideoGalleryWall` / `VideoGalleryLightbox`（去掉整墙一个的 `libraryId` 形参），看图的两个偏好（按作品分组 / 瀑布流密度）抽成 `WallPrefItems` 供两处菜单共用。

浏览模式偏好与单库页共享同一份 localStorage；收藏一部都没有时不给这颗键。

## 测试

- 新增收藏图廊两例：名单顺序与跨库落点库、按作品分页（没图的作品也占一组）；
- 成员越权守护测试登记新路由（`test_every_route_denies_member_overreach`）；
- e2e `test_favorites_browser.py` 补一段「切进图廊 → ⋯ 菜单 → 切回海报墙」，本地跑通；
- `ruff check .`、`pnpm web:lint`、`pnpm web:typecheck` 干净。

不涉及运行时依赖与数据库迁移，`docker/runtime-version` 无需 bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ymDpimuekdqp888zs6qqp

---
_Generated by [Claude Code](https://claude.ai/code/session_013ymDpimuekdqp888zs6qqp)_