### PR TITLE
入库后自动补章节图；章节作业不再和扫描抢库租约

### DIFF
--- a/docs/design/video-chapters.md
+++ b/docs/design/video-chapters.md
@@ -299,9 +299,16 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
   只有补缺判据认它。没有墓碑，"只跳过抓齐的"会让每一轮作业、每一次打开
   详情页都对着同一个抓不出图的文件重跑一遍。force 时不复用墓碑，仍重试。
   ffmpeg 整个缺失是另一回事：什么都不写（保持 NULL），装好后自动补。
+  **文件在抓图过程中不见了**（整理改名、条目转移、洗版换文件）同样不是
+  「抓不出来」：不记墓碑、当场收尾，已抓到的落库，这一行仍算没抓齐，下一轮
+  台账指向新路径后再来。误记一条墓碑等于这一行的图永远缺着。
 - **孤儿清理**：文件行被删除/洗版替换后，`{item}/chapters/{old_file_id}/`
   成为孤儿。Job 处理某条目时顺手删掉该条目下不再对应任何在位文件行的
-  chapters 子目录；条目删除时随资产目录一起清。
+  chapters 子目录；条目删除时随资产目录一起清。**整库作业收尾再按台账扫一遍
+  全库**（`cleanup_library_orphan_dirs`）：单条目入口只清自己处理的那个条目，
+  而「条目已经抓齐、只是少了一集」留下的孤儿连作业目标都不是，等不到任何
+  单条目入口——不扫这一遍它就永远躺在盘上。一个条目一次 listdir，资产目录在
+  本地盘，上千个条目是毫秒级。
 
 ### 4.5 触发时机
 
@@ -370,6 +377,21 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
 不放进 `ScanPhase.ASSETS`：那一阶段只覆盖本轮新挂锚条目，且一部电影
 8～12 次 seek 乘以整库会把"扫描"拖长数倍；独立 Job 让扫描进度语义不变，
 用户也能单独停掉它。
+
+**与扫描并行**：整库作业把 `library` 资源挂成 `context` 关系而不是默认的
+`target`——`target` 会占用 `library:{id}` 租约，而首轮回填可能跑几个小时：
+占着租约意味着这几小时里用户点「扫描」的作业只能干等，监听触发的增量扫描与
+定时对账看到「本库有作业在跑」更是整轮放弃（`scan_library` 的让路检查），
+新落盘的文件迟迟不入账。章节作业只读媒体文件、只写自己那两列 JSON，与扫描
+没有真冲突，因此 `scan_library` 的让路检查点名只看 `target`
+（`jobs.list_jobs(relation="target")`）。真正会互相踩的是**整理/转移**（它们在
+改文件路径），由处理器开头的 `is_organizing / is_transferring` 单独挡下并退回
+队列，与 `scan_library` 同一套处理。同库去重仍由 `dedupe_key` 保证。
+
+**优先级**：整库作业与**入库落账后**那份条目作业都压到 -10（用户没在等这批
+图，执行器只有 4 个并发槽，一次批量入库能排出几十份，默认优先级会让后面的
+入库作业跟着一起等）；条目菜单「重新生成章节」保持 0——用户正站在详情页等
+这一部的图。
 
 **库开关** `extract_chapter_images` 默认开：抓图在后台低优先级 Job 里，
 网络挂载大库的用户可以关；关掉后已生成的图保留（与 Jellyfin 删图的做法
@@ -473,7 +495,10 @@ Agent 工具无需改动：`spec.json` 重导出后 `library.items.get` 自动�
 | 章节 > 48 或平均间隔 < 1s → 只列表不抓图 | `chapters.py` 单测 |
 | 重启后不重抓已完成的文件，进度不归零 | `test_library_job_resumes_after_restart` |
 | 条目重抓是可恢复 Job，排队期间详情页仍轮询 | `test_item_regenerate_route_enqueues_resumable_job` |
-| 入库落账后新条目有条目级补缺作业（库开关关掉则没有） | `tests/api/test_library_ingest.py` |
+| 入库落账后新条目有条目级补缺作业（库开关关掉则没有），优先级 -10 | `tests/api/test_library_ingest.py` |
+| 章节作业不占库租约，扫描照常跑；target 关系的作业仍让路 | `test_chapter_job_does_not_hold_the_library_lease` |
+| 文件抓图中途消失不记墓碑 | `test_file_vanishing_midway_leaves_no_tombstone` |
+| 整库作业收尾清掉孤儿 chapters 目录 | `test_library_orphan_chapter_dirs_are_swept` |
 | `Chapters` 受 fields 门控、单条目全开 | `tests/jellyfin` |
 | 列表请求不加载章节 JSON 列 | `_list_load_columns` |
 | 详情接口不触发 ffprobe | `build_item_detail` |

--- a/docs/design/video-chapters.md
+++ b/docs/design/video-chapters.md
@@ -347,7 +347,17 @@ ffmpeg -v info -y -skip_frame nokey -ss <t> -copyts -i <file> -an -sn \
    场景图」（force）两项。原「重新生成缩略图」菜单改名「重新生成封面」，
    后端进度短语同步（封面 = 主图，与场景图是两件事）。
 
