### PR TITLE
媒体库记住上次滑到哪：进来时底部胶囊问一句要不要跳回去

### DIFF
--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/library-confirm";
 import { chapterJobLabel } from "@/lib/library-manage";
 import {
+  HistoryIcon,
   LockIcon,
   MasonryIcon,
   MoreIcon,
@@ -97,6 +98,8 @@ import { HttpError } from "@/lib/http";
 import { formatBytes } from "@/lib/format";
 import { formatLibraryInventorySummary } from "@/lib/library-inventory-summary";
 import { activeWallInitialAtViewport, wallInitialAtOffset } from "@/lib/library-wall-index";
+import { firstVisibleAnchorId, wallRecallScope } from "@/lib/library-wall-recall";
+import { useWallRecall } from "@/lib/use-wall-recall";
 import { formatRelativeTime } from "@/lib/time";
 import { cachedImageUrl, cardVariantFor, imageUrl } from "@/lib/image-proxy";
 import { keepIfEqual, reconcileList } from "@/lib/poll-reconcile";
@@ -164,6 +167,10 @@ function keepOnError<T>(rows: Promise<T[]>): Promise<T[] | null> {
 
 export function LibraryDetailView({ libraryId }: { libraryId: number }) {
   const initialSnapshot = getLibraryDetailSnapshot(libraryId);
+  // 本次是不是「重新进入」：首帧没有会话快照 = 冷启动 / 刷新 / 换了库进来的。
+  // 必须在首帧定格——本组件挂载后自己就会写快照，之后每次 render 都读得到它。
+  // 「回到上次位置」的胶囊只在重新进入时弹（会话内返回由滚动恢复自动回位）
+  const freshEntry = useRef(initialSnapshot === undefined);
   const { canManageLibraries } = usePermissions();
   const { activeJobs } = useJobs();
   // 影视库 / 其他库的图床浏览模式（video-gallery.tsx）：海报墙换成每部作品的
@@ -243,7 +250,10 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
     initialSnapshot?.galleryGroups ?? [],
   );
   const [galleryHasMore, setGalleryHasMore] = useState(initialSnapshot?.galleryHasMore ?? false);
-  // 已请求到的条目数（按页长推进，不按拿到的组数——没图的条目也占一组）
+  // 当前图廊窗口在整份排序里的起点（0 = 墙首；「回到上次位置」跳过来后不为 0）。
+  // 与海报墙的 wallOffset 同一个意思，图廊的分页口径也是条目数
+  const galleryStart = useRef(initialSnapshot?.galleryStart ?? 0);
+  // 已请求到第几个条目（绝对位置，按页长推进，不按拿到的组数——没图的条目也占一组）
   const galleryLoaded = useRef(initialSnapshot?.galleryLoaded ?? 0);
 
   // 轮询乱序守卫：扫描期间后端响应时间抖动大，上一轮的慢响应可能晚于
@@ -277,6 +287,7 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
         wallOffset: wallOffset.current,
         galleryGroups,
         galleryHasMore,
+        galleryStart: galleryStart.current,
         galleryLoaded: galleryLoaded.current,
         stale: snapshotStale,
       }
@@ -631,19 +642,20 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
    * 不缩窗口、不动滚动位置；失败就留着旧窗口，下次返回再对账。
    */
   const refreshGallery = useCallback(() => {
-    const loaded = galleryLoaded.current;
+    const start = galleryStart.current;
+    const loaded = galleryLoaded.current - start;
     if (loaded <= 0 || galleryLoading.current) return;
     galleryLoading.current = true; // 对账期间别让滚动哨兵同时追加下一页
     Promise.all(
       Array.from({ length: Math.ceil(loaded / GALLERY_PAGE_SIZE) }, (_, page) =>
         listLibraryGallery(libraryId, {
           limit: GALLERY_PAGE_SIZE,
-          offset: page * GALLERY_PAGE_SIZE,
+          offset: start + page * GALLERY_PAGE_SIZE,
         }),
       ),
     )
       .then((pages) => {
-        galleryLoaded.current = pages.reduce((sum, page) => sum + page.length, 0);
+        galleryLoaded.current = start + pages.reduce((sum, page) => sum + page.length, 0);
         setGalleryGroups(dedupeGalleryGroups(pages.flat()));
         setGalleryHasMore((pages.at(-1)?.length ?? 0) >= GALLERY_PAGE_SIZE);
       })
@@ -652,6 +664,29 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
         galleryLoading.current = false;
       });
   }, [libraryId]);
