### PR TITLE
边下边入库只搬白名单，洗版留下的旧任务不再卡死

### DIFF
--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -502,6 +502,34 @@ def _snapshot_ready_files(entry: Path, ready_files: list[_ReadyDownloadFile]) ->
     )
 
 
+def _ready_batch_sources(videos: list[Path]) -> list[Path]:
+    """白名单批次的搬运范围：白名单视频 + 各自的同名附属。
+
+    同名判据沿用整理器的 sidecar 口径（``同名`` / ``同名.语言`` / ``同名-标记``）。
+    这里不按扩展名白名单收附属，而是"同名的非视频文件"全收：原样落盘本就不
+    改名、不挑剔 sidecar 形态，漏搬一个附属比多搬一个代价大得多。视频扩展名
+    反过来必须排除——另一个视频只能凭下载器证据自己进白名单，不能被同名规则
+    顺带捎进来（它可能还在下载）。
+    """
+    picked: dict[Path, None] = {}
+    for video in videos:
+        picked[video] = None
+        stem = video.stem.lower()
+        try:
+            siblings = sorted(video.parent.iterdir())
+        except OSError:
+            continue
+        for sibling in siblings:
+            if not sibling.is_file() or sibling.name.startswith("."):
+                continue
+            if sibling.suffix.lower() in VIDEO_EXTS:
+                continue
+            name = sibling.stem.lower()
+            if name == stem or name.startswith(f"{stem}.") or name.startswith(f"{stem}-"):
+                picked[sibling] = None
+    return list(picked)
+
+
 def _ingest_path_id(entry_path: str) -> str:
     """把绝对路径收敛成稳定、无敏感目录信息的资源 id。"""
     return hashlib.sha256(entry_path.encode("utf-8")).hexdigest()
@@ -2442,11 +2470,21 @@ async def _ingest_raw_drop(
             f"主视频「{main.name}」探测失败——可能尚未下载完成或已损坏，文件变化后自动重试",
         )
     dest_base = Path(root) / entry.name if entry.is_dir() else Path(root)
-    # 全部常规文件原样搬（视频 + NFO/字幕/图片），隐藏文件与下载器标记不带
-    if entry.is_dir():
-        sources = sorted(p for p in entry.rglob("*") if p.is_file() and not p.name.startswith("."))
-    else:
+    # 全部常规文件原样搬（视频 + NFO/字幕/图片），隐藏文件与下载器标记不带。
+    # 例外是边下边入库的白名单批次（``ready:`` 指纹）：条目里还有下载器没放行
+    # 的文件正在被写入，把它们一并搬只会让 _copy_ingest_chunk 的 size/mtime
+    # 校验必然失败——每轮重试烧掉一次额度、进度在不同文件间反复重来，最终
+    # JOB_RETRY_EXHAUSTED（2026-09-09 生产事故，同源另一条目已因此失败）。
+    # 白名单批次因此只搬白名单视频与其同名附属，其余文件留给整种完成后的
+    # 整树批次收尾（那一轮 ready_files=None，见 _sweep_dir）。
+    # 自定义目录（library is None）不收窄：中转文件是"过客"，外部工具消费后
+    # 会删掉落点文件，拆成两轮搬运可能让整树批次重搬、造成重复上传。
+    if not entry.is_dir():
         sources = [entry]
+    elif snap.fingerprint.startswith("ready:") and library is not None:
+        sources = sorted(_ready_batch_sources(snap.videos))
+    else:
+        sources = sorted(p for p in entry.rglob("*") if p.is_file() and not p.name.startswith("."))
     notes: list[str] = []
     env_error = conflict = False
     transferred: list[tuple[Path, Path]] = []

