### PR TITLE
生成章节的补缺判据改成「抓齐没有」，不再是「抓过没有」

### DIFF
--- a/apps/web/lib/api/libraries.ts
+++ b/apps/web/lib/api/libraries.ts
@@ -750,7 +750,8 @@ export function getMetadataRefreshProgress(id: number): Promise<MetadataRefreshP
 
 /**
  * 整库生成章节场景图（docs/design/video-chapters.md §4.5）：低优先级后台作业，
- * 默认只补缺，force 全部重抓。扫描结束会自动排一份，这是手动入口。
+ * 默认只补缺（跳过已经抓齐的文件），force 全部重抓。扫描结束会自动排一份，
+ * 这是手动入口。
  */
 export function startLibraryChapterImages(
   id: number,

--- a/apps/web/lib/library-confirm.ts
+++ b/apps/web/lib/library-confirm.ts
@@ -54,14 +54,14 @@ export function refreshItemConfirm(title: string): ConfirmOptions {
   };
 }
 
-/** 整库生成章节：默认只补缺，勾选项决定是否全部重做（force）。
- *  一个菜单入口 + 弹窗内开关，与「刷新元数据」的交互保持一致。 */
+/** 整库生成章节：默认只补缺（跳过已经抓齐的文件），勾选项决定是否全部重做
+ *  （force）。一个菜单入口 + 弹窗内开关，与「刷新元数据」的交互保持一致。 */
 export function chapterImagesConfirm(name: string): ConfirmOptions & { checkbox: ConfirmCheckbox } {
   return {
     title: `为「${name}」生成章节？`,
     description: "后台低优先级执行，可在任务中心观察或取消：",
     bullets: [
-      "只处理还没有章节的文件，已有的不动",
+      "只处理章节图还缺的文件（含上次没抓完、图丢了的），已经齐的不动",
       "每个文件按章节数定位读取若干次，网络挂载的库会有读取流量",
       "不会移动、修改或删除你的视频文件",
     ],

--- a/docs/design/video-chapters.md
+++ b/docs/design/video-chapters.md
@@ -162,7 +162,7 @@ HLS 转码不携带容器章节（Jellyfin 自己也是 `-map_chapters -1`，
 | 抽帧失败整文件作废 | 部分产物落库，超时预算内能抓几张是几张 |
 | 分辨率跟源 | 固定宽 960（§4.4） |
 | 图片路径含 mtime | 路径按 `start_ms` 命名，失效靠文件 `file_mtime_ns` 变化触发重抓 |
-| 每日计划任务 + 失败记忆文件 | 持久化 Job（§4.5），失败写 `[]` 由 force 重试 |
+| 每日计划任务 + 失败记忆文件 | 持久化 Job（§4.5），失败的章节记墓碑、由 force 重试 |
 | `ImagePath` 输出到客户端 | **省略**（服务器内部路径对客户端无意义），登记为偏离 |
 
 ## 3. 本项目现状
@@ -279,7 +279,7 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
 - 单文件内串行；跨文件并发由 Job 并发数控制；与 `thumbs.py` 共享一把
   `asyncio.Semaphore(2)` 的 ffmpeg 闸，避免扫描期 CPU 被打满。
 - 失效：`chapter_images` 里记录时的 `file_mtime_ns` 不必单独存——Job 用
-  "`chapter_images IS NULL` 或 force"选目标，文件内容变更走扫描的
+  "**没抓齐**（`stills_complete` 为假）或 force"选目标，文件内容变更走扫描的
   重探测路径把 `chapters` 与 `chapter_images` 一并置 NULL。
 - **真实帧时间**：滤镜链末尾加 `showinfo`，从 stderr 解析被选中那一帧的
   `pts_time` 得到 `frame_ms`（`thumbnail` 选帧后 showinfo 只打印一行）。
@@ -294,7 +294,11 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
   用户最可能去看的先有图；单条目懒触发（§4.5）再兜住点开的那一部。
 - **体积**：JPEG `-q:v 4`，960 宽一张约 60～90KB，一部片 10 张 ≈ 0.8MB，
   1000 部 ≈ 0.8GB（对照 metadata.md §289 的海报估算 2.3GB）。发版说明写明。
-- 失败（ffmpeg 缺失/超时/损坏）写 `[]` 并记中文日志，force 重试。
+- 失败（超时/损坏/编码不支持）给那一章记一条**墓碑** `{"start_ms",
+  "failed": true}` 并记中文日志：没有 `image`，消费方照旧当"这章没图"，
+  只有补缺判据认它。没有墓碑，"只跳过抓齐的"会让每一轮作业、每一次打开
+  详情页都对着同一个抓不出图的文件重跑一遍。force 时不复用墓碑，仍重试。
+  ffmpeg 整个缺失是另一回事：什么都不写（保持 NULL），装好后自动补。
 - **孤儿清理**：文件行被删除/洗版替换后，`{item}/chapters/{old_file_id}/`
   成为孤儿。Job 处理某条目时顺手删掉该条目下不再对应任何在位文件行的
   chapters 子目录；条目删除时随资产目录一起清。
@@ -307,12 +311,23 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
 顺带补探（只跑 `ffprobe -show_chapters`，读容器头，毫秒级）。
 
 **场景图**：新持久化 Job `library.chapter_images`（`register_job_handler`），
-输入 `{library_id, force}`，目标 = 库内在位文件中 `chapter_images IS NULL`
+输入 `{library_id, force}`，目标 = 库内在位文件中**还没抓齐**的
 （force 时全部），`dedupe_key` 按库，低优先级，进度分子分母=文件数，
 `raise_if_cancelled` 逐文件检查、可停可续。
 
+**补缺的判据是"抓齐没有"而不是"抓过没有"**（`stills_complete`）：一个文件算
+齐，当且仅当计划抓图的每一章都有结论——图登记在台账里**且文件还在磁盘上**，
+或者留了抓不出来的墓碑；按规则整体不抓图的（没有章节、章节过密、章节过多）
+也算齐。只看 `chapter_images IS NULL` 会漏掉三种半成品，它们再也等不到补缺：
+单文件预算耗尽写回的部分产物（§4.4 明说部分产物落库，却没有"下次接着补"的
+另一半）、事后没了的图文件（清过资产目录、只恢复了数据库备份、迁移丢图）、
+以及当时该有图却写成 `[]` 的行（抓帧全失败、时长当时没探出来）。判据与抓图
+计划共用同一个 `still_plan`——两处各写一遍，迟早出现"判定没抓齐、真去抓又抓
+不出那一张"的死循环。代价是目标筛选从一条 SQL 变成取回候选行在 Python 里判
+（含一次列目录的磁盘 IO，放线程里做）。
+
 **断点**（重启/应用内更新会把 Job 退回队列、处理器整体重跑一遍）：补缺模式
-下逐文件写回台账即是检查点，重取目标时 `chapter_images IS NULL` 自然排除已
+下逐文件写回台账即是检查点，重取目标时 `stills_complete` 自然排除已
 完成的行；**force 重抓每一行都要重做，台账不再是检查点**，因此把"上一轮最后
 一个处理完的文件"记进进度的 `details.cursor`，恢复时按同一份排序跳过它之前
 的行（节流窗口内的那一两个文件会重做，抓图幂等）。进度的 `current`/`total`
@@ -335,8 +350,8 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
 4. **详情页懒触发**（**不做成 Job**：用户没发起任何动作，一次次打开详情页
    却在任务中心堆出一串条目作业既是噪音、也违背 persistent-jobs.md 的"Job 只
    承载用户可感知、需要追踪的异步业务"；重启把它丢了也无妨，下次打开原地再
-   触发，已抓好的文件靠台账不会重做）：`GET /libraries/{lib}/items/{id}` 发现选中文件
-   `chapter_images IS NULL` 且库开关打开时，`asyncio.create_task(
+   触发，已抓齐的文件靠台账不会重做）：`GET /libraries/{lib}/items/{id}` 发现有在位
+   文件**没抓齐**（判据与整库作业同源）且库开关打开时，`asyncio.create_task(
    refresh_chapter_images(item_id))`，用 `_in_flight` 集合去重（与
    `trickplay.py:58` 同款）；响应里 `chapters_pending: true`，前端每 3 秒
    重拉详情、最多 20 次，图一张张补上。这是升级后第一次打开旧条目的体验

--- a/src/movieclaw_api/api/routes/libraries.py
+++ b/src/movieclaw_api/api/routes/libraries.py
@@ -2150,12 +2150,16 @@ async def get_library_item(
     playback_warmup.schedule(
         media_item_id, [row for row in rows if row.state == FileState.IN_PLACE]
     )
-    # 章节场景图懒触发（docs/design/video-chapters.md §4.5）：有在位文件没抓过
-    # 图就后台抓这一个条目，前端按 chapters_pending 轮询几轮把图补上——升级后
-    # 第一次打开旧条目不用等整库作业排到它
+    # 章节场景图懒触发（docs/design/video-chapters.md §4.5）：有在位文件的图
+    # 还没抓齐就后台抓这一个条目，前端按 chapters_pending 轮询几轮把图补上——
+    # 升级后第一次打开旧条目不用等整库作业排到它。判据与整库作业同源
+    # （stills_complete）：半成品、图丢了的行在这里同样会被认出来
     chapters_pending = chapters_mod.item_pending(media_item_id)
+    chapter_assets_root = media_scrape.assets_root()
     needs_stills = any(
-        row.chapter_images is None and chapters_mod.stills_eligible(row) for row in rows
+        chapters_mod.stills_eligible(row)
+        and not chapters_mod.stills_complete(row, chapter_assets_root)
+        for row in rows
     )
     if library.extract_chapter_images and not chapters_pending:
         # 条目菜单发起的重抓是持久化 Job（重启不丢），内存里的懒触发标记看不到它

--- a/src/movieclaw_api/services/library/chapters.py
+++ b/src/movieclaw_api/services/library/chapters.py
@@ -138,12 +138,25 @@ def effective_chapters(embedded: list[dict] | None, duration_seconds: int | None
 
 
 def chapter_image_map(chapter_images: list | None) -> dict[int, dict]:
-    """``library_file.chapter_images`` → {start_ms: 元素}，供有效章节 join。"""
+    """``library_file.chapter_images`` → {start_ms: 元素}，供有效章节 join。
+
+    只给出真有图的元素：抓不出来的章节记的是墓碑（没有 ``image``），对详情页
+    与 Jellyfin 客户端来说它和"这章没图"是一回事。
+    """
     result: dict[int, dict] = {}
     for entry in chapter_images or []:
         if isinstance(entry, dict) and "start_ms" in entry and entry.get("image"):
             result[int(entry["start_ms"])] = entry
     return result
+
+
+def _previous_entries(chapter_images: list | None) -> dict[int, dict]:
+    """抓图复用用的上一轮结果：图与墓碑都要（消费方那张表只给图）。"""
+    return {
+        int(entry["start_ms"]): entry
+        for entry in chapter_images or []
+        if isinstance(entry, dict) and "start_ms" in entry
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +193,72 @@ def stills_eligible(row: LibraryFile) -> bool:
         row.state == "in_place"
         and (row.container or "") not in ("bluray", "dvd", "iso")
         and not row.file_path.lower().endswith(STRM_EXT)
+    )
+
+
+def still_plan(
+    chapters: list[Chapter], duration_seconds: int | None
+) -> tuple[list[Chapter], str | None]:
+    """真正要抓图的章节，以及整体跳过的中文原因（没跳过为 None）。
+
+    抓图流程与"补缺时判断一个文件抓齐了没"必须共用这一份判据：两处各写一遍，
+    迟早出现"判定没抓齐、真去抓又抓不出那一张"的死循环——每一轮作业都对着
+    同一批文件白跑。
+    """
+    if not chapters:
+        return [], None
+    if len(chapters) > _MAX_STILLS:
+        return [], f"有效章节 {len(chapters)} 个，超过 {_MAX_STILLS} 张上限"
+    if len(chapters) >= 2:
+        gaps = [b.start_ms - a.start_ms for a, b in zip(chapters, chapters[1:], strict=False)]
+        if sum(gaps) / len(gaps) < _MIN_AVG_GAP_MS:
+            return [], "章节平均间隔不足 1 秒"
+    if not duration_seconds:
+        return list(chapters), None
+    total_ms = duration_seconds * 1000
+    return [c for c in chapters if c.start_ms < total_ms], None
+
+
+def _image_names(image_dir: Path) -> set[str]:
+    """目录里现存的图片文件名；目录不在返回空集。一次列目录代替逐张 stat。"""
+    try:
+        return {path.name for path in image_dir.iterdir()}
+    except OSError:
+        return set()
+
+
+def stills_complete(row: LibraryFile, assets_root: Path) -> bool:
+    """这一行的章节图抓齐了没——补缺模式唯一的跳过判据（设计文档 §4.5）。
+
+    齐 = 计划抓图的每一章都有结论：图登记在台账里且文件还在磁盘上，或者留了
+    一条抓不出来的墓碑（``{"start_ms", "failed"}``）；按规则整体不抓图的
+    （没有章节、章节过密、章节过多）也算齐。章节或图任一没探过（NULL）不算齐。
+
+    只看"抓过没有"（``chapter_images IS NULL``）会漏掉三种半成品，它们再也
+    等不到补缺：单文件预算耗尽写回的部分产物、事后没了的图文件（清过资产
+    目录、只恢复了数据库备份）、以及当时该有图却写成 ``[]`` 的行。
+    """
+    if row.chapters is None or row.chapter_images is None:
+        return False
+    if row.id is None or row.media_item_id is None:
+        return True  # 没挂条目的行本来就不抓图，交给资格判断（stills_eligible）
+    planned, _ = still_plan(
+        effective_chapters(row.chapters, row.duration_seconds), row.duration_seconds
+    )
+    if not planned:
+        return True
+    images = chapter_image_map(row.chapter_images)
+    failed = {
+        int(entry["start_ms"])
+        for entry in row.chapter_images
+        if isinstance(entry, dict) and entry.get("failed") and "start_ms" in entry
+    }
+    if any(c.start_ms not in images and c.start_ms not in failed for c in planned):
+        return False
+    names = _image_names(assets_root / str(row.media_item_id) / "chapters" / str(row.id))
+    return all(
+        c.start_ms in failed or Path(str(images[c.start_ms]["image"])).name in names
+        for c in planned
     )
 
 
@@ -257,8 +336,8 @@ def extract_file_stills(
 ) -> list[dict] | None:
     """同步版：给一个文件的有效章节逐章抓图，返回 ``chapter_images`` 的元素列表。
 
-    - 已有且文件仍在的图直接复用（``force`` 重抓）；
-    - 起点 ≥ 片长的章节停止；平均间隔 <1s 或章节数超上限整体跳过；
+    - 已有且文件仍在的图、以及抓不出来的墓碑直接复用（``force`` 重抓）；
+    - 计划抓哪些章节见 ``still_plan``（越界截断、过密/过多整体跳过）；
     - 单文件预算耗尽返回已抓到的（部分产物也落库，设计文档 §4.4）；
     - 有效列表里对不上的旧图（策略调档、章节变了）当死图删掉；
     - 系统里没有 ffmpeg 返回 None：调用方保持 NULL，装好后下次自动补，
@@ -267,31 +346,29 @@ def extract_file_stills(
     result: list[dict] = []
     image_dir = assets_root / str(media_item_id) / "chapters" / str(file_id)
     keep: set[str] = set()
-    if len(chapters) == 0 or len(chapters) > _MAX_STILLS:
+    planned, skipped = still_plan(chapters, duration_seconds)
+    if skipped:
+        logger.info("%s，跳过章节场景图：%s", skipped, video)
+    if not planned:
         _delete_dead_images(image_dir, keep)
         return result
-    if len(chapters) >= 2:
-        gaps = [b.start_ms - a.start_ms for a, b in zip(chapters, chapters[1:], strict=False)]
-        if sum(gaps) / len(gaps) < _MIN_AVG_GAP_MS:
-            logger.info("章节平均间隔不足 1 秒，跳过场景图：%s", video)
-            _delete_dead_images(image_dir, keep)
-            return result
-    total_ms = duration_seconds * 1000 if duration_seconds else None
     # 色彩特征整个文件探一次就够：DOVI 配置在流的 side data 里，与抓哪一帧无关。
     # 放在预算计时之前——它是一次轻量 ffprobe，不该算进逐章抓图的预算。
     color = video_color_for(video, fallback_hdr=hdr)
     deadline = time.monotonic() + _FILE_BUDGET_SECONDS
     try:
-        for chapter in chapters:
-            if total_ms is not None and chapter.start_ms >= total_ms:
-                break
+        for chapter in planned:
             rel = image_rel_path(media_item_id, file_id, chapter.start_ms)
             dest = assets_root / rel
             previous = existing.get(chapter.start_ms)
-            if not force and previous and previous.get("image") == rel and dest.is_file():
-                result.append(previous)
-                keep.add(dest.name)
-                continue
+            if not force and previous:
+                if previous.get("failed"):
+                    result.append(previous)  # 上一轮认定抓不出来，补缺不再重试
+                    continue
+                if previous.get("image") == rel and dest.is_file():
+                    result.append(previous)
+                    keep.add(dest.name)
+                    continue
             if time.monotonic() > deadline:
                 logger.warning("章节场景图超出单文件预算，已抓到的先落库：%s", video)
                 break
@@ -308,6 +385,11 @@ def extract_file_stills(
                 logger.warning("章节抓帧超时（%s 秒）：%s @ %ss", _FFMPEG_TIMEOUT, video, seek)
                 frame_ms = None
             if frame_ms is None:
+                # 这一章抓不出来（坏帧、编码不支持、定位超时）：留一条墓碑，让
+                # 补缺判据认它"已有结论"。否则每一轮作业、每一次打开详情页都会
+                # 对着同一个文件重跑一遍同样抓不出来的命令；勾了「已有的章节也
+                # 重新生成」（force）时墓碑不复用，仍会重试。
+                result.append({"start_ms": chapter.start_ms, "failed": True})
                 continue
             result.append({"start_ms": chapter.start_ms, "frame_ms": frame_ms, "image": rel})
             keep.add(dest.name)
@@ -353,14 +435,16 @@ async def refresh_file_chapter_images(
     """给一行台账补探章节（NULL 时）并抓图，写回 ``chapter_images``。
 
     返回是否有写入。库开关由调用方判断；这里只管资格（在位/非原盘/非 strm）。
-    抓帧失败不抛：写 ``[]`` 并记日志，force 可重试；章节补探失败或 ffmpeg
-    缺失则什么都不写（保持 NULL），下次入口自动再来。
+    补缺模式只跳过**已经抓齐**的行（``stills_complete``）：半成品、图丢了的
+    行都会接着抓，已有的图原样复用。抓帧失败不抛：失败的章节记墓碑并记日志，
+    force 可重试；章节补探失败或 ffmpeg 缺失则什么都不写（保持 NULL），下次
+    入口自动再来。
     """
     from movieclaw_api.services.media_scrape import assets_root
 
     if row.id is None or row.media_item_id is None or not stills_eligible(row):
         return False
-    if not force and row.chapter_images is not None:
+    if not force and stills_complete(row, assets_root()):
         return False
     video = Path(row.file_path)
     if not await asyncio.to_thread(video.is_file):
@@ -384,7 +468,7 @@ async def refresh_file_chapter_images(
             duration_seconds=row.duration_seconds,
             hdr=row.hdr,
             assets_root=assets_root(),
-            existing=chapter_image_map(row.chapter_images),
+            existing=_previous_entries(row.chapter_images),
             force=force,
         )
     if images is None:
@@ -532,10 +616,18 @@ def chapter_job_view(job: Job | None) -> ChapterJobView | None:
 
 
 async def _job_targets(session: AsyncSession, library_id: int, *, force: bool) -> list[int]:
-    """待处理的台账行 id：在位、非原盘/strm、没抓过图（force 时全部）。
-    新入库的排前面——刚入库最可能被点开看。"""
+    """待处理的台账行 id：在位、非原盘/strm，补缺模式再去掉已经抓齐的
+    （force 时全部）。新入库的排前面——刚入库最可能被点开看。
+
+    "抓齐没有"要比对有效章节与磁盘上的图（``stills_complete``），SQL 表达不了，
+    所以把候选行取回来在 Python 里判。两处刻意的写法：整行流式分批读（几万个
+    文件的库一次性全取回来，光 chapters/chapter_images 两列 JSON 就能吃掉几百
+    MB），每批的判定放线程里做（含一次列目录的磁盘 IO，别占住事件循环）。
+    """
+    from movieclaw_api.services.media_scrape import assets_root
+
     query = (
-        select(LibraryFile.id, LibraryFile.file_path, LibraryFile.container)
+        select(LibraryFile)
         .where(
             LibraryFile.library_id == library_id,
             LibraryFile.media_item_id.is_not(None),  # type: ignore[union-attr]
@@ -543,15 +635,24 @@ async def _job_targets(session: AsyncSession, library_id: int, *, force: bool) -
         )
         .order_by(LibraryFile.created_at.desc(), LibraryFile.id.desc())
     )
-    if not force:
-        query = query.where(LibraryFile.chapter_images.is_(None))  # type: ignore[union-attr]
-    rows = (await session.execute(query)).all()
-    return [
-        int(file_id)
-        for file_id, path, container in rows
-        if (container or "") not in ("bluray", "dvd", "iso")
-        and not str(path).lower().endswith(STRM_EXT)
-    ]
+    root = assets_root()
+    targets: list[int] = []
+    result = await session.stream(query)
+    async for batch in result.scalars().partitions(500):
+        rows = [row for row in batch if row.id is not None and stills_eligible(row)]
+        if force:
+            targets.extend(int(row.id) for row in rows)  # type: ignore[arg-type]
+            continue
+        targets.extend(
+            await asyncio.to_thread(
+                lambda pending=rows: [
+                    int(row.id)  # type: ignore[arg-type]
+                    for row in pending
+                    if not stills_complete(row, root)
+                ]
+            )
+        )
+    return targets
 
 
 async def _run_targets(
@@ -564,7 +665,7 @@ async def _run_targets(
     断点都要有：
 
     - **补缺**（``force=False``）：逐文件写回台账即是检查点，重新取目标时
-      ``chapter_images IS NULL`` 自然把已完成的行排除在外；
+      ``stills_complete`` 自然把已经抓齐的行排除在外；
     - **重抓**（``force=True``）：每一行都要重做，台账不再是检查点，因此把
       "上一轮最后一个处理完的文件"记进进度的 ``details.cursor``，恢复时按
       同一份排序跳过它之前的行。进度写入有节流（1 秒），所以最多重做节流

--- a/src/movieclaw_db/models/library_file.py
+++ b/src/movieclaw_db/models/library_file.py
@@ -234,10 +234,13 @@ class LibraryFile(TimestampMixin, table=True):
         sa_column=Column(_NullableJson, nullable=True),
         description="内嵌章节清单 JSON；NULL=未探测",
     )
-    # chapter_images 三态：NULL=没抓过图，[]=抓过无产物（无章节/跳过/失败）。
+    # chapter_images 三态：NULL=没抓过图，[]=抓过无产物（无章节/整体跳过）。
     #   元素 {"start_ms", "frame_ms", "image"}：start_ms 是与有效章节 join 的键，
     #   frame_ms 是图上那一帧的真实时间（只解关键帧会比章节起点晚几秒），
-    #   image 是相对资产根目录的路径 {item}/chapters/{file_id}/{start_ms}.jpg
+    #   image 是相对资产根目录的路径 {item}/chapters/{file_id}/{start_ms}.jpg。
+    #   抓不出来的章节记一条墓碑 {"start_ms", "failed": True}：没有 image，
+    #   消费方（chapter_image_map）照旧过滤掉，只有补缺判据（stills_complete）
+    #   认它——否则每一轮作业都会重跑同一个抓不出图的文件。
     chapter_images: list | None = Field(
         default=None,
         sa_column=Column(_NullableJson, nullable=True),

--- a/tests/api/test_chapter_images.py
+++ b/tests/api/test_chapter_images.py
@@ -173,10 +173,15 @@ async def test_synthetic_chapters_get_stills_and_item_refresh_cleans_orphans(db,
     assert await chapters_mod.refresh_chapter_images(item_id) == 1
     async with db.session() as session:
         row = await session.get(LibraryFile, file_id)
-        # 合成起点 6s / 50s / 94s：94s 超出实际片长，ffmpeg 抓不到帧则没图，前两张必有
-        starts = [e["start_ms"] for e in row.chapter_images]
-        assert starts[:2] == [6000, 50000]
-        assert all(e["frame_ms"] >= e["start_ms"] for e in row.chapter_images)
+        # 合成起点 6s / 50s / 94s：94s 超出实际片长，抓不到帧就记一条墓碑
+        # （不是干脆没记录，否则补缺每一轮都会对着它重跑），前两张必有图
+        images = [e for e in row.chapter_images if "image" in e]
+        assert [e["start_ms"] for e in images][:2] == [6000, 50000]
+        assert all(e["frame_ms"] >= e["start_ms"] for e in images)
+        assert [e for e in row.chapter_images if e.get("failed")] in (
+            [],
+            [{"start_ms": 94000, "failed": True}],
+        )
     assert not orphan.exists()  # 孤儿目录（没有对应台账行）被清掉
 
 
@@ -188,7 +193,11 @@ async def test_detail_projects_chapters_without_touching_ffmpeg(db, tmp_path, mo
         {"start_ms": 0, "end_ms": 20000, "title": "Opening"},
         {"start_ms": 20000, "end_ms": None, "title": None},
     ]
-    images = [{"start_ms": 20000, "frame_ms": 22000, "image": "1/chapters/1/0000020000.jpg"}]
+    # 第 0 章抓不出来（墓碑）：详情页照旧当"这章没图"，补缺也认它已有结论
+    images = [
+        {"start_ms": 0, "failed": True},
+        {"start_ms": 20000, "frame_ms": 22000, "image": "1/chapters/1/0000020000.jpg"},
+    ]
     lib_id, item_id, file_id = await _seed(db, video, chapters=embedded, chapter_images=images)
     assets = Path(get_settings().metadata_dir) / "images" / "1" / "chapters" / "1"
     assets.mkdir(parents=True)
@@ -206,13 +215,22 @@ async def test_detail_projects_chapters_without_touching_ffmpeg(db, tmp_path, mo
     assert chapters[0].end_ms == 20000 and chapters[1].end_ms == 60000
     assert chapters[1].frame_ms == 22000 and not chapters[1].synthetic
     assert chapters[1].image_url.startswith("/images/assets/1/chapters/1/0000020000.jpg?v=")
-    # 已抓过图：不懒触发
+    # 已抓齐（有图的 + 墓碑）：不懒触发
     assert view.chapters_pending is False and scheduled == []
 
-    # 没抓过图（chapter_images=NULL）：详情页懒触发一次并告知前端轮询
+    # 没抓齐（这里是 chapter_images=NULL）：详情页懒触发一次并告知前端轮询
     async with db.session() as session:
         row = await session.get(LibraryFile, file_id)
         row.chapter_images = None
+        await session.commit()
+        view = (await get_library_item(lib_id, item_id, _ADMIN, session)).data
+    assert view.chapters_pending is True and scheduled == [item_id]
+
+    # 半成品（第 0 章既没图也没墓碑）同样懒触发——只看"抓过没有"会永远漏掉它
+    scheduled.clear()
+    async with db.session() as session:
+        row = await session.get(LibraryFile, file_id)
+        row.chapter_images = images[1:]
         await session.commit()
         view = (await get_library_item(lib_id, item_id, _ADMIN, session)).data
     assert view.chapters_pending is True and scheduled == [item_id]
@@ -268,6 +286,18 @@ async def test_job_targets_skip_done_disc_and_strm(db, tmp_path):
                 source=FileSource.SCANNED,
             ),
         ]
+        # 半成品：600s 该合成 6 张，台账里只有一张且图还不在磁盘上
+        partial = LibraryFile(
+            library_id=lib_id,
+            media_item_id=item_id,
+            file_path=str(video.parent / "e.mkv"),
+            container="mkv",
+            duration_seconds=600,
+            chapters=[],
+            chapter_images=[{"start_ms": 36000, "frame_ms": 36000, "image": "x.jpg"}],
+            source=FileSource.SCANNED,
+        )
+        extra.append(partial)
         session.add_all(extra)
         await session.commit()
         pending = await chapters_mod._job_targets(session, lib_id, force=False)
@@ -277,8 +307,151 @@ async def test_job_targets_skip_done_disc_and_strm(db, tmp_path):
                 select(LibraryFile.id).where(LibraryFile.file_path.endswith("b.mkv"))
             )
         ).scalar_one()
-    assert pending == [b_id]  # 已抓过的、原盘、strm、未识别的都不在
-    assert set(everything) == {done_id, b_id}
+    # 抓齐的、原盘、strm、未识别的都不在；没抓过的与半成品都要处理
+    assert set(pending) == {b_id, partial.id}
+    assert set(everything) == {done_id, b_id, partial.id}
+
+
+def _bare_row(tmp_path, *, chapters, chapter_images, duration=600) -> LibraryFile:
+    """只给 stills_complete 读属性用的台账行，不进数据库。"""
+    return LibraryFile(
+        id=1,
+        library_id=1,
+        media_item_id=1,
+        file_path=str(tmp_path / "a.mkv"),
+        container="mkv",
+        duration_seconds=duration,
+        chapters=chapters,
+        chapter_images=chapter_images,
+        source=FileSource.SCANNED,
+    )
+
+
+def test_stills_complete_only_counts_finished_files(tmp_path):
+    """补缺的判据是"抓齐没有"而不是"抓过没有"（设计文档 §4.5）：半成品、图丢了、
+    该有图却写成 [] 的行都要接着抓；墓碑与整体不抓图的才算齐。"""
+    assets = tmp_path / "assets"
+    embedded = [
+        {"start_ms": 0, "end_ms": 20000, "title": "Opening"},
+        {"start_ms": 20000, "end_ms": None, "title": None},
+    ]
+
+    def _image(start: int) -> dict:
+        rel = chapters_mod.image_rel_path(1, 1, start)
+        path = assets / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"jpg")
+        return {"start_ms": start, "frame_ms": start + 2000, "image": rel}
+
+    first, second = _image(0), _image(20000)
+    complete = _bare_row(tmp_path, chapters=embedded, chapter_images=[first, second])
+    assert chapters_mod.stills_complete(complete, assets)
+    # 上一轮预算耗尽写回的半成品：缺的那一章要接着抓
+    partial = _bare_row(tmp_path, chapters=embedded, chapter_images=[second])
+    assert not chapters_mod.stills_complete(partial, assets)
+    # 抓不出来的章节留了墓碑：算齐，别每轮对着它重跑
+    tombstone = _bare_row(
+        tmp_path, chapters=embedded, chapter_images=[{"start_ms": 0, "failed": True}, second]
+    )
+    assert chapters_mod.stills_complete(tombstone, assets)
+    # 章节或图没探过
+    assert not chapters_mod.stills_complete(
+        _bare_row(tmp_path, chapters=None, chapter_images=[first, second]), assets
+    )
+    assert not chapters_mod.stills_complete(
+        _bare_row(tmp_path, chapters=embedded, chapter_images=None), assets
+    )
+    # [] 的两面：该有图（600s 合成 6 张）却是空的要重来；60s 短片合成 0 张算齐
+    assert not chapters_mod.stills_complete(
+        _bare_row(tmp_path, chapters=[], chapter_images=[], duration=600), assets
+    )
+    assert chapters_mod.stills_complete(
+        _bare_row(tmp_path, chapters=[], chapter_images=[], duration=60), assets
+    )
+    # 台账有记录、图文件没了（清过资产目录、只恢复了数据库备份）：重抓
+    (assets / str(first["image"])).unlink()
+    assert not chapters_mod.stills_complete(complete, assets)
+
+
+async def test_partial_and_failed_stills_resume_next_round(db, tmp_path, monkeypatch):
+    """半成品下一轮接着抓（已有的图原样复用），图丢了会重抓，抓不出来的记墓碑
+    不再重试，force 时墓碑也重试。"""
+    video = tmp_path / "media" / "p.mkv"
+    video.parent.mkdir()
+    video.write_bytes(b"x")
+    embedded = [
+        {"start_ms": 0, "end_ms": 20000, "title": "Opening"},
+        {"start_ms": 20000, "end_ms": None, "title": None},
+    ]
+    _lib_id, item_id, file_id = await _seed(db, video, chapters=embedded)
+    assets = Path(get_settings().metadata_dir) / "images"
+    rel_first = chapters_mod.image_rel_path(item_id, file_id, 0)
+    seeded = {
+        "start_ms": 20000,
+        "frame_ms": 22000,
+        "image": chapters_mod.image_rel_path(item_id, file_id, 20000),
+    }
+    (assets / seeded["image"]).parent.mkdir(parents=True, exist_ok=True)
+    (assets / seeded["image"]).write_bytes(b"jpg")
+    async with db.session() as session:
+        row = await session.get(LibraryFile, file_id)
+        row.chapter_images = [seeded]  # 上一轮只抓到第 2 章
+        await session.commit()
+
+    seeks: list[float] = []
+    state = {"fail": False}
+
+    def _grab(_video, dest, *, seek_seconds, color):
+        seeks.append(seek_seconds)
+        if state["fail"]:
+            return None
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"jpg")
+        return int(seek_seconds * 1000) + 500
+
+    monkeypatch.setattr(chapters_mod, "video_color_for", lambda *_a, **_k: None)
+    monkeypatch.setattr(chapters_mod, "grab_chapter_still", _grab)
+
+    async with db.session() as session:
+        row = await session.get(LibraryFile, file_id)
+        assert await chapters_mod.refresh_file_chapter_images(session, row)
+        assert seeks == [15.0]  # 只补缺的那一章（第 0 章从 15s 抓）
+        assert [e["start_ms"] for e in row.chapter_images] == [0, 20000]
+        assert row.chapter_images[1] == seeded  # 已有的图原样复用
+
+        # 抓齐了：再来一次是 no-op
+        seeks.clear()
+        assert not await chapters_mod.refresh_file_chapter_images(session, row)
+        assert seeks == []
+
+        # 图文件没了：补缺重抓那一张
+        (assets / rel_first).unlink()
+        assert await chapters_mod.refresh_file_chapter_images(session, row)
+        assert seeks == [15.0]
+
+        # 这一章 ffmpeg 抓不出来：记墓碑，下一轮不再对着它重跑
+        (assets / rel_first).unlink()
+        state["fail"] = True
+        seeks.clear()
+        assert await chapters_mod.refresh_file_chapter_images(session, row)
+        assert row.chapter_images[0] == {"start_ms": 0, "failed": True}
+        seeks.clear()
+        assert not await chapters_mod.refresh_file_chapter_images(session, row)
+        assert seeks == []
+
+        # 同一个文件因为别的章节缺图再进来时，墓碑那一章也不重试
+        state["fail"] = False
+        (assets / seeded["image"]).unlink()
+        seeks.clear()
+        assert await chapters_mod.refresh_file_chapter_images(session, row)
+        assert seeks == [20.0]
+        assert row.chapter_images[0] == {"start_ms": 0, "failed": True}
+
+        # force 不认墓碑，也不认已有的图
+        seeks.clear()
+        assert await chapters_mod.refresh_file_chapter_images(session, row, force=True)
+        assert seeks == [15.0, 20.0]
+        assert all("image" in e for e in row.chapter_images)
 
 
 async def test_probe_failure_and_missing_ffmpeg_leave_row_untouched(db, tmp_path, monkeypatch):
@@ -458,13 +631,29 @@ async def test_library_job_resumes_after_restart(db, tmp_path, monkeypatch, forc
     calls: list[int] = []
     stop_after = 2  # 抓完第二个文件就"停机"
 
+    assets = Path(get_settings().metadata_dir) / "images"
+
     async def fake_refresh(session, row, *, force=False):
-        if not force and row.chapter_images is not None:
+        """抓图的替身：跳过条件与落库形态都照真的来——补缺的断点就是"抓齐没有"，
+        只写半套图（或者图不落盘）会被判成半成品、下一轮又重来。"""
+        if not force and chapters_mod.stills_complete(row, assets):
             return False
         calls.append(row.id)
         if len(calls) > stop_after:
             raise asyncio.CancelledError("模拟重启")  # 停机会直接取消执行协程
-        row.chapter_images = [{"start_ms": 0, "frame_ms": 0, "image": f"x/{row.id}.jpg"}]
+        planned, _ = chapters_mod.still_plan(
+            chapters_mod.effective_chapters(row.chapters, row.duration_seconds),
+            row.duration_seconds,
+        )
+        images = []
+        for chapter in planned:
+            rel = chapters_mod.image_rel_path(row.media_item_id, row.id, chapter.start_ms)
+            (assets / rel).parent.mkdir(parents=True, exist_ok=True)
+            (assets / rel).write_bytes(b"jpg")
+            images.append(
+                {"start_ms": chapter.start_ms, "frame_ms": chapter.start_ms, "image": rel}
+            )
+        row.chapter_images = images
         session.add(row)
         await session.commit()
         return True


### PR DESCRIPTION
## 问题

「生成章节」不勾「已有的章节也重新生成」时，补缺此前只认 `chapter_images IS NULL`，也就是「这一行抓没抓过」。三种半成品因此再也等不到补缺，只能整库勾 force 重抓：

- **单文件预算耗尽（300s）或中途出错写回的部分产物**——设计文档 §4.4 明说部分产物落库，却没有「下次接着补」的另一半；
- **台账有记录、图文件却没了的行**（清过资产目录、只恢复了数据库备份、迁移丢图）：`extract_file_stills` 里 `dest.is_file()` 那条复用判断本来就是为这种情况写的，被上游的 NULL 守卫挡得永远走不到；
- **当时该有图却写成 `[]` 的行**（抓帧全失败、时长当时没探出来）。

## 改动

判据换成 `stills_complete()`：一个文件算齐，当且仅当计划抓图的每一章都有结论——图登记在台账里**且文件还在磁盘上**，或者留了一条抓不出来的墓碑；按规则整体不抓图的（没有章节、章节过密、章节过多）也算齐。整库作业目标筛选、单文件刷新、详情页懒触发三个入口共用同一判据。

配套的两样：

- **`still_plan()`**：抓图计划（越界截断、过密/过多整体跳过）从 `extract_file_stills` 抽出来，与完整性判据共用。两处各写一遍迟早出现「判定没抓齐、真去抓又抓不出那一张」的死循环。
- **墓碑 `{"start_ms", "failed": true}`**：某一章 ffmpeg 抓不出来（坏帧、编码不支持、定位超时）时记一条。没有它，「只跳过抓齐的」会让每一轮作业、每一次打开详情页都对着同一个抓不出图的文件重跑一遍。墓碑没有 `image`，`chapter_image_map` 照旧过滤掉，详情页与 Jellyfin 侧看到的仍是「这章没图」；force 不复用墓碑，仍会重试。

一处性能取舍：目标筛选没法再用一条 SQL（「齐没齐」要算有效章节 + 看磁盘），改成流式分批（500 行一批）取回候选行、每批判定丢线程里做——直接整库 `.all()` 的话，几万文件的库光 `chapters`/`chapter_images` 两列 JSON 就能吃掉几百 MB。

数据格式向前兼容：墓碑是新增元素，旧版本读到会被 `chapter_image_map` 过滤掉，回退无碍；无迁移，运行时依赖未变（不需要 bump `docker/runtime-version`）。

文案与文档同步：弹窗第一条「只处理还没有章节的文件，已有的不动」→「只处理章节图还缺的文件（含上次没抓完、图丢了的），已经齐的不动」；`docs/design/video-chapters.md` §4.4/§4.5 与模型注释一并更新。

## 测试

`tests/api/test_chapter_images.py` 新增：

- `stills_complete` 判据矩阵：完整 / 半成品 / 图丢了 / 墓碑 / `[]` 的两面（该有图 vs 短片本就没有）/ 章节或图未探测；
- 端到端续抓：半成品只补缺的那一章、已有的图原样复用、图没了会重抓、抓不出来记墓碑后不再重试（含「因别的章节缺图再进来时墓碑也不重试」）、force 全部重来；
- `_job_targets` 用例加了半成品行；重启断点用例的抓图替身改成照真的落库（写实际图文件），否则会被判成半成品。

本地装了 ffmpeg 跑完整版：`tests/api/test_chapter_images.py`、`tests/media/test_chapters.py`、`tests/jellyfin/test_chapters.py` 全绿（27 passed），`test_playback_chapters.py`、`test_still_color.py`、`test_storage.py` 也绿；`ruff check src tests` 通过。

⚠️ `tests/api/test_library_item_detail.py` 的 `test_item_detail_assembles_local_scrape` 与 `test_wall_reports_probe_pending_count` 在我这个容器里失败，但在父提交上同样失败——是容器里装了真 ffprobe 之后、用例那个假 `.mkv` 探测不出音轨导致的（`EBML header parsing failed`），与本次改动无关。`tests/api` 全量本地未跑完，按项目约定交给 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RHevu9rXhpFirQoj1CBpV

---
_Generated by [Claude Code](https://claude.ai/code/session_015RHevu9rXhpFirQoj1CBpV)_