### PR TITLE
PT 搜索图览：海报派生从 328 框换到 720 框，修 #356 做糊了的问题

### DIFF
--- a/apps/web/components/search-results.tsx
+++ b/apps/web/components/search-results.tsx
@@ -2577,11 +2577,22 @@ const TorrentPosterCard = memo(function TorrentPosterCard({
         className="relative aspect-[2/3] cursor-zoom-in outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
       >
         <PosterImage
-          // 走后端派生（328×492 的 WebP）而不是站点图床的原图：卡片只有 150 CSS px
-          // 宽，原图动辄几百 KB 到几 MB，几百张结果一屏就是几百 MB 解码位图。
-          // 派生图还顺带解决动图——后端只取首帧（见 image_variants._render_webp），
-          // 一墙缩略图不必各自播各自的动画（媒体库的海报墙一直是这个口径）
-          src={hit.poster_url ? cachedImageUrl(hit.poster_url, "poster-card") : undefined}
+          // 走后端派生而不是站点图床的原图：原图动辄几百 KB 到几 MB，几百张结果
+          // 一屏就是几百 MB 解码位图；派生还顺带解决动图——后端只取首帧
+          // （见 image_variants._render_webp），一墙缩略图不必各自播各自的动画。
+          //
+          // 用 720 外接框那一档（gallery-tile）而不是媒体库墙用的 poster-card（328）。
+          // 两个原因，都在这张卡上成立而在媒体库的墙上不成立：
+          //   1. 这个网格是 minmax(150px,1fr)，窄屏列数少、卡反而更宽（414 视口
+          //      175 CSS px、834 视口 185），dpr3 手机需要 525 设备像素，328 只
+          //      覆盖 62%——肉眼就是糊；
+          //   2. **PT 的 poster_url 是种子图集的第一张**（见 tracker/models.py），
+          //      很可能是宽幅截图而不是 2:3 海报。派生是等比装进外接框、不裁切，
+          //      16:9 的源装进 328×492 只剩 328×185，再被这张卡的 aspect-[2/3]
+          //      + object-cover 撑开，要放大 2.8~4.3 倍。换 720 框后同一张源是
+          //      720×405，放大降到 1.3~1.9 倍。
+          // 预设名里的「gallery」说的是它的来历，这里取的是它的尺寸档位。
+          src={hit.poster_url ? cachedImageUrl(hit.poster_url, "gallery-tile") : undefined}
           // 挂上来的卡必然在窗口内（虚拟化就是按这个切的），直接取图，不必再让
           // PosterImage 自己等那个 400px 的观察器——那点提前量比窗口窄，滑快了
           // 会露出一小截占位。探针没有海报地址，这里对它无影响


### PR DESCRIPTION
用户反馈「种子页海报的分辨率变低了」。属实——是 #356 把卡片从站点原图换成 `poster-card` 派生（328×492 外接框）造成的，我当时有两处没算。

## 一、`poster-card` 是给媒体库那面墙定的，不是给这张卡的

预设注释写着「竖海报最大 164 CSS px，328px 覆盖 2x 屏」，对应媒体库的 `minmax(148px,1fr)`。PT 这个网格是 `minmax(150px,1fr)`，**窄屏列数少、卡片反而更宽**（414 视口 175 CSS px、834 视口 185.5），加上 dpr3 手机很普遍：

| 视口 / DPR | 卡片 CSS 宽 | 需要设备像素 | 328 框 | 720 框 |
|---|---|---|---|---|
| 414 @ **dpr3** | 175 | 525 | **62%** | **91%** |
| 414 @ dpr2 | 175 | 350 | 94% | 137% |
| 834 @ dpr2 | 185.5 | 371 | 88% | 129% |
| 1440 @ dpr2 | 161.5 | 323 | 102% | 149% |

## 二、更糟的一档：PT 的 poster_url 不保证是 2:3 海报

`src/movieclaw_tracker/models.py` 的注释说得很清楚——「全部图片（海报 + 截图等），**poster_url 是其中第一张**」，mteam 的实现也是 `poster_url = image_list[0]`。所以它**很可能是宽幅截图或横幅**。

后端派生是「等比装进外接框、不裁切」，于是 16:9 的源装进 328×492 只剩 **328×185**，再被这张卡的 `aspect-[2/3]` + `object-cover` 撑开，要放大 **2.8~4.3 倍**：

| 源比例 | 328 框派生 | 撑到卡片要放大 | 720 框派生 | 撑到卡片要放大 |
|---|---|---|---|---|
| 2:3 正规海报 | 328×492 | 1.07~1.60× | 480×720 | 足够 ~1.09× |
| **16:9 截图当海报** | 328×185 | **2.84~4.26×** | 720×405 | **1.30~1.94×** |
| 3:4 偏方海报 | 328×437 | 1.20~1.80× | 540×720 | 足够 ~1.09× |

剩下那点放大是「把宽图裁进竖框」本身带来的，换多大的框都躲不掉。

## 改动

这一处的 variant 从 `poster-card` 换成 `gallery-tile`（720×720 外接框）。预设名里的「gallery」说的是它的来历，这里取的是它的尺寸档位——注释里写明了。**一个文件、一处调用。**

## 代价（2000 条 / 模拟 4× 降速的手机 / 414×896）

| | 328 框（#356） | **720 框（本 PR）** | 改前（吃原图） |
|---|---|---|---|
| 解码位图 | 21.8MB | **37.2MB** | 290.4MB |
| 静止主线程占用 | 0.018 | **0.036** | 0.109 |
| INP | 80ms | **88~144ms** | 400ms |
| 滚动 fps | 59.5 | 59.4~59.7 | 42.8 |
| 丢帧率 | 0.009 | 0.010 | 0.286 |
| 滚动主线程占用 | 0.175 | 0.175 | 0.828 |
| 挂载 / DOM 节点 / 页面内存 | — | 不变 | — |

INP 跑了三次是 144 / 136 / 88，比 328 框那版（80~96）**确实有一点真实增加，不全是噪声**；但离改前的 400ms 还很远，也在「良好」区间（<200ms）内。

一句话：把清晰度补回来，付出的是解码位图 21.8MB → 37.2MB，**仍然只有改前的八分之一**，其余指标基本没动。

## 验证

- `pnpm --filter web exec tsc --noEmit`、`eslint`、`node --test` 全过（`test/time.test.mjs` 那一处失败是既有的时区问题——容器跑 UTC 而用例期望 UTC+8，与本次无关）
- 1000~8000px/s 各档滑动，视口内卡片「已有图」的比例仍为 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HXNTWcSccjgd8ExiznAuM

---
_Generated by [Claude Code](https://claude.ai/code/session_019HXNTWcSccjgd8ExiznAuM)_