+  /**
+   * 图廊跳到整份排序里的某个位置：与海报墙的 jumpTo 是同一件事——换掉整个
+   * 窗口（而不是从头追加到那里），此后照常向下滚动加载。图廊的分页口径也是
+   * 条目数，两面墙的 offset 通用，「回到上次位置」因此两种形态都能跳。
+   */
+  const jumpGalleryTo = useCallback(
+    (offset: number) => {
+      galleryLoading.current = true; // 跳转期间挡住滚动哨兵与对账，别让旧窗口的页插进来
+      galleryStart.current = offset;
+      listLibraryGallery(libraryId, { limit: GALLERY_PAGE_SIZE, offset })
+        .then((page) => {
+          galleryLoaded.current = offset + page.length;
+          setGalleryGroups(dedupeGalleryGroups(page));
+          setGalleryHasMore(page.length >= GALLERY_PAGE_SIZE);
+          wallTop.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+        })
+        .catch(() => {})
+        .finally(() => {
+          galleryLoading.current = false;
+        });
+    },
+    [libraryId],
+  );
   /**
    * 图廊里点心：收藏 / 取消收藏整部作品（与详情页那颗心同一落点）。
    *
@@ -695,11 +730,61 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
       return;
     }
     galleryWindowLibrary.current = libraryId;
+    galleryStart.current = 0;
     galleryLoaded.current = 0;
     setGalleryGroups([]);
     setGalleryHasMore(false);
     loadMoreGallery();
   }, [gallery, libraryId, loadMoreGallery, refreshGallery]);
+
+  /* —— 「回到上次浏览的位置」（lib/library-wall-recall.ts）——
+     大库滑到第几十屏是常态，关掉页面第二天再进来又从墙首开始。这里在底部弹
+     一枚胶囊问一句：要跳回去点它，不要就继续滑——滑够一屏胶囊自己让位，
+     从那一刻起记的是新位置。会话内从详情页返回不弹（滚动恢复已经自动回位）。 */
+  // 墙的形态决定 offset 的口径：图廊按标题序分页，其他库的海报墙按内容时间序，
+  // 两者的「第 300 个」不是同一部作品，形态对不上就不提示（见 WallRecall.view）
+  const wallView = gallery ? "gallery" : timeline ? "wall:time" : "wall:title";
+  // 条目 id → 它在整份排序里的绝对位置。滚动时按首个可见格反查（图廊按瓦片
+  // 所属的作品），DOM 上只挂 id，不必给每一格再算一遍下标
+  const offsetById = useMemo(
+    () => new Map(items.map((item, index) => [String(item.media_item_id), wallStart + index])),
+    [items, wallStart],
+  );
+  // galleryStart 只在窗口被整体换掉时变，与 galleryGroups 同一时刻，不必进依赖
+  const galleryOffsetById = useMemo(
+    () =>
+      new Map(
+        galleryGroups.map((group, index) => [
+          String(group.media_item_id),
+          galleryStart.current + index,
+        ]),
+      ),
+    [galleryGroups],
+  );
+  const wallOffsetAt = useCallback(() => {
+    const wall = wallTop.current;
+    if (!wall || !scrollElement) return null;
+    const id = firstVisibleAnchorId(
+      wall,
+      gallery ? "data-gallery-item-id" : "data-library-item-id",
+      scrollElement.getBoundingClientRect().top,
+    );
+    // 反查不到就不记：未识别分区的格子也挂着条目 id，但它不在主排序里，
+    // 拿它的位置去跳会跳到一部毫不相干的作品上
+    return id === null ? null : ((gallery ? galleryOffsetById : offsetById).get(id) ?? null);
+  }, [gallery, galleryOffsetById, offsetById, scrollElement]);
+  const { recallOffset, dismissRecall } = useWallRecall({
+    scope: wallRecallScope(libraryId),
+    view: wallView,
+    scroller: scrollElement,
+    // 补探阶段的排序是临时的（几分钟后自动落回拼音序），那期间不记也不提示
+    enabled: !probing && (gallery ? galleryGroups.length > 0 : items.length > 0),
+    offer: freshEntry.current,
+    offsetAt: wallOffsetAt,
+  });
+  // 记录可能指向已经不存在的位置（库被清空、大批删除），跳过去只会是一面空墙
+  const recallable =
+    recallOffset !== null && recallOffset < (library?.stats.item_count ?? 0) ? recallOffset : null;
   const wideCards = Boolean(library && library.capabilities.default_aspect > 1);
   // 其他库的主图两种形态并存：刮削器放好 -poster 的是 2:3 竖版海报，只有 -thumb /
   // 抓帧的是横版缩略图。竖横混在一个网格里对不齐，按主图比例切成两区，各自用
