### PR TITLE
硬件转码修三处：10-bit 源不再编不出来、色彩转换不喂硬件帧、软件滤镜也留硬解

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,14 +219,22 @@ services:
       # - /volume2/movies:/movies
     environment:
       - TZ=Asia/Shanghai              # ← change to your timezone
-    # Want hardware transcoding with an iGPU / dGPU? First run `ls /dev/dri` on the host
-    # to confirm it exists (ARM boxes and CPU-only hosts usually don't have it). Enable
-    # the two lines below without it, and the container gets recreated and then fails to
-    # start, leaving nothing but "no such file or directory". When in doubt, leave them
-    # alone: the first-start log will tell you outright whether hardware decoding is
-    # available and what's missing.
+      # For NVIDIA hardware transcoding, enable these two together with
+      # `runtime: nvidia` below:
+      # - NVIDIA_VISIBLE_DEVICES=all
+      # - NVIDIA_DRIVER_CAPABILITIES=all
+    # Want hardware transcoding with an Intel / AMD iGPU? First run `ls /dev/dri` on the
+    # host to confirm it exists (ARM boxes and CPU-only hosts usually don't have it).
+    # Enable the two lines below without it, and the container gets recreated and then
+    # fails to start, leaving nothing but "no such file or directory".
     # devices:
     #   - /dev/dri:/dev/dri
+    # Using an NVIDIA dGPU? It does **not** go through /dev/dri — don't mount that when
+    # you have no iGPU (the container won't start). Install the NVIDIA Container Toolkit
+    # on the host first, then enable this line:
+    # runtime: nvidia
+    # When in doubt, leave them alone: the first-start log will tell you outright whether
+    # hardware decoding is available and what's missing.
     restart: unless-stopped
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,12 +205,18 @@ services:
       # - /volume2/movies:/movies
     environment:
       - TZ=Asia/Shanghai
-    # 想用核显 / 独显做硬件转码？先在宿主上 `ls /dev/dri` 确认它存在（ARM 机型、
-    # 纯 CPU 主机通常没有）。不存在却打开下面两行，容器会被重建然后起不来，
-    # 只留一句英文 no such file or directory。不确定就先别动：装好后首启日志
-    # 会直接告诉你能不能硬解、缺什么。
+      # NVIDIA 独显做硬件转码时，与下面的 runtime: nvidia 配套打开这两行：
+      # - NVIDIA_VISIBLE_DEVICES=all
+      # - NVIDIA_DRIVER_CAPABILITIES=all
+    # 想用 Intel / AMD 核显做硬件转码？先在宿主上 `ls /dev/dri` 确认它存在
+    # （ARM 机型、纯 CPU 主机通常没有）。不存在却打开下面两行，容器会被重建
+    # 然后起不来，只留一句英文 no such file or directory。
     # devices:
     #   - /dev/dri:/dev/dri
+    # 用 NVIDIA 独显？它**不走 /dev/dri**，没有核显就别去挂那个（挂了必起不来）。
+    # 宿主先装好 NVIDIA Container Toolkit，再打开下面这行：
+    # runtime: nvidia
+    # 不确定就先别动：装好后首启日志会直接告诉你能不能硬解、缺什么。
     restart: unless-stopped
 ```
 

--- a/docs/design/web-player.md
+++ b/docs/design/web-player.md
@@ -1516,8 +1516,27 @@ Mac mini 验证。做成发版前的人工清单，列进 `.claude/skills/releas
   发现决策引擎的 `VideoPlan(action="copy")` 原先不带 codec，导致这个标签
   **永远打不上**——根因已修（copy 也记录流经的编码）。
 - **上游 ffmpeg 没有 `tonemap_cuda`**（`tonemap_vaapi` / `tonemap_opencl` /
-  `libplacebo` 都有），印证了 §5.3 关于 jellyfin-ffmpeg 补丁的说法。命令装配
-  据此在无原生滤镜的后端上退回「软件解码 + 软件 tone-map + 硬件编码」。
+  `libplacebo` 都有），印证了 §5.3 关于 jellyfin-ffmpeg 补丁的说法。但官方镜像
+  装的就是 jellyfin-ffmpeg（§12.14），补丁在容器里是有的——所以**不按构建假定，
+  由硬件自检真跑一遍这条链**（`hwprobe._probe_native_tonemap`，探测链与真实
+  转码链同构）：跑通就整条链留在 GPU 上，跑不通就退回软件 tone-map。这是全项目
+  唯一一处运行期 ffmpeg 能力探测，理由是它有真实的双形态（官方镜像有补丁、
+  源码部署多半没有），而 §12.14 那条「不做能力探测降级」针对的是恒定内置的
+  `tonemapx`。
+- **软件滤镜链不等于软件解码**。以前只要滤镜链落到软件侧（软件 tone-map、
+  烧录字幕、色彩空间转换），`-hwaccel` 整个不发，4K HEVC 10-bit 的解码被压回
+  CPU——NAS 上就是幻灯片，而用户以为自己的显卡在干活。现在恒发 `-hwaccel`，
+  只在需要软件帧时不发 `-hwaccel_output_format`，由 ffmpeg 自己把解码帧下载
+  回系统内存。
+- **硬件 scale 必须钉死输出像素格式**（`scale_cuda=format=yuv420p` /
+  `scale_vaapi=format=nv12` / `scale_qsv=format=nv12`）。10-bit 的 SDR 源不进
+  tone-map 分支，硬件帧的 sw_format 一路保持 p010，而三家的 H.264 编码器都只吃
+  8-bit，滤镜协商又不会在硬件帧之间插格式转换——软件档的 `-pix_fmt yuv420p`
+  是同一个坑的对应兜底。
+- **`colorspace` 是软件滤镜，不能排在硬件帧前面**。BT.2020 的 SDR 源要插它
+  （§7-④e / issue #331），此时整条滤镜链落软件侧；吃不了软件帧的 VAAPI/QSV
+  按与烧录同一条规则整体退出硬件档，交给统一降档，而不是让 ffmpeg 带着一条
+  装不起来的链子去失败。
 
 ### 12.4 与本文的偏离
 