--- a/src/movieclaw_api/services/subscription/replacement.py
+++ b/src/movieclaw_api/services/subscription/replacement.py
@@ -1036,14 +1036,34 @@ async def reconcile_pending_cleanup(attempt_id: int) -> bool:
                 .where(
                     SubscriptionDownloadAttempt.replaces_attempt_id == old.id,
                     SubscriptionDownloadAttempt.status.in_(  # type: ignore[attr-defined]
-                        (DownloadAttemptStatus.ACTIVE, DownloadAttemptStatus.COMPLETED)
+                        (
+                            DownloadAttemptStatus.ACTIVE,
+                            DownloadAttemptStatus.COMPLETED,
+                            # 洗版链路的新源在挂起旧任务时就已经入库了（见下）
+                            DownloadAttemptStatus.IMPORTED,
+                        )
                     ),
                 )
                 .order_by(SubscriptionDownloadAttempt.id.desc())  # type: ignore[attr-defined]
             )
         ).scalars().first()
-        if new is None or new.downloader_id is None:
+        if new is None:
             logger.warning("旧下载尝试 #%s 等待清理，但找不到仍有效的替代源台账", attempt_id)
+            return False
+        if new.status == DownloadAttemptStatus.IMPORTED:
+            # 洗版（upgrade.py）是在新版本入库的同一时刻才把旧任务挂进
+            # CLEANUP_PENDING，此时新 attempt 已是 IMPORTED。旧口径只认
+            # ACTIVE/COMPLETED，于是洗版留下的旧任务永远等不到清理，就地卡死
+            # （NAS 实测一条从 2026-09-07 挂到 09-09，每轮巡检刷一条上面那句
+            # 警告）。这条分支只收敛状态、不删任何东西，因此也不需要像删除路径
+            # 那样先读到新源来比较文件重叠——新源是否还在下载器里都不影响结论。
+            await _converge_upgraded_old_attempt(session, old)
+            return old.status in (
+                DownloadAttemptStatus.SUPERSEDED,
+                DownloadAttemptStatus.RETAINED,
+            )
+        if new.downloader_id is None:
+            logger.warning("旧下载尝试 #%s 等待清理，但替代源台账没有下载器归属", attempt_id)
             return False
         downloader = await session.get(DownloaderClient, new.downloader_id)
         if downloader is None:
@@ -1366,11 +1386,89 @@ async def _cleanup_replaced_attempt(
     )
 
 
+async def _converge_upgraded_old_attempt(
+    session: AsyncSession,
+    old: SubscriptionDownloadAttempt,
+) -> None:
+    """洗版留下的旧任务：只收敛状态，不碰下载器。
+
+    删旧种是换源链路一直在做的事，洗版链路因为口径不一致从来没有真正执行过。
+    这里先把状态收敛掉止血——下载器里已经没有的直接判 SUPERSEDED，还在的保留
+    做种并如实写明原因；要不要连带删除是一次真实的做种行为变更，交给用户显式
+    决定，不借这次修复顺手打开。
+    """
+    downloader = (
+        await session.get(DownloaderClient, old.downloader_id)
+        if old.downloader_id is not None
+        else None
+    )
+    if downloader is None:
+        await _retain_old(
+            session,
+            old,
+            "无法确认旧任务所在下载器，保留做种",
+            message="洗版已完成，但无法确认旧任务所在下载器，旧任务保留做种",
+        )
+        return
+    repo = DownloaderRepository(session)
+    adapter = create_downloader(
+        DownloaderConfig(
+            type=downloader.client_type.value,
+            url=downloader.url,
+            username=downloader.username,
+            password=repo.decrypted_password(downloader),
+        )
+    )
+    try:
+        present = await adapter.get_torrent(old.info_hash) is not None
+    except Exception as exc:  # noqa: BLE001 -- 读不到不能反过来把状态判死
+        await _retain_old(
+            session,
+            old,
+            f"旧任务状态查询失败：{exc}",
+            message=f"洗版已完成，但旧任务状态查询失败：{exc}；旧任务保留做种",
+        )
+        return
+    finally:
+        try:
+            await adapter.close()
+        except Exception:  # noqa: BLE001 -- 关闭失败不改变状态证据
+            logger.warning("关闭旧任务下载器连接失败", exc_info=True)
+    if present:
+        await _retain_old(
+            session,
+            old,
+            "洗版已完成，旧任务保留做种，可在活动页手动清理",
+            message="洗版已完成，旧任务保留做种，可在活动页手动清理",
+        )
+        return
+    old.status = DownloadAttemptStatus.SUPERSEDED
+    old.cleanup_note = "旧任务已不在下载器中"
+    old.updated_at = utcnow()
+    session.add(old)
+    await session.commit()
+    await SubscriptionRepository(session).add_activity(
+        SubscriptionActivity(
+            subscription_id=old.subscription_id,
+            type=ActivityType.REPLACEMENT_CLEANUP,
+            message=old.cleanup_note,
+            payload={"info_hash": old.info_hash},
+        )
+    )
+
+
 async def _retain_old(
     session: AsyncSession,
     old: SubscriptionDownloadAttempt,
     reason: str,
+    *,
+    message: str | None = None,
 ) -> None:
