### PR TITLE
PT 搜索图览模式：卡片改吃派生图 + 网格虚拟化

### DIFF
--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -16,6 +17,7 @@ import type { Route } from "next";
 import { useToast } from "@/components/feedback";
 import { LayersIcon, ListIcon, PhotoIcon, XIcon } from "@/components/icons";
 import { Modal } from "@/components/modal";
+import { useTileWindow } from "@/components/photo-wall";
 import { PosterImage } from "@/components/poster-image";
 import { Tooltip } from "@/components/tooltip";
 import { ZoomLightbox, type ZoomLightboxSlide } from "@/components/zoom-lightbox";
@@ -46,6 +48,7 @@ import {
   getSubscription,
 } from "@/lib/api/subscriptions";
 import { cachedImageUrl } from "@/lib/image-proxy";
+import { layoutPosterGrid } from "@/lib/wall-window";
 import { usePermissions } from "@/lib/permissions";
 import { formatDateTime, formatRelativeTime } from "@/lib/time";
 import { useScrollRestoration } from "@/lib/use-scroll-restoration";
@@ -2247,13 +2250,7 @@ function PosterResults({ hits }: { hits: TorrentHit[] }) {
   }, [hits]);
   return (
     <div className="space-y-5">
-      {withPoster.length > 0 && (
-        <ul className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-3">
-          {withPoster.map((hit) => (
-            <TorrentPosterCard key={`${hit.site_id}:${hit.torrent_id}`} hit={hit} />
-          ))}
-        </ul>
-      )}
+      {withPoster.length > 0 && <PosterGrid hits={withPoster} />}
       {withoutPoster.length > 0 && (
         <div>
           {withPoster.length > 0 && (
@@ -2270,6 +2267,161 @@ function PosterResults({ hits }: { hits: TorrentHit[] }) {
       )}
     </div>
   );
+}
+
+/* —— 海报网格：只挂视口附近的卡片 ——
+ *
+ * PT 搜索一次动辄上千条结果，全部上墙就是上万个 DOM 节点、几百 MB 解码位图。
+ * 实测（600 条、模拟 4× 降速的手机）：节点 13293、挂载阻塞 1141ms、INP 168ms、
+ * 每来一批新结果重渲 51ms。`content-visibility` 试过，只省绘制，节点与 INP
+ * 一点没动。
+ *
+ * 做法与媒体库那三面墙同一套（`lib/wall-window.ts` + `useTileWindow`）：列数与
+ * 列宽照搬 CSS `auto-fill minmax()` 的口径，坐标自己算，只渲染窗口内的卡片。
+ * 一格的高 = 海报框（列宽 × 1.5）+ 文字区；文字区有 2 行和 3 行两种（清晰度·
+ * 体积那行是条件渲染），所以行高按「这一行里最高的那张」算，与 CSS `auto`
+ * 行高同语义，观感不变。
+ */
+const POSTER_GRID_SPEC = { minColumn: 150, gapX: 12, gapY: 12 } as const;
+
+function PosterGrid({ hits }: { hits: TorrentHit[] }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLUListElement>(null);
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setWidth(el.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      const next = Math.floor(entries[0]?.contentRect.width ?? el.clientWidth);
+      setWidth((current) => (current === next ? current : next));
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // 文字区高度只能实测：它是文字，随字号档位走，写死 px 既是魔法数字也扛不住
+  // 断点切换。两枚隐藏探针（3 行 / 2 行各一），ResizeObserver 兜住后续变化
+  const { metrics, probes } = usePosterCardMetrics(hits[0]);
+
+  const layout = useMemo(() => {
+    if (width === 0 || !metrics) return null;
+    const columns = Math.max(
+      1,
+      Math.floor((width + POSTER_GRID_SPEC.gapX) / (POSTER_GRID_SPEC.minColumn + POSTER_GRID_SPEC.gapX)),
+    );
+    const cellWidth = (width - POSTER_GRID_SPEC.gapX * (columns - 1)) / columns;
+    // 海报框是 aspect-[2/3]，高 = 宽 × 1.5
+    const base = cellWidth * 1.5 + metrics.short;
+    return layoutPosterGrid(hits.length, width, { ...POSTER_GRID_SPEC, cellHeight: base }, (i) =>
+      hasSpecLine(hits[i]) ? metrics.tall - metrics.short : 0,
+    );
+  }, [hits, width, metrics]);
+
+  const placements = useMemo(() => layout?.placements ?? [], [layout]);
+  const [from, to] = useTileWindow(gridRef, placements);
+  // 灯箱开着的那张必须留在墙上：它就渲染在卡片里，卡片一卸载灯箱跟着消失
+  // （窗口只在滚动与改窗口大小时动，转屏正好会踩到）
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const onViewerChange = useCallback(
+    (index: number, open: boolean) => setOpenIndex(open ? index : null),
+    [],
+  );
+  const visible = useMemo(() => {
+    const range: number[] = [];
+    for (let i = from; i < to; i += 1) range.push(i);
+    if (openIndex !== null && (openIndex < from || openIndex >= to)) range.push(openIndex);
+    return range;
+  }, [from, to, openIndex]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      {probes}
+      <ul ref={gridRef} className="relative" style={{ height: layout?.height ?? 0 }}>
+        {layout &&
+          visible.map((i) => {
+            const hit = hits[i];
+            const placement = placements[i];
+            return (
+              <TorrentPosterCard
+                key={`${hit.site_id}:${hit.torrent_id}`}
+                hit={hit}
+                index={i}
+                onViewerChange={onViewerChange}
+                x={placement.x}
+                y={placement.y}
+                width={placement.width}
+              />
+            );
+          })}
+      </ul>
+    </div>
+  );
+}
+
+/** 这张卡的文字区有没有「清晰度 · 体积」那一行（决定它是 3 行还是 2 行） */
+function hasSpecLine(hit: TorrentHit): boolean {
+  return Boolean(hit.attrs?.resolution || hit.size || formatBytes(hit.size_bytes));
+}
+
+/**
+ * 量一张卡有多高：两枚隐藏探针，一枚带「清晰度 · 体积」那行、一枚不带，
+ * 差额就是那一行的高度。用 `visibility:hidden` 而不是 `display:none`——后者
+ * 不参与布局，量不出高度。探针不给海报地址，渲染的是占位底，不多发请求。
+ */
+const PROBE_WIDTH = 150;
+function usePosterCardMetrics(sample: TorrentHit | undefined) {
+  const [metrics, setMetrics] = useState<{ short: number; tall: number } | null>(null);
+  const tallRef = useRef<HTMLUListElement>(null);
+  const shortRef = useRef<HTMLUListElement>(null);
+
+  useLayoutEffect(() => {
+    const tall = tallRef.current;
+    const short = shortRef.current;
+    if (!tall || !short) return;
+    const measure = () => {
+      // 海报框高是算得出来的（探针宽固定、比例 2:3），差额就是文字区
+      const poster = PROBE_WIDTH * 1.5;
+      const next = {
+        short: short.getBoundingClientRect().height - poster,
+        tall: tall.getBoundingClientRect().height - poster,
+      };
+      if (next.short <= 0) return; // 还没排上版
+      setMetrics((current) =>
+        current &&
+        Math.abs(current.short - next.short) < 0.5 &&
+        Math.abs(current.tall - next.tall) < 0.5
+          ? current
+          : next,
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(tall);
+    observer.observe(short);
+    return () => observer.disconnect();
+  }, [sample]);
+
+  const probes = sample ? (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none invisible absolute left-0 top-0"
+      style={{ width: PROBE_WIDTH }}
+    >
+      <ul ref={tallRef}>
+        <TorrentPosterCard hit={{ ...sample, poster_url: null }} measuring />
+      </ul>
+      <ul ref={shortRef}>
+        <TorrentPosterCard
+          hit={{ ...sample, poster_url: null, size: "", size_bytes: 0, attrs: null }}
+          measuring
+        />
+      </ul>
+    </div>
+  ) : null;
+
+  return { metrics, probes };
 }
 
 /**
@@ -2351,9 +2503,34 @@ function seasonEpisodeChip(attrs: TorrentAttrs | null): { text: string; pack: bo
 const noop = () => {};
 
 // memo：与 TorrentRow 同理，流式进结果时已有卡片的 hit 引用不变，整卡跳过
-const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: TorrentHit }) {
+const TorrentPosterCard = memo(function TorrentPosterCard({
+  hit,
+  index,
+  onViewerChange,
+  x,
+  y,
+  width,
+  measuring = false,
+}: {
+  hit: TorrentHit;
+  /** 本卡在有海报的那一份列表里的下标；量高度的探针不传 */
+  index?: number;
+  /** 灯箱开合回报给墙：开着的卡不能被窗口卸载掉（见 PosterGrid） */
+  onViewerChange?: (index: number, open: boolean) => void;
+  /** 由墙算好的位置与宽度（虚拟化）；探针不传，走正常流 */
+  x?: number;
+  y?: number;
+  width?: number;
+  /** 只为量高度而渲染的探针 */
+  measuring?: boolean;
+}) {
   // 灯箱当前看的是第几张；null = 没打开（灯箱受控翻页，与媒体库那套一致）
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+  const open = viewerIndex !== null;
+  useEffect(() => {
+    if (index === undefined || !onViewerChange) return;
+    onViewerChange(index, open);
+  }, [index, onViewerChange, open]);
   const [actionsOpen, setActionsOpen] = useState(false);
   const size = hit.size ?? formatBytes(hit.size_bytes);
   const name = parsedName(hit);
@@ -2376,7 +2553,14 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
     [hit.poster_url, hit.image_urls, hit.title],
   );
   return (
-    <li className="group relative overflow-hidden rounded-xl border border-white/[0.08] bg-[rgba(14,16,22,0.75)] transition-colors hover:border-white/[0.2]">
+    // 位置由墙算好（虚拟化）：用 left/top 而不是 transform——transform 会给卡片
+    // 造一个合成层，里面的文字改走灰度抗锯齿，字形与改前不一样
+    <li
+      className={`group overflow-hidden rounded-xl border border-white/[0.08] bg-[rgba(14,16,22,0.75)] transition-colors hover:border-white/[0.2] ${
+        measuring ? "relative" : "absolute"
+      }`}
+      style={measuring ? undefined : { left: x, top: y, width }}
+    >
       <div
         role="button"
         tabIndex={0}
@@ -2393,7 +2577,15 @@ const TorrentPosterCard = memo(function TorrentPosterCard({ hit }: { hit: Torren
         className="relative aspect-[2/3] cursor-zoom-in outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
       >
         <PosterImage
-          src={hit.poster_url ? cachedImageUrl(hit.poster_url) : undefined}
+          // 走后端派生（328×492 的 WebP）而不是站点图床的原图：卡片只有 150 CSS px
+          // 宽，原图动辄几百 KB 到几 MB，几百张结果一屏就是几百 MB 解码位图。
+          // 派生图还顺带解决动图——后端只取首帧（见 image_variants._render_webp），
+          // 一墙缩略图不必各自播各自的动画（媒体库的海报墙一直是这个口径）
+          src={hit.poster_url ? cachedImageUrl(hit.poster_url, "poster-card") : undefined}
+          // 挂上来的卡必然在窗口内（虚拟化就是按这个切的），直接取图，不必再让
+          // PosterImage 自己等那个 400px 的观察器——那点提前量比窗口窄，滑快了
+          // 会露出一小截占位。探针没有海报地址，这里对它无影响
+          preload
           alt={hit.title}
           className="absolute inset-0 size-full transition-transform duration-500 ease-out group-hover:scale-[1.04]"
           fallback={


### PR DESCRIPTION
用户反馈图览模式很卡、**出现动态图片更卡**。用真件（`PosterResults` / `TorrentPosterCard`，由跑分构建单独补一行导出，源码不动）＋ mock 数据（600 / 2000 条，其中五分之一海报是真动图——现造的 APNG，验证过确实在动）端到端跑分，定位到两件事。

## 一、卡片直接吃站点图床的原图

`cachedImageUrl(hit.poster_url)` 没带 variant，而卡片只有 150 CSS px 宽。实测一张原图 **93.5KB**、派生图 **2.1KB**——45 倍。600 条结果滑一遍就是 292MB 解码位图。

动图这条更直接：原图是 GIF / 动态 WebP 就一直在解码播放，桌面一屏 5 张动图、什么都不做也吃掉 6% 主线程。而后端派生**本来就只取动图首帧**（`image_variants._render_webp` 里的 `opened.seek(0)`，注释写着「卡片缩略图不承诺播放动画」）。媒体库的海报墙一直走这个口径，这里是漏了。

改成 `poster-card` 派生（328×492 的 WebP）。

## 二、结果全部上墙

PT 一次搜索动辄上千条（`TorrentRow` 的注释也写着「结果动辄上千行」）。2000 条 = 44270 个 DOM 节点、挂载阻塞 4.5 秒、最坏一帧 4.2 秒、INP 400ms。

先试了最省事的 `content-visibility`（列表模式早就有）：挂载降三成，**节点、INP、追加一批新结果的代价一点没动**——和媒体库海报墙那次的结论一样，它只省绘制。

所以改成与媒体库那三面墙同一套虚拟化（`lib/wall-window.ts` 的 `layoutPosterGrid` + `useTileWindow`）：列数与列宽照搬 CSS `auto-fill minmax()` 的口径，行高按「这一行里最高的那张」算——文字区有 2 行和 3 行两种（清晰度·体积那行是条件渲染），与 CSS `auto` 行高同语义。文字区高度用两枚隐藏探针实测（随字号档位走，不能写死 px）。

顺带处理一个坑：**灯箱就渲染在卡片里**，转屏时窗口重算会把开着灯箱的那张卡连根拔掉——把它排除在卸载之外。

## 实测（模拟 4× 降速的手机、414×896）

| | 600 条 | 2000 条 |
|---|---|---|
| 挂载 | 1596 → **629ms** | 5513 → **809ms** |
| 挂载阻塞 | 1168 → **361ms** | 4488 → **554ms** |
| 最坏一帧 | 1045 → **243ms** | 4177 → **401ms** |
| DOM 节点 | 13293 → **2595** | 44270 → **7777** |
| 页面内存 | 21 → **6.1MB** | 44.1 → **9.6MB** |
| 解码位图 | 292.5 → **20.5MB** | 290.4 → **21.8MB** |
| **静止主线程占用**（动图开销） | 0.039 → **0.018** | 0.109 → **0.017** |
| 滚动 fps | 57.8 → **59.5** | 42.8 → **59.9** |
| 丢帧率 | 0.036 → **0.008** | 0.286 → **0.012** |
| 滚动主线程占用 | 0.353 → **0.160** | 0.828 → **0.206** |
| INP | 152 → **80ms** | 400 → **80ms** |
| 追加一批结果 | 51.0 → **16.3ms** | 52.4 → **12.4ms** |

剩下的 7777 个节点是**没有海报**的那部分结果——它们走列表、已带 `content-visibility`、且是少数，本次没动。

## 观感

**虚拟化本身是像素中性的**：只改虚拟化不改图源，与改前同数据同位置逐像素比 **0.000–0.012%**（同一版跑两次的噪声底是 0.000–0.001%）。三档视口下每张卡的 x / y / 宽 / 高 / 标题位置到小数位完全一致，墙的总高度分毫不差（414px 33593、834px 19014、1440px 10583）。

画面上真正变了的只有海报本身，两处都是有意的：
- **原图 → 派生图**（重采样不同）
- **动图卡片显示首帧而不是动画** —— 与媒体库海报墙一致，灯箱里本来也是静帧（`photo-screen` 同样只取首帧）

1000–8000px/s 各档滑动，视口内卡片「已有图」的比例恒为 **100%**。

## 验证

- `pnpm --filter web exec tsc --noEmit`、`eslint`、`node --test` 全过（`test/time.test.mjs` 那一处失败是既有的时区问题——容器跑 UTC 而用例期望 UTC+8，与本次无关）
- 复用的 `lib/wall-window.ts` 已有 14 个单测，本次没有改动它

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HXNTWcSccjgd8ExiznAuM

---
_Generated by [Claude Code](https://claude.ai/code/session_019HXNTWcSccjgd8ExiznAuM)_