--- a/src/movieclaw_api/services/playback/ffmpeg_args.py
+++ b/src/movieclaw_api/services/playback/ffmpeg_args.py
@@ -158,14 +158,28 @@ _DOWNMIX_PAN = (
 )
 
 
+#: NVIDIA 的原生 HDR→SDR 色调映射滤镜。**不写死进 HW_BACKENDS**：
+#: ``tonemap_cuda`` 是 jellyfin-ffmpeg 的补丁，上游 ffmpeg 没有，而本项目
+#: 除官方镜像外还有源码部署（用发行版 ffmpeg）。由硬件自检真跑一遍这条链
+#: 确认可用后回写（``register_native_tonemap``），探不到就维持
+#: 「软件 tone-map + 硬件编解码」的老路——多花些 CPU，但不会整片放不了。
+#:
+#: 参数与软件档 ``_SOFTWARE_TONEMAP`` 对齐：BT.2390 EETF + 落到 BT.709 的
+#: 三件套 + 8-bit 输出。三件套一项都不能少，理由见 VAAPI 那条注释。
+NVENC_TONEMAP = (
+    "tonemap_cuda=tonemap=bt2390:desat=0:p=bt709:t=bt709:m=bt709:format=yuv420p"
+)
+
+
 @dataclass(frozen=True)
 class HwBackend:
     """一个硬件加速后端的参数三件套。
 
-    ``tonemap_filter`` 为 None 表示该后端在**上游 ffmpeg** 里没有原生色调映射
-    滤镜（实测：``tonemap_cuda`` 不在上游，是 jellyfin-ffmpeg 的补丁）。这种
-    情况下退回「软件解码 + 软件 tone-map + 硬件编码」，而不是硬凑一条
-    hwdownload/hwupload 的链子——后者在不同驱动上碎得厉害。
+    ``tonemap_filter`` 为 None 表示该后端没有**恒定可用**的原生色调映射滤镜
+    （NVIDIA 的 ``tonemap_cuda`` 要靠自检确认，见 ``NVENC_TONEMAP``）。这种
+    情况下滤镜链退回软件侧，而不是硬凑一条 hwdownload/hwupload 的链子——
+    后者在不同驱动上碎得厉害。注意**解码依然留在硬件上**（只是不再要求
+    输出硬件帧），见 ``build_hls_command`` 里 ``-hwaccel`` 的发法。
     """
 
     name: str
@@ -174,6 +188,12 @@ class HwBackend:
     hwaccel_output_format: str | None = None
     scale_filter: str | None = None  # 形如 "scale_vaapi"；None=用软件 scale
     tonemap_filter: str | None = None
+    #: 硬件 scale 滤镜的输出像素格式。**必须显式钉死 8-bit**：10-bit 的 SDR
+    #: 源（动漫 HEVC 压制极常见）不触发 tone-map，硬件帧的 sw_format 会一路
+    #: 保持 p010 送进 H.264 编码器，而 NVENC / VAAPI / QSV 的 H.264 都只吃
+    #: 8-bit，实测直接报错退出（滤镜自动协商不会在硬件帧之间插格式转换）。
+    #: 软件档的 ``-pix_fmt yuv420p`` 就是同一个坑的对应兜底。
+    scale_format: str | None = None
     device: str | None = None
     #: 编码器能否直接吃系统内存帧。烧录（overlay 是软件滤镜）会把整条滤镜链
     #: 拉回软件侧：NVENC / VideoToolbox 的编码器接软件帧没问题；VAAPI / QSV
@@ -193,6 +213,7 @@ HW_BACKENDS: dict[str, HwBackend] = {
         # 原色与矩阵，播放器照标签做色域扩展——实测渲染差平均 13.4/255、
         # 最高 90，观感是整体偏红发品（issue #331）。
         tonemap_filter="tonemap_vaapi=format=nv12:t=bt709:m=bt709:p=bt709",
+        scale_format="nv12",
         device="/dev/dri/renderD128",
         sw_frames_ok=False,
     ),
@@ -207,6 +228,7 @@ HW_BACKENDS: dict[str, HwBackend] = {
             "vpp_qsv=tonemap=1:format=nv12:out_color_transfer=bt709"
             ":out_color_matrix=bt709:out_color_primaries=bt709"
         ),
