### PR TITLE
fix(web): 灯箱顶栏图标键在移动端放大到 44px

### DIFF
--- a/apps/web/components/photo-lightbox.tsx
+++ b/apps/web/components/photo-lightbox.tsx
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { DownloadIcon, InfoIcon, XIcon } from "@/components/icons";
-import { ZoomLightbox, type ZoomLightboxSlide } from "@/components/zoom-lightbox";
+import {
+  LIGHTBOX_ACTION_CLASS,
+  LIGHTBOX_ACTION_ICON_CLASS,
+  ZoomLightbox,
+  type ZoomLightboxSlide,
+} from "@/components/zoom-lightbox";
 import {
   type LibraryItem,
   type LibraryItemDetail,
@@ -187,9 +192,9 @@ export function PhotoLightbox({
               title="下载原图"
               aria-label="下载原图"
               onClick={(e) => void downloadOriginal(e)}
-              className="rounded-full p-2 text-white/70 transition-colors hover:bg-white/[0.12] hover:text-white"
+              className={LIGHTBOX_ACTION_CLASS}
             >
-              <DownloadIcon className="size-[18px]" />
+              <DownloadIcon className={LIGHTBOX_ACTION_ICON_CLASS} />
             </a>
           )}
           <button
@@ -198,11 +203,11 @@ export function PhotoLightbox({
             aria-label="拍摄信息"
             aria-pressed={infoOpen}
             onClick={() => setInfoOpen((open) => !open)}
-            className={`rounded-full p-2 transition-colors hover:bg-white/[0.12] hover:text-white ${
-              infoOpen ? "bg-white/[0.12] text-white" : "text-white/70"
-            }`}
+            // 按下态（面板开着）走 aria-pressed 变体：属性选择器压得住共用类里的
+            // text-white/70，不必跟它比类名先后
+            className={`${LIGHTBOX_ACTION_CLASS} aria-pressed:bg-white/[0.12] aria-pressed:text-white`}
           >
-            <InfoIcon className="size-[18px]" />
+            <InfoIcon className={LIGHTBOX_ACTION_ICON_CLASS} />
           </button>
         </>
       }

--- a/apps/web/components/video-gallery.tsx
+++ b/apps/web/components/video-gallery.tsx
@@ -17,7 +17,12 @@ import {
   type PhotoWallDensity,
 } from "@/components/photo-wall";
 import { PosterImage } from "@/components/poster-image";
-import { ZoomLightbox, type ZoomLightboxSlide } from "@/components/zoom-lightbox";
+import {
+  LIGHTBOX_ACTION_CLASS,
+  LIGHTBOX_ACTION_ICON_CLASS,
+  ZoomLightbox,
+  type ZoomLightboxSlide,
+} from "@/components/zoom-lightbox";
 import type { LibraryGalleryGroup, LibraryGalleryImage } from "@/lib/api/libraries";
 import { imageUrl } from "@/lib/image-proxy";
 import { playHref, rememberPlayerReturnPath } from "@/lib/player/play-links";
@@ -599,8 +604,6 @@ export function VideoGalleryLightbox({
   // 收藏的是整部作品（与详情页那颗心同一落点），不是当前这张图或这一集
   const favorite = entry.group.is_favorite;
   const favoriteLabel = favorite ? "取消收藏" : "收藏";
-  const buttonClass =
-    "rounded-full p-2 text-white/70 transition-colors hover:bg-white/[0.12] hover:text-white";
 
   return (
     <ZoomLightbox
@@ -618,9 +621,9 @@ export function VideoGalleryLightbox({
             title={playLabel}
             aria-label={playLabel}
             onClick={play}
-            className={buttonClass}
+            className={LIGHTBOX_ACTION_CLASS}
           >
-            <PlayIcon className="size-[18px]" />
+            <PlayIcon className={LIGHTBOX_ACTION_ICON_CLASS} />
           </button>
           <button
             type="button"
@@ -628,10 +631,10 @@ export function VideoGalleryLightbox({
             aria-label={favoriteLabel}
             aria-pressed={favorite}
             onClick={() => onToggleFavorite(entry.group.media_item_id, !favorite)}
-            className={buttonClass}
+            className={LIGHTBOX_ACTION_CLASS}
           >
             <HeartIcon
-              className={favorite ? "size-[18px] text-[var(--danger)]" : "size-[18px]"}
+              className={`${LIGHTBOX_ACTION_ICON_CLASS} ${favorite ? "text-[var(--danger)]" : ""}`}
               fill={favorite ? "currentColor" : "none"}
             />
           </button>
@@ -639,9 +642,9 @@ export function VideoGalleryLightbox({
             href={detailHref(entry)}
             title="前往影片详情"
             aria-label="前往影片详情"
-            className={buttonClass}
+            className={LIGHTBOX_ACTION_CLASS}
           >
-            <OpenIcon className="size-[18px]" />
+            <OpenIcon className={LIGHTBOX_ACTION_ICON_CLASS} />
           </Link>
         </>
       }

--- a/apps/web/components/zoom-lightbox.tsx
+++ b/apps/web/components/zoom-lightbox.tsx
@@ -48,6 +48,19 @@ import {
  * 一起收放——顶栏都没了、只剩一块面板浮在画面上很怪。
  * Portal 到 body，与 ImageLightbox 同一层叠约定。
  */
+/**
+ * 顶栏图标键的统一形状（关闭键与调用方塞进 ``actions`` 的按钮共用一套）。
+ *
+ * 尺寸与全站顶栏（PAGE_NAV_BUTTON_CLASS）对齐、分两档：移动端 44px——iOS HIG
+ * 的最小可点目标，之前是 `p-2` 撑出的 34px，手指在几颗紧挨的小键之间很容易点错
+ * （用户反馈 2026-09-08）；桌面端 36px（鼠标精度高，44px 反而笨重）。
+ * 图标同比例缩放（约为键径的一半），改动时两档要一起看。
+ */
+export const LIGHTBOX_ACTION_CLASS =
+  "grid size-9 shrink-0 place-items-center rounded-full text-white/70 transition-colors hover:bg-white/[0.12] hover:text-white max-md:size-11";
+/** 顶栏图标键里的图标尺寸，与 LIGHTBOX_ACTION_CLASS 成对使用 */
+export const LIGHTBOX_ACTION_ICON_CLASS = "size-[18px] max-md:size-[22px]";
+
 const STRIP_WINDOW = 30;
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 5;
@@ -655,9 +668,9 @@ export function ZoomLightbox({
             type="button"
             aria-label="关闭 (Esc)"
             onClick={onClose}
-            className="rounded-full p-2 text-white/70 transition-colors hover:bg-white/[0.12] hover:text-white"
+            className={LIGHTBOX_ACTION_CLASS}
           >
-            <XIcon className="size-5" />
+            <XIcon className={LIGHTBOX_ACTION_ICON_CLASS} />
           </button>
         </div>
       </div>


### PR DESCRIPTION
媒体库图廊灯箱右上角的播放 / 收藏 / 详情三颗键（以及图片库灯箱的下载 /
信息、两处共用的关闭键）此前是 `p-2` + 18px 图标撑出的 34px 命中区，低于
iOS HIG 的 44px 最小可点目标，手指在几颗紧挨的小键之间容易点错。

把三处各自写死的类名收成 zoom-lightbox 导出的 LIGHTBOX_ACTION_CLASS /
LIGHTBOX_ACTION_ICON_CLASS 一套，尺寸与全站顶栏 PAGE_NAV_BUTTON_CLASS
对齐：桌面 36px、移动端 44px，图标 18px / 22px 同比例缩放。

图片库信息键的按下态改用 aria-pressed 变体（属性选择器），不再与共用类里的
text-white/70 比类名先后。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011M64HamW9f8ZotczBzuPeW