@@ -1276,8 +1361,8 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
                 {/* 图廊与海报墙各自分页，哨兵按当前模式接线（图廊按作品数计） */}
                 <WallLoadMore
                   hasMore={gallery ? galleryHasMore : wallHasMore}
-                  loaded={gallery ? galleryLoaded.current : items.length}
-                  start={gallery ? 0 : wallStart}
+                  loaded={gallery ? galleryLoaded.current - galleryStart.current : items.length}
+                  start={gallery ? galleryStart.current : wallStart}
                   total={library.stats.item_count}
                   onReach={gallery ? loadMoreGallery : loadMore}
                   rootMargin={gallery ? GALLERY_LOAD_MARGIN : undefined}
@@ -1370,6 +1455,18 @@ export function LibraryDetailView({ libraryId }: { libraryId: number }) {
       )}
 
       </>
+      )}
+
+      {/* 上次滑到哪：进来时问一句要不要跳回去，不理它、往下滑一屏就自己消失 */}
+      {recallable !== null && (
+        <WallRecallPill
+          onJump={() => {
+            dismissRecall();
+            if (gallery) jumpGalleryTo(recallable);
+            else jumpTo(recallable);
+          }}
+          onDismiss={dismissRecall}
+        />
       )}
 
       {canManageLibraries && (
@@ -1727,6 +1824,44 @@ export const InventoryCell = memo(function InventoryCell({
     </div>
   );
 });
+
+/**
+ * 「回到上次浏览的位置」胶囊：贴在视口底部中央，与 Toast 同一套浮入语言。
+ *
+ * 为什么是胶囊而不是直接跳回去：跳转会换掉整个分页窗口（上方的内容不再加载），
+ * 这一步得由用户决定——有人回来就是想从头看看新入库了什么。所以只问一句，
+ * 不理它往下滑一屏它就让位（见 lib/use-wall-recall.ts），× 是给想立刻清屏的人。
+ *
+ * z-[45]：压过墙与索引条，但低于弹层（50/60）、灯箱（70）与 Toast（95）——
+ * 它只是个建议，任何真正的操作都该盖住它。
+ */
+function WallRecallPill({ onJump, onDismiss }: { onJump: () => void; onDismiss: () => void }) {
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 bottom-[calc(var(--safe-bottom)+18px)] z-[45] flex justify-center px-4"
+    >
+      <div className="toast-item pointer-events-auto flex items-center gap-1 rounded-full border border-white/[0.12] bg-[rgba(16,18,26,0.92)] py-1 pl-1 pr-1.5 shadow-[0_18px_50px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <button
+          type="button"
+          onClick={onJump}
+          className="flex items-center gap-2 rounded-full px-3 py-1.5 text-sub font-medium text-white/90 transition hover:bg-white/[0.1] active:scale-[0.98]"
+        >
+          <HistoryIcon className="size-4 shrink-0 text-[var(--accent)]" />
+          回到上次浏览的位置
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="不用了"
+          className="flex size-7 shrink-0 items-center justify-center rounded-full text-white/45 transition hover:bg-white/[0.1] hover:text-white/80"
+        >
+          <XIcon className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
 
 /**
  * 海报墙底部的滚动加载哨兵。

--- a/apps/web/components/photo-wall.tsx
+++ b/apps/web/components/photo-wall.tsx
@@ -423,6 +423,9 @@ const PhotoTile = memo(function PhotoTile({
     // 瓦片跳过绘制——尺寸是显式的，不需要 intrinsic-size 占位
     <button
       type="button"
+      // 位置锚点：会话内的滚动恢复（lib/use-scroll-restoration.ts）与跨会话的
+      // 「回到上次位置」（lib/library-wall-recall.ts）都按它认这一屏是哪几张
+      data-library-item-id={item.media_item_id}
       aria-label={`查看 ${item.title}`}
       onClick={onOpen}
       className="group/tile absolute left-0 top-0 block overflow-hidden rounded-xl bg-[#141824] text-left shadow-[0_8px_22px_rgba(0,0,0,0.35)] ring-1 ring-white/[0.07] transition-[transform,width,height,box-shadow] duration-300 ease-out [content-visibility:auto] hover:z-[2] hover:shadow-[0_18px_44px_rgba(0,0,0,0.6)] hover:ring-white/25 focus-visible:z-[2] focus-visible:ring-2 focus-visible:ring-[var(--accent)] motion-reduce:transition-none"

--- a/apps/web/components/video-gallery.tsx
+++ b/apps/web/components/video-gallery.tsx
@@ -485,6 +485,9 @@ const GalleryTile = memo(function GalleryTile({
       // 首个可见瓦片，返回时按它回位。纯像素位在窗口宽度变过（转屏、缩窗口）
       // 之后会错行——masonry 重排后同一个 y 已经不是同一批图了
       data-gallery-tile-id={tileKey(group, image)}
+      // 所属作品：图廊按作品分页，「回到上次位置」记的是作品在整份排序里的
+      // 位置（lib/library-wall-recall.ts），单张图的下标没法用来跳转
+      data-gallery-item-id={group.media_item_id}
       aria-label={`查看 ${group.title} · ${image.label}${group.is_favorite ? "（已收藏）" : ""}`}
       onClick={() => onOpen(index)}
       className="group/tile absolute left-0 top-0 block overflow-hidden rounded-xl bg-[#141824] text-left shadow-[0_8px_22px_rgba(0,0,0,0.35)] ring-1 ring-white/[0.07] transition-[transform,width,height,box-shadow] duration-300 ease-out [content-visibility:auto] hover:z-[2] hover:shadow-[0_18px_44px_rgba(0,0,0,0.6)] hover:ring-white/25 focus-visible:z-[2] focus-visible:ring-2 focus-visible:ring-[var(--accent)] motion-reduce:transition-none"

--- a/apps/web/lib/library-detail-snapshot.ts
+++ b/apps/web/lib/library-detail-snapshot.ts
@@ -40,7 +40,9 @@ export interface LibraryDetailSnapshot {
    */
   galleryGroups: LibraryGalleryGroup[];
   galleryHasMore: boolean;
-  /** 已向服务端请求到第几个条目（图廊按条目分页），返回后按同样的页数对账 */
+  /** 这份窗口在整份排序里的起点（「回到上次位置」跳过来后不为 0） */
+  galleryStart: number;
+  /** 已向服务端请求到第几个条目（绝对位置，图廊按条目分页），返回后按同样的页数对账 */
   galleryLoaded: number;
   /** 删除或转移等操作后标记为过期；保留旧窗口只为让滚动恢复有落脚点。 */
   stale: boolean;

--- a/apps/web/lib/library-wall-recall.ts
+++ b/apps/web/lib/library-wall-recall.ts
@@ -1,0 +1,152 @@
+/**
+ * 媒体库墙的「上次浏览到哪」——跨会话的位置记忆（配合底部胶囊）。
+ *
+ * 与 lib/use-scroll-restoration.ts 的分工，两者互不覆盖：
+ *   - 滚动恢复只活在**同一次浏览会话**里（内存 Map）：点进详情页再返回，
+ *     自动回到原处，不问用户；
+ *   - 这里记的是**跨会话**的位置（localStorage）：关掉标签页、明天再打开，
+ *     底部弹一枚胶囊问「要不要回到上次的位置」。跳不跳由用户决定，所以
+ *     不还原像素，只存一个「首个可见条目在整份排序里的绝对位置」，跳转走
+ *     墙自己的分页跳转（与 A-Z 索引条同一条路：换一个从该位置起的窗口）。
+ *
+ * 为什么存绝对位置而不是 scrollTop：墙是分页的，几千部的库离开时可能已经
+ * 加载了十几屏。按像素恢复要把这十几屏原样重拉一遍（十几个请求），按位置
+ * 跳转只需一页——代价是跳过去之后上方的内容没有加载，这与索引条跳字母的
+ * 行为一致，用户是熟悉的。
+ *
+ * 纯逻辑模块（存储可注入），`node --test` 直接跑。
+ */
+
+export interface KeyValueStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** 一面墙的位置记录。 */
+export interface WallRecall {
+  /** 上次首个可见条目在整份排序里的绝对位置（0 = 墙首） */
+  offset: number;
+  /**
+   * 记录时那面墙的形态：海报墙 / 图廊、以及排序口径。形态一换，同一个 offset
+   * 指向的就不是同一部作品了（比如按时间排的其他库与按标题排的图廊），
+   * 对不上就当作没有记录，宁可不提示也不要把人送到莫名其妙的位置。
+   */
+  view: string;
+  updatedAt: number;
+}
+
+/** 全部墙的记录合存一个键：一库一个键会在 localStorage 里越积越多且无人清理。 */
+const STORAGE_KEY = "movieclaw.wall-recall";
+/** 最多记住多少面墙（超出按最久未更新淘汰） */
+const MAX_ENTRIES = 20;
+/**
+ * 过期时长：两周前看到哪里，今天已经不是「上次」了，弹胶囊只剩打扰。
+ * 库的内容也在变，太旧的绝对位置多半已经指向别的作品。
+ */
+export const RECALL_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+/**
+ * 浅于这个位置不提示：一两屏的距离用户自己滑更快，胶囊只是碍事。
+ * 24 ≈ 桌面海报墙两行多、手机三行多。
+ */
+export const RECALL_MIN_OFFSET = 24;
+
+function storageOrNull(storage?: KeyValueStorage): KeyValueStorage | null {
+  if (storage) return storage;
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null; // 隐私模式 / 禁用站点数据：当作没有记录，功能静默降级
+  }
+}
+
+function readAll(store: KeyValueStorage): Record<string, WallRecall> {
+  try {
+    const raw = store.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const rows: Record<string, WallRecall> = {};
+    for (const [scope, value] of Object.entries(parsed as Record<string, unknown>)) {
+      const row = value as Partial<WallRecall> | null;
+      if (!row || typeof row.offset !== "number" || typeof row.view !== "string") continue;
+      rows[scope] = {
+        offset: Math.max(0, Math.trunc(row.offset)),
+        view: row.view,
+        updatedAt: typeof row.updatedAt === "number" ? row.updatedAt : 0,
+      };
+    }
+    return rows;
+  } catch {
+    return {}; // 存的内容坏了就当没记过，下一次滚动会重新写入
+  }
+}
+
+function writeAll(store: KeyValueStorage, rows: Record<string, WallRecall>) {
+  // 超限时淘汰最久未更新的那几面墙
+  const entries = Object.entries(rows).sort((a, b) => b[1].updatedAt - a[1].updatedAt);
+  try {
+    store.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(entries.slice(0, MAX_ENTRIES))));
+  } catch {
+    /* 配额满 / 隐私模式：位置记不住而已，不影响浏览 */
+  }
+}
+
+/** 一面墙的记录键：单库页是 `library:12`。 */
+export function wallRecallScope(libraryId: number): string {
+  return `library:${libraryId}`;
+}
+
+/**
+ * 读上次的位置。形态对不上、太浅、过期、没记过一律回 null——调用方据此
+ * 决定要不要弹胶囊，拿到 null 就当作「这次是从头看」。
+ */
+export function readWallRecall(
+  scope: string,
+  view: string,
+  storage?: KeyValueStorage,
+  now: number = Date.now(),
+): WallRecall | null {
+  const store = storageOrNull(storage);
+  if (!store) return null;
+  const saved = readAll(store)[scope];
+  if (!saved || saved.view !== view) return null;
+  if (saved.offset < RECALL_MIN_OFFSET) return null;
+  if (now - saved.updatedAt > RECALL_MAX_AGE_MS) return null;
+  return saved;
+}
+
+/** 记下当前位置（同一面墙覆盖上一条）。 */
+export function writeWallRecall(
+  scope: string,
+  view: string,
+  offset: number,
+  storage?: KeyValueStorage,
+  now: number = Date.now(),
+) {
+  const store = storageOrNull(storage);
+  if (!store) return;
+  const rows = readAll(store);
+  rows[scope] = { offset: Math.max(0, Math.trunc(offset)), view, updatedAt: now };
+  writeAll(store, rows);
+}
+
+/**
+ * 找出滚动容器里第一个还露在视口内的锚点。
+ *
+ * 锚点按 DOM 顺序传入（海报墙一格一个条目，图廊一张图一个瓦片，瓦片带的是
+ * 所属作品）。命中即返回，不必量完整面墙——用户在第几屏，就只多读几屏的
+ * 矩形。`viewportTop` 是滚动容器可视区的顶边（不是页面顶边）。
+ */
+export function firstVisibleAnchorId(
+  container: Element,
+  attribute: string,
+  viewportTop: number,
+): string | null {
+  for (const node of container.querySelectorAll(`[${attribute}]`)) {
+    if (node.getBoundingClientRect().bottom > viewportTop) {
+      return node.getAttribute(attribute);
+    }
+  }
+  return null;
+}