+    """旧任务保留不删，并把原因如实写进台账与活动流水。
+
+    ``message`` 只给非换种场景（如洗版收尾）覆盖开头那句话用——默认的
+    "已完成换种" 放在洗版流水里会读成"已完成换种，但洗版已完成……"。
+    """
     old.status = DownloadAttemptStatus.RETAINED
     old.cleanup_note = reason
     old.updated_at = utcnow()
@@ -1380,7 +1478,7 @@ async def _retain_old(
         SubscriptionActivity(
             subscription_id=old.subscription_id,
             type=ActivityType.REPLACEMENT_CLEANUP,
-            message=f"已完成换种，但{reason}",
+            message=message or f"已完成换种，但{reason}",
             payload={"info_hash": old.info_hash, "retained": True},
         )
     )

--- a/tests/api/test_library_video_kind.py
+++ b/tests/api/test_library_video_kind.py
@@ -597,3 +597,98 @@ def test_build_thumbnail_grabs_frame_and_reports_size(tmp_path) -> None:
     Image.new("RGB", (640, 360), "gray").save(tmp_path / "clip-fanart.jpg")
     dest6 = tmp_path / "assets" / "6" / "backdrop.jpg"
     assert build_backdrop(video, dest6) is True and dest6.is_file()
+
+
+# ---------------------------------------------------------------------------
+# 边下边入库：白名单批次的搬运范围
+# ---------------------------------------------------------------------------
+
+
+async def _raw_drop_ready_scoped(
+    db, rule: ImportWatch, library: Library | None, entry: Path, watch: Path, videos: list[Path]
+) -> IngestEntry:
+    """按"下载器只放行了 videos 这几个文件"的口径跑一次原样落盘。
+
+    file-scoped 的判据是快照指纹的 ``ready:`` 前缀（与 ingest 内部同一口径），
+    这里直接构造该形态的快照，免去搭整套下载器桩件。
+    """
+    snap = ingest_mod._EntrySnapshot(
+        fingerprint="ready:" + "0" * 8,
+        has_marker=False,
+        has_disc=False,
+        videos=sorted(videos),
+    )
+    async with db.session() as session:
+        fresh_rule = await session.get(ImportWatch, rule.id) if rule.id else rule
+        fresh_library = await session.get(Library, library.id) if library is not None else None
+        record = await ingest_mod._ingest_entry(
+            session, fresh_rule, fresh_library, watch, entry, snap, None
+        )
+        await session.commit()
+        return record
+
+
+async def test_raw_drop_file_scoped_skips_files_still_downloading(
+    db, tmp_path, monkeypatch
+) -> None:
+    """白名单批次只搬白名单视频与它的同名附属，不碰仍在写入的其他文件。
+
+    2026-09-09 生产事故：原样落盘无视文件白名单、直接遍历整个条目目录，于是
+    每一轮都会去复制下载器仍在写的文件，``_copy_ingest_chunk`` 的 size/mtime
+    校验必然失败 → JobRetry → 30 秒一轮，直到把 24 次重试额度烧光（同目录的
+    另一个条目已因此 JOB_RETRY_EXHAUSTED 失败）。
+    """
+    root = tmp_path / "home"
+    root.mkdir()
+    library = await _make_video_library(db, root)
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _p: _FAKE_SPEC)
+    async with db.session() as session:
+        session.add(ImportWatch(source_path=str(watch), strategy="copy", library_id=library.id))
+        await session.commit()
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+
+    entry = watch / "整合合集"
+    entry.mkdir()
+    ready = entry / "已完成.mp4"
+    ready.write_bytes(b"a" * 10)
+    (entry / "已完成.nfo").write_text("<movie><title>已完成</title></movie>", encoding="utf-8")
+    (entry / "已完成.chs.srt").write_text("1", encoding="utf-8")
+    # 下载器还没放行的两个文件：一个视频、一个属于它的附属
+    writing = entry / "还在下.mp4"
+    writing.write_bytes(b"b" * 10)
+    (entry / "还在下.nfo").write_text("<movie><title>还在下</title></movie>", encoding="utf-8")
+
+    await _raw_drop_ready_scoped(db, rule, library, entry, watch, [ready])
+
+    dest = root / "整合合集"
+    assert sorted(p.name for p in dest.iterdir()) == ["已完成.chs.srt", "已完成.mp4", "已完成.nfo"]
+    async with db.session() as session:
+        rows = list((await session.execute(select(LibraryFile))).scalars().all())
+        assert len(rows) == 1, "白名单外的视频不应建台账"
+
+
+async def test_raw_drop_whole_tree_still_moves_everything(db, tmp_path, monkeypatch) -> None:
+    """整种完成后的整树批次照旧搬走全部常规文件——收窄只针对白名单批次。"""
+    root = tmp_path / "home"
+    root.mkdir()
+    library = await _make_video_library(db, root, name="整树库")
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _p: _FAKE_SPEC)
+    async with db.session() as session:
+        session.add(ImportWatch(source_path=str(watch), strategy="copy", library_id=library.id))
+        await session.commit()
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+
+    entry = watch / "整树合集"
+    entry.mkdir()
+    (entry / "甲.mp4").write_bytes(b"a" * 10)
+    (entry / "乙.mp4").write_bytes(b"b" * 10)
+    (entry / "说明.txt").write_text("readme", encoding="utf-8")
+
+    await _sweep_twice(db, rule, library)
+
+    dest = root / "整树合集"
+    assert sorted(p.name for p in dest.iterdir()) == ["乙.mp4", "甲.mp4", "说明.txt"]