+        scale_format="nv12",
     ),
     "nvenc": HwBackend(
         name="nvenc",
@@ -214,7 +236,8 @@ HW_BACKENDS: dict[str, HwBackend] = {
         hwaccel="cuda",
         hwaccel_output_format="cuda",
         scale_filter="scale_cuda",
-        tonemap_filter=None,  # 上游没有 tonemap_cuda，见类文档
+        tonemap_filter=None,  # tonemap_cuda 由自检确认后回写，见 NVENC_TONEMAP
+        scale_format="yuv420p",
         sw_frames_ok=True,
     ),
     "videotoolbox": HwBackend(
@@ -230,19 +253,80 @@ HW_BACKENDS: dict[str, HwBackend] = {
 }
 
 
+#: 后端名 → 经硬件自检确认可用的原生 tone-map 滤镜。见 ``NVENC_TONEMAP``。
+_PROBED_TONEMAP: dict[str, str] = {}
+
+
+def register_native_tonemap(backend: str, filter_expr: str | None) -> None:
+    """自检确认某后端的原生 tone-map 滤镜可用（或不再可用）。
+
+    由 ``hwprobe`` 在真跑过一遍滤镜链后调用，是**能力探测唯一的写入口**。
+    装配层自己不跑 ffmpeg：命令装配必须是纯函数，才能被表驱动单测钉住。
+    """
+    if filter_expr:
+        _PROBED_TONEMAP[backend] = filter_expr
+    else:
+        _PROBED_TONEMAP.pop(backend, None)
+
+
+def native_tonemap_filter(backend: HwBackend) -> str | None:
+    """该后端这次能用的原生 tone-map 滤镜；None=只能走软件 tone-map。"""
+    return _PROBED_TONEMAP.get(backend.name, backend.tonemap_filter)
+
+
+def _needs_software_filters(
+    plan: PlaybackPlan, backend: HwBackend | None, *, burn: bool
+) -> bool:
+    """这条计划的滤镜链是不是必须落到软件侧（帧在系统内存里）。
+
+    三种来源，都是「这一步只有软件滤镜做得了」：
+
+    1. 烧录字幕——``overlay`` 是软件滤镜；
+    2. 要 tone-map 但该后端没有可用的原生滤镜（见 ``native_tonemap_filter``）；
+    3. 要色彩空间转换——``colorspace`` 同样是软件滤镜。**这条最容易漏**：
+       BT.2020 的 SDR 源（10-bit 压制常见）不进 tone-map 分支，却照样要插
+       ``colorspace``，把它排在 ``scale_cuda`` / ``scale_vaapi`` 前面就是让
+       软件滤镜去吃硬件帧——ffmpeg 不会自动插 hwdownload，整条命令直接失败。
+
+    VideoToolbox 还多一条：位深未知时无法安全选择 ``hwdownload`` 的格式
+    （见 ``_filter_chain``），同样按软件滤镜处理。
+
+    ``burn`` 由调用方给：装配层用的是解析后的轨道序号（解析不出来就不烧），
+    决策层只有计划字段，两者不能互相假定。
+    """
+    if burn:
+        return True
+    if plan.video.tone_map and (
+        backend is None or native_tonemap_filter(backend) is None
+    ):
+        return True
+    if _color_convert_filter(plan) is not None:
+        return True
+    return (
+        backend is not None
+        and backend.name == "videotoolbox"
+        and bool(plan.video.height)
+        and plan.video.source_bit_depth not in (8, 10)
+    )
+
+
 def effective_hw_backend(plan: PlaybackPlan, hw_backend: str | None) -> str | None:
     """这次会话**实际**用哪个硬件后端。
 
-    烧录（``video.burn_subtitle``）把滤镜链拉回软件侧，编码器吃不了软件帧的
-    后端（VAAPI/QSV）退回软件编码。诊断面板的 ``hw_backend`` 必须走这里——
-    报一个实际没用上的后端名，用户查「为什么转码这么卡」时会被带偏。
+    滤镜链被拉回软件侧时（烧录、软件 tone-map、色彩空间转换），编码器吃不了
+    软件帧的后端（VAAPI/QSV）退回软件编码。诊断面板的 ``hw_backend`` 必须走
+    这里——报一个实际没用上的后端名，用户查「为什么转码这么卡」时会被带偏；
+    路由层也据此判断硬件档还能不能执行（不能就走统一降档，而不是让 ffmpeg
+    带着一条装不起来的滤镜链去失败）。
     """
     if plan.video.action != "transcode" or hw_backend is None:
         return None if plan.video.action != "transcode" else hw_backend
     backend = HW_BACKENDS.get(hw_backend)
     if backend is None:
         return None
-    if plan.video.burn_subtitle is not None and not backend.sw_frames_ok:
+    if not backend.sw_frames_ok and _needs_software_filters(
+        plan, backend, burn=plan.video.burn_subtitle is not None
+    ):
         return None
     return hw_backend
 
@@ -284,20 +368,9 @@ def build_hls_command(
         HW_BACKENDS.get(effective_hw_backend(plan, hw_backend) or "") if transcoding_video else None
     )
     burn_index = _burn_subtitle_index(plan) if transcoding_video else None
-    videotoolbox_unknown_bit_depth = (
-        backend is not None
-        and backend.name == "videotoolbox"
-        and bool(plan.video.height)
-        and plan.video.source_bit_depth not in (8, 10)
+    software_filters = transcoding_video and _needs_software_filters(
+        plan, backend, burn=burn_index is not None
     )
-    # 需要 tone-map 但该后端没有原生滤镜，或要烧录字幕（overlay 是软件滤镜）
-    # → 走软件解码，让软件滤镜链能接上。VideoToolbox 只有软件 scale 时不在
-    # 这里回退：_filter_chain 会按源位深显式下载 videotoolbox_vld 帧后再缩放，
-    # 保留硬解；位深未知或不是 8/10 时无法安全选择下载格式，回退软件解码。
-    software_filters = burn_index is not None or (
-        bool(plan.video.tone_map)
-        and (backend is None or backend.tonemap_filter is None)
-    ) or videotoolbox_unknown_bit_depth
 
     # -ss 必须在 -i 之前：input seek 快得多（不用解码到该点）
     if start_ms > 0:
@@ -320,9 +393,14 @@ def build_hls_command(
         "-readrate", str(READRATE_COPY if not transcoding_video else READRATE),
         "-readrate_initial_burst", str(READRATE_BURST_SECONDS),
     ]
-    if backend and backend.hwaccel and not software_filters:
+    if backend and backend.hwaccel:
+        # 解码**恒定留在硬件上**，哪怕滤镜链是软件的：不发
+        # ``-hwaccel_output_format`` 时 ffmpeg 自己把解码帧下载回系统内存，
+        # 软件滤镜照样接得上，而最贵的那步（4K HEVC 10-bit 解码）不再压回
+        # CPU——NAS 上 CPU 软解 4K 就是幻灯片，用户体感是「插了显卡还是卡」。
+        # 硬解初始化不了时 ffmpeg 会自行退回软解，不需要我们再兜一层。
         argv += ["-hwaccel", backend.hwaccel]
-        if backend.hwaccel_output_format:
+        if backend.hwaccel_output_format and not software_filters:
             argv += ["-hwaccel_output_format", backend.hwaccel_output_format]
         if backend.device:
             argv += ["-hwaccel_device", backend.device]
@@ -533,10 +611,12 @@ def _filter_chain(
     parts: list[str] = []
     height = plan.video.height
     if plan.video.tone_map:
-        if backend is not None and backend.tonemap_filter and not software_filters:
-            parts.append(backend.tonemap_filter)
-        else:
-            parts.append(_SOFTWARE_TONEMAP)
+        native = (
+            native_tonemap_filter(backend)
+            if backend is not None and not software_filters
+            else None
+        )
+        parts.append(native or _SOFTWARE_TONEMAP)
     else:
         # 非 HDR 的非 709 源同样要显式转换，scale 不会替我们做
         convert = _color_convert_filter(plan)
@@ -544,7 +624,12 @@ def _filter_chain(
             parts.append(convert)
     if height:
         if backend is not None and backend.scale_filter and not software_filters:
-            parts.append(f"{backend.scale_filter}=w=-2:h={height}")
+            # format 必须写在硬件 scale 上：10-bit 源的硬件帧不会自己变成
+            # 8-bit，而 H.264 的硬件编码器只吃 8-bit（见 scale_format）。
+            opts = f"w=-2:h={height}"
+            if backend.scale_format:
+                opts = f"format={backend.scale_format}:{opts}"
+            parts.append(f"{backend.scale_filter}={opts}")
         else:
             # -2 保持宽高比并对齐到偶数（编码器要求）
             if backend is not None and backend.name == "videotoolbox" and not software_filters:

--- a/src/movieclaw_api/services/playback/hwprobe.py
+++ b/src/movieclaw_api/services/playback/hwprobe.py
@@ -28,7 +28,11 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from movieclaw_api.services.playback.ffmpeg_args import HW_BACKENDS
+from movieclaw_api.services.playback.ffmpeg_args import (
+    HW_BACKENDS,
+    NVENC_TONEMAP,
+    register_native_tonemap,
+)
 from movieclaw_api.services.playback.remote_worker import remote_worker_available
 
 logger = logging.getLogger("movieclaw_api.playback.hwprobe")
@@ -46,6 +50,21 @@ _PROBE_FILTERS: dict[str, list[str]] = {
     "qsv": ["-vf", "format=nv12,hwupload=extra_hw_frames=64"],
     "nvenc": ["-vf", "format=yuv420p"],
     "videotoolbox": ["-vf", "format=nv12"],
+}
+
+#: 需要真跑一遍才敢启用的原生 tone-map 链：``tonemap_cuda`` 是 jellyfin-ffmpeg
+#: 的补丁，上游 ffmpeg 没有；即便滤镜在，老驱动也可能初始化不起来。值是一对：
+#: 给命令装配层用的滤镜串，以及探测用的完整滤镜链模板（``{filter}`` 处填前者）。
+#:
+#: 探测链与真实转码链**同构**——上传到显存 → tone-map → 硬件缩放 → 硬件编码，
+#: 否则会出现「探得通、真用炸」。输入要合成成 HDR10（PQ 曲线 + BT.2020 三件套）：
+#: tone-map 滤镜拒绝非 HDR 输入，拿 testsrc2 直接喂它必然失败。
+_NATIVE_TONEMAP_PROBES: dict[str, tuple[str, str]] = {
+    "nvenc": (
+        NVENC_TONEMAP,
+        "format=p010le,setparams=color_primaries=bt2020:color_trc=smpte2084"
+        ":colorspace=bt2020ncl,hwupload_cuda,{filter},scale_cuda=format=yuv420p:w=-2:h=240",
+    ),
 }
 
 #: 后端 → 面向用户的名字。设置页里「vaapi」不如「Intel/AMD 核显」好懂。
@@ -95,6 +114,8 @@ def probe_backends(*, force: bool = False) -> list[HwBackendStatus]:
 
     encoders = _list_encoders()
     _cache = [_probe_one(name, encoders) for name in HW_BACKENDS]
+    for status in _cache:
+        _probe_native_tonemap(status.name, available=status.available)
     usable = [s.name for s in _cache if s.available]
     if usable:
         logger.info("硬件加速自检通过：%s", "、".join(usable))
@@ -131,9 +152,11 @@ def hardware_available() -> bool:
 
 
 def reset_probe_cache() -> None:
-    """测试用：丢掉缓存。"""
+    """测试用：丢掉缓存。回写给装配层的 tone-map 结论也要一并撤销。"""
     global _cache
     _cache = None
+    for name in _NATIVE_TONEMAP_PROBES:
+        register_native_tonemap(name, None)
 
 
 async def probe_backends_async(*, force: bool = False) -> list[HwBackendStatus]:
@@ -185,7 +208,7 @@ def _probe_one(name: str, encoders: frozenset[str]) -> HwBackendStatus:
     if device_problem is not None:
         return status(False, device_problem)
 
-    proc = _run_probe(backend.encoder, name)
+    proc = _run_probe(backend.encoder, _PROBE_FILTERS.get(name, []))
     if proc is None:
         return status(False, "硬件编码探测超时——设备可能被占用或驱动无响应。")
     if proc.returncode == 0:
@@ -193,17 +216,56 @@ def _probe_one(name: str, encoders: frozenset[str]) -> HwBackendStatus:
     return status(False, _explain_failure(proc.stderr.decode(errors="replace")))
 
 
-def _run_probe(encoder: str, name: str) -> subprocess.CompletedProcess[bytes] | None:
+def _run_probe(
+    encoder: str, filters: list[str]
+) -> subprocess.CompletedProcess[bytes] | None:
     argv = [
         "ffmpeg", "-hide_banner", "-v", "error",
         "-f", "lavfi", "-i", _PROBE_SOURCE,
-        *_PROBE_FILTERS.get(name, []),
+        *filters,
         "-c:v", encoder, "-f", "null", "-",
     ]
     try:
         return subprocess.run(argv, capture_output=True, timeout=_PROBE_TIMEOUT)
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None
+
+
+def _probe_native_tonemap(name: str, *, available: bool) -> None:
+    """确认该后端的原生 tone-map 链能不能真跑起来，结论回写给命令装配层。
+
+    探不到不是错误，只是回到「软件 tone-map + 硬件编解码」：多花 CPU，但
+    HDR 片照样能放。探到了则整条链留在 GPU 上——NVIDIA 用户的 4K HDR 从
+    「CPU 扛 tone-map」变成全程显卡，这是这个探测存在的唯一理由。
+    """
+    entry = _NATIVE_TONEMAP_PROBES.get(name)
+    if entry is None:
+        return
+    filter_expr, chain = entry
+    if not available:
+        register_native_tonemap(name, None)
+        return
+    proc = _run_probe(
+        HW_BACKENDS[name].encoder, ["-vf", chain.format(filter=filter_expr)]
+    )
+    if proc is not None and proc.returncode == 0:
+        register_native_tonemap(name, filter_expr)
+        logger.info(
+            "%s 的原生色调映射可用，HDR 转码全程留在显卡上。",
+            BACKEND_LABELS.get(name, name),
+        )
+        return
+    register_native_tonemap(name, None)
+    reason = (
+        "探测超时"
+        if proc is None
+        else " ".join(proc.stderr.decode(errors="replace").split())[:200]
+    )
+    logger.info(
+        "%s 没有可用的原生色调映射，HDR 片改用软件色调映射（画质一致，多占些 CPU）。原因：%s",
+        BACKEND_LABELS.get(name, name),
+        reason or "（ffmpeg 未给出原因）",
+    )
 
 
 def _device_problem(name: str) -> str | None:
@@ -217,9 +279,11 @@ def _device_problem(name: str) -> str | None:
     if name == "nvenc":
         if not Path("/dev/nvidia0").exists() and not Path("/dev/nvidiactl").exists():
             return (
-                "未检测到 NVIDIA 设备节点。Docker 部署需要安装 NVIDIA Container "
-                "Toolkit，并在 compose 里声明 `deploy.resources.reservations.devices` "
-                "或加 `--gpus all`。"
+                "未检测到 NVIDIA 设备节点。Docker 部署需要先在宿主机装 NVIDIA "
+                "Container Toolkit，再在 compose 里加 `runtime: nvidia` 与 "
+                "`NVIDIA_VISIBLE_DEVICES=all`（或声明 "
+                "`deploy.resources.reservations.devices`、`docker run --gpus all`）。"
+                "注意 NVIDIA 独显不走 /dev/dri，宿主机没有核显时别去挂它。"
             )
         return None
     # vaapi / qsv 都走 /dev/dri

--- a/tests/playback/test_ffmpeg_args.py
+++ b/tests/playback/test_ffmpeg_args.py
@@ -15,8 +15,11 @@ import pytest
 
 from movieclaw_api.services.playback.ffmpeg_args import (
     MAX_GOP_FRAMES,
+    NVENC_TONEMAP,
     SEGMENT_SECONDS,
     build_hls_command,
+    effective_hw_backend,
+    register_native_tonemap,
 )
 from movieclaw_playback.decide import (
     AudioPlan,
@@ -58,6 +61,14 @@ def argv_of(p: PlaybackPlan, **kwargs) -> list[str]:
 def pair(argv: list[str], flag: str) -> str | None:
     """取某个标志的值；标志不存在返回 None。"""
     return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+@pytest.fixture
+def probed_nvenc_tonemap():
+    """模拟硬件自检真跑通了 tonemap_cuda（CI 里没有 NVIDIA，只能注入结论）。"""
+    register_native_tonemap("nvenc", NVENC_TONEMAP)
+    yield
+    register_native_tonemap("nvenc", None)
 
 
 # ---------------------------------------------------------------------------
@@ -330,8 +341,12 @@ def test_videotoolbox_uses_p010le_bridge_for_10bit_source():
     assert pair(argv, "-vf") == "hwdownload,format=p010le,scale=-2:1080,format=yuv420p"
 
 
-def test_videotoolbox_unknown_bit_depth_uses_software_decode():
-    """未知位深不能猜下载格式，宁可软件解码也不能让 Worker 起空转进程。"""
+def test_videotoolbox_unknown_bit_depth_keeps_hardware_decode():
+    """未知位深不能猜 hwdownload 的格式——但也不必把解码一起丢回 CPU。
+
+    不发 ``-hwaccel_output_format`` 时 ffmpeg 自己把解码帧下载回系统内存，
+    软件 scale 照样接得上，解码仍在 VideoToolbox 上。
+    """
     argv = argv_of(
         plan(
             PlaybackTier.HARDWARE_TRANSCODE,
@@ -340,7 +355,8 @@ def test_videotoolbox_unknown_bit_depth_uses_software_decode():
         hw_backend="videotoolbox",
     )
 
-    assert "-hwaccel" not in argv
+    assert pair(argv, "-hwaccel") == "videotoolbox"
+    assert "-hwaccel_output_format" not in argv  # 要软件帧，不能要硬件帧
     assert pair(argv, "-vf") == "scale=-2:1080"
     assert pair(argv, "-c:v") == "h264_videotoolbox"
 
@@ -382,9 +398,13 @@ def test_vaapi_uses_native_tonemap_filter():
     assert "scale_vaapi" in vf
 
 
-def test_nvenc_without_native_tonemap_falls_back_to_software_chain():
-    """实测：上游 ffmpeg 没有 tonemap_cuda（那是 jellyfin-ffmpeg 的补丁）。
-    此时走软件解码 + 软件 tone-map + 硬件编码，而不是硬凑 hwdownload 链。"""
+def test_nvenc_without_probed_tonemap_uses_software_tonemap_but_keeps_nvdec():
+    """自检没确认 tonemap_cuda 时走软件 tone-map——但解码必须留在 NVDEC。
+
+    ``tonemap_cuda`` 是 jellyfin-ffmpeg 的补丁，上游没有，所以默认不假定它
+    存在。可即便滤镜链落在软件侧，也没有理由把 4K HEVC 10-bit 的解码一起
+    压回 CPU：那是整条链里最贵的一步，NAS 上就是幻灯片。
+    """
     argv = argv_of(
         plan(
             PlaybackTier.HARDWARE_TRANSCODE,
@@ -394,8 +414,96 @@ def test_nvenc_without_native_tonemap_falls_back_to_software_chain():
     )
     vf = pair(argv, "-vf")
     assert vf and "tonemapx=tonemap=bt2390" in vf  # BT.2390 EETF，不是简单 clip
-    assert "-hwaccel" not in argv  # 解码退回软件，滤镜链才接得上
+    assert pair(argv, "-hwaccel") == "cuda"  # 解码仍在显卡上
+    assert "-hwaccel_output_format" not in argv  # 但要软件帧，软件滤镜才接得上
     assert pair(argv, "-c:v") == "h264_nvenc"  # 编码仍然用硬件
+
+
+def test_nvenc_with_probed_tonemap_stays_on_gpu(probed_nvenc_tonemap):
+    """自检真跑通 tonemap_cuda 后，HDR 转码整条链留在显卡上。"""
+    argv = argv_of(
+        plan(
+            PlaybackTier.HARDWARE_TRANSCODE,
+            video=VideoPlan(action="transcode", codec="h264", height=1080, tone_map=True),
+        ),
+        hw_backend="nvenc",
+    )
+    vf = pair(argv, "-vf")
+    assert vf and vf.startswith("tonemap_cuda=")
+    assert "tonemapx" not in vf
+    assert vf.count("bt709") >= 3  # 三件套一项都不能少（issue #331）
+    assert pair(argv, "-hwaccel") == "cuda"
+    assert pair(argv, "-hwaccel_output_format") == "cuda"  # 全程硬件帧
+    assert "scale_cuda=format=yuv420p:w=-2:h=1080" in vf
+
+
+@pytest.mark.parametrize(
+    "backend, expected",
+    [
+        ("vaapi", "scale_vaapi=format=nv12:w=-2:h=1080"),
+        ("qsv", "scale_qsv=format=nv12:w=-2:h=1080"),
+        ("nvenc", "scale_cuda=format=yuv420p:w=-2:h=1080"),
+    ],
+)
+def test_hardware_scale_pins_eight_bit_output(backend, expected):
+    """10-bit 的 SDR 源必须在硬件 scale 上钉死 8-bit，否则整片编不出来。
+
+    动漫的 HEVC 10-bit SDR 压制极常见：它不是 HDR，不进 tone-map 分支，
+    硬件帧的 sw_format 会一路保持 p010 送进 H.264 编码器——而 NVENC /
+    VAAPI / QSV 的 H.264 都只吃 8-bit，滤镜协商又不会在硬件帧之间插格式
+    转换，结果是硬件档直接失败、用户被弹窗问「要不要开软件转码」。
+    软件档的 ``-pix_fmt yuv420p``（2026-08-25 真机事故）是同一个坑。
+    """
+    argv = argv_of(
+        plan(
+            PlaybackTier.HARDWARE_TRANSCODE,
+            video=VideoPlan(
+                action="transcode", codec="h264", height=1080, source_bit_depth=10
+            ),
+        ),
+        hw_backend=backend,
+    )
+    assert expected in (pair(argv, "-vf") or "")
+
+
+@pytest.mark.parametrize("backend", ["vaapi", "qsv", "nvenc", "videotoolbox"])
+def test_color_convert_never_feeds_software_filter_hardware_frames(backend):
+    """``colorspace`` 是软件滤镜，绝不能排在硬件帧前面。
+
+    BT.2020 的 SDR 源不进 tone-map 分支，却照样要插 ``colorspace``。把它排在
+    ``scale_cuda`` / ``scale_vaapi`` 之前，就是让软件滤镜去吃硬件帧——ffmpeg
+    不会自动插 hwdownload，整条命令起不来。要么整条链落到软件侧（解码仍在
+    硬件上），要么这个后端根本不该被选中。
+    """
+    p = plan(
+        PlaybackTier.HARDWARE_TRANSCODE,
+        video=VideoPlan(
+            action="transcode", codec="h264", height=1080, source_color="BT.2020"
+        ),
+    )
+    if effective_hw_backend(p, backend) is None:
+        return  # 吃不了软件帧的后端（VAAPI/QSV）诚实退出，交给统一降档
+    argv = argv_of(p, hw_backend=backend)
+    vf = pair(argv, "-vf") or ""
+    assert vf.startswith("colorspace=")
+    assert "-hwaccel_output_format" not in argv  # 拿的是软件帧
+    assert "scale_cuda" not in vf and "scale_vaapi" not in vf and "scale_qsv" not in vf
+
+
+@pytest.mark.parametrize("backend", ["vaapi", "qsv"])
+def test_color_convert_drops_backends_that_cannot_take_software_frames(backend):
+    """VAAPI/QSV 的编码器吃不了软件帧，滤镜链落软件侧时必须整体退出。
+
+    与烧录同一条规则。报一个实际用不上的后端名，只会让路由层把一条装不
+    起来的命令交给 ffmpeg，用户看到的是分片 404 而不是明确的降档。
+    """
+    p = plan(
+        PlaybackTier.HARDWARE_TRANSCODE,
+        video=VideoPlan(
+            action="transcode", codec="h264", height=1080, source_color="BT.2020"
+        ),
+    )
+    assert effective_hw_backend(p, backend) is None
 
 
 def test_tone_map_uses_bt2390_not_clip():
@@ -771,9 +879,10 @@ def test_burn_forces_software_pipeline_for_vaapi():
 
 
 def test_burn_keeps_nvenc_encoder_on_software_frames():
-    """NVENC 编码器接系统内存帧没问题：软件解码+overlay，硬件编码。"""
+    """NVENC 编码器接系统内存帧没问题：硬件解码 → overlay → 硬件编码。"""
     argv = argv_of(_burn_plan(), hw_backend="nvenc")
-    assert "-hwaccel" not in argv  # 解码侧仍是软件（滤镜链在软件侧）
+    assert pair(argv, "-hwaccel") == "cuda"  # 解码留在显卡上
+    assert "-hwaccel_output_format" not in argv  # overlay 要软件帧
     assert "h264_nvenc" in argv
 
 
@@ -788,7 +897,7 @@ def test_no_burn_keeps_plain_vf_path():
     )
     assert "-filter_complex" not in argv
     assert "0:v:0" in [argv[i + 1] for i, a in enumerate(argv) if a == "-map"]
-    assert "scale_vaapi=w=-2:h=720" in " ".join(argv)
+    assert "scale_vaapi=format=nv12:w=-2:h=720" in " ".join(argv)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/playback/test_hwprobe.py
+++ b/tests/playback/test_hwprobe.py
@@ -140,6 +140,60 @@ def test_probe_timeout_is_reported_not_swallowed(monkeypatch, tmp_path):
     assert "超时" in status_of(hwprobe.probe_backends(), "vaapi").detail
 
 
+def _nvenc_ready(monkeypatch, tmp_path):
+    """一台「NVENC 编码器在、设备节点也在」的机器。"""
+    monkeypatch.setattr(hwprobe.shutil, "which", lambda _n: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(hwprobe, "_list_encoders", lambda: frozenset({"h264_nvenc"}))
+    monkeypatch.setattr(hwprobe, "Path", lambda _p: tmp_path)
+
+
+def test_native_tonemap_is_enabled_only_after_a_real_run(monkeypatch, tmp_path):
+    """``tonemap_cuda`` 是 jellyfin-ffmpeg 的补丁，上游没有——所以不能按构建
+    假定它存在，跑通了才回写给命令装配层。而探测链必须与真实转码链同源，
+    否则会出现「探得通、真用炸」。"""
+    from movieclaw_api.services.playback.ffmpeg_args import (
+        HW_BACKENDS,
+        NVENC_TONEMAP,
+        native_tonemap_filter,
+    )
+
+    _nvenc_ready(monkeypatch, tmp_path)
+    seen: list[list[str]] = []
+
+    def fake_probe(_encoder, filters):
+        seen.append(filters)
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    monkeypatch.setattr(hwprobe, "_run_probe", fake_probe)
+    assert status_of(hwprobe.probe_backends(), "nvenc").available is True
+    assert native_tonemap_filter(HW_BACKENDS["nvenc"]) == NVENC_TONEMAP
+
+    chain = " ".join(seen[-1])
+    assert NVENC_TONEMAP in chain, "探测用的滤镜串必须就是真实转码用的那一串"
+    assert "hwupload_cuda" in chain and "scale_cuda" in chain  # 与真实链同构
+    assert "smpte2084" in chain, "tone-map 滤镜拒绝非 HDR 输入，得先合成 PQ 源"
+
+
+def test_native_tonemap_failure_keeps_hardware_transcoding(monkeypatch, tmp_path):
+    """探不到色调映射不是「硬件不可用」：HDR 片改用软件 tone-map 照样能放，
+    其余的解码与编码仍在显卡上。"""
+    from movieclaw_api.services.playback.ffmpeg_args import (
+        HW_BACKENDS,
+        native_tonemap_filter,
+    )
+
+    _nvenc_ready(monkeypatch, tmp_path)
+
+    def fake_probe(_encoder, filters):
+        if any("tonemap_cuda" in f for f in filters):
+            return subprocess.CompletedProcess([], 1, b"", b"No such filter: 'tonemap_cuda'")
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    monkeypatch.setattr(hwprobe, "_run_probe", fake_probe)
+    assert status_of(hwprobe.probe_backends(), "nvenc").available is True
+    assert native_tonemap_filter(HW_BACKENDS["nvenc"]) is None
+
+
 def test_result_is_cached_until_forced(monkeypatch):
     calls = {"n": 0}
 


### PR DESCRIPTION
承 #344。那个 issue 问的是「能不能接 NVIDIA」——NVENC 早就是一等后端，用户挂上 GPU 就能用（唯一要提醒的是别顺手挂 `/dev/dri`）。但顺着这条链读下来，硬件档有三个真缺口，前两个是「插了显卡反而放不了」。

## 改了什么

**1. 硬件 scale 钉死 8-bit 输出格式**（`HwBackend.scale_format`）

`scale_cuda=format=yuv420p` / `scale_vaapi=format=nv12` / `scale_qsv=format=nv12`。10-bit 的 SDR 源（动漫 HEVC 压制极常见）不是 HDR，不进 tone-map 分支，硬件帧的 sw_format 会一路保持 p010 送进 H.264 编码器——而三家的 H.264 都只吃 8-bit，滤镜协商又不会在硬件帧之间插格式转换。结果是硬件档直接失败、用户被弹窗问「要不要开软件转码」。软件档的 `-pix_fmt yuv420p`（2026-08-25 真机事故）是同一个坑的对应兜底，硬件档一直缺这一条。

**2. `colorspace` 是软件滤镜，不能排在硬件帧前面**

BT.2020 的 SDR 源要插它（#331），此时整条滤镜链必须落到软件侧。原先这条不进「需要软件滤镜」的判定，于是 `colorspace=...,scale_cuda=...` 直接去吃硬件帧，ffmpeg 不会自动插 hwdownload，整条命令起不来。现在与烧录、软件 tone-map 并列成同一类判定（`_needs_software_filters`），由 `effective_hw_backend` 与命令装配共用；吃不了软件帧的 VAAPI/QSV 按与烧录同一条规则整体退出硬件档，交给统一降档，而不是让 ffmpeg 带着一条装不起来的链子去失败。

**3. 滤镜链落到软件侧时，解码不再一起回 CPU**

原先只要 `software_filters` 为真，`-hwaccel` 整个不发，4K HEVC 10-bit 的解码被压回 CPU——NAS 上就是幻灯片，而用户以为自己的显卡在干活。现在 `-hwaccel` 恒发，只在需要软件帧时不发 `-hwaccel_output_format`，由 ffmpeg 自己把解码帧下载回系统内存。NVIDIA 的 HDR 片、烧录字幕、VideoToolbox 位深未知这三条路径都因此把最贵的一步搬回了 GPU。这条不依赖任何真机验证。

**4. NVIDIA 的原生色调映射：自检真跑一遍后才启用**

`tonemap_cuda` 是 jellyfin-ffmpeg 的补丁，官方镜像有、源码部署多半没有，所以不按构建假定。`hwprobe` 跑一条与真实转码链同构的探测链（合成 PQ 源 → `hwupload_cuda` → `tonemap_cuda` → `scale_cuda` → `h264_nvenc`），跑通才把滤镜串回写给命令装配层；探不到就维持软件 tone-map，HDR 片照样能放，日志说明原因。

**即使 `tonemap_cuda` 的参数写法猜错了也不会有人放不了片**，最坏情况只是拿不到这块收益。这是全项目唯一一处运行期 ffmpeg 能力探测，理由写进了设计文档 §12.3：`tonemapx` 是镜像恒定内置的，`tonemap_cuda` 却有真实的双形态。

**5. 文档**

README 中英文都只讲了 `/dev/dri`，而 NVIDIA 独显根本不走那个节点——补上 Container Toolkit + `runtime: nvidia` + 两个环境变量的写法，以及「没核显别顺手挂 `/dev/dri`，挂了容器起不来」这个坑。硬件自检的中文提示同步，设计文档 §12.3 那条过时的实测结论一并更新。

## 验证

- `pytest tests/playback -m "not integration"` 全绿；新增/改写 7 条用例，把上面每条都钉住了，含「自检探到 / 没探到 `tonemap_cuda`」两条链。
- 全量 `pytest -m "not integration"` 在本地沙箱只剩 8 条失败，全在 `tests/enrich`（缺 NER 模型）与 `tests/net/test_egress`（沙箱注入了 `HTTPS_PROXY`），与本次改动无关，失败断言已核对。
- ruff 通过。未动运行时依赖，`docker/runtime-version` 不需要 bump。

## 没做的

Dolby Vision Profile 5 仍未真正解决（缺真片，§12.4 已记着）；HDR 直出、Opus 音轨、跨厂商 GPU 分工按 #344 里的判断不做。另有一处相邻问题**本次没有动**：烧录字幕时 VAAPI/QSV 整体退到 libx264，解码也一起回 CPU。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDXz4CZTZS2meztUPYXVVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDXz4CZTZS2meztUPYXVVu)_