--- a/apps/web/lib/use-wall-recall.ts
+++ b/apps/web/lib/use-wall-recall.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { readWallRecall, writeWallRecall } from "@/lib/library-wall-recall";
+
+/** 记录节流：滚动中最多这么久写一次（用户滑得再快也只写十几次） */
+const RECORD_THROTTLE_MS = 500;
+/** 停下来这么久再补记一次，落定的位置才是「上次看到哪」 */
+const RECORD_SETTLE_MS = 300;
+/** 胶囊自动消失的滚动距离下限：不足一屏的窄视口也得滑够这么多 */
+const DISMISS_MIN_DISTANCE_PX = 400;
+
+interface WallRecallOptions {
+  /** 记录键，见 wallRecallScope */
+  scope: string;
+  /** 当前墙的形态 + 排序口径，见 WallRecall.view */
+  view: string;
+  /** 真正的滚动容器 */
+  scroller: HTMLElement | null;
+  /** 数据到齐、排序稳定时才开工；false 时既不提示也不记录 */
+  enabled: boolean;
+  /**
+   * 这次是不是「重新进入」。会话内从详情页返回由滚动恢复自动回位
+   * （lib/use-scroll-restoration.ts），那种情况不该再弹胶囊问一遍。
+   */
+  offer: boolean;
+  /** 读当前首个可见条目在整份排序里的绝对位置；量不到给 null */
+  offsetAt: () => number | null;
+}
+
+/**
+ * 「回到上次浏览的位置」的记录与提示。
+ *
+ * 一句话规则：**胶囊在，就不记新位置**——否则用户刚进页面（在墙首）的那几次
+ * 滚动会立刻把上次的位置覆盖成 0，胶囊按下去等于原地不动。所以：
+ *
+ *   1. 进入时读一次记录，够深且形态对得上就把 offset 交给调用方弹胶囊；
+ *   2. 胶囊在期间只数滚动距离，滑够一屏就自己消失（用户用行动表示不需要）；
+ *   3. 胶囊消失或被点掉之后，才开始把新位置写回去。
+ */
+export function useWallRecall({
+  scope,
+  view,
+  scroller,
+  enabled,
+  offer,
+  offsetAt,
+}: WallRecallOptions) {
+  const [recallOffset, setRecallOffset] = useState<number | null>(null);
+  // 滚动回调里要读最新的取值函数与胶囊状态，但重建监听器会丢掉已累计的
+  // 滚动距离，因此都走 ref
+  const offsetAtRef = useRef(offsetAt);
+  offsetAtRef.current = offsetAt;
+  const pendingRef = useRef<number | null>(null);
+  pendingRef.current = recallOffset;
+
+  // 同一面墙只问一次：数据分几批到达会让 enabled 反复变 true。换了形态
+  //（切图床浏览）算另一面墙，先撤掉上一枚胶囊——它的 offset 是按上一种排序
+  // 记的，留着按下去会跳到别处
+  const asked = useRef<string | null>(null);
+  useEffect(() => {
+    const token = `${scope}|${view}`;
+    if (asked.current === token) return;
+    setRecallOffset(null);
+    if (!enabled) return; // 数据还没到齐，等这面墙画出来再问
+    asked.current = token;
+    if (offer) setRecallOffset(readWallRecall(scope, view)?.offset ?? null);
+  }, [enabled, offer, scope, view]);
+
+  const dismissRecall = useCallback(() => setRecallOffset(null), []);
+
+  useEffect(() => {
+    if (!scroller || !enabled) return;
+
+    let lastTop = scroller.scrollTop;
+    let travelled = 0;
+    let lastWrite = 0;
+    let settle: ReturnType<typeof setTimeout> | undefined;
+    const record = () => {
+      const offset = offsetAtRef.current();
+      if (offset === null) return; // 墙还没画出来，等下一次滚动
+      lastWrite = Date.now();
+      writeWallRecall(scope, view, offset);
+    };
+    const onScroll = () => {
+      const top = scroller.scrollTop;
+      travelled += Math.abs(top - lastTop);
+      lastTop = top;
+      if (pendingRef.current !== null) {
+        // 胶囊还在：用户滑过一屏就当他自己找位置去了，胶囊让位、记录接管
+        if (travelled >= Math.max(DISMISS_MIN_DISTANCE_PX, scroller.clientHeight)) {
+          setRecallOffset(null);
+        }
+        return;
+      }
+      // 滚动中按节流写一次（用户可能随时关掉页面，不能只等停下来那一下），
+      // 停下来再补一次落定位置
+      if (Date.now() - lastWrite >= RECORD_THROTTLE_MS) record();
+      clearTimeout(settle);
+      settle = setTimeout(record, RECORD_SETTLE_MS);
+    };
+
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      clearTimeout(settle);
+      scroller.removeEventListener("scroll", onScroll);
+    };
+  }, [enabled, scope, scroller, view]);
+
+  return { recallOffset, dismissRecall };
+}