-4. **详情页懒触发**（**不做成 Job**：用户没发起任何动作，一次次打开详情页
+4. **入库落账后**（`ingest.py` 的两处收尾，与封面资产补齐同一位置）：监听
+   入库不经过扫描，入口 1 覆盖不到自动下载入库的新片——不补这一步，新片要等
+   用户点开详情页才由懒触发抓图，只用 Infuse / Jellyfin 客户端的用户则一直
+   没有图。排的是**条目级**补缺作业（`media.chapter_images`，`force=False`：
+   追剧每来一集都把整部剧重抓一遍等于几十次白跑的抽帧），不是整库那份——
+   整库作业挂 `library` 资源，而 `scan_library` 开场看到本库有未完成作业就
+   顺延，一次几小时的整库回填会把监听触发的增量扫描一并挡住；条目作业挂
+   `media_item`，与扫描互不相干。同条目已有作业在跑时按 `dedupe_key` 复用，
+   那一份可能已取完目标、赶不上刚落账的这一集，由下一次入库或详情页懒触发
+   兜底。
+5. **详情页懒触发**（**不做成 Job**：用户没发起任何动作，一次次打开详情页
    却在任务中心堆出一串条目作业既是噪音、也违背 persistent-jobs.md 的"Job 只
    承载用户可感知、需要追踪的异步业务"；重启把它丢了也无妨，下次打开原地再
    触发，已抓齐的文件靠台账不会重做）：`GET /libraries/{lib}/items/{id}` 发现有在位
@@ -463,6 +473,7 @@ Agent 工具无需改动：`spec.json` 重导出后 `library.items.get` 自动�
 | 章节 > 48 或平均间隔 < 1s → 只列表不抓图 | `chapters.py` 单测 |
 | 重启后不重抓已完成的文件，进度不归零 | `test_library_job_resumes_after_restart` |
 | 条目重抓是可恢复 Job，排队期间详情页仍轮询 | `test_item_regenerate_route_enqueues_resumable_job` |
+| 入库落账后新条目有条目级补缺作业（库开关关掉则没有） | `tests/api/test_library_ingest.py` |
 | `Chapters` 受 fields 门控、单条目全开 | `tests/jellyfin` |
 | 列表请求不加载章节 JSON 列 | `_list_load_columns` |
 | 详情接口不触发 ffprobe | `build_item_detail` |

