### PR TITLE
待处理抽屉的顶栏为状态栏让位，iOS 独立 App 里 tab 不再被时间和电量压住

### DIFF
--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -1849,8 +1849,10 @@ function IssueDrawer({
         className="absolute inset-0 cursor-default bg-black/50 backdrop-blur-[2px]"
       />
       <div className="absolute right-0 top-0 flex h-full w-full max-w-[600px] flex-col border-l border-white/10 bg-[rgba(16,18,26,0.94)] shadow-[-24px_0_70px_rgba(0,0,0,0.55)] backdrop-blur-2xl max-md:max-w-none">
-        {/* 头部：tab + 关闭 */}
-        <div className="flex items-center justify-between gap-3 border-b border-white/[0.08] px-5 py-3.5">
+        {/* 头部：tab + 关闭。padding-top 叠 --safe-top：面板 top-0 贴的是屏幕物理顶边，
+            iOS 独立 App（black-translucent + viewport-fit=cover）里状态栏正压在这一行上，
+            不让位就会与 tab 胶囊糊在一起（见 globals.css 的安全区说明） */}
+        <div className="flex items-center justify-between gap-3 border-b border-white/[0.08] px-5 py-3.5 [padding-top:calc(0.875rem+var(--safe-top))]">
           <div className="flex items-center gap-1.5">
             <button
               type="button"


### PR DESCRIPTION
## 问题

媒体库详情页的「待处理」抽屉（缺失 / 待识别 / 身份复核 / 已忽略）在 iOS
「添加到主屏幕」的独立 App 里，顶栏被系统状态栏压住：窄屏上「缺失」「待识别」
两个 tab 胶囊和系统时间叠在一起，右上角的关闭按钮压着电量图标，两者都难点中。

原因是这个抽屉的面板是 `absolute right-0 top-0 ... h-full` 的全高层，而
`apple-mobile-web-app-status-bar-style=black-translucent` + `viewport-fit=cover`
下视口顶边贴的就是屏幕物理顶边 —— 状态栏正好落在头部那一行上。

抽屉的**底部**一侧本来就已经按 `globals.css` 里的约定处理过了：

- 外层 `[bottom:calc(-1*var(--vp-overshoot))]` 铺到屏幕物理底边
- 列表容器 `pb-[calc(1rem+var(--safe-bottom)+var(--vp-overshoot))]`

唯独顶部漏了 `--safe-top`。项目里其它贴顶的全屏层都做了这件事
（`photo-lightbox.tsx`、`image-lightbox.tsx`、`search-command.tsx`、
播放器顶栏与诊断面板），这个抽屉是这一类里唯一的漏网。

## 修复

头部行的 padding-top 叠上 `--safe-top`：

```diff
-        <div className="... px-5 py-3.5">
+        <div className="... px-5 py-3.5 [padding-top:calc(0.875rem+var(--safe-top))]">
```

`py-3.5 == 0.875rem`，所以非刘海设备上算出来仍是原来的 14px。`--safe-top`
在桌面端、Android、浏览器标签页里恒为 0，现有观感不变；只有 iOS 全面屏的
独立 App 会多让出状态栏那一截。

写法与 `image-lightbox.tsx:149`、`photo-lightbox.tsx:470` 的头部一致，没有
引入新的模式。

## 范围

只改了这一行 className 加一段注释。抽屉的布局、tab 逻辑、列表内容均未触碰；
未动运行时依赖，无需 bump `docker/runtime-version`。

## 验证边界

提交环境没装前端依赖（`apps/web/node_modules` 不存在），我没有跑 eslint 与
`next build`，改动是单个 className 字符串。另外扫过一遍
`absolute right-0 top-0` / `inset-y-0 right-0` / `vp-overshoot` 的用法，
确认全仓只有这一处贴顶全屏层缺 `--safe-top`。
