### PR TITLE
弹窗超长内容不再滚不动：基座兜底滚动，长表单头/底栏常驻

### DIFF
--- a/apps/web/components/download-target-dialog.tsx
+++ b/apps/web/components/download-target-dialog.tsx
@@ -469,9 +469,12 @@ function DialogContent({
 
   return (
     <Modal open onClose={onClose} label="选择保存位置">
-      <div className="space-y-4 p-6">
-          <h2 className="text-title font-bold text-white">选择保存位置</h2>
+      {/* 头部常驻：目录一多就得滚，标题不跟着滚走才知道自己在选什么 */}
+      <div className="border-b border-white/[0.07] px-6 pb-4 pt-6">
+        <h2 className="text-title font-bold text-white">选择保存位置</h2>
+      </div>
 
+      <div className="scroll-thin min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
           {error && (
             <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
               {error}
@@ -607,20 +610,21 @@ function DialogContent({
               配置路径映射，提交时会自动翻译成下载器视角。
             </p>
           )}
+      </div>
 
-          <div className="flex justify-end gap-3 pt-1">
-            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
-              取消
-            </button>
-            <button
-              type="button"
-              onClick={submit}
-              disabled={busy || selected === null}
-              className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
-            >
-              {busy ? "提交中…" : "确认下载"}
-            </button>
-          </div>
+      {/* 底栏常驻：确认按钮永远在屏幕上，不必先把长列表滚到底才找得到 */}
+      <div className="flex justify-end gap-3 border-t border-white/[0.07] px-6 py-4">
+        <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
+          取消
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy || selected === null}
+          className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
+        >
+          {busy ? "提交中…" : "确认下载"}
+        </button>
       </div>
     </Modal>
   );

--- a/apps/web/components/downloader-config-section.tsx
+++ b/apps/web/components/downloader-config-section.tsx
@@ -741,17 +741,18 @@ function DownloaderLimitsModal({
 
   return (
     <Modal open={open} onClose={onClose} label="限速与队列" width="lg">
-      <div className="space-y-4 p-6">
-        <div>
-          <h2 className="text-title font-bold text-[var(--text)]">
-            限速与队列 · {downloader.name}
-          </h2>
-          <p className="mt-1 text-sub leading-5 text-[var(--text-muted)]">
-            实时读写下载器的全局设置。限速留空 = 不限；队列上限决定同时活动的任务数，
-            开着刷流大量做种时建议调大做种/活动上限，避免新任务排队。
-          </p>
-        </div>
+      {/* 头部常驻 */}
+      <div className="border-b border-white/[0.07] px-6 pb-4 pt-6">
+        <h2 className="text-title font-bold text-[var(--text)]">
+          限速与队列 · {downloader.name}
+        </h2>
+        <p className="mt-1 text-sub leading-5 text-[var(--text-muted)]">
+          实时读写下载器的全局设置。限速留空 = 不限；队列上限决定同时活动的任务数，
+          开着刷流大量做种时建议调大做种/活动上限，避免新任务排队。
+        </p>
+      </div>
 
+      <div className="scroll-thin min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
         {error && (
           <div className="rounded-xl border border-[#ff6b6b]/30 bg-[#ff6b6b]/10 px-4 py-3 text-body text-[#ff6b6b]">
             {error}
@@ -844,25 +845,26 @@ function DownloaderLimitsModal({
             )}
           </div>
         )}
+      </div>
 
-        <div className="flex justify-end gap-2.5 pt-1">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={busy}
-            className="btn-glass px-4 py-2 text-sub font-medium"
-          >
-            取消
-          </button>
-          <button
-            type="button"
-            onClick={() => void save()}
-            disabled={busy || loading}
-            className="btn-accent rounded-full px-4 py-2 text-sub font-semibold disabled:opacity-60"
-          >
-            {busy ? "保存中…" : "保存"}
-          </button>
-        </div>
+      {/* 底栏常驻 */}
+      <div className="flex justify-end gap-2.5 border-t border-white/[0.07] px-6 py-4">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={busy}
+          className="btn-glass px-4 py-2 text-sub font-medium"
+        >
+          取消
+        </button>
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={busy || loading}
+          className="btn-accent rounded-full px-4 py-2 text-sub font-semibold disabled:opacity-60"
+        >
+          {busy ? "保存中…" : "保存"}
+        </button>
       </div>
     </Modal>
   );

--- a/apps/web/components/import-watch-section.tsx
+++ b/apps/web/components/import-watch-section.tsx
@@ -546,11 +546,14 @@ function RuleFormDialog({
   return (
     <>
       <Modal open onClose={onClose} label={rule ? "编辑自动入库规则" : "添加自动入库规则"}>
-        <div className="space-y-4 p-6">
+        {/* 头部常驻 */}
+        <div className="border-b border-white/[0.07] px-6 pb-4 pt-6">
           <h2 className="text-title font-bold text-white">
             {rule ? "编辑自动入库规则" : "添加自动入库规则"}
           </h2>
+        </div>
 
+        <div className="scroll-thin min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
           {error && (
             <p className="rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-ui leading-6 text-red-200">
               {error}
@@ -763,20 +766,21 @@ function RuleFormDialog({
                 : "规则生效时目录里已有的条目会被标记为「已忽略」（不整理、不报错），之后只处理新增的下载；忽略的条目随时可在清单中恢复处理。适合目录里有其他工具管理的存量内容的场景。"}
             </p>
           </div>
+        </div>
 
-          <div className="flex items-center justify-end gap-3 pt-1">
-            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
-              取消
-            </button>
-            <button
-              type="button"
-              onClick={submit}
-              disabled={!canSubmit}
-              className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
-            >
-              {busy ? "保存中…" : "保存"}
-            </button>
-          </div>
+        {/* 底栏常驻：表单比屏幕长，保存按钮不能跟着内容滚出视野 */}
+        <div className="flex items-center justify-end gap-3 border-t border-white/[0.07] px-6 py-4">
+          <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
+            取消
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!canSubmit}
+            className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
+          >
+            {busy ? "保存中…" : "保存"}
+          </button>
         </div>
       </Modal>
 

--- a/apps/web/components/media-source-annotation-dialog.tsx
+++ b/apps/web/components/media-source-annotation-dialog.tsx
@@ -81,14 +81,24 @@ export function MediaSourceAnnotationDialog({
   };
 
   return (
-    <Modal open onClose={onClose} label="标注片源" width="lg" raised={raised}>
-      <div className="scroll-thin max-h-[80dvh] overflow-y-auto p-6 max-md:p-5">
+    <Modal
+      open
+      onClose={onClose}
+      label="标注片源"
+      width="lg"
+      raised={raised}
+      panelClassName="max-h-[80dvh]"
+    >
+      {/* 头部常驻 */}
+      <div className="border-b border-white/[0.07] px-6 pb-4 pt-6 max-md:px-5">
         <h2 className="text-title font-bold text-white">标注{scopeLabel}的片源</h2>
         <p className="mt-1 text-sub leading-6 text-[var(--text-muted)]">
           这些文件的文件名里没有可识别的片源标记，系统无法确认它们是否低于洗版目标。
           看一眼文件名，把你知道的来源告诉系统——标注一次，之后整季自动参与洗版判定。
         </p>
+      </div>
 
+      <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
         {error && (
           <p className="mt-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-sub leading-6 text-red-200">
             {error}
@@ -160,27 +170,24 @@ export function MediaSourceAnnotationDialog({
             );
           })}
         </div>
+      </div>
 
-        <div className="mt-6 flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="btn-glass h-10 px-4 text-ui font-medium"
-          >
-            取消
-          </button>
-          <button
-            type="button"
-            disabled={busy || !option || !candidates?.length}
-            onClick={() => void apply()}
-            className="btn-accent inline-flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
-          >
-            {busy && (
-              <span className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white/90" />
-            )}
-            确认标注
-          </button>
-        </div>
+      {/* 底栏常驻：文件一多就要滚，确认按钮不能被滚出屏幕 */}
+      <div className="flex justify-end gap-2 border-t border-white/[0.07] px-6 py-4 max-md:px-5">
+        <button type="button" onClick={onClose} className="btn-glass h-10 px-4 text-ui font-medium">
+          取消
+        </button>
+        <button
+          type="button"
+          disabled={busy || !option || !candidates?.length}
+          onClick={() => void apply()}
+          className="btn-accent inline-flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
+        >
+          {busy && (
+            <span className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white/90" />
+          )}
+          确认标注
+        </button>
       </div>
     </Modal>
   );

--- a/apps/web/components/modal.tsx
+++ b/apps/web/components/modal.tsx
@@ -12,8 +12,13 @@
  * 3. **玻璃面板视觉**（圆角/描边/阴影/毛玻璃）收敛为一份，改一处全局生效。
  *
  * 页面弹窗在外层包业务壳（如 download-target-dialog、subscribe-dialog），
- * 面板内部布局（滚动区/头部/底栏）由 children 自理；需要定制时用 width 换
- * 宽度档位、panelClassName 追加布局类（如 "flex max-h-[76vh] flex-col"）。
+ * 需要定制时用 width 换宽度档位、panelClassName 追加面板类（如换限高档位）。
+ *
+ * **面板高度与滚动由基座兜底**（见下方 SCROLL_CLS）：面板恒为「限高的 flex
+ * 列」，children 落在一个自动滚动区里。调用方什么都不做，内容再长也滚得到
+ * 底部按钮；想要「头部与底栏常驻、只有中间滚」，把 children 写成三个兄弟
+ * 节点、中间那个加 "min-h-0 flex-1 overflow-y-auto" 即可（本仓库既有的
+ * reidentify-dialog / notice-center 就是这个写法）。
  *
  * 嵌套弹窗（弹窗内再开弹窗，如表单里的目录选择器）：上层置 raised 抬高
  * z 层级；上层若需拦截 Esc（如输入态只退输入不关弹窗），自行在 capture
@@ -74,6 +79,23 @@ const WIDTH_CLS = {
   full: "max-w-none",
 } as const;
 
+/**
+ * children 的容器：一个「限高的 flex 列 + 自动滚动」的中间层。
+ *
+ * 它同时伺候两种 children，靠的是 flex 列里 min-height:auto 的默认行为：
+ * - **不分段的弹窗**（一个 `<div class="space-y-4 p-6">` 包住全部内容）：
+ *   该 div 是本容器唯一的 flex 项，自动最小尺寸 = 内容高，压不扁，于是
+ *   超长部分由本容器滚出滚动条——不会再被面板 overflow-hidden 裁掉、
+ *   底部按钮也不会消失在屏幕外（移动端 items-end 时溢出方向朝**上**，
+ *   裁掉的正是头部与底部按钮，用户既看不到也滚不动）。
+ * - **头/身/底三段的弹窗**：中间那段自己带 overflow-y-auto（自动最小尺寸
+ *   随之归零、可被压缩），头尾按内容高占位，本容器就永远不需要滚动——
+ *   等于结构透明，头部与底栏照旧常驻。
+ *
+ * overscroll-contain：滚到尽头不把滚动传给身后的页面（iOS 上尤其明显）。
+ */
+const SCROLL_CLS = "flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain scroll-thin";
+
 export function Modal({
   open,
   onClose,
@@ -111,6 +133,11 @@ export function Modal({
   // 软键盘遮挡高度：>0 时把容器 bottom 抬到键盘之上（iOS PWA 输入弹窗的救命绳）
   const keyboardInset = useKeyboardInset(open);
 
+  // 桌面端默认限高到容器（= 视口减去外层 p-6），超出部分交给滚动区。
+  // 调用方自带 max-h/h 档位时让位：同为 max-height 的两个类谁生效取决于
+  // 生成 CSS 的先后，不确定；干脆不叠加，调用方的意图优先。
+  const defaultMaxH = /(^|[\s!:])(max-)?h-/.test(panelClassName) ? "" : "max-h-full";
+
   if (!open || typeof document === "undefined") return null;
 
   return createPortal(
@@ -143,9 +170,9 @@ export function Modal({
         className="absolute inset-0 cursor-default bg-black/60 backdrop-blur-sm"
       />
       <div
-        className={`relative w-full ${WIDTH_CLS[width]} overflow-hidden rounded-2xl border border-white/10 bg-[rgba(16,18,26,0.92)] shadow-[0_32px_90px_rgba(0,0,0,0.7)] backdrop-blur-2xl max-md:!max-h-full max-md:!max-w-none max-md:rounded-b-none max-md:border-x-0 max-md:border-b-0 max-md:pb-[calc(var(--safe-bottom)+var(--vp-overshoot))] ${panelClassName}`}
+        className={`relative flex w-full flex-col ${WIDTH_CLS[width]} ${defaultMaxH} overflow-hidden rounded-2xl border border-white/10 bg-[rgba(16,18,26,0.92)] shadow-[0_32px_90px_rgba(0,0,0,0.7)] backdrop-blur-2xl max-md:!max-h-full max-md:!max-w-none max-md:rounded-b-none max-md:border-x-0 max-md:border-b-0 max-md:pb-[calc(var(--safe-bottom)+var(--vp-overshoot))] ${panelClassName}`}
       >
-        {children}
+        <div className={SCROLL_CLS}>{children}</div>
       </div>
     </div>,
     document.body,

--- a/apps/web/components/rule-sets-panel.tsx
+++ b/apps/web/components/rule-sets-panel.tsx
@@ -746,8 +746,10 @@ export function RuleSetEditorDialog({
       label={ruleSet ? `编辑规则组「${ruleSet.name}」` : "新建规则组"}
       width="lg"
       raised={raised}
+      panelClassName="max-h-[76dvh]"
     >
-      <div className="scroll-thin max-h-[76dvh] overflow-y-auto p-6 max-md:p-5">
+      {/* 头部常驻：规则组表单比一屏长得多，标题要一直在 */}
+      <div className="border-b border-white/[0.07] px-6 pb-4 pt-6 max-md:px-5">
         <h2 className="text-title font-bold text-white">
           {ruleSet ? "编辑规则组" : "新建规则组"}
         </h2>
@@ -760,8 +762,10 @@ export function RuleSetEditorDialog({
             （已下载的内容不受影响）。
           </p>
         )}
+      </div>
 
-        <div className="mt-4 space-y-5">
+      <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
+        <div className="space-y-5">
           <Field label="名称">
             <input
               type="text"
@@ -1153,21 +1157,22 @@ export function RuleSetEditorDialog({
               {error}
             </p>
           )}
-
-          <div className="flex justify-end gap-3 pt-1">
-            <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
-              取消
-            </button>
-            <button
-              type="button"
-              disabled={busy || !name.trim()}
-              onClick={() => void submit()}
-              className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-50"
-            >
-              {busy ? "正在保存…" : "保存"}
-            </button>
-          </div>
         </div>
+      </div>
+
+      {/* 底栏常驻 */}
+      <div className="flex justify-end gap-3 border-t border-white/[0.07] px-6 py-4 max-md:px-5">
+        <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
+          取消
+        </button>
+        <button
+          type="button"
+          disabled={busy || !name.trim()}
+          onClick={() => void submit()}
+          className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-50"
+        >
+          {busy ? "正在保存…" : "保存"}
+        </button>
       </div>
     </Modal>
   );

--- a/apps/web/components/share-dialog.tsx
+++ b/apps/web/components/share-dialog.tsx
@@ -151,7 +151,8 @@ export function ShareDialog({
 
   return (
     <Modal open={open} onClose={busy ? () => {} : onClose} label="分享影片" width="lg">
-      <div className="p-6">
+      {/* 头部常驻：标题与影片身份——滚到表单底部时仍知道在分享哪一部 */}
+      <div className="border-b border-white/[0.07] p-6">
         <h3 className="text-title-sm font-semibold text-[var(--text)]">
           {share ? `《${title}》已分享` : `分享《${title}》`}
         </h3>
@@ -168,7 +169,9 @@ export function ShareDialog({
             </p>
           </div>
         </div>
+      </div>
 
+      <div className="scroll-thin min-h-0 flex-1 overflow-y-auto px-6 pb-6 pt-1">
         {share ? (
           <ShareReady
             share={share}
@@ -260,28 +263,31 @@ export function ShareDialog({
             <p className="mt-5 text-caption text-[var(--text-faint)]">
               访客的播放会出现在「活动」页，你随时可以取消分享。
             </p>
-
-            <div className="mt-5 flex justify-end gap-2">
-              <button
-                type="button"
-                disabled={busy}
-                onClick={onClose}
-                className="btn-glass px-4 py-2 text-ui text-[var(--text-muted)] disabled:opacity-50"
-              >
-                取消
-              </button>
-              <button
-                type="button"
-                disabled={busy}
-                onClick={create}
-                className="rounded-xl bg-white px-4 py-2 text-ui font-semibold text-black transition hover:bg-white/90 disabled:opacity-50"
-              >
-                {busy ? "正在生成…" : "生成链接"}
-              </button>
-            </div>
           </>
         )}
       </div>
+
+      {/* 底栏常驻（仅创建态；已分享态的出口按钮在 ShareReady 里） */}
+      {!share && (
+        <div className="flex justify-end gap-2 border-t border-white/[0.07] px-6 py-4">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onClose}
+            className="btn-glass px-4 py-2 text-ui text-[var(--text-muted)] disabled:opacity-50"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={create}
+            className="rounded-xl bg-white px-4 py-2 text-ui font-semibold text-black transition hover:bg-white/90 disabled:opacity-50"
+          >
+            {busy ? "正在生成…" : "生成链接"}
+          </button>
+        </div>
+      )}
     </Modal>
   );
 }

--- a/apps/web/components/subscribe-dialog.tsx
+++ b/apps/web/components/subscribe-dialog.tsx
@@ -297,8 +297,15 @@ export function SubscribeDialog({
 
   if (upgradeReport) {
     return (
-      <Modal open onClose={onClose} label={`订阅《${target.title}》`} width="lg">
-        <div className="scroll-thin max-h-[76dvh] overflow-y-auto p-6 max-md:p-5">
+      <Modal
+        open
+        onClose={onClose}
+        label={`订阅《${target.title}》`}
+        width="lg"
+        panelClassName="max-h-[76dvh]"
+      >
+        {/* 报告态：自带标题与出口按钮，整体滚动即可 */}
+        <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
           <UpgradeRunReportView
             title={target.title}
             isMovie={(prepared?.media?.kind ?? target.kind) === "movie"}
@@ -311,21 +318,30 @@ export function SubscribeDialog({
   }
 
   return (
-    <Modal open onClose={onClose} label={`订阅《${target.title}》`} width="lg">
-      <div className="scroll-thin max-h-[76dvh] overflow-y-auto p-6 max-md:p-5">
-          <h2 className="text-title font-bold text-white">
-            {upgradeMode ? "订阅并洗版" : "订阅追踪"}
-            <span className="ml-2 text-ui font-normal text-[var(--text-muted)]">
-              {target.title}
-              {target.year ? ` (${target.year})` : ""}
-            </span>
-          </h2>
-          {upgradeMode && (
-            <p className="mt-1 text-sub leading-6 text-[var(--text-muted)]">
-              洗版通过订阅持续追踪更好的版本：确认后建立订阅并立即体检库里已有的每一集。
-            </p>
-          )}
+    <Modal
+      open
+      onClose={onClose}
+      label={`订阅《${target.title}》`}
+      width="lg"
+      panelClassName="max-h-[76dvh]"
+    >
+      {/* 头部常驻：剧集选季 + 规则摘要能滚很长，标题不该跟着走 */}
+      <div className="border-b border-white/[0.07] px-6 pb-4 pt-6 max-md:px-5">
+        <h2 className="text-title font-bold text-white">
+          {upgradeMode ? "订阅并洗版" : "订阅追踪"}
+          <span className="ml-2 text-ui font-normal text-[var(--text-muted)]">
+            {target.title}
+            {target.year ? ` (${target.year})` : ""}
+          </span>
+        </h2>
+        {upgradeMode && (
+          <p className="mt-1 text-sub leading-6 text-[var(--text-muted)]">
+            洗版通过订阅持续追踪更好的版本：确认后建立订阅并立即体检库里已有的每一集。
+          </p>
+        )}
+      </div>
 
+      <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
           {/* —— 加载 / 错误 —— */}
           {!prepared && !error && (
             <div className="mt-8 flex items-center justify-center gap-2.5 pb-4 text-ui text-[var(--text-muted)]">
@@ -605,32 +621,33 @@ export function SubscribeDialog({
                 </section>
               )}
 
-              <div className="flex justify-end gap-3 pt-1">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="btn-glass h-9 px-4 text-ui font-medium"
-                >
-                  取消
-                </button>
-                <button
-                  type="button"
-                  disabled={!canSubmit}
-                  onClick={submit}
-                  className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-50"
-                >
-                  {busy
-                    ? upgradeMode
-                      ? "正在订阅并体检…"
-                      : "正在订阅…"
-                    : upgradeMode
-                      ? "订阅并开始洗版"
-                      : "确认订阅"}
-                </button>
-              </div>
             </div>
           )}
       </div>
+
+      {/* 底栏常驻（仅订阅表单态；管理态的按钮短，留在正文里） */}
+      {prepared?.status === "ready" && !prepared.existing_subscription_id && (
+        <div className="flex justify-end gap-3 border-t border-white/[0.07] px-6 py-4 max-md:px-5">
+          <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
+            取消
+          </button>
+          <button
+            type="button"
+            disabled={!canSubmit}
+            onClick={submit}
+            className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-50"
+          >
+            {busy
+              ? upgradeMode
+                ? "正在订阅并体检…"
+                : "正在订阅…"
+              : upgradeMode
+                ? "订阅并开始洗版"
+                : "确认订阅"}
+          </button>
+        </div>
+      )}
+
       {canManageSubscriptions && creatingRuleSet && (
         <RuleSetEditorDialog
           ruleSet={null}

--- a/apps/web/components/subscription-adjust-dialog.tsx
+++ b/apps/web/components/subscription-adjust-dialog.tsx
@@ -145,14 +145,17 @@ export function SubscriptionAdjustDialog({
   };
 
   return (
-    <Modal open onClose={onClose} label="调整订阅" width="lg">
-      <div className="scroll-thin max-h-[76dvh] overflow-y-auto p-6 max-md:p-5">
+    <Modal open onClose={onClose} label="调整订阅" width="lg" panelClassName="max-h-[76dvh]">
+      {/* 头部常驻 */}
+      <div className="border-b border-white/[0.07] px-6 pb-4 pt-6 max-md:px-5">
         <h2 className="text-title font-bold text-white">调整订阅</h2>
         <p className="mt-1 text-sub leading-6 text-[var(--text-muted)]">
           《{detail.media.title}》——加季会恢复或补建追踪；减季会让整季退出追踪范围，
           但不会删除下载器任务、已下载文件或入库内容。
         </p>
+      </div>
 
+      <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
         {error && (
           <p className="mt-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-sub leading-6 text-red-200">
             {error}
@@ -229,20 +232,21 @@ export function SubscriptionAdjustDialog({
             </section>
           )}
         </div>
+      </div>
 
-        <div className="mt-6 flex justify-end gap-3">
-          <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
-            取消
-          </button>
-          <button
-            type="button"
-            disabled={busy || !dirty || (!isMovie && selectedSeasons.size === 0)}
-            onClick={() => void save()}
-            className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
-          >
-            {busy ? "保存中…" : "保存调整"}
-          </button>
-        </div>
+      {/* 底栏常驻：季数一多就要滚，保存按钮不能被滚出屏幕 */}
+      <div className="flex justify-end gap-3 border-t border-white/[0.07] px-6 py-4 max-md:px-5">
+        <button type="button" onClick={onClose} className="btn-glass h-9 px-4 text-ui font-medium">
+          取消
+        </button>
+        <button
+          type="button"
+          disabled={busy || !dirty || (!isMovie && selectedSeasons.size === 0)}
+          onClick={() => void save()}
+          className="btn-accent h-9 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
+        >
+          {busy ? "保存中…" : "保存调整"}
+        </button>
       </div>
     </Modal>
   );

--- a/apps/web/components/upgrade-run-dialog.tsx
+++ b/apps/web/components/upgrade-run-dialog.tsx
@@ -118,9 +118,16 @@ export function UpgradeRunDialog({
   };
 
   return (
-    <Modal open onClose={report ? onFinished : onClose} label="洗一轮版" width="lg">
-      <div className="scroll-thin max-h-[80dvh] overflow-y-auto p-6 max-md:p-5">
-        {report ? (
+    <Modal
+      open
+      onClose={report ? onFinished : onClose}
+      label="洗一轮版"
+      width="lg"
+      panelClassName="max-h-[80dvh]"
+    >
+      {report ? (
+        // 报告态：自带标题与出口按钮，整体滚动即可
+        <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
           <UpgradeRunReportView
             title={detail.media.title}
             isMovie={isMovie}
@@ -132,14 +139,19 @@ export function UpgradeRunDialog({
             }}
             onClose={onFinished}
           />
-        ) : (
-          <>
+        </div>
+      ) : (
+        // 触发态：规则组一多就得滚，标题与「开始体检」固定在两头
+        <>
+          <div className="border-b border-white/[0.07] px-6 pb-4 pt-6 max-md:px-5">
             <h2 className="text-title font-bold text-white">洗一轮版</h2>
             <p className="mt-1 text-sub leading-6 text-[var(--text-muted)]">
               逐集检查《{detail.media.title}
               》库里已有的版本，低于洗版目标的立即排入搜索；洗到新版本入库并验证通过后，旧文件自动替换。
             </p>
+          </div>
 
+          <div className="scroll-thin min-h-0 flex-1 overflow-y-auto p-6 max-md:p-5">
             {error && (
               <p className="mt-3 rounded-lg border border-red-400/25 bg-red-500/10 px-3.5 py-2.5 text-sub leading-6 text-red-200">
                 {error}
@@ -264,29 +276,30 @@ export function UpgradeRunDialog({
               </div>
             )}
 
-            <div className="mt-6 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={onClose}
-                className="btn-glass h-10 px-4 text-ui font-medium"
-              >
-                返回
-              </button>
-              <button
-                type="button"
-                disabled={busy || !selectedRule}
-                onClick={() => void run()}
-                className="btn-accent inline-flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
-              >
-                {busy && (
-                  <span className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white/90" />
-                )}
-                {paused ? "恢复并触发洗版" : "开始体检并洗版"}
-              </button>
-            </div>
-          </>
-        )}
-      </div>
+          </div>
+
+          <div className="flex justify-end gap-2 border-t border-white/[0.07] px-6 py-4 max-md:px-5">
+            <button
+              type="button"
+              onClick={onClose}
+              className="btn-glass h-10 px-4 text-ui font-medium"
+            >
+              返回
+            </button>
+            <button
+              type="button"
+              disabled={busy || !selectedRule}
+              onClick={() => void run()}
+              className="btn-accent inline-flex h-10 items-center gap-2 rounded-full px-5 text-ui font-semibold disabled:opacity-40"
+            >
+              {busy && (
+                <span className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white/90" />
+              )}
+              {paused ? "恢复并触发洗版" : "开始体检并洗版"}
+            </button>
+          </div>
+        </>
+      )}
 
       {creatingRuleSet && (
         <RuleSetEditorDialog


### PR DESCRIPTION
## 问题

移动端弹窗是贴底抽屉（`items-end`），而 `Modal` 面板只有 `overflow-hidden`——既没有限高，也没有滚动容器，内部布局全交给每个业务弹窗自理。内容一超过一屏，溢出部分被裁掉且滚不到，标题与底部按钮双双消失，弹窗等于废了。

仓库里只有 13 个弹窗自己写了「限高 flex 列 + 内部滚动区」（`panelClassName="flex max-h-[80vh] flex-col"`）才幸免，其余三十多个都踩这个坑。

## 改法

### 1. 基座兜底（`components/modal.tsx`）

- 面板恒为**限高的 flex 列**（调用方自带 `max-h`/`h` 档位时让位，不叠加同属性的类——谁生效取决于生成 CSS 的先后，不确定）；
- children 落进一个 `flex 列 + overflow-y-auto + overscroll-contain` 的中间层。

这一层能同时伺候两种 children，靠的是 flex 列里 `min-height:auto` 的默认行为：

- **不分段的弹窗**（一个 div 包住全部内容）压不扁 → 由中间层滚出滚动条，按钮一定够得着；
- **三段式弹窗**的中间段自带 `overflow-y-auto`（自动最小尺寸归零、可被压缩）→ 中间层永不滚动，等于结构透明，头部与底栏照旧常驻。

**调用方一行不改**也不会再有够不着的按钮。

### 2. 十个最长的弹窗改成三段式

标题与操作按钮固定，只有中间滚动——这些在手机上必然超过一屏，滚到底才找得到「保存」不是好体验：

选择保存位置、调整订阅、标注片源、自动入库规则、限速与队列、规则组编辑器、订阅追踪、洗一轮版、分享影片。

后三个的按钮条按状态分叉，收敛成「共用头部 + 滚动正文 + 状态相关的底栏」：订阅的底栏只在表单态出现（管理态按钮短，留在正文）、报告态自带出口整体滚动；分享的底栏只在创建态出现，已分享态的出口按钮在 `ShareReady` 内。

顺带把这几处自管的 `max-h` 从内层 div 移到 `panelClassName`——限高归面板、滚动归中间层，与基座分工一致。

## 验证

Chromium（390×700）实测三种形态：

| 形态 | 结果 |
|---|---|
| 不分段 children | 可滚动，滚到底后按钮条完整可见 ✅ |
| 三段式 children | 外层无需滚动、中间滚到底后头部与底栏仍在视口内 ✅ |
| 改动前的基座 | 同样内容下按钮条落在视口外且无法滚到 ✅（复现原 bug） |

改动文件均经 esbuild 解析通过；`node --test` 388/391（3 个失败是本地未装 node_modules，`dayjs` 等找不到，与本改动无关）。

## 影响面

纯前端布局，无运行时依赖变更（不涉及 `docker/runtime-version`）、无迁移、无新增 `data/` 目录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRKrrVFZ6L8rCJHab6jvi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRKrrVFZ6L8rCJHab6jvi8)_