--- a/apps/web/test/library-wall-recall.test.mjs
+++ b/apps/web/test/library-wall-recall.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RECALL_MAX_AGE_MS,
+  RECALL_MIN_OFFSET,
+  readWallRecall,
+  wallRecallScope,
+  writeWallRecall,
+} from "../lib/library-wall-recall.ts";
+
+/** 内存版 localStorage：只实现这三个方法，与浏览器里那份接口一致。 */
+function memoryStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    store,
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v);
+    },
+    removeItem: (k) => {
+      delete store[k];
+    },
+  };
+}
+
+const SCOPE = wallRecallScope(7);
+const NOW = 1_700_000_000_000;
+
+test("记下的位置按同一面墙读得回来", () => {
+  const storage = memoryStorage();
+  writeWallRecall(SCOPE, "wall:title", 320, storage, NOW);
+  assert.deepEqual(readWallRecall(SCOPE, "wall:title", storage, NOW), {
+    offset: 320,
+    view: "wall:title",
+    updatedAt: NOW,
+  });
+});
+
+test("换了墙的形态就当作没记过（同一个位置指向的不是同一部作品）", () => {
+  const storage = memoryStorage();
+  writeWallRecall(SCOPE, "wall:title", 320, storage, NOW);
+  assert.equal(readWallRecall(SCOPE, "gallery", storage, NOW), null);
+  assert.equal(readWallRecall(wallRecallScope(8), "wall:title", storage, NOW), null);
+});
+
+test("太浅的位置不提示：一两屏用户自己滑更快", () => {
+  const storage = memoryStorage();
+  writeWallRecall(SCOPE, "wall:title", RECALL_MIN_OFFSET - 1, storage, NOW);
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW), null);
+  writeWallRecall(SCOPE, "wall:title", RECALL_MIN_OFFSET, storage, NOW);
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW)?.offset, RECALL_MIN_OFFSET);
+});
+
+test("太旧的记录不再提示", () => {
+  const storage = memoryStorage();
+  writeWallRecall(SCOPE, "wall:title", 320, storage, NOW);
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW + RECALL_MAX_AGE_MS + 1), null);
+  assert.ok(readWallRecall(SCOPE, "wall:title", storage, NOW + RECALL_MAX_AGE_MS));
+});
+
+test("同一面墙覆盖上一条，超限时淘汰最久未更新的墙", () => {
+  const storage = memoryStorage();
+  writeWallRecall(SCOPE, "wall:title", 320, storage, NOW);
+  writeWallRecall(SCOPE, "wall:title", 640, storage, NOW + 1000);
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW + 1000)?.offset, 640);
+
+  // 最早写入的那一面墙（0 号）应当在写满 20 面之后被挤掉
+  for (let i = 0; i < 21; i += 1) {
+    writeWallRecall(wallRecallScope(100 + i), "wall:title", 100 + i, storage, NOW + 2000 + i);
+  }
+  assert.equal(readWallRecall(wallRecallScope(100), "wall:title", storage, NOW + 3000), null);
+  assert.equal(
+    readWallRecall(wallRecallScope(120), "wall:title", storage, NOW + 3000)?.offset,
+    120,
+  );
+});
+
+test("存储内容损坏时当作没记过，不抛异常", () => {
+  const storage = memoryStorage({ "movieclaw.wall-recall": "{不是 JSON" });
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW), null);
+  writeWallRecall(SCOPE, "wall:title", 320, storage, NOW);
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW)?.offset, 320);
+});
+
+test("读不到 storage（隐私模式）时静默降级", () => {
+  const failing = {
+    getItem: () => {
+      throw new Error("denied");
+    },
+    setItem: () => {
+      throw new Error("denied");
+    },
+    removeItem: () => {},
+  };
+  assert.equal(readWallRecall(SCOPE, "wall:title", failing, NOW), null);
+  assert.doesNotThrow(() => writeWallRecall(SCOPE, "wall:title", 320, failing, NOW));
+});