--- a/tests/api/test_subscription_replacement.py
+++ b/tests/api/test_subscription_replacement.py
@@ -732,3 +732,145 @@ async def test_pending_cleanup_is_idempotently_reconciled_after_restart(db, monk
     async with db.session() as session:
         old = await session.get(SubscriptionDownloadAttempt, old_id)
         assert old.status == DownloadAttemptStatus.SUPERSEDED
+
+
+@pytest.mark.asyncio
+async def test_upgraded_old_attempt_converges_when_torrent_gone(db, monkeypatch) -> None:
+    """洗版留下的 cleanup_pending 能收敛：下载器里已经没有的旧任务判 SUPERSEDED。
+
+    2026-09-07 生产事故：洗版链路是在新版本入库的同一时刻才把旧任务挂进
+    CLEANUP_PENDING，此时新 attempt 已是 IMPORTED；而巡检只按 ACTIVE/COMPLETED
+    找替代源台账，找不到就直接返回，旧任务原地卡死两天（NAS 上《早春晴朗》
+    S01E19 的 1080p 死种，从头到尾一个字节没下）。
+    """
+    async with db.session() as session:
+        downloader = DownloaderClient(
+            name="洗版下载器", client_type="qbittorrent", url="http://downloader:8080"
+        )
+        media = MediaItem(kind="tv", tmdb_id=46, title="洗版收敛", original_title="Converge")
+        rule = RuleSet(name="洗版规则")
+        session.add_all([downloader, media, rule])
+        await session.flush()
+        subscription = Subscription(media_item_id=media.id, kind="tv", rule_set_id=rule.id)
+        session.add(subscription)
+        await session.flush()
+        old = SubscriptionDownloadAttempt(
+            subscription_id=subscription.id,
+            downloader_id=downloader.id,
+            info_hash="3" * 40,
+            units=[[1, 19]],
+            quality={"resolution": "1080p"},
+            owned_by_movieclaw=True,
+            # 生产现场就是"考核状态未知"，不能靠 hit_and_run=False 才走通
+            hit_and_run=None,
+            status="cleanup_pending",
+            last_progress_at=utcnow(),
+        )
+        session.add(old)
+        await session.flush()
+        new = SubscriptionDownloadAttempt(
+            subscription_id=subscription.id,
+            downloader_id=downloader.id,
+            replaces_attempt_id=old.id,
+            info_hash="4" * 40,
+            units=[[1, 19]],
+            quality={"resolution": "2160p"},
+            owned_by_movieclaw=True,
+            hit_and_run=False,
+            status=DownloadAttemptStatus.IMPORTED,
+            last_progress_at=utcnow(),
+        )
+        session.add(new)
+        await session.commit()
+        old_id = old.id
+
+    deleted: list[tuple[str, bool]] = []
+
+    class FakeAdapter:
+        async def get_torrent(self, info_hash, *, include_files=True):
+            return None  # 新旧两个种子都已不在下载器里（生产现场如此）
+
+        async def delete_torrent(self, info_hash, *, delete_files=False):
+            deleted.append((info_hash, delete_files))
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(replacement_mod, "create_downloader", lambda config: FakeAdapter())
+    assert await replacement_mod.reconcile_pending_cleanup(old_id)
+    assert deleted == [], "状态收敛不得连带删除下载器任务"
+    async with db.session() as session:
+        old = await session.get(SubscriptionDownloadAttempt, old_id)
+        assert old.status == DownloadAttemptStatus.SUPERSEDED
+        assert old.cleanup_note == "旧任务已不在下载器中"
+
+
+@pytest.mark.asyncio
+async def test_upgraded_old_attempt_kept_seeding_when_still_present(db, monkeypatch) -> None:
+    """旧种还在下载器里：保留做种并如实说明，不在洗版链路上新开删除行为。"""
+    async with db.session() as session:
+        downloader = DownloaderClient(
+            name="洗版下载器2", client_type="qbittorrent", url="http://downloader:8080"
+        )
+        media = MediaItem(kind="tv", tmdb_id=47, title="洗版保留", original_title="Retain")
+        rule = RuleSet(name="洗版规则2")
+        session.add_all([downloader, media, rule])
+        await session.flush()
+        subscription = Subscription(media_item_id=media.id, kind="tv", rule_set_id=rule.id)
+        session.add(subscription)
+        await session.flush()
+        old = SubscriptionDownloadAttempt(
+            subscription_id=subscription.id,
+            downloader_id=downloader.id,
+            info_hash="5" * 40,
+            units=[[1, 20]],
+            quality={"resolution": "1080p"},
+            owned_by_movieclaw=True,
+            hit_and_run=False,
+            status="cleanup_pending",
+            last_progress_at=utcnow(),
+        )
+        session.add(old)
+        await session.flush()
+        new = SubscriptionDownloadAttempt(
+            subscription_id=subscription.id,
+            downloader_id=downloader.id,
+            replaces_attempt_id=old.id,
+            info_hash="6" * 40,
+            units=[[1, 20]],
+            quality={"resolution": "2160p"},
+            owned_by_movieclaw=True,
+            hit_and_run=False,
+            status=DownloadAttemptStatus.IMPORTED,
+            last_progress_at=utcnow(),
+        )
+        session.add(new)
+        await session.commit()
+        old_id = old.id
+
+    deleted: list[tuple[str, bool]] = []
+
+    class FakeAdapter:
+        async def get_torrent(self, info_hash, *, include_files=True):
+            return TorrentStatus(
+                info_hash=info_hash,
+                name="Seeding",
+                progress=1.0,
+                completed=True,
+                save_path="/downloads",
+                files=[],
+            )
+
+        async def delete_torrent(self, info_hash, *, delete_files=False):
+            deleted.append((info_hash, delete_files))
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(replacement_mod, "create_downloader", lambda config: FakeAdapter())
+    assert await replacement_mod.reconcile_pending_cleanup(old_id)
+    assert deleted == [], "洗版链路此前从未删过旧种，不能借这次修复顺手打开"
+    async with db.session() as session:
+        old = await session.get(SubscriptionDownloadAttempt, old_id)
+        assert old.status == DownloadAttemptStatus.RETAINED
+        assert "保留做种" in (old.cleanup_note or "")


### PR DESCRIPTION
两处线上卡死的根因修复，都由 NAS 真实现场反推，测试先写复现再改代码。

## 1. 原样落盘无视文件白名单

`_ingest_raw_drop` 直接 `entry.rglob("*")` 遍历整个条目目录，完全不看 file-scoped 白名单（白名单只剩"判定就绪"和"统计入库数"两个用途）。于是边下边入库的批次必然去复制下载器仍在写的文件，`_copy_ingest_chunk` 的 size/mtime 校验必败 → `JobRetry` → 30 秒一轮。

现场证据：作业白名单只有 1 个文件（2.75GB），但 job_event 里它先后去复制了 5 个不同文件、进度分母是 13.6GB，最终 result 却是「入库 1 个视频」。同一监听目录的另一条目已因此 `JOB_RETRY_EXHAUSTED` 失败。

改为：白名单批次只搬白名单视频与其同名附属（同名判据沿用整理器 sidecar 口径），其余文件留给整种完成后的整树批次收尾。

**只影响原样落盘路径**——影视库走 `files = list(snap.videos)`，本来就尊重白名单。**自定义目录（中转）刻意不收窄**：中转文件被外部工具消费后会删掉落点文件，拆成两轮搬运可能让整树批次重搬、造成重复上传。

## 2. 洗版留下的旧任务永远等不到清理

`upgrade.py` 是在新版本入库的**同一时刻**才把旧任务挂进 `CLEANUP_PENDING`，此时新 attempt 已是 `IMPORTED`；而 `reconcile_pending_cleanup` 只按 `ACTIVE`/`COMPLETED` 找替代源台账，找不到就返回 False，旧任务原地卡死、每轮巡检刷一条「找不到仍有效的替代源台账」。

现场证据：NAS 上一条 `cleanup_pending` 从 2026-09-07 挂到 09-09；全库 `cleanup_pending` 只此一条（29 条 `retained` 都有明确归宿），且新旧两个种子都已不在 qb。

改为：查询纳入 `IMPORTED`，并为它单开一条**只收敛状态、不碰下载器**的分支——因此不需要像删除路径那样先读到新源比较文件重叠。下载器里已经没有的判 `SUPERSEDED`，还在的 `RETAINED` 并如实说明。

`_cleanup_replaced_attempt` **一行未动**：删旧种是换源链路一直在做的事，洗版链路此前从未真正执行过，不借这次修复顺手打开。

## 顺带

`_retain_old` 固定套「已完成换种，但…」，洗版场景会读成「已完成换种，但洗版已完成…」。加可选 `message` 参数，默认行为不变。

## 测试

新增 4 项，均先确认能复现线上现象再改代码：

- `test_raw_drop_file_scoped_skips_files_still_downloading` — 改前失败于 `first extra item: '还在下.mp4'`
- `test_raw_drop_whole_tree_still_moves_everything` — 守住整树批次不受影响
- `test_upgraded_old_attempt_converges_when_torrent_gone` — 改前日志与生产一字不差；用 `hit_and_run=None`（生产就是"考核状态未知"），断言 `deleted == []`
- `test_upgraded_old_attempt_kept_seeding_when_still_present` — 断言不打开删除行为

回归：入库 / 订阅洗版 / 下载器三组 347 项全过，`ruff check` 通过。

## 部署影响

纯服务层，不动 API 面、依赖、迁移 —— `spec_hash` 不变、`docker/runtime-version` 无需 bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)