--- a/src/movieclaw_api/api/routes/libraries.py
+++ b/src/movieclaw_api/api/routes/libraries.py
@@ -2155,16 +2155,19 @@ async def get_library_item(
     # 升级后第一次打开旧条目不用等整库作业排到它。判据与整库作业同源
     # （stills_complete）：半成品、图丢了的行在这里同样会被认出来
     chapters_pending = chapters_mod.item_pending(media_item_id)
-    chapter_assets_root = media_scrape.assets_root()
-    needs_stills = any(
-        chapters_mod.stills_eligible(row)
-        and not chapters_mod.stills_complete(row, chapter_assets_root)
-        for row in rows
-    )
     if library.extract_chapter_images and not chapters_pending:
         # 条目菜单发起的重抓是持久化 Job（重启不丢），内存里的懒触发标记看不到它
         chapters_pending = await chapters_mod.item_job_active(session, media_item_id)
-    if library.extract_chapter_images and not chapters_pending and needs_stills:
+    # "抓齐没有"要逐个文件列一次资产目录，因此**放线程里、而且只在结论真会被
+    # 用到时才算**：库关了开关、或已经在抓的条目算了也白算，而前端在抓图期间
+    # 每 3 秒就回来一次，白算的代价要乘上轮询次数
+    if (
+        library.extract_chapter_images
+        and not chapters_pending
+        and await asyncio.to_thread(
+            chapters_mod.item_needs_stills, rows, media_scrape.assets_root()
+        )
+    ):
         chapters_pending = chapters_mod.schedule_item_chapter_images(media_item_id)
     bundle = await build_item_detail(session, library, item, rows)
 

--- a/src/movieclaw_api/services/jobs.py
+++ b/src/movieclaw_api/services/jobs.py
@@ -361,9 +361,17 @@ async def list_jobs(
     job_type: str | None = None,
     resource_type: str | None = None,
     resource_id: str | int | None = None,
+    relation: str | None = None,
     active_only: bool = False,
     limit: int = 50,
 ) -> list[Job]:
+    """按资源/类型/状态筛任务。
+
+    ``relation`` 只在按资源筛时有意义：``"target"`` 是会占用该资源租约的
+    作业（同一资源同时只跑一份），其余关系（``"context"``）只用于聚合与
+    导航。要回答"这个资源上有没有作业正在动它"的调用方必须点名 target——
+    不点名会把只是"提到"该资源的作业也算进去，让本可以并行的两件事互相等。
+    """
     statement = select(Job)
     if resource_type is not None or resource_id is not None:
         statement = statement.join(JobResource, JobResource.job_id == Job.id)
@@ -371,6 +379,8 @@ async def list_jobs(
             statement = statement.where(JobResource.resource_type == resource_type)
         if resource_id is not None:
             statement = statement.where(JobResource.resource_id == str(resource_id))
+        if relation is not None:
+            statement = statement.where(JobResource.relation == relation)
     if active_only:
         statement = statement.where(Job.status.in_(ACTIVE_STATUS_VALUES))
     elif statuses:

--- a/src/movieclaw_api/services/library/chapters.py
+++ b/src/movieclaw_api/services/library/chapters.py
@@ -38,6 +38,7 @@ from sqlmodel import select
 from movieclaw_api.schemas.library import ChapterJobView
 from movieclaw_api.services import jobs
 from movieclaw_api.services.library.layout import STRM_EXT
+from movieclaw_api.services.library.profile import profile_of
 from movieclaw_api.services.library.thumbs import FRAME_GRAB_GATE, build_filter_chains
 from movieclaw_api.services.media_probe import VideoColor, probe_chapters, video_color_for
 from movieclaw_db.engine import get_database
@@ -756,22 +757,27 @@ async def enqueue_item_chapter_images_job(
     media_item_id: int,
     title: str,
     *,
+    force: bool = True,
     actor_kind: str | None = None,
     actor_name: str | None = None,
     actor_id: str | None = None,
     origin: str = "system",
 ) -> jobs.CreateJobResult:
-    """把单条目重抓固化成可恢复 Job；同条目同时只跑一份。
+    """把单条目抓图固化成可恢复 Job；同条目同时只跑一份。
 
     做成 Job 而不是裸协程（详情页懒触发那种）有三个理由：用户明确点了菜单，
     要在任务中心看到它、能停它；一部剧几十集重抓要跑很久，重启不该白跑；
     整库作业已经是 Job，两者共用同一套断点与进度口径。
+
+    ``force`` 默认真（条目菜单「重新生成章节」的口径：已有的图也重做）；
+    入库落账后的补图传假，只补没抓齐的——追剧每来一集都把整部剧重抓一遍，
+    代价是几十次白跑的抽帧。
     """
     return await jobs.create_job(
         session,
         job_type=ITEM_JOB_TYPE,
         subject=title,
-        input_data={"media_item_id": media_item_id, "force": True},
+        input_data={"media_item_id": media_item_id, "force": bool(force)},
         resources=[jobs.ResourceRef("media_item", media_item_id)],
         dedupe_key=f"{ITEM_JOB_TYPE}:{media_item_id}",
         conflict_policy="return_existing",
@@ -782,8 +788,37 @@ async def enqueue_item_chapter_images_job(
         actor_name=actor_name,
         actor_id=actor_id,
         origin=origin,
-        progress=jobs.default_progress(f"等待重新生成《{title}》的章节"),
+        progress=jobs.default_progress(
+            f"等待重新生成《{title}》的章节" if force else f"等待生成《{title}》的章节"
+        ),
     )
+
+
+async def enqueue_ingested_item_chapter_images(
+    session: AsyncSession,
+    library: Library,
+    media_item_id: int,
+    title: str,
+) -> bool:
+    """入库落账后给新条目补章节图（补缺模式），返回是否入队。
+
+    监听入库不经过扫描，扫描收尾那次整库入队（``scan.py`` 的
+    ``_run_scan_job``）覆盖不到它：自动下载入库的新片只能等用户点开详情页
+    才由懒触发抓图，只用 Infuse / Jellyfin 客户端的用户则一直没有图。
+
+    走**条目级**作业而不是整库那份，是因为整库作业挂在 ``library`` 资源上，
+    而扫描开场看到本库有未完成作业就会顺延（``scan_library`` 给后台作业
+    让路）——一次几小时的整库回填会把监听触发的增量扫描一并挡住。条目作业
+    挂 ``media_item``，与扫描互不相干，处理的也正好是刚入库的这一部。
+
+    库关了章节开关、或不是可播库（图片库没有章节）就什么都不做。同条目已有
+    作业在跑时按去重复用它——那一份可能已经取完目标、赶不上刚落账的这一集，
+    由下一次入库或详情页懒触发兜底，不为这点概率再排一份重复作业。
+    """
+    if not library.extract_chapter_images or not profile_of(library).playable:
+        return False
+    await enqueue_item_chapter_images_job(session, media_item_id, title, force=False)
+    return True
 
 
 async def item_job_active(session: AsyncSession, media_item_id: int) -> bool:

--- a/src/movieclaw_api/services/library/chapters.py
+++ b/src/movieclaw_api/services/library/chapters.py
@@ -263,6 +263,16 @@ def stills_complete(row: LibraryFile, assets_root: Path) -> bool:
     )
 
 
+def item_needs_stills(rows: list[LibraryFile], assets_root: Path) -> bool:
+    """该条目还有没抓齐图的在位文件（详情页懒触发的判据）。
+
+    每一行都要列一次资产目录（``stills_complete`` 里的磁盘 IO），所以调用方
+    必须放进线程——详情接口在抓图期间会被前端每 3 秒重拉一次，同步跑等于把
+    这些 listdir 乘上轮询次数压在事件循环上。
+    """
+    return any(stills_eligible(row) and not stills_complete(row, assets_root) for row in rows)
+
+
 def _filter_chains(color: VideoColor) -> list[list[str]]:
     """滤镜链：隔行化 → 5 个关键帧里选代表帧 → 缩放 → [色调映射] → showinfo。
 
@@ -386,6 +396,13 @@ def extract_file_stills(
                 logger.warning("章节抓帧超时（%s 秒）：%s @ %ss", _FFMPEG_TIMEOUT, video, seek)
                 frame_ms = None
             if frame_ms is None:
+                if not video.is_file():
+                    # 文件在抓图过程中被搬走/删掉（整理改名、条目转移、洗版）：
+                    # 这不是"这一章抓不出来"，绝不能记墓碑——墓碑在补缺模式下
+                    # 不再重试，那这一行的图就永远缺着了。已抓到的先落库，剩下
+                    # 的等下一轮（台账那时也已指向新路径）
+                    logger.info("文件已不在原位，本轮章节抓图提前收尾：%s", video)
+                    break
                 # 这一章抓不出来（坏帧、编码不支持、定位超时）：留一条墓碑，让
                 # 补缺判据认它"已有结论"。否则每一轮作业、每一次打开详情页都会
                 # 对着同一个文件重跑一遍同样抓不出来的命令；勾了「已有的章节也
@@ -423,6 +440,51 @@ def cleanup_orphan_dirs(media_item_id: int, live_file_ids: set[int], assets_root
     for sub in base.iterdir():
         if sub.is_dir() and sub.name.isdigit() and int(sub.name) not in live_file_ids:
             shutil.rmtree(sub, ignore_errors=True)
+
+
+async def cleanup_library_orphan_dirs(session: AsyncSession, library_id: int) -> int:
+    """清掉本库各条目下不再对应任何台账行的 chapters 子目录，返回删掉的目录数。
+
+    孤儿有两个来源：台账行被清出（扫描的自动清理丢失记录、面板手动清理）、
+    洗版换了文件行 id。单条目入口（详情页懒触发、条目作业）跑完会顺手清自己
+    那一份，但"条目已经抓齐、只是少了一集"的孤儿等不到任何单条目入口——整库
+    作业每轮收尾扫一遍是唯一能自愈的地方，否则那些图永远躺在盘上。
+
+    一个条目一次 listdir，且资产目录在 ``data/`` 下（本地盘），上千个条目也是
+    毫秒级；磁盘遍历整体放线程里做。
+    """
+    from movieclaw_api.services.media_scrape import assets_root
+
+    rows = (
+        await session.execute(
+            select(LibraryFile.media_item_id, LibraryFile.id).where(
+                LibraryFile.library_id == library_id,
+                LibraryFile.media_item_id.is_not(None),  # type: ignore[union-attr]
+            )
+        )
+    ).all()
+    live: dict[int, set[int]] = {}
+    for media_item_id, file_id in rows:
+        if media_item_id is not None and file_id is not None:
+            live.setdefault(int(media_item_id), set()).add(int(file_id))
+    root = assets_root()
+
+    def _sweep() -> int:
+        removed = 0
+        for media_item_id, file_ids in live.items():
+            base = root / str(media_item_id) / "chapters"
+            if not base.is_dir():
+                continue
+            before = {sub.name for sub in base.iterdir() if sub.is_dir()}
+            cleanup_orphan_dirs(media_item_id, file_ids, root)
+            removed += len(before - {sub.name for sub in base.iterdir() if sub.is_dir()})
+        return removed
+
+    try:
+        return await asyncio.to_thread(_sweep)
+    except OSError as exc:  # 清理失败（权限/挂载抖动）不该让整轮抓图算作失败
+        logger.warning("媒体库 #%s 章节图孤儿目录清理失败：%s", library_id, exc)
+        return 0
 
 
 # ---------------------------------------------------------------------------
@@ -569,13 +631,22 @@ async def enqueue_library_chapter_images_job(
     actor_id: str | None = None,
     origin: str = "system",
 ) -> jobs.CreateJobResult:
-    """把整库抓图固化成可恢复 Job；同库同时只跑一份。"""
+    """把整库抓图固化成可恢复 Job；同库同时只跑一份。
+
+    库资源挂 ``context`` 而不是默认的 ``target``：``target`` 会占用
+    ``library:{id}`` 租约，而这个作业首轮回填可能跑几个小时——占着租约意味着
+    这几小时里用户点「扫描」的作业只能干等，监听触发的增量扫描与定时对账
+    看到"本库有作业在跑"更是整轮放弃（``scan_library`` 的让路检查），新下载
+    的文件迟迟不入账。它只读媒体文件、只写自己那两列 JSON，与扫描没有真冲突；
+    真正会互相踩的是整理/转移（它们在改文件路径），那两个由处理器开头的
+    ``is_organizing / is_transferring`` 单独挡下。同库去重仍由 ``dedupe_key`` 保证。
+    """
     return await jobs.create_job(
         session,
         job_type=JOB_TYPE,
         subject=library_name,
         input_data={"library_id": library_id, "force": bool(force)},
-        resources=[jobs.ResourceRef("library", library_id)],
+        resources=[jobs.ResourceRef("library", library_id, "context")],
         dedupe_key=f"{JOB_TYPE}:{library_id}",
         conflict_policy="return_existing",
         handler_revision=f"{JOB_TYPE}.v1",
@@ -726,8 +797,16 @@ async def _run_chapter_images_job(
     context: jobs.JobContext, input_data: dict[str, Any]
 ) -> dict[str, Any]:
     """整库抓图处理器：目标是库内待处理的台账行，断点见 ``_run_targets``。"""
+    from movieclaw_api.services.library.organize import is_organizing
+    from movieclaw_api.services.library.transfer import is_transferring
+
     library_id = int(input_data["library_id"])
     force = bool(input_data.get("force", False))
+    # 与整理/转移互斥：它们正在批量改文件路径，此刻抓图抓的是随时会消失的
+    # 路径。作业不占库租约（见 enqueue_library_chapter_images_job），所以这道
+    # 检查要自己做——与 scan_library 同一处理：退回队列，稍后自动继续
+    if is_organizing(library_id) or is_transferring(library_id):
+        raise jobs.JobRetry("媒体库正在变更文件路径，章节生成稍后自动继续", delay_seconds=30)
     db = get_database()
     async with db.session() as session:
         library = await session.get(Library, library_id)
@@ -739,6 +818,8 @@ async def _run_chapter_images_job(
     processed, failed = await _run_targets(
         context, targets, force=force, subject=f"媒体库 #{library_id}"
     )
+    async with db.session() as session:
+        await cleanup_library_orphan_dirs(session, library_id)
     message = f"章节生成完成：处理 {processed} 个文件"
     if failed:
         message += f"，{failed} 个失败（可在库菜单重新生成）"
@@ -758,6 +839,7 @@ async def enqueue_item_chapter_images_job(
     title: str,
     *,
     force: bool = True,
+    priority: int = 0,
     actor_kind: str | None = None,
     actor_name: str | None = None,
     actor_id: str | None = None,
@@ -772,6 +854,11 @@ async def enqueue_item_chapter_images_job(
     ``force`` 默认真（条目菜单「重新生成章节」的口径：已有的图也重做）；
     入库落账后的补图传假，只补没抓齐的——追剧每来一集都把整部剧重抓一遍，
     代价是几十次白跑的抽帧。
+
+    ``priority`` 默认 0：条目菜单是用户站在详情页等这一部的图，不该排在
+    别人后面。入库那一路要传 -10（与整库那份同档）——用户没在等这批图，而
+    执行器只有 4 个并发槽，一次批量入库能排出几十份章节作业，默认优先级会
+    让后面的入库作业跟着一起等。
     """
     return await jobs.create_job(
         session,
@@ -783,7 +870,7 @@ async def enqueue_item_chapter_images_job(
         conflict_policy="return_existing",
         handler_revision=f"{ITEM_JOB_TYPE}.v1",
         max_attempts=2,
-        # 不压低优先级：用户正站在详情页等这一部的图，与整库那份（-10）不同
+        priority=priority,
         actor_kind=actor_kind,
         actor_name=actor_name,
         actor_id=actor_id,
@@ -817,7 +904,7 @@ async def enqueue_ingested_item_chapter_images(
     """
     if not library.extract_chapter_images or not profile_of(library).playable:
         return False
-    await enqueue_item_chapter_images_job(session, media_item_id, title, force=False)
+    await enqueue_item_chapter_images_job(session, media_item_id, title, force=False, priority=-10)
     return True
 
 

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -2308,6 +2308,12 @@ async def _ingest_entry(
                 },
             )
             await ensure_assets(item.id)
+        # 章节图（docs/design/video-chapters.md §4.5）：入库不走扫描，扫描收尾
+        # 那次整库入队覆盖不到新入库的文件——给这一部单独排一份条目作业，
+        # 用户点开详情页时图已经在了，只用 Infuse/Jellyfin 的用户也有图
+        from movieclaw_api.services.library.chapters import enqueue_ingested_item_chapter_images
+
+        await enqueue_ingested_item_chapter_images(session, dest_library, item.id, item.title)
 
     verb = "硬链接" if strategy == "hardlink" else "复制"
     if imported:
@@ -2527,7 +2533,7 @@ async def _ingest_raw_drop(
     kind = MediaKind(library.kind)
     first_item: MediaItem | None = None
     imported = 0
-    new_item_ids: list[int] = []
+    new_items: list[tuple[int, str]] = []
     for src_file, final in transferred:
         if src_file not in video_set:
             continue
@@ -2573,11 +2579,13 @@ async def _ingest_raw_drop(
             )
         )
         imported += 1
-        new_item_ids.append(local_item.id)
+        new_items.append((local_item.id, local_item.title))
     if imported:
         await LibraryRepository(session).refresh_stats([library.id])
         await session.commit()
-        for item_id in new_item_ids:
+        from movieclaw_api.services.library.chapters import enqueue_ingested_item_chapter_images
+
+        for item_id, item_title in new_items:
             # 缩略图属于锦上添花：作业内顺手做完，后台 tick 则丢给事件循环
             if job_context is None:
                 asyncio.get_running_loop().create_task(ensure_assets(item_id))
@@ -2591,6 +2599,8 @@ async def _ingest_raw_drop(
                     details={"entry_name": entry.name, "library_id": library.id},
                 )
                 await ensure_assets(item_id)
+            # 章节图与上面的封面同理，只是慢得多，交给条目作业在后台跑
+            await enqueue_ingested_item_chapter_images(session, library, item_id, item_title)
     if imported:
         return first_item, imported, (
             IngestStatus.IMPORTED,

--- a/src/movieclaw_api/services/library/scan.py
+++ b/src/movieclaw_api/services/library/scan.py
@@ -690,6 +690,11 @@ async def scan_library(
     summary = ScanSummary(library_id=library_id)
     # watchdog 与定时对账仍是轻量直接触发，但必须服从 Job 的库级租约。
     # Job 处理器传入自己的 id 后可穿过这道检查；其他直接扫描看到锁就让路。
+    # **只给 target 关系的作业让路**：那些才是会占用库租约、真的在动文件与
+    # 台账的作业（扫描/整理/转移/元数据刷新）。章节图这类只读文件、只写自己
+    # 那两列的作业挂的是 context 关系——不点名 target 的话，一次几小时的章节
+    # 回填会把监听触发的增量扫描与定时对账整段挡在门外（issue：新下载的文件
+    # 迟迟不入账）。
     db = get_database()
     async with db.session() as lock_session:
         queued_jobs = (
@@ -700,6 +705,7 @@ async def scan_library(
                     active_only=True,
                     resource_type="library",
                     resource_id=library_id,
+                    relation="target",
                     limit=20,
                 )
                 if row.status is not JobStatus.BLOCKED

--- a/src/movieclaw_api/services/storage/registry.py
+++ b/src/movieclaw_api/services/storage/registry.py
@@ -266,10 +266,12 @@ DATA_DIRS: tuple[DataDir, ...] = (
     DataDir(
         key="metadata.images",
         title="刮削图片资产",
-        summary="刮削下载的海报、背景与剧照",
+        summary="刮削下载的海报、背景，以及本地抽帧的章节图",
         description=(
-            "刮削下载的海报、背景与剧照，是媒体库展示的事实源。整体重建等于整库"
-            "刷新元数据（大量外网流量并受 TMDB 限速），因此只提供清理孤儿条目。"
+            "刮削下载的海报、背景与剧照，是媒体库展示的事实源；每个条目目录下的 "
+            "chapters/ 是本地抽帧生成的视频章节图（一部片 8～12 张，约 1MB，可在"
+            "媒体库设置里关掉「生成章节」）。整体重建等于整库刷新元数据（大量外网"
+            "流量并受 TMDB 限速），因此只提供清理孤儿条目。"
         ),
         default="data/metadata/images",
         resolve=lambda s: Path(s.metadata_dir) / "images",

--- a/tests/api/test_chapter_images.py
+++ b/tests/api/test_chapter_images.py
@@ -454,6 +454,108 @@ async def test_partial_and_failed_stills_resume_next_round(db, tmp_path, monkeyp
         assert all("image" in e for e in row.chapter_images)
 
 
+async def test_file_vanishing_midway_leaves_no_tombstone(db, tmp_path, monkeypatch):
+    """文件在抓图过程中被搬走/删掉（整理改名、条目转移、洗版）：不记墓碑。
+
+    墓碑在补缺模式下不再重试，为一次路径变更误记一条，等于这一行的图永远
+    缺着。正确的收场是把已抓到的落库、这一行仍然算"没抓齐"，下一轮再来。
+    """
+    video = tmp_path / "media" / "v.mkv"
+    video.parent.mkdir()
+    video.write_bytes(b"x")
+    embedded = [
+        {"start_ms": 0, "end_ms": 20000, "title": None},
+        {"start_ms": 20000, "end_ms": None, "title": None},
+    ]
+    _lib_id, _item_id, file_id = await _seed(db, video, chapters=embedded)
+    assets = Path(get_settings().metadata_dir) / "images"
+
+    seeks: list[float] = []
+
+    def _grab(_video, dest, *, seek_seconds, color):
+        seeks.append(seek_seconds)
+        video.unlink(missing_ok=True)  # 抓第一张时文件被整理搬走
+        return None
+
+    monkeypatch.setattr(chapters_mod, "video_color_for", lambda *_a, **_k: None)
+    monkeypatch.setattr(chapters_mod, "grab_chapter_still", _grab)
+
+    async with db.session() as session:
+        row = await session.get(LibraryFile, file_id)
+        assert await chapters_mod.refresh_file_chapter_images(session, row)
+        assert seeks == [15.0]  # 第一章失败即收尾，不再对着已经不在的文件跑第二章
+        assert row.chapter_images == []
+        assert not chapters_mod.stills_complete(row, assets)  # 下一轮还会重来
+
+        # 文件回到原位（整理结束）：照常抓，墓碑没留下过
+        video.write_bytes(b"x")
+        monkeypatch.setattr(
+            chapters_mod,
+            "grab_chapter_still",
+            lambda _v, dest, *, seek_seconds, color: (
+                dest.parent.mkdir(parents=True, exist_ok=True),
+                dest.write_bytes(b"jpg"),
+                int(seek_seconds * 1000),
+            )[2],
+        )
+        assert await chapters_mod.refresh_file_chapter_images(session, row)
+        assert [e["start_ms"] for e in row.chapter_images] == [0, 20000]
+        assert all("image" in e for e in row.chapter_images)
+
+
+async def test_library_orphan_chapter_dirs_are_swept(db, tmp_path):
+    """整库作业收尾清孤儿目录：台账行被清出（自动清理丢失记录、手动清理、
+    洗版换行）后留下的 ``{item}/chapters/{file_id}/`` 没有任何单条目入口会
+    去清它——条目已经抓齐时它连作业目标都不是。"""
+    video = tmp_path / "media" / "o.mkv"
+    video.parent.mkdir()
+    video.write_bytes(b"x")
+    library_id, item_id, file_id = await _seed(db, video, chapters=[], chapter_images=[])
+    assets = Path(get_settings().metadata_dir) / "images"
+    live_dir = assets / str(item_id) / "chapters" / str(file_id)
+    stale_dir = assets / str(item_id) / "chapters" / str(file_id + 9)
+    for directory in (live_dir, stale_dir):
+        directory.mkdir(parents=True)
+        (directory / "0000000000.jpg").write_bytes(b"jpg")
+
+    async with db.session() as session:
+        assert await chapters_mod.cleanup_library_orphan_dirs(session, library_id) == 1
+    assert live_dir.is_dir()
+    assert not stale_dir.exists()
+
+
+async def test_chapter_job_does_not_hold_the_library_lease(db, tmp_path):
+    """章节作业挂 context 关系、不占库租约：它排队/运行期间，监听与定时对账
+    触发的扫描照常跑。
+
+    首轮回填可能跑几个小时，让路就等于这几个小时里新落盘的文件都不入账。
+    对照组：真正会动文件与台账的作业（target 关系）仍然让扫描顺延。
+    """
+    from movieclaw_api.services.library.scan import scan_library
+
+    root = tmp_path / "empty-root"
+    root.mkdir()
+    async with db.session() as session:
+        lib = Library(name="空库", kind="video", source="local", root_paths=[str(root)])
+        session.add(lib)
+        await session.commit()
+        library_id = lib.id
+        await chapters_mod.enqueue_library_chapter_images_job(session, library_id, lib.name)
+
+    summary = await scan_library(library_id, backfill_existing_specs=False)
+    assert summary.errors == []
+
+    async with db.session() as session:
+        await jobs.create_job(
+            session,
+            job_type="library.organize",
+            input_data={"library_id": library_id},
+            resources=[jobs.ResourceRef("library", library_id)],
+        )
+    summary = await scan_library(library_id, backfill_existing_specs=False)
+    assert any("后台作业" in message for message in summary.errors)
+
+
 async def test_probe_failure_and_missing_ffmpeg_leave_row_untouched(db, tmp_path, monkeypatch):
     """章节补探失败或系统没有 ffmpeg：什么都不写（保持 NULL），下次入口自动再来。"""
     video = tmp_path / "media" / "x.mkv"

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -711,6 +711,9 @@ async def test_import_enqueues_chapter_images_job(db, tmp_path, monkeypatch):
     assert job.input_data["media_item_id"] == item.id
     # 补缺而不是重抓：追剧每来一集都把整部剧重抓一遍，代价是几十次白跑的抽帧
     assert job.input_data["force"] is False
+    # 压低优先级：执行器只有 4 个并发槽，一次批量入库能排出几十份章节作业，
+    # 默认优先级会让后面的入库作业跟着一起等（条目菜单那一路仍是 0）
+    assert job.priority == -10
     # 挂 media_item 而不是 library：整库那份会让扫描开场看到"本库有作业在跑"
     # 而顺延，一次几小时的回填能把监听触发的增量扫描一并挡住
     assert [(r.resource_type, r.resource_id) for r in resources] == [("media_item", str(item.id))]

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -117,6 +117,12 @@ async def _get_library(db, library_id: int) -> Library:
         return row
 
 
+def _ingest_jobs():
+    """只筛入库作业：一次入库还会给新条目排一份章节图作业
+    （``media.chapter_images``），"任务中心里有几份"的断言说的是前者。"""
+    return select(Job).where(Job.job_type == "library.ingest")
+
+
 async def _add_ingest_job(session, *, job_id: str, entry_id: int, status: JobStatus) -> Job:
     row = Job(id=job_id, job_type="library.ingest", status=status, input_data={})
     session.add(row)
@@ -671,6 +677,83 @@ async def test_movie_hardlink_import_and_ledger(db, tmp_path, monkeypatch):
     async with db.session() as session:
         files = list((await session.execute(select(LibraryFile))).scalars().all())
     assert len(files) == 1
+
+
+@pytest.mark.asyncio
+async def test_import_enqueues_chapter_images_job(db, tmp_path, monkeypatch):
+    """入库落账后给新条目排一份章节图作业（docs/design/video-chapters.md §4.5）。
+
+    监听入库不经过扫描，扫描收尾那次整库入队覆盖不到它——少了这一份，自动
+    下载入库的新片要等用户点开详情页才由懒触发抓图，只用 Infuse / Jellyfin
+    客户端的用户则一直没有图。
+    """
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="某电影", year=2020)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda p: _FAKE_SPEC)
+
+    entry = watch / "Some.Movie.2020.1080p"
+    entry.mkdir()
+    (entry / "some.movie.mkv").write_bytes(b"video")
+    await _sweep_twice(db, library_id, watch)
+
+    async with db.session() as session:
+        job = (
+            await session.execute(select(Job).where(Job.job_type == "media.chapter_images"))
+        ).scalar_one()
+        resources = list(
+            (
+                await session.execute(select(JobResource).where(JobResource.job_id == job.id))
+            ).scalars()
+        )
+    assert job.input_data["media_item_id"] == item.id
+    # 补缺而不是重抓：追剧每来一集都把整部剧重抓一遍，代价是几十次白跑的抽帧
+    assert job.input_data["force"] is False
+    # 挂 media_item 而不是 library：整库那份会让扫描开场看到"本库有作业在跑"
+    # 而顺延，一次几小时的回填能把监听触发的增量扫描一并挡住
+    assert [(r.resource_type, r.resource_id) for r in resources] == [("media_item", str(item.id))]
+
+    # 幂等：同条目再入库不重复排队（dedupe_key 按条目）
+    (entry / "some.movie.mkv").write_bytes(b"video-2")
+    await _sweep_twice(db, library_id, watch)
+    async with db.session() as session:
+        jobs_after = list(
+            (
+                await session.execute(select(Job).where(Job.job_type == "media.chapter_images"))
+            ).scalars()
+        )
+    assert len(jobs_after) == 1
+
+
+@pytest.mark.asyncio
+async def test_import_skips_chapter_images_job_when_library_disabled(db, tmp_path, monkeypatch):
+    """库关了「生成章节」开关：入库不排章节图作业（作业本身也会空转返回）。"""
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    async with db.session() as session:
+        library = await session.get(Library, library_id)
+        assert library is not None
+        library.extract_chapter_images = False
+        await session.commit()
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="某电影", year=2020)
+    _stub_identify(monkeypatch, item)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda p: _FAKE_SPEC)
+
+    entry = watch / "Some.Movie.2020.1080p"
+    entry.mkdir()
+    (entry / "some.movie.mkv").write_bytes(b"video")
+    await _sweep_twice(db, library_id, watch)
+
+    async with db.session() as session:
+        chapter_jobs = list(
+            (
+                await session.execute(select(Job).where(Job.job_type == "media.chapter_images"))
+            ).scalars()
+        )
+    assert chapter_jobs == []
 
 
 @pytest.mark.asyncio
@@ -1961,7 +2044,7 @@ async def test_blocked_batch_does_not_stall_remaining_episodes(db, tmp_path, mon
     completed_later[ep3.name] = True
     await ingest_mod._sweep_dir(rule, library)
     async with db.session() as session:
-        all_jobs = list((await session.execute(select(Job))).scalars())
+        all_jobs = list((await session.execute(_ingest_jobs())).scalars())
     assert len(all_jobs) == 3
     third = max(all_jobs, key=lambda job: job.created_at)
     assert [ready["path"] for ready in third.input_data["ready_files"]] == [ep3.name]
@@ -2510,7 +2593,7 @@ async def test_upgrade_retries_legacy_partial_import_through_job(db, tmp_path, m
     await ingest_mod._sweep_dir(rule, library)
 
     async with db.session() as session:
-        job = (await session.execute(select(Job))).scalar_one()
+        job = (await session.execute(_ingest_jobs())).scalar_one()
     assert job.handler_revision == ingest_mod._ingest_handler_revision()
     await jobs.init_job_dispatcher(max_parallel=1)
     await _wait_job_status(job.id, JobStatus.SUCCEEDED)
@@ -3017,7 +3100,7 @@ async def test_upgrade_unblocks_old_revision_parser_gap_job(db, tmp_path, monkey
     assert completed.id == job.id
 
     async with db.session() as session:
-        all_jobs = list((await session.execute(select(Job))).scalars())
+        all_jobs = list((await session.execute(_ingest_jobs())).scalars())
         record = (await session.execute(select(IngestEntry))).scalar_one()
     assert len(all_jobs) == 1
     assert record.status == IngestStatus.IMPORTED
@@ -3085,7 +3168,7 @@ async def test_blocked_parser_gap_job_wakes_on_content_change(db, tmp_path, monk
     assert completed.id == job.id
 
     async with db.session() as session:
-        all_jobs = list((await session.execute(select(Job))).scalars())
+        all_jobs = list((await session.execute(_ingest_jobs())).scalars())
         record = (await session.execute(select(IngestEntry))).scalar_one()
     assert len(all_jobs) == 1
     assert record.status == IngestStatus.IMPORTED
@@ -3113,7 +3196,7 @@ async def test_model_upgrade_wakes_blocked_parser_gap_job(db, tmp_path, monkeypa
     assert completed.handler_revision == f"{ingest_mod._INGEST_HANDLER_REVISION}+torrent-ner-v9"
 
     async with db.session() as session:
-        all_jobs = list((await session.execute(select(Job))).scalars())
+        all_jobs = list((await session.execute(_ingest_jobs())).scalars())
         record = (await session.execute(select(IngestEntry))).scalar_one()
     assert len(all_jobs) == 1
     assert record.status == IngestStatus.IMPORTED
@@ -3152,7 +3235,7 @@ async def test_compensation_zero_new_import_keeps_imported_summary(db, tmp_path,
     await ingest_mod._sweep_dir(rule, library)
     await ingest_mod._sweep_dir(rule, library)
     async with db.session() as session:
-        job = (await session.execute(select(Job))).scalar_one()
+        job = (await session.execute(_ingest_jobs())).scalar_one()
     await jobs.init_job_dispatcher(max_parallel=1)
     await _wait_job_status(job.id, JobStatus.BLOCKED)
 


### PR DESCRIPTION
## 起因

「媒体库新入库的资源不会顺带生成章节吗」——不会。章节**列表**（`library_file.chapters`）入库时本来就写了，缺的是**图**：章节图此前只有四个入口（扫描作业收尾整库入队、库菜单、条目菜单、详情页懒触发），而监听入库不经过扫描（ingest 直接搬文件写台账），扫描收尾那次覆盖不到它。结果是自动下载入库的新片只能等用户点开详情页才由懒触发抓图，只用 Infuse / Jellyfin 客户端的用户则一直没有图。

## 改动

### 1. 入库落账后补章节图（`98e2214`）

在入库两处收尾（正常影视入库 `_ingest_entry`、原样落盘 `_ingest_raw_drop`）与封面资产补齐同一位置排一份章节图作业。原盘（BDMV/VIDEO_TS）不排，`stills_eligible` 本来就把它排除在外。

用**条目级**作业（`media.chapter_images`）而不是整库那份：整库作业挂 `library` 资源，而 `scan_library` 开场看到本库有未完成作业就顺延，一次几小时的整库回填会把监听触发的增量扫描一并挡住；条目作业挂 `media_item`，与扫描互不相干，处理的也正好是刚入库的这一部。

`enqueue_item_chapter_images_job` 因此新增 `force` 参数：条目菜单「重新生成章节」仍是 `force=True`（默认值不变），入库这一路传 `False` 只补没抓齐的——追剧每来一集都把整部剧重抓一遍，代价是几十次白跑的抽帧。

### 2. 顺着这块又通读一遍，修掉五处（`baf1af4`）

- **入库触发的条目作业压到 -10**。执行器只有 4 个并发槽，一次批量入库能排出几十份章节作业，默认优先级会让后面的入库作业跟着一起等。条目菜单那一路仍是 0——用户正站在详情页等这一部的图。
- **整库作业不再占用 `library` 租约**。它此前挂 `target` 关系，而首轮回填可能跑几个小时：这期间用户点「扫描」的作业只能干等，监听触发的增量扫描与定时对账看到"本库有作业在跑"更是整轮放弃，新落盘的文件迟迟不入账。章节作业只读媒体文件、只写自己那两列 JSON，与扫描没有真冲突，改挂 `context`；`scan_library` 的让路检查相应点名 `relation="target"`（`jobs.list_jobs` 新增该参数），只给真的在动文件与台账的作业让路。字幕生成早就用了 `container` 关系（`subtitle_gen/tasks.py:801`），此前也被这道检查误伤，一并修好。真正会互相踩的整理/转移由处理器开头的 `is_organizing / is_transferring` 单独挡下并退回队列。
- **文件在抓图过程中消失不再记墓碑**。整理改名、条目转移、洗版都会让抓帧失败，而墓碑在补缺模式下不再重试——误记一条等于这一行的图永远缺着。现在当场收尾，已抓到的落库，这一行仍算没抓齐，下一轮再来。这道守卫对所有入口（作业、懒触发）都生效。
- **整库作业收尾清一遍孤儿 `chapters` 目录**。台账行被清出（自动清理丢失记录、手动清理）或洗版换了行 id 之后留下的目录，单条目入口清不到——"条目已经抓齐、只是少了一集"连作业目标都不是。一个条目一次 listdir，本地盘上千个条目也是毫秒级。
- **详情接口的"抓齐没有"判据挪进线程，且只在结论真会被用到时才算**。它逐个文件列资产目录，此前同步跑在事件循环上，而前端在抓图期间每 3 秒重拉一次详情——白算的代价要乘上轮询次数。

另外把缓存面板「刮削图片资产」的说明补上章节图：那个目录现在有一大块是本地抽帧产物（一部片 8～12 张、约 1MB），标着"重建要走 TMDB 配额"已经和事实对不上了。

## 测试

新增回归：

- `tests/api/test_library_ingest.py`：入库后有条目级补缺作业（挂 `media_item`、`force=False`、`priority=-10`、按条目去重），库开关关掉则不排；
- `tests/api/test_chapter_images.py`：章节作业在跑时扫描照常、`target` 关系的作业仍让路；文件抓图中途消失不记墓碑且下一轮能抓上；整库孤儿目录被清掉。

既有断言里有 6 处 `select(Job).scalar_one()` 收窄为只筛 `library.ingest`——它们说的是"任务中心里有几份入库作业"，现在一次入库还会多一份章节作业。

## 其他

不动运行时依赖（`docker/runtime-version` 不变），无数据库迁移。设计文档 `docs/design/video-chapters.md` §4.4/§4.5 与守卫清单同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BW5o7K87xtcgdTrt5NS1Xv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW5o7K87xtcgdTrt5NS1Xv)_