### PR DESCRIPTION
大库滑到第几十屏是常态，关掉页面第二天再进来又得从墙首重滑一遍。这个 PR 让墙记住上次看到哪，重新进入时在底部弹一枚胶囊问一句。

## 怎么做的

**记的是「位置」不是像素**（`lib/library-wall-recall.ts`）：存的是「首个可见条目在整份排序里的绝对位置」，写进 localStorage（一库一条、最多 20 面墙、两周过期）。墙本身是分页的——按 scrollTop 恢复要把离开时的十几屏原样重拉一遍（十几个请求），按位置跳转只要一页，走的是墙已有的窗口跳转（与 A-Z 索引条点字母同一条路）。代价是跳过去之后上方内容没有加载，这与索引条跳字母的行为一致。

**胶囊的三条规则**（`lib/use-wall-recall.ts`）：

1. 进来时读一次记录，够深（≥24 个条目）、形态对得上、没过期才弹；
2. **胶囊在期间不记新位置**——否则刚进页面（还在墙首）的那几下滚动会立刻把目标覆盖成 0，按下去等于原地不动；
3. 往下滑够一屏胶囊自己让位，从那一刻起记的是新位置；× 给想立刻收掉的人。

**三种形态都支持**：海报墙、图片库相册墙、图床浏览。图廊此前只能从墙首往后翻，这里补上窗口起点 `galleryStart`（跳转、对账、加载哨兵的进度文案都按它算）；相册墙瓦片补了 `data-library-item-id`，顺带让图片库的会话内滚动恢复也有锚点可用（此前它只能按像素恢复）。

**特意不做的**：

- 会话内从条目详情页返回不弹胶囊——那条路由由既有的滚动恢复（`lib/use-scroll-restoration.ts`）自动回位，再问一遍是打扰。胶囊只在冷启动 / 刷新 / 换库进来时出现；
- 扫描补探阶段的排序是临时的，那几分钟不记也不提示；
- 未识别分区的格子也挂着条目 id，但它不在主排序里，量到它就不记，免得跳到毫不相干的作品上。

## 改动

| 文件 | 内容 |
| --- | --- |
| `lib/library-wall-recall.ts` | 新增：跨会话位置记录（纯逻辑，存储可注入） |
| `lib/use-wall-recall.ts` | 新增：记录 + 提示的 hook（节流写入、滚动自动让位） |
| `components/library-detail-view.tsx` | 接线 + 胶囊组件 + 图廊窗口起点 |
| `components/photo-wall.tsx` / `components/video-gallery.tsx` | 瓦片补位置锚点属性 |
| `lib/library-detail-snapshot.ts` | 会话快照带上 `galleryStart` |
| `test/library-wall-recall.test.mjs` | 新增 7 个用例 |

## 测试

- `pnpm web:typecheck`、`pnpm web:lint` 全绿（仅两处既有 warning）；
- `node --test test/library-wall-recall.test.mjs` 7/7 通过（形态不匹配、太浅、过期、超限淘汰、存储损坏、隐私模式降级）；
- 全量 `node --test` 406/407，唯一失败是既有的 `time.test.mjs`（容器时区 UTC，用例按 Asia/Shanghai 断言），与本次改动无关；
- 未跑真机视觉验证：需要后端 + 有内容的大库，容器里起不来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqKZYJPtfESvyjHqBXsXWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqKZYJPtfESvyjHqBXsXWG)_