### PR TITLE
fix(web): 收藏页补齐两层位置记忆，与单库页拉平

### DIFF
--- a/apps/web/components/collection-grid-view.tsx
+++ b/apps/web/components/collection-grid-view.tsx
@@ -16,11 +16,11 @@ import { SearchIcon } from "@/components/icons";
 import { PosterCard } from "@/components/poster-card";
 import { browseDiscoveryCollection } from "@/lib/api/discover";
 import type { MediaItem } from "@/lib/media-types";
+import { createSessionSnapshots } from "@/lib/session-snapshot";
 import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 const TMDB_PAGE_SIZE = 20;
 const DOUBAN_FULL_LIMIT = 500;
-const MAX_COLLECTION_SNAPSHOTS = 32;
 
 interface CollectionGridSnapshot {
   items: MediaItem[];
@@ -30,7 +30,8 @@ interface CollectionGridSnapshot {
   hasMore: boolean;
 }
 
-const collectionGridSnapshots = new Map<string, CollectionGridSnapshot>();
+// 一个片单一条，超限时优先淘汰最久未更新的片单（见 lib/session-snapshot.ts）
+const collectionGridSnapshots = createSessionSnapshots<string, CollectionGridSnapshot>(32);
 
 function getCollectionGridSnapshot(collectionRef: string) {
   return collectionGridSnapshots.get(collectionRef);
@@ -40,13 +41,7 @@ function rememberCollectionGridSnapshot(
   collectionRef: string,
   snapshot: CollectionGridSnapshot,
 ) {
-  collectionGridSnapshots.delete(collectionRef);
   collectionGridSnapshots.set(collectionRef, snapshot);
-  while (collectionGridSnapshots.size > MAX_COLLECTION_SNAPSHOTS) {
-    const oldest = collectionGridSnapshots.keys().next().value;
-    if (oldest === undefined) break;
-    collectionGridSnapshots.delete(oldest);
-  }
 }
 
 /**

--- a/apps/web/components/favorites-view.tsx
+++ b/apps/web/components/favorites-view.tsx
@@ -7,10 +7,10 @@ import type { Route } from "next";
 
 import { useToast } from "@/components/feedback";
 import { MasonryIcon, MoreIcon, PosterGridIcon } from "@/components/icons";
-import { WallLoadMore } from "@/components/library-detail-view";
+import { WallLoadMore, WallLoadPrev, WallRecallPill } from "@/components/library-detail-view";
 import { PosterWall } from "@/components/poster-wall";
 import { PAGE_NAV_BUTTON_CLASS, PageNav } from "@/components/page-nav";
-import { usePhotoWallDensity } from "@/components/photo-wall";
+import { remeasureWalls, usePhotoWallDensity } from "@/components/photo-wall";
 import {
   GALLERY_LOAD_MARGIN,
   GALLERY_PAGE_SIZE,
@@ -29,11 +29,30 @@ import {
   listFavoritesGallery,
   setPlaybackMarks,
 } from "@/lib/api/playback";
+import {
+  firstVisibleAnchorId,
+  isReentryAfterAbsence,
+  wallRecallScope,
+} from "@/lib/library-wall-recall";
 import { usePageTitle } from "@/lib/use-page-title";
 import { useScrollRestoration } from "@/lib/use-scroll-restoration";
+import { useWallRecall } from "@/lib/use-wall-recall";
 
 /** 每次向服务端要的格数，与单库海报墙同一页长。 */
 const PAGE_SIZE = 60;
+
+/** 「回到上次浏览的位置」的记录键（lib/library-wall-recall.ts）。 */
+const RECALL_SCOPE = wallRecallScope("favorites");
+
+/**
+ * 记录的形态口径（见 WallRecall.view）。
+ *
+ * 收藏页只有一种排序（最近收藏在前），海报墙与图廊又是同一份名单、同一种按
+ * 作品分页——「第 300 个」在两种形态里指向同一部作品，因此共用一条记录：在
+ * 图廊里看到哪，切回海报墙照样跳得回去。单库页两种墙的排序不同，那边才必须
+ * 分开记。
+ */
+const RECALL_VIEW = "favorites";
 
 /**
  * 「全部收藏」页离开再返回时的会话快照。
@@ -48,13 +67,17 @@ const PAGE_SIZE = 60;
  * 它只活在当前浏览会话里（刷新页面即失效），与滚动位置同一口径。
  */
 interface FavoritesSnapshot {
-  /** 海报墙已加载的整个窗口（收藏墙不支持跳转，起点恒为 0） */
+  /** 海报墙已加载的整个窗口 */
   items: FavoriteItem[];
   total: number;
+  /** 这份窗口在整份名单里的起点（「回到上次位置」跳过来后不为 0） */
+  wallStart: number;
   /** 图床浏览模式已加载的整个窗口；空数组 = 这一次浏览没进过图廊 */
   galleryGroups: LibraryGalleryGroup[];
   galleryHasMore: boolean;
-  /** 已向服务端请求到第几个作品（图廊按作品分页，没图的作品也占一组） */
+  /** 图廊窗口的起点，与 wallStart 同一个意思 */
+  galleryStart: number;
+  /** 已向服务端请求到第几个作品（绝对位置；没图的作品也占一组） */
   galleryLoaded: number;
 }
 
@@ -93,33 +116,68 @@ const FAVORITES_FRAME_ASPECT = 2 / 3;
  *
  * 两种形态各自分页、互不干扰；海报墙那一份始终会拉（页头的总数与切回来时的
  * 首屏都靠它），与单库页同一处理。
+ *
+ * 位置记忆也与单库页同一套，两层各管一段（谁都不覆盖谁）：
+ *   - 会话内：从作品详情页返回时，快照把整个已加载窗口接回来，滚动位置由
+ *     lib/use-scroll-restoration.ts 自动回位，不问用户；
+ *   - 跨会话：关掉页面第二天再进来，底部弹一枚胶囊问要不要回到上次的位置
+ *     （lib/library-wall-recall.ts），点了就把窗口整体换到那一段。
  */
 export function FavoritesView() {
   usePageTitle("我的收藏");
   const toast = useToast();
+  const initialSnapshot = snapshot;
+  // 本次是不是「重新进入」：首帧没有会话快照 = 冷启动 / 刷新 / 从别处进来的；
+  // 或者本次页面加载期间挂过很久后台（iOS PWA 恢复应用不重新加载页面，只能
+  // 靠这条认）。重新进入时不自动回位，改由底部胶囊来问——两者同时来的话，
+  // 人已经在原处了，胶囊就成了指着脚下的废话
+  const freshEntry = useRef(initialSnapshot === null || isReentryAfterAbsence(RECALL_SCOPE));
   const [galleryPreferred, setGalleryMode] = useVideoGalleryMode();
   const [galleryGrouped, setGalleryGrouped] = useVideoGalleryGrouped();
   const [density, setDensity] = usePhotoWallDensity();
   // 两种墙的滚动锚点不同：海报墙一格一个条目，图廊一部作品十几张图按瓦片认
-  const scrollRef = useScrollRestoration("library:favorites", {
+  const restoreScrollRef = useScrollRestoration("library:favorites", {
     anchorAttribute: galleryPreferred ? "data-gallery-tile-id" : "data-library-item-id",
+    restore: !freshEntry.current,
   });
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
+  // 滚动恢复、位置记录与前置加载的滚动补偿共用同一个真实滚动容器，合并
+  // callback ref，免得几套监听器各自去猜 window/document
+  const scrollRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      restoreScrollRef(node);
+      setScrollElement(node);
+    },
+    [restoreScrollRef],
+  );
   // 首帧就把上次的窗口接回来，滚动恢复才有落脚的高度
-  const [items, setItems] = useState<FavoriteItem[] | null>(snapshot?.items ?? null);
-  const [total, setTotal] = useState(snapshot?.total ?? 0);
+  const [items, setItems] = useState<FavoriteItem[] | null>(initialSnapshot?.items ?? null);
+  const [total, setTotal] = useState(initialSnapshot?.total ?? 0);
+  // 当前窗口在整份名单里的起点：0 = 墙首；「回到上次位置」跳过来后不为 0
+  const [wallStart, setWallStart] = useState(initialSnapshot?.wallStart ?? 0);
   const [failed, setFailed] = useState(false);
+  // 起点的 ref 版：几个回调每次都读最新值，不必为它重建回调链
+  const wallOffset = useRef(initialSnapshot?.wallStart ?? 0);
   // 翻页请求进行中：哨兵重新观察时不重复发同一页
   const loading = useRef(false);
   // 进这一屏时快照里有多少格（挂载后本组件自己就会改写 snapshot，得先定格）
-  const restoredCount = useRef(snapshot?.items.length ?? 0);
+  const restoredCount = useRef(initialSnapshot?.items.length ?? 0);
+  // 海报墙顶部的锚：跳转后滚回墙首，位置记录也按它量首个可见格
+  const wallTop = useRef<HTMLDivElement>(null);
 
+  /** 墙尾追加一页。 */
   const load = useCallback(async (offset: number) => {
     if (loading.current) return;
     loading.current = true;
     try {
       const page = await listFavorites(PAGE_SIZE, offset);
       setTotal(page.total);
-      setItems((prev) => (offset === 0 || !prev ? page.items : [...prev, ...page.items]));
+      setItems((prev) => {
+        if (!prev) return page.items;
+        // 与前置加载/跳转交叠着回来时同一部可能拿到两次，按 id 去重再拼
+        const seen = new Set(prev.map((i) => i.media_item_id));
+        return [...prev, ...page.items.filter((i) => !seen.has(i.media_item_id))];
+      });
       setFailed(false);
     } catch {
       setFailed(true);
@@ -136,14 +194,26 @@ export function FavoritesView() {
   const reload = useCallback(async (loadedCount: number) => {
     if (loading.current) return;
     loading.current = true;
+    const start = wallOffset.current;
     try {
       const pages = await Promise.all(
         Array.from({ length: Math.ceil(loadedCount / PAGE_SIZE) }, (_, page) =>
-          listFavorites(PAGE_SIZE, page * PAGE_SIZE),
+          listFavorites(PAGE_SIZE, start + page * PAGE_SIZE),
         ),
       );
-      setTotal(pages[0].total);
-      setItems(pages.flatMap((page) => page.items));
+      const rows = pages.flatMap((page) => page.items);
+      if (rows.length === 0 && start > 0) {
+        // 这一段整个被取消收藏了（跳到过靠后的位置，回来时那里已经空了）：
+        // 退回墙首重取，否则明明还有收藏，这一屏却什么都没有
+        wallOffset.current = 0;
+        setWallStart(0);
+        const head = await listFavorites(PAGE_SIZE, 0);
+        setTotal(head.total);
+        setItems(head.items);
+      } else {
+        setTotal(pages[0].total);
+        setItems(rows);
+      }
       setFailed(false);
     } catch {
       setFailed(true);
@@ -158,21 +228,98 @@ export function FavoritesView() {
   }, [load, reload]);
 
   const loaded = items?.length ?? 0;
-  const hasMore = items !== null && loaded < total;
+  const hasMore = items !== null && wallStart + loaded < total;
   /** 收藏是跨库的一面墙，每一格落回它自己所属的库 */
   const ownerLibraryOf = useCallback((item: FavoriteItem) => item.library_id, []);
   const loadMore = useCallback(() => {
-    void load(loaded);
-  }, [load, loaded]);
+    void load(wallStart + loaded);
+  }, [load, loaded, wallStart]);
+
+  /* —— 向上补页 ——
+     「回到上次位置」会把整个窗口换成从那一段开始的一页，窗口起点因此不为 0：
+     上方明明还有作品，往上滑却是一堵墙。这里补上反方向的分页——墙顶的哨兵
+     提前 600px 触发，把上一页接到已加载内容前面（与单库页同一条路）。 */
+  const loadingPrev = useRef(false);
+  // 前置加载前滚动容器的高度；null = 本次 items 变化不是前置加载，不必补偿
+  const prependFrom = useRef<number | null>(null);
+  const loadPrev = useCallback(() => {
+    if (loadingPrev.current) return;
+    const until = wallOffset.current;
+    if (until <= 0) return; // 已经到墙首，上方没有东西可补
+    loadingPrev.current = true;
+    const from = Math.max(0, until - PAGE_SIZE);
+    listFavorites(until - from, from)
+      .then((page) => {
+        // 一部都没拿到（这一段刚好被取消收藏取空了）：起点保持不动就此打住，
+        // 否则起点一路往前挪、哨兵每次都重新观察，会把这段空区间反复请求
+        if (page.items.length === 0) return;
+        // 起点按**实拿到的条数**回推：拿少了（并发取消收藏）时窗口起点仍与
+        // 已加载内容对得上，「上次位置」才不会整体错位
+        const start = until - page.items.length;
+        wallOffset.current = start;
+        prependFrom.current = scrollElement?.scrollHeight ?? null;
+        setTotal(page.total);
+        setWallStart(start);
+        setItems((current) => {
+          const seen = new Set((current ?? []).map((i) => i.media_item_id));
+          return [...page.items.filter((i) => !seen.has(i.media_item_id)), ...(current ?? [])];
+        });
+      })
+      // 失败就先不补：哨兵还在墙顶，用户下次滑离再滑回来会重新触发
+      .catch(() => {})
+      .finally(() => {
+        loadingPrev.current = false;
+      });
+  }, [scrollElement]);
+
+  // 前置加载的滚动补偿：墙长高了多少就把 scrollTop 加回多少。放 layout effect
+  // 里在绘制前完成；补完立刻让虚拟化窗口重量一次——滚动事件要到下一帧才来，
+  // 不补这一下会闪一帧空墙
+  useLayoutEffect(() => {
+    const before = prependFrom.current;
+    prependFrom.current = null;
+    if (before === null || !scrollElement) return;
+    const grown = scrollElement.scrollHeight - before;
+    if (grown <= 0) return;
+    scrollElement.scrollTop += grown;
+    remeasureWalls();
+  }, [items, scrollElement]);
+
+  /**
+   * 跳到整份名单里的某个位置：换掉整个窗口（而不是从头一页页追加过去），
+   * 此后向下照常滚动加载，向上由墙顶哨兵把上文补回来（loadPrev）。
+   */
+  const jumpTo = useCallback((offset: number) => {
+    // 跳转期间两头的哨兵都挡住，别让旧窗口的追加/补页插进来
+    loading.current = true;
+    loadingPrev.current = true;
+    wallOffset.current = offset;
+    listFavorites(PAGE_SIZE, offset)
+      .then((page) => {
+        setTotal(page.total);
+        setWallStart(offset);
+        setItems(page.items);
+        // 瞬时而不是平滑：墙上的内容已经整段换掉，平滑滚过去的是一堆不存在的
+        // 旧内容；落地后墙顶哨兵还会立刻补一页，那一下的滚动补偿会打断动画
+        wallTop.current?.scrollIntoView({ block: "start", behavior: "instant" });
+      })
+      .catch(() => {})
+      .finally(() => {
+        loading.current = false;
+        loadingPrev.current = false;
+      });
+  }, []);
 
   // —— 图床浏览模式 —— //
   const [galleryGroups, setGalleryGroups] = useState<LibraryGalleryGroup[]>(
-    snapshot?.galleryGroups ?? [],
+    initialSnapshot?.galleryGroups ?? [],
   );
-  const [galleryHasMore, setGalleryHasMore] = useState(snapshot?.galleryHasMore ?? false);
+  const [galleryHasMore, setGalleryHasMore] = useState(initialSnapshot?.galleryHasMore ?? false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-  // 已请求到的作品数（按页长推进，不按拿到的组数——没图的作品也占一组）
-  const galleryLoaded = useRef(snapshot?.galleryLoaded ?? 0);
+  // 这份图廊窗口的起点（与海报墙的 wallStart 同一个意思）
+  const galleryStart = useRef(initialSnapshot?.galleryStart ?? 0);
+  // 已请求到的作品数（绝对位置，按页长推进，不按拿到的组数——没图的作品也占一组）
+  const galleryLoaded = useRef(initialSnapshot?.galleryLoaded ?? 0);
   const galleryLoading = useRef(false);
   const galleryEntries = useMemo(() => flattenGallery(galleryGroups), [galleryGroups]);
 
@@ -194,20 +341,41 @@ export function FavoritesView() {
 
   /** 图廊窗口的对账，与海报墙的 reload 同一个意思（整窗重拉、整体替换）。 */
   const refreshGallery = useCallback(() => {
-    const loaded = galleryLoaded.current;
-    if (loaded <= 0 || galleryLoading.current) return;
+    const start = galleryStart.current;
+    const loadedGroups = galleryLoaded.current - start;
+    if (loadedGroups <= 0 || galleryLoading.current) return;
     galleryLoading.current = true; // 对账期间别让滚动哨兵同时追加下一页
     Promise.all(
-      Array.from({ length: Math.ceil(loaded / GALLERY_PAGE_SIZE) }, (_, page) =>
-        listFavoritesGallery({ limit: GALLERY_PAGE_SIZE, offset: page * GALLERY_PAGE_SIZE }),
+      Array.from({ length: Math.ceil(loadedGroups / GALLERY_PAGE_SIZE) }, (_, page) =>
+        listFavoritesGallery({
+          limit: GALLERY_PAGE_SIZE,
+          offset: start + page * GALLERY_PAGE_SIZE,
+        }),
       ),
     )
       .then((pages) => {
-        galleryLoaded.current = pages.reduce((sum, page) => sum + page.length, 0);
+        galleryLoaded.current = start + pages.reduce((sum, page) => sum + page.length, 0);
         setGalleryGroups(dedupeGalleryGroups(pages.flat()));
         setGalleryHasMore((pages.at(-1)?.length ?? 0) >= GALLERY_PAGE_SIZE);
       })
       .catch(() => undefined)
+      .finally(() => {
+        galleryLoading.current = false;
+      });
+  }, []);
+
+  /** 图廊跳到某个位置：与海报墙的 jumpTo 是同一件事——换掉整个窗口。 */
+  const jumpGalleryTo = useCallback((offset: number) => {
+    galleryLoading.current = true; // 跳转期间挡住滚动哨兵与对账，别让旧窗口的页插进来
+    galleryStart.current = offset;
+    listFavoritesGallery({ limit: GALLERY_PAGE_SIZE, offset })
+      .then((page) => {
+        galleryLoaded.current = offset + page.length;
+        setGalleryGroups(dedupeGalleryGroups(page));
+        setGalleryHasMore(page.length >= GALLERY_PAGE_SIZE);
+        wallTop.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+      })
+      .catch(() => {})
       .finally(() => {
         galleryLoading.current = false;
       });
@@ -252,15 +420,68 @@ export function FavoritesView() {
     snapshot = {
       items,
       total,
+      wallStart,
       galleryGroups,
       galleryHasMore,
+      galleryStart: galleryStart.current,
       galleryLoaded: galleryLoaded.current,
     };
-  }, [galleryGroups, galleryHasMore, items, total]);
+  }, [galleryGroups, galleryHasMore, items, total, wallStart]);
 
   // 收藏一部都没有时不给切换键：两种形态都是空页，多一颗键只会让人以为点了没反应
   const empty = items !== null && items.length === 0;
   const gallery = galleryPreferred && !empty;
+
+  /* —— 「回到上次浏览的位置」（lib/library-wall-recall.ts）——
+     收藏攒到几百部之后，滑到第几十屏是常态，关掉页面第二天再进来又从墙首
+     开始。底部弹一枚胶囊问一句：要跳回去点它，不要就继续滑——滑够一屏胶囊
+     自己让位，从那一刻起记的是新位置。会话内从详情页返回不弹（滚动恢复已经
+     自动回位）。 */
+  // 作品 id → 它在整份名单里的绝对位置。滚动时按首个可见格反查（图廊按瓦片
+  // 所属的作品），DOM 上只挂 id，不必给每一格再算一遍下标
+  const offsetById = useMemo(
+    () =>
+      new Map((items ?? []).map((item, index) => [String(item.media_item_id), wallStart + index])),
+    [items, wallStart],
+  );
+  // galleryStart 只在窗口被整体换掉时变，与 galleryGroups 同一时刻，不必进依赖
+  const galleryOffsetById = useMemo(
+    () =>
+      new Map(
+        galleryGroups.map((group, index) => [
+          String(group.media_item_id),
+          galleryStart.current + index,
+        ]),
+      ),
+    [galleryGroups],
+  );
+  const wallOffsetAt = useCallback(() => {
+    const wall = wallTop.current;
+    if (!wall || !scrollElement) return null;
+    const id = firstVisibleAnchorId(
+      wall,
+      gallery ? "data-gallery-item-id" : "data-library-item-id",
+      scrollElement.getBoundingClientRect().top,
+    );
+    return id === null ? null : ((gallery ? galleryOffsetById : offsetById).get(id) ?? null);
+  }, [gallery, galleryOffsetById, offsetById, scrollElement]);
+  // 久别回归时把这一屏复位：页面没重新加载，人还停在离开时的位置上，不回到
+  // 顶部的话胶囊指着的就是脚下这一格。瞬时而不是平滑——这是「重新进入」，
+  // 不是一次导航，几万像素的平滑动画只会让人以为页面失控了
+  const resetWallToTop = useCallback(() => {
+    scrollElement?.scrollTo({ top: 0, behavior: "instant" });
+  }, [scrollElement]);
+  const { recallOffset, dismissRecall } = useWallRecall({
+    scope: RECALL_SCOPE,
+    view: RECALL_VIEW,
+    scroller: scrollElement,
+    enabled: gallery ? galleryGroups.length > 0 : loaded > 0,
+    offer: freshEntry.current,
+    offsetAt: wallOffsetAt,
+    onReenter: resetWallToTop,
+  });
+  // 记录可能指向已经不存在的位置（收藏被大批取消），跳过去只会是一面空墙
+  const recallable = recallOffset !== null && recallOffset < total ? recallOffset : null;
 
   return (
     <div ref={scrollRef} className="scroll-thin scroll-safe flex-1 overflow-y-auto pb-10">
@@ -350,30 +571,33 @@ export function FavoritesView() {
 
         {items !== null && items.length > 0 && (
           <>
-            {gallery ? (
-              <div className="mt-6">
+            {/* overflow-anchor:none：向上补页后墙会长高，浏览器自带的滚动锚定
+                会跟着自己补一次 scrollTop，与我们按长高量做的补偿叠加就是跳两下
+                （何况 Safari 根本没有滚动锚定）。这一段的位置全部自己算 */}
+            <div ref={wallTop} className="mt-6 [overflow-anchor:none]">
+              {/* 墙顶还有上文时向上补页：跳「回到上次位置」之后仍然能往上滑 */}
+              {!gallery && <WallLoadPrev start={wallStart} onReach={loadPrev} />}
+              {gallery ? (
                 <VideoGalleryWall
                   groups={galleryGroups}
                   density={density}
                   grouped={galleryGrouped}
                   onOpen={setLightboxIndex}
                 />
-              </div>
-            ) : (
-              <div className="mt-6">
+              ) : (
                 <PosterWall
                   items={items}
                   libraryIdOf={ownerLibraryOf}
                   wide={false}
                   frameAspect={FAVORITES_FRAME_ASPECT}
                 />
-              </div>
-            )}
+              )}
+            </div>
             {/* 两种形态各自分页，哨兵按当前模式接线（图廊按作品数计） */}
             <WallLoadMore
               hasMore={gallery ? galleryHasMore : hasMore}
-              loaded={gallery ? galleryLoaded.current : loaded}
-              start={0}
+              loaded={gallery ? galleryLoaded.current - galleryStart.current : loaded}
+              start={gallery ? galleryStart.current : wallStart}
               total={total}
               onReach={gallery ? loadMoreGallery : loadMore}
               rootMargin={gallery ? GALLERY_LOAD_MARGIN : undefined}
@@ -381,6 +605,17 @@ export function FavoritesView() {
           </>
         )}
       </div>
+      {/* 上次滑到哪：进来时问一句要不要跳回去，不理它、往下滑一屏就自己消失 */}
+      {recallable !== null && (
+        <WallRecallPill
+          onJump={() => {
+            dismissRecall();
+            if (gallery) jumpGalleryTo(recallable);
+            else jumpTo(recallable);
+          }}
+          onDismiss={dismissRecall}
+        />
+      )}
       {gallery && lightboxIndex !== null && galleryEntries[lightboxIndex] && (
         <VideoGalleryLightbox
           entries={galleryEntries}

--- a/apps/web/components/favorites-view.tsx
+++ b/apps/web/components/favorites-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import type { Route } from "next";
@@ -34,6 +34,31 @@ import { useScrollRestoration } from "@/lib/use-scroll-restoration";
 
 /** 每次向服务端要的格数，与单库海报墙同一页长。 */
 const PAGE_SIZE = 60;
+
+/**
+ * 「全部收藏」页离开再返回时的会话快照。
+ *
+ * 与单库页的 lib/library-detail-snapshot.ts 是同一件事：这面墙与作品详情页是
+ * 两个路由，Next 切走时组件会被卸载。返回时若只补第一页，容器就矮到装不下
+ * 离开时的滚动位置，lib/use-scroll-restoration.ts 既找不到锚点、又等不到足够
+ * 的高度，超时后只能放弃——人被甩回墙首。这正是「收藏页没有滚动记忆、和别的
+ * 媒体库不一样」的由来（单库页早已有快照，收藏页一直没有）。
+ *
+ * 一个账号只有一面收藏墙，一份模块级快照就够，不必像单库页那样按 id 存 Map。
+ * 它只活在当前浏览会话里（刷新页面即失效），与滚动位置同一口径。
+ */
+interface FavoritesSnapshot {
+  /** 海报墙已加载的整个窗口（收藏墙不支持跳转，起点恒为 0） */
+  items: FavoriteItem[];
+  total: number;
+  /** 图床浏览模式已加载的整个窗口；空数组 = 这一次浏览没进过图廊 */
+  galleryGroups: LibraryGalleryGroup[];
+  galleryHasMore: boolean;
+  /** 已向服务端请求到第几个作品（图廊按作品分页，没图的作品也占一组） */
+  galleryLoaded: number;
+}
+
+let snapshot: FavoritesSnapshot | null = null;
 
 /** 本页 ⋯ 菜单的行样式（与全站各处菜单同一副长相）。 */
 const ITEM_CLASS =
@@ -79,11 +104,14 @@ export function FavoritesView() {
   const scrollRef = useScrollRestoration("library:favorites", {
     anchorAttribute: galleryPreferred ? "data-gallery-tile-id" : "data-library-item-id",
   });
-  const [items, setItems] = useState<FavoriteItem[] | null>(null);
-  const [total, setTotal] = useState(0);
+  // 首帧就把上次的窗口接回来，滚动恢复才有落脚的高度
+  const [items, setItems] = useState<FavoriteItem[] | null>(snapshot?.items ?? null);
+  const [total, setTotal] = useState(snapshot?.total ?? 0);
   const [failed, setFailed] = useState(false);
   // 翻页请求进行中：哨兵重新观察时不重复发同一页
   const loading = useRef(false);
+  // 进这一屏时快照里有多少格（挂载后本组件自己就会改写 snapshot，得先定格）
+  const restoredCount = useRef(snapshot?.items.length ?? 0);
 
   const load = useCallback(async (offset: number) => {
     if (loading.current) return;
@@ -100,9 +128,34 @@ export function FavoritesView() {
     }
   }, []);
 
+  /**
+   * 按已加载的页数重拉整个窗口并整体替换：快照恢复出来的是离开这一屏时的旧
+   * 数据，在详情页取消了收藏的那部要跟着消失。不缩窗口、不动滚动位置；请求
+   * 失败就留着旧窗口，下次返回再对账。
+   */
+  const reload = useCallback(async (loadedCount: number) => {
+    if (loading.current) return;
+    loading.current = true;
+    try {
+      const pages = await Promise.all(
+        Array.from({ length: Math.ceil(loadedCount / PAGE_SIZE) }, (_, page) =>
+          listFavorites(PAGE_SIZE, page * PAGE_SIZE),
+        ),
+      );
+      setTotal(pages[0].total);
+      setItems(pages.flatMap((page) => page.items));
+      setFailed(false);
+    } catch {
+      setFailed(true);
+    } finally {
+      loading.current = false;
+    }
+  }, []);
+
   useEffect(() => {
-    void load(0);
-  }, [load]);
+    if (restoredCount.current > 0) void reload(restoredCount.current);
+    else void load(0);
+  }, [load, reload]);
 
   const loaded = items?.length ?? 0;
   const hasMore = items !== null && loaded < total;
@@ -113,11 +166,13 @@ export function FavoritesView() {
   }, [load, loaded]);
 
   // —— 图床浏览模式 —— //
-  const [galleryGroups, setGalleryGroups] = useState<LibraryGalleryGroup[]>([]);
-  const [galleryHasMore, setGalleryHasMore] = useState(false);
+  const [galleryGroups, setGalleryGroups] = useState<LibraryGalleryGroup[]>(
+    snapshot?.galleryGroups ?? [],
+  );
+  const [galleryHasMore, setGalleryHasMore] = useState(snapshot?.galleryHasMore ?? false);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   // 已请求到的作品数（按页长推进，不按拿到的组数——没图的作品也占一组）
-  const galleryLoaded = useRef(0);
+  const galleryLoaded = useRef(snapshot?.galleryLoaded ?? 0);
   const galleryLoading = useRef(false);
   const galleryEntries = useMemo(() => flattenGallery(galleryGroups), [galleryGroups]);
 
@@ -137,12 +192,36 @@ export function FavoritesView() {
       });
   }, []);
 
-  // 切进图廊（或进页面时偏好就在图廊）：拉第一页。海报墙那一份照常自己拉，
-  // 切回去时首屏已经在手上
+  /** 图廊窗口的对账，与海报墙的 reload 同一个意思（整窗重拉、整体替换）。 */
+  const refreshGallery = useCallback(() => {
+    const loaded = galleryLoaded.current;
+    if (loaded <= 0 || galleryLoading.current) return;
+    galleryLoading.current = true; // 对账期间别让滚动哨兵同时追加下一页
+    Promise.all(
+      Array.from({ length: Math.ceil(loaded / GALLERY_PAGE_SIZE) }, (_, page) =>
+        listFavoritesGallery({ limit: GALLERY_PAGE_SIZE, offset: page * GALLERY_PAGE_SIZE }),
+      ),
+    )
+      .then((pages) => {
+        galleryLoaded.current = pages.reduce((sum, page) => sum + page.length, 0);
+        setGalleryGroups(dedupeGalleryGroups(pages.flat()));
+        setGalleryHasMore((pages.at(-1)?.length ?? 0) >= GALLERY_PAGE_SIZE);
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        galleryLoading.current = false;
+      });
+  }, []);
+
+  // 切进图廊（或进页面时偏好就在图廊）：第一次从头拉一页；快照带回窗口时
+  // **不能**清空重拉——只补第一页的话容器矮到装不下离开时的滚动位置，人被
+  // 甩回墙首（与单库页同一处理），改成按已加载的页数整窗对账。
+  // 海报墙那一份照常自己拉，切回去时首屏已经在手上
   useEffect(() => {
-    if (!galleryPreferred || galleryLoaded.current > 0) return;
-    loadMoreGallery();
-  }, [galleryPreferred, loadMoreGallery]);
+    if (!galleryPreferred) return;
+    if (galleryLoaded.current > 0) refreshGallery();
+    else loadMoreGallery();
+  }, [galleryPreferred, loadMoreGallery, refreshGallery]);
 
   /**
    * 灯箱里点心：取消收藏后**不把瓦片抽走**——正在看的这张图连同它所在的那一段
@@ -165,6 +244,19 @@ export function FavoritesView() {
     },
     [toast],
   );
+
+  // 布局提交后就更新快照，路由切换的下一棵树可以在首帧直接读到它；只在卸载
+  // 时写是来不及的——新路由的首次 render 可能早于被动 effect 的 cleanup
+  useLayoutEffect(() => {
+    if (items === null) return;
+    snapshot = {
+      items,
+      total,
+      galleryGroups,
+      galleryHasMore,
+      galleryLoaded: galleryLoaded.current,
+    };
+  }, [galleryGroups, galleryHasMore, items, total]);
 
   // 收藏一部都没有时不给切换键：两种形态都是空页，多一颗键只会让人以为点了没反应
   const empty = items !== null && items.length === 0;

--- a/apps/web/components/favorites-view.tsx
+++ b/apps/web/components/favorites-view.tsx
@@ -7,7 +7,7 @@ import type { Route } from "next";
 
 import { useToast } from "@/components/feedback";
 import { MasonryIcon, MoreIcon, PosterGridIcon } from "@/components/icons";
-import { WallLoadMore, WallLoadPrev, WallRecallPill } from "@/components/library-detail-view";
+import { WallLoadMore, WallLoadPrev, WallRecallPill } from "@/components/wall-chrome";
 import { PosterWall } from "@/components/poster-wall";
 import { PAGE_NAV_BUTTON_CLASS, PageNav } from "@/components/page-nav";
 import { remeasureWalls, usePhotoWallDensity } from "@/components/photo-wall";

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -1964,8 +1964,9 @@ function MetadataRefreshPanel({
  *
  * z-[45]：压过墙与索引条，但低于弹层（50/60）、灯箱（70）与 Toast（95）——
  * 它只是个建议，任何真正的操作都该盖住它。
+ * 「全部收藏」页弹的是同一枚胶囊。
  */
-function WallRecallPill({ onJump, onDismiss }: { onJump: () => void; onDismiss: () => void }) {
+export function WallRecallPill({ onJump, onDismiss }: { onJump: () => void; onDismiss: () => void }) {
   return (
     <div
       aria-live="polite"
@@ -2066,8 +2067,9 @@ export function WallLoadMore({
  * 零高度、不显示加载态：它加在墙**上方**，一旦露出加载文案就要把整墙往下推，
  * 与前置加载自己的滚动补偿打架。补页要么已经提前到位，要么慢一点到——不会
  * 出现"卡住不动"的画面。
+ * 「全部收藏」页的墙同样用它向上补页。
  */
-function WallLoadPrev({ start, onReach }: { start: number; onReach: () => void }) {
+export function WallLoadPrev({ start, onReach }: { start: number; onReach: () => void }) {
   const sentinel = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const target = sentinel.current;

--- a/apps/web/components/library-detail-view.tsx
+++ b/apps/web/components/library-detail-view.tsx
@@ -16,7 +16,6 @@ import {
 import { chapterJobLabel } from "@/lib/library-manage";
 import {
   CheckIcon,
-  HistoryIcon,
   LockIcon,
   MasonryIcon,
   MoreIcon,
@@ -38,6 +37,7 @@ import {
   type PhotoWallDensity,
 } from "@/components/photo-wall";
 import { PosterCardVisual, type PosterVisualItem } from "@/components/poster-card";
+import { WallLoadMore, WallLoadPrev, WallRecallPill } from "@/components/wall-chrome";
 import { InventoryCell, PosterWall, WALL_GRID_WIDE } from "@/components/poster-wall";
 import {
   GALLERY_LOAD_MARGIN,
@@ -1951,146 +1951,6 @@ function MetadataRefreshPanel({
         全量重刷：重拉 TMDB 档案、按当前尺寸重下图片、覆盖媒体目录镜像；
         你手动选定的图不受影响
       </p>
-    </div>
-  );
-}
-
-/**
- * 「回到上次浏览的位置」胶囊：贴在视口底部中央，与 Toast 同一套浮入语言。
- *
- * 为什么是胶囊而不是直接跳回去：跳转会换掉整个分页窗口（上方的内容要往上滑
- * 才补回来），这一步得由用户决定——有人回来就是想从头看看新入库了什么。所以只问一句，
- * 不理它往下滑一屏它就让位（见 lib/use-wall-recall.ts），× 是给想立刻清屏的人。
- *
- * z-[45]：压过墙与索引条，但低于弹层（50/60）、灯箱（70）与 Toast（95）——
- * 它只是个建议，任何真正的操作都该盖住它。
- * 「全部收藏」页弹的是同一枚胶囊。
- */
-export function WallRecallPill({ onJump, onDismiss }: { onJump: () => void; onDismiss: () => void }) {
-  return (
-    <div
-      aria-live="polite"
-      className="pointer-events-none fixed inset-x-0 bottom-[calc(var(--safe-bottom)+18px)] z-[45] flex justify-center px-4"
-    >
-      <div className="toast-item pointer-events-auto flex items-center gap-1 rounded-full border border-white/[0.12] bg-[rgba(16,18,26,0.92)] py-1 pl-1 pr-1.5 shadow-[0_18px_50px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
-        <button
-          type="button"
-          onClick={onJump}
-          className="flex items-center gap-2 rounded-full px-3 py-1.5 text-sub font-medium text-white/90 transition hover:bg-white/[0.1] active:scale-[0.98]"
-        >
-          <HistoryIcon className="size-4 shrink-0 text-[var(--accent)]" />
-          回到上次浏览的位置
-        </button>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="不用了"
-          className="flex size-7 shrink-0 items-center justify-center rounded-full text-white/45 transition hover:bg-white/[0.1] hover:text-white/80"
-        >
-          <XIcon className="size-3.5" />
-        </button>
-      </div>
-    </div>
-  );
-}
-
-/**
- * 海报墙底部的滚动加载哨兵。
- *
- * 提前 600px 触发下一页，正常滚动速度下新一批在滚到底之前就已到位，看不出
- * 分页。已加载数变化后重新观察：一页塞不满视口时哨兵仍在屏内，重新观察会
- * 立刻再触发一次，直到填满或到底——否则墙会停在半屏、再也不加载。
- * 「全部收藏」页的墙同样用它翻页。
- */
-export function WallLoadMore({
-  hasMore,
-  loaded,
-  start,
-  total,
-  onReach,
-  rootMargin = "600px 0px",
-}: {
-  hasMore: boolean;
-  loaded: number;
-  /** 当前窗口在整份排序里的起点（跳字母后不为 0），决定进度文案的口径 */
-  start: number;
-  total: number;
-  onReach: () => void;
-  /**
-   * 提前多远开始取下一页。海报墙 600px（约半屏）够用：格子小、图也小，到底
-   * 那一下基本无感。图床浏览模式要给得更宽——一页只有二十几部作品但每张图
-   * 都大，等滑到底再发请求，接上来的一屏全是还在下载的空瓦片。
-   */
-  rootMargin?: string;
-}) {
-  const sentinel = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const target = sentinel.current;
-    if (!target || !hasMore) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) onReach();
-      },
-      { rootMargin },
-    );
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [hasMore, loaded, onReach, rootMargin]);
-
-  return (
-    <div
-      ref={sentinel}
-      className="mt-8 flex h-10 items-center justify-center text-sub text-[var(--text-muted)]"
-      aria-live="polite"
-    >
-      {hasMore ? (
-        <>
-          {/* 转圈：这一条原先只有一行字，静止不动时看着像卡住了 */}
-          <span
-            aria-hidden="true"
-            className="mr-2 size-3.5 animate-spin rounded-full border-2 border-white/15 border-t-white/60 motion-reduce:animate-none"
-          />
-          {`加载中…（第 ${start + 1}–${start + loaded} 部 / 共 ${Math.max(total, start + loaded)}）`}
-        </>
-      ) : null}
-    </div>
-  );
-}
-
-/**
- * 海报墙顶部的向上加载哨兵（与底部的 WallLoadMore 对称）。
- *
- * 窗口起点不为 0 时才挂（跳字母 / 回到上次位置之后）。提前 600px 触发，正常
- * 上滑速度下上一页在滑到墙顶之前就已到位；跳转刚落地时墙顶正贴着视口顶边，
- * 它会立刻补一页，于是"跳过去马上往上滑"也是有内容的。
- *
- * 零高度、不显示加载态：它加在墙**上方**，一旦露出加载文案就要把整墙往下推，
- * 与前置加载自己的滚动补偿打架。补页要么已经提前到位，要么慢一点到——不会
- * 出现"卡住不动"的画面。
- * 「全部收藏」页的墙同样用它向上补页。
- */
-export function WallLoadPrev({ start, onReach }: { start: number; onReach: () => void }) {
-  const sentinel = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const target = sentinel.current;
-    if (!target || start <= 0) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) onReach();
-      },
-      { rootMargin: "600px 0px" },
-    );
-    observer.observe(target);
-    return () => observer.disconnect();
-    // start 每补一页就变一次：重新观察，够到墙顶就接着往上补
-  }, [onReach, start]);
-
-  return (
-    // 外层零高度：哨兵在墙**上方**，占哪怕一像素都要把整面墙推下去。里面那块
-    // 绝对定位、给足 1px——IntersectionObserver 对零面积目标的判定各家浏览器
-    // 并不一致，有一点真实面积才稳
-    <div aria-hidden="true" className="relative h-0">
-      <div ref={sentinel} className="absolute inset-x-0 top-0 h-px" />
     </div>
   );
 }

--- a/apps/web/components/wall-chrome.tsx
+++ b/apps/web/components/wall-chrome.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { HistoryIcon, XIcon } from "@/components/icons";
+
+/**
+ * 一面墙的三个通用部件：底部滚动加载哨兵、顶部向上补页哨兵、
+ * 「回到上次浏览的位置」胶囊。
+ *
+ * 它们原先长在单库页里（components/library-detail-view.tsx），「全部收藏」页
+ * 接同一套位置记忆时是从那个文件 import 出来用的——公共件寄居在某一个页面
+ * 文件里，谁都得绕道那边。搬到这里，两页平级引用。
+ *
+ * 三者都只管「墙的边框」，不碰数据：分页窗口怎么取、位置记在哪，仍由各页
+ * 自己的状态机决定（lib/library-wall-recall.ts 负责跨会话那一层）。
+ */
+
+/**
+ * 海报墙底部的滚动加载哨兵。
+ *
+ * 提前 600px 触发下一页，正常滚动速度下新一批在滚到底之前就已到位，看不出
+ * 分页。已加载数变化后重新观察：一页塞不满视口时哨兵仍在屏内，重新观察会
+ * 立刻再触发一次，直到填满或到底——否则墙会停在半屏、再也不加载。
+ * 「全部收藏」页的墙同样用它翻页。
+ */
+export function WallLoadMore({
+  hasMore,
+  loaded,
+  start,
+  total,
+  onReach,
+  rootMargin = "600px 0px",
+}: {
+  hasMore: boolean;
+  loaded: number;
+  /** 当前窗口在整份排序里的起点（跳字母后不为 0），决定进度文案的口径 */
+  start: number;
+  total: number;
+  onReach: () => void;
+  /**
+   * 提前多远开始取下一页。海报墙 600px（约半屏）够用：格子小、图也小，到底
+   * 那一下基本无感。图床浏览模式要给得更宽——一页只有二十几部作品但每张图
+   * 都大，等滑到底再发请求，接上来的一屏全是还在下载的空瓦片。
+   */
+  rootMargin?: string;
+}) {
+  const sentinel = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const target = sentinel.current;
+    if (!target || !hasMore) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) onReach();
+      },
+      { rootMargin },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasMore, loaded, onReach, rootMargin]);
+
+  return (
+    <div
+      ref={sentinel}
+      className="mt-8 flex h-10 items-center justify-center text-sub text-[var(--text-muted)]"
+      aria-live="polite"
+    >
+      {hasMore ? (
+        <>
+          {/* 转圈：这一条原先只有一行字，静止不动时看着像卡住了 */}
+          <span
+            aria-hidden="true"
+            className="mr-2 size-3.5 animate-spin rounded-full border-2 border-white/15 border-t-white/60 motion-reduce:animate-none"
+          />
+          {`加载中…（第 ${start + 1}–${start + loaded} 部 / 共 ${Math.max(total, start + loaded)}）`}
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * 海报墙顶部的向上加载哨兵（与底部的 WallLoadMore 对称）。
+ *
+ * 窗口起点不为 0 时才挂（跳字母 / 回到上次位置之后）。提前 600px 触发，正常
+ * 上滑速度下上一页在滑到墙顶之前就已到位；跳转刚落地时墙顶正贴着视口顶边，
+ * 它会立刻补一页，于是"跳过去马上往上滑"也是有内容的。
+ *
+ * 零高度、不显示加载态：它加在墙**上方**，一旦露出加载文案就要把整墙往下推，
+ * 与前置加载自己的滚动补偿打架。补页要么已经提前到位，要么慢一点到——不会
+ * 出现"卡住不动"的画面。
+ * 「全部收藏」页的墙同样用它向上补页。
+ */
+export function WallLoadPrev({ start, onReach }: { start: number; onReach: () => void }) {
+  const sentinel = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const target = sentinel.current;
+    if (!target || start <= 0) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) onReach();
+      },
+      { rootMargin: "600px 0px" },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+    // start 每补一页就变一次：重新观察，够到墙顶就接着往上补
+  }, [onReach, start]);
+
+  return (
+    // 外层零高度：哨兵在墙**上方**，占哪怕一像素都要把整面墙推下去。里面那块
+    // 绝对定位、给足 1px——IntersectionObserver 对零面积目标的判定各家浏览器
+    // 并不一致，有一点真实面积才稳
+    <div aria-hidden="true" className="relative h-0">
+      <div ref={sentinel} className="absolute inset-x-0 top-0 h-px" />
+    </div>
+  );
+}
+
+/**
+ * 「回到上次浏览的位置」胶囊：贴在视口底部中央，与 Toast 同一套浮入语言。
+ *
+ * 为什么是胶囊而不是直接跳回去：跳转会换掉整个分页窗口（上方的内容要往上滑
+ * 才补回来），这一步得由用户决定——有人回来就是想从头看看新入库了什么。所以只问一句，
+ * 不理它往下滑一屏它就让位（见 lib/use-wall-recall.ts），× 是给想立刻清屏的人。
+ *
+ * z-[45]：压过墙与索引条，但低于弹层（50/60）、灯箱（70）与 Toast（95）——
+ * 它只是个建议，任何真正的操作都该盖住它。
+ * 「全部收藏」页弹的是同一枚胶囊。
+ */
+export function WallRecallPill({ onJump, onDismiss }: { onJump: () => void; onDismiss: () => void }) {
+  return (
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 bottom-[calc(var(--safe-bottom)+18px)] z-[45] flex justify-center px-4"
+    >
+      <div className="toast-item pointer-events-auto flex items-center gap-1 rounded-full border border-white/[0.12] bg-[rgba(16,18,26,0.92)] py-1 pl-1 pr-1.5 shadow-[0_18px_50px_rgba(0,0,0,0.55)] backdrop-blur-2xl">
+        <button
+          type="button"
+          onClick={onJump}
+          className="flex items-center gap-2 rounded-full px-3 py-1.5 text-sub font-medium text-white/90 transition hover:bg-white/[0.1] active:scale-[0.98]"
+        >
+          <HistoryIcon className="size-4 shrink-0 text-[var(--accent)]" />
+          回到上次浏览的位置
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="不用了"
+          className="flex size-7 shrink-0 items-center justify-center rounded-full text-white/45 transition hover:bg-white/[0.1] hover:text-white/80"
+        >
+          <XIcon className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/library-detail-snapshot.ts
+++ b/apps/web/lib/library-detail-snapshot.ts
@@ -10,6 +10,7 @@ import type {
   UnidentifiedGroup,
 } from "@/lib/api/libraries";
 import type { Subscription } from "@/lib/api/subscriptions";
+import { createSessionSnapshots } from "@/lib/session-snapshot";
 
 /**
  * 单库页离开再返回时的会话快照。
@@ -48,8 +49,8 @@ export interface LibraryDetailSnapshot {
   stale: boolean;
 }
 
-const MAX_LIBRARY_DETAIL_SNAPSHOTS = 20;
-const snapshots = new Map<number, LibraryDetailSnapshot>();
+// 一库一条，超限时优先淘汰最久未更新的库（见 lib/session-snapshot.ts）
+const snapshots = createSessionSnapshots<number, LibraryDetailSnapshot>(20);
 
 export function getLibraryDetailSnapshot(libraryId: number) {
   return snapshots.get(libraryId);
@@ -59,14 +60,7 @@ export function setLibraryDetailSnapshot(
   libraryId: number,
   snapshot: LibraryDetailSnapshot,
 ) {
-  // 重新写入时移到 Map 尾部，超限时优先淘汰最久未更新的库。
-  snapshots.delete(libraryId);
   snapshots.set(libraryId, snapshot);
-  while (snapshots.size > MAX_LIBRARY_DETAIL_SNAPSHOTS) {
-    const oldest = snapshots.keys().next().value;
-    if (oldest === undefined) break;
-    snapshots.delete(oldest);
-  }
 }
 
 /**

--- a/apps/web/lib/library-wall-recall.ts
+++ b/apps/web/lib/library-wall-recall.ts
@@ -92,8 +92,13 @@ function writeAll(store: KeyValueStorage, rows: Record<string, WallRecall>) {
   }
 }
 
-/** 一面墙的记录键：单库页是 `library:12`。 */
-export function wallRecallScope(libraryId: number): string {
+/**
+ * 一面墙的记录键：单库页是 `library:12`，「全部收藏」页是 `library:favorites`。
+ *
+ * 与会话内滚动恢复用的键同一副长相（lib/use-scroll-restoration.ts），两处一眼
+ * 对得上；收藏墙不是某个库，所以这里收一个 "favorites" 字面量而不是库 id。
+ */
+export function wallRecallScope(libraryId: number | "favorites"): string {
   return `library:${libraryId}`;
 }
 

--- a/apps/web/lib/session-snapshot.ts
+++ b/apps/web/lib/session-snapshot.ts
@@ -1,0 +1,52 @@
+/**
+ * 会话快照的通用存放处：一个带上限的「最近用过的留下」小仓库。
+ *
+ * 为什么全站需要它：列表页与详情页是两个路由，Next 切走时列表组件会被卸载。
+ * 返回时若从零重新加载，已加载的分页窗口就没了——容器矮到装不下离开时的滚动
+ * 位置，滚动恢复（lib/use-scroll-restoration.ts）找不到落脚点，人被甩回列表首。
+ * 所以每一面墙都要把「离开时的那一屏」留在内存里，返回时先接回来再与服务端对账。
+ *
+ * 这件事本身各页都一样，只有存什么不一样，于是收成这一份：调用方给出上限和
+ * 自己的快照类型，拿到 get / set 两个口子。写入时把这一条移到队尾，超限时淘汰
+ * 最久没写过的那一条——用户在几十个列表间来回导航时条目不会无限增长。
+ *
+ * **只活在当前浏览会话里**（模块级内存，不写 localStorage）：刷新页面即失效。
+ * 位置与窗口都属于一次导航上下文，刷新后从列表顶部重新开始才符合预期；跨会话
+ * 的位置记忆是另一件事，走 lib/library-wall-recall.ts 的胶囊问一句。
+ *
+ * 纯逻辑模块，`node --test` 直接跑。
+ */
+
+export interface SessionSnapshots<K, V> {
+  /** 没存过（或已被淘汰）时返回 undefined，调用方据此走完整加载。 */
+  get(key: K): V | undefined;
+  set(key: K, value: V): void;
+  /** 当前存着几条（测试与调试用）。 */
+  readonly size: number;
+}
+
+/**
+ * 建一个上限为 `capacity` 的快照仓库。
+ *
+ * key 用什么由调用方定：单库页用库 id，片单页用片单引用，滚动位置用列表键。
+ * 同一个 key 重复写入是覆盖，并把它当作「刚用过」。
+ */
+export function createSessionSnapshots<K, V>(capacity: number): SessionSnapshots<K, V> {
+  const entries = new Map<K, V>();
+  return {
+    get: (key) => entries.get(key),
+    set(key, value) {
+      // 先删再插：Map 按插入顺序迭代，这样队首恒是最久没写过的那一条
+      entries.delete(key);
+      entries.set(key, value);
+      while (entries.size > capacity) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) break;
+        entries.delete(oldest);
+      }
+    },
+    get size() {
+      return entries.size;
+    },
+  };
+}

--- a/apps/web/lib/use-scroll-restoration.ts
+++ b/apps/web/lib/use-scroll-restoration.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useLayoutEffect, useState } from "react";
 
+import { createSessionSnapshots } from "@/lib/session-snapshot";
+
 /**
  * 列表页的滚动位置只在当前浏览会话内保留，不写入 localStorage：
  * 位置属于一次导航上下文，刷新页面后重新从列表顶部开始更符合预期。
@@ -17,21 +19,10 @@ interface ScrollPosition {
   anchor?: ScrollAnchor;
 }
 
-const positions = new Map<string, ScrollPosition>();
-const MAX_SCROLL_POSITIONS = 100;
+// 位置只服务于当前浏览会话，超限按最久未写入淘汰（见 lib/session-snapshot.ts）
+const positions = createSessionSnapshots<string, ScrollPosition>(100);
 const MAX_RESTORE_MS = 5000;
 const MAX_ANCHOR_SETTLE_MS = 800;
-
-function rememberScrollPosition(key: string, position: ScrollPosition) {
-  // 位置只服务于当前浏览会话，限制条目数避免用户在大量列表间导航时无限增长。
-  positions.delete(key);
-  positions.set(key, position);
-  while (positions.size > MAX_SCROLL_POSITIONS) {
-    const oldest = positions.keys().next().value;
-    if (oldest === undefined) break;
-    positions.delete(oldest);
-  }
-}
 
 function isEditableTarget(target: EventTarget | null) {
   if (!(target instanceof Element)) return false;
@@ -133,7 +124,7 @@ export function useScrollRestoration(key: string, options: ScrollRestorationOpti
         } else {
           // 数据最终不足以撑到旧位置时，放弃旧值，让之后的真实滚动继续记忆。
           pendingPosition = undefined;
-          rememberScrollPosition(key, capturePosition());
+          positions.set(key, capturePosition());
         }
         return;
       }
@@ -153,7 +144,7 @@ export function useScrollRestoration(key: string, options: ScrollRestorationOpti
     const remember = () => {
       // 等待异步列表数据期间，忽略框架初始化的归零滚动，保住本次返回目标。
       if (pendingPosition != null) return;
-      rememberScrollPosition(key, capturePosition());
+      positions.set(key, capturePosition());
     };
     const resizes =
       typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleRestore);

--- a/apps/web/test/library-wall-recall.test.mjs
+++ b/apps/web/test/library-wall-recall.test.mjs
@@ -45,6 +45,16 @@ test("换了墙的形态就当作没记过（同一个位置指向的不是同�
   assert.equal(readWallRecall(wallRecallScope(8), "wall:title", storage, NOW), null);
 });
 
+test("收藏墙是独立的一面墙，与任何库的记录互不串门", () => {
+  const storage = memoryStorage();
+  const favorites = wallRecallScope("favorites");
+  assert.equal(favorites, "library:favorites");
+  writeWallRecall(favorites, "favorites", 300, storage, NOW);
+  writeWallRecall(SCOPE, "wall:title", 320, storage, NOW);
+  assert.equal(readWallRecall(favorites, "favorites", storage, NOW)?.offset, 300);
+  assert.equal(readWallRecall(SCOPE, "wall:title", storage, NOW)?.offset, 320);
+});
+
 test("太浅的位置不提示：一两屏用户自己滑更快", () => {
   const storage = memoryStorage();
   writeWallRecall(SCOPE, "wall:title", RECALL_MIN_OFFSET - 1, storage, NOW);

--- a/apps/web/test/session-snapshot.test.mjs
+++ b/apps/web/test/session-snapshot.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createSessionSnapshots } from "../lib/session-snapshot.ts";
+
+test("存进去的快照按同一个 key 取得回来，没存过的是 undefined", () => {
+  const snapshots = createSessionSnapshots(3);
+  snapshots.set("a", { items: [1, 2] });
+  assert.deepEqual(snapshots.get("a"), { items: [1, 2] });
+  assert.equal(snapshots.get("b"), undefined);
+});
+
+test("同一个 key 是覆盖，不是新增一条", () => {
+  const snapshots = createSessionSnapshots(3);
+  snapshots.set("a", 1);
+  snapshots.set("a", 2);
+  assert.equal(snapshots.get("a"), 2);
+  assert.equal(snapshots.size, 1);
+});
+
+test("超限时淘汰最久没写过的那一条", () => {
+  const snapshots = createSessionSnapshots(2);
+  snapshots.set("a", 1);
+  snapshots.set("b", 2);
+  snapshots.set("c", 3);
+  assert.equal(snapshots.size, 2);
+  assert.equal(snapshots.get("a"), undefined);
+  assert.equal(snapshots.get("b"), 2);
+  assert.equal(snapshots.get("c"), 3);
+});
+
+test("重新写入算「刚用过」，下一次淘汰轮不到它", () => {
+  const snapshots = createSessionSnapshots(2);
+  snapshots.set("a", 1);
+  snapshots.set("b", 2);
+  snapshots.set("a", 11); // a 回到队尾，队首变成 b
+  snapshots.set("c", 3);
+  assert.equal(snapshots.get("a"), 11);
+  assert.equal(snapshots.get("b"), undefined);
+});
+
+test("读取不改变淘汰顺序：只有写入算「用过」", () => {
+  // 墙每次滚动都会写快照，读只发生在返回那一刻——按写入排序足够，也更好预测
+  const snapshots = createSessionSnapshots(2);
+  snapshots.set("a", 1);
+  snapshots.set("b", 2);
+  snapshots.get("a");
+  snapshots.set("c", 3);
+  assert.equal(snapshots.get("a"), undefined);
+});
+
+test("上限为 1 时永远只留最后写入的那一条", () => {
+  const snapshots = createSessionSnapshots(1);
+  snapshots.set("a", 1);
+  snapshots.set("b", 2);
+  assert.equal(snapshots.size, 1);
+  assert.equal(snapshots.get("b"), 2);
+});

--- a/scripts/perf/e2e_favorites_recall.py
+++ b/scripts/perf/e2e_favorites_recall.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""「全部收藏」页位置记忆的端到端验收（Playwright + Chromium，真实浏览器）。
+
+验的是两层位置记忆在真实浏览器里到底成不成立（设计见 apps/web 里
+lib/use-scroll-restoration.ts 与 lib/library-wall-recall.ts）：
+
+    A. 会话内：滚到第 N 屏 → 进作品详情 → 返回 → 位置与窗口条数都在
+    B. 数据变了也在：在详情页取消收藏 → 返回 → 那一部消失、位置仍在
+    C. 跨会话：写一条旧记录 → 重新打开这一页 → 底部弹胶囊 → 点它跳过去
+    D. 跳过去还能往上滑：墙顶哨兵把上文补回来，窗口起点回到 0
+    E. 图床浏览模式同样保持（锚点换成瓦片，窗口同样整份接回来）
+
+为什么必须用真实浏览器：这几件事全部发生在「Next 卸载组件 → 新组件挂载 →
+虚拟化窗口重新量测 → 图片撑开高度」这条真实时间线上，jsdom 与单测都复现不出来。
+
+数据自带（--seed）：直接往已跑过 alembic 迁移的 SQLite 里灌一个库 + 若干部
+作品 + 对应的收藏行。与 scripts/perf/seed_library_dataset.py 同一条思路——
+读路径只关心落库的行，不必走真实扫描管线。
+
+用法::
+
+    # 1. 建库并灌数据（一次就够）
+    .venv/bin/alembic upgrade head
+    python scripts/perf/e2e_favorites_recall.py --seed --db data/movieclaw.db
+
+    # 2. 起后端与前端（另开两个终端）
+    .venv/bin/uvicorn movieclaw_api.main:app --port 8000
+    pnpm --filter web build && pnpm --filter web exec next start -p 3000
+
+    # 3. 首次需要一个管理员账号（已有就跳过）
+    curl -X POST localhost:8000/api/v1/auth/bootstrap -H 'Content-Type: application/json' \
+        -d '{"username":"admin","password":"movieclaw-e2e"}'
+
+    # 4. 跑验收（每次跑之前重新灌一遍数据，断言才有确定的起点）
+    python scripts/perf/e2e_favorites_recall.py \
+        --web http://127.0.0.1:3000 --user admin --password 'movieclaw-e2e'
+
+改动前后都要跑一遍：把 favorites-view.tsx 换回修复前的版本重新构建，
+A / C / E 必须**失败**（位置回到墙首、墙缩回一页、胶囊不出现）——测不出差别的
+验收等于没验收。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import glob
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+
+# —— 数据集形状 ——
+# 收藏数刻意跨过好几页：前端一页 60 格（PAGE_SIZE），要让「返回时只补第一页
+# 就装不下离开时的位置」这个 bug 真的能复现，收藏必须远多于一页。
+FAVORITE_COUNT = 320
+LIBRARY_ID = 1
+NOW = datetime(2026, 9, 1, 12, 0, 0)
+
+
+def _write_assets(assets_root, item_id: int) -> tuple[str, str]:
+    """给一部作品画一张海报和一张剧照（纯色 JPEG，几百字节）。
+
+    为什么非要有真图：图廊模式的一组就是一部作品的图，没有图就没有瓦片，
+    那一半功能根本测不到；海报墙这边也一样——真实的「图片解码撑开高度」正是
+    滚动恢复要熬过去的那段时间窗，用占位方块测等于把最难的部分绕开了。
+    """
+    from PIL import Image
+
+    folder = assets_root / str(item_id)
+    folder.mkdir(parents=True, exist_ok=True)
+    tone = (item_id * 37 % 200 + 40, item_id * 53 % 200 + 40, item_id * 71 % 200 + 40)
+    Image.new("RGB", (200, 300), tone).save(folder / "poster.jpg", quality=60)
+    Image.new("RGB", (320, 180), tone).save(folder / "backdrop.jpg", quality=60)
+    return f"{item_id}/poster.jpg", f"{item_id}/backdrop.jpg"
+
+
+def seed(db_path: str, assets_dir: str) -> None:
+    """灌一个库 + FAVORITE_COUNT 部电影 + 每部一行收藏 + 每部两张图。
+
+    收藏顺序由 playback_state.updated_at 倒序决定（服务端就是这么排的），
+    这里让第 i 部的 updated_at 依次递减，于是墙上的顺序恒等于「测试收藏 001、
+    002、003……」——断言里可以直接按片名认位置。
+    """
+    from pathlib import Path
+
+    assets_root = Path(assets_dir)
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys=OFF")
+    cur = conn.cursor()
+    for table in ("playback_state", "library_file", "media_metadata", "media_item", "library"):
+        cur.execute(f"DELETE FROM {table}")
+
+    ts = NOW.isoformat(sep=" ")
+    cur.execute(
+        "INSERT INTO library (id,name,kind,root_paths,is_default,sort_order,"
+        "stats_item_count,stats_episode_count,stats_file_count,stats_total_size_bytes,"
+        "stats_unidentified_count,stats_missing_count,stats_ignored_count,"
+        "stats_refreshed_at,created_at,updated_at,match_rules,write_media_assets,"
+        "auto_clear_missing,realtime_watch) "
+        f"VALUES ({LIBRARY_ID},'端到端电影库','movie','[\"/media/e2e\"]',1,1,"
+        f"{FAVORITE_COUNT},0,{FAVORITE_COUNT},0,0,0,0,?,?,?,'[]',1,0,0)",
+        (ts, ts, ts),
+    )
+
+    items, files, marks, metas = [], [], [], []
+    for i in range(1, FAVORITE_COUNT + 1):
+        title = f"测试收藏 {i:03d}"
+        poster_file, backdrop_file = _write_assets(assets_root, i)
+        metas.append((i, poster_file, 200, 300, backdrop_file,
+                      "[]", "[]", "[]", "[]", "[]", "zh-CN", ts, ts))
+        tmdb_id = 900_000 + i
+        # external_id 是身份锚的第三个分量（source, kind, external_id）；
+        # 走 SQL 直插时列默认回调不生效，这里显式补上 tmdb_id 的字符串形式
+        # metadata_refreshed_at / next_refresh_at 一起给足：进详情页会触发自动补刮削，
+        # 不压住的话种子条目会被真实 TMDB 档案改写（片名、海报都换掉），
+        # 断言就跟着飘。测试要的是稳定的一份数据，不是联网结果
+        items.append((i, "movie", tmdb_id, str(tmdb_id), "tmdb", title, title,
+                      2000 + i % 25, "[]", "released", None, None,
+                      ts, "2099-01-01 00:00:00", ts, ts))
+        files.append((
+            i, LIBRARY_ID, i, 0, 0, f"/media/e2e/{title}.mkv", 1_000_000, "mkv",
+            "1080p", "h264", None, 8, 5400, 4_000_000, 23.976, "bt709", "web-dl", None,
+            "scan", "in_place", None, None, None, None, "[]", "[]", "[]", None, "manual",
+            None, 0, ts, ts,
+        ))
+        # 第 1 部最新收藏，第 320 部最早——墙上就是 001 在最前
+        marked = (NOW - timedelta(minutes=i)).isoformat(sep=" ")
+        marks.append((i, 0, 0, 0, 0, 0, 1, None, 0, marked, marked))
+
+    cur.executemany(
+        "INSERT INTO media_item (id,kind,tmdb_id,external_id,source,title,original_title,"
+        "year,aliases,status,poster_path,backdrop_path,metadata_refreshed_at,next_refresh_at,"
+        "created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        items,
+    )
+    cur.executemany(
+        "INSERT INTO library_file (id,library_id,media_item_id,season_number,episode_number,"
+        "file_path,size_bytes,container,resolution,video_codec,hdr,bit_depth,duration_seconds,"
+        "bit_rate,frame_rate,color_space,media_source,release_group,source,state,missing_since,"
+        "ignored_at,unidentified_reason,unidentified_code,audio_streams,subtitle_streams,"
+        "external_subtitles,added_batch_id,identity_source,resolved_version,file_mtime_ns,"
+        "created_at,updated_at) VALUES "
+        "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        files,
+    )
+    cur.executemany(
+        "INSERT INTO media_metadata (media_item_id,poster_file,poster_width,poster_height,"
+        "backdrop_file,genres,origin_countries,studios,directors,\"cast\",scrape_language,"
+        "created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        metas,
+    )
+    cur.executemany(
+        "INSERT INTO playback_state (media_item_id,season_number,episode_number,position_ms,"
+        "played,play_count,is_favorite,last_played_at,member_id,created_at,updated_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        marks,
+    )
+    conn.commit()
+    conn.close()
+    print(f"已灌入：1 个媒体库 / {FAVORITE_COUNT} 部作品 / {FAVORITE_COUNT} 条收藏 / "
+          f"{FAVORITE_COUNT * 2} 张图片资产")
+
+
+def _chromium_path() -> str | None:
+    """本机预装的 Chromium（会话环境已装好，不联网下载）。"""
+    for pattern in (
+        "/opt/pw-browsers/chromium-*/chrome-linux/chrome",
+        "/opt/pw-browsers/chromium/chrome-linux/chrome",
+    ):
+        found = sorted(glob.glob(pattern))
+        if found:
+            return found[-1]
+    return None
+
+
+# 墙上每一格挂的位置锚点（apps/web/components/poster-wall.tsx）
+CELL = "[data-library-item-id]"
+# 图廊里一部作品一个组（apps/web/components/video-gallery.tsx）
+GALLERY_ITEM = "[data-gallery-item-id]"
+
+RESULTS: list[tuple[bool, str, str]] = []
+
+
+def check(ok: bool, name: str, detail: str = "") -> None:
+    RESULTS.append((ok, name, detail))
+    print(f"  {'✅' if ok else '❌'} {name}{('  —— ' + detail) if detail else ''}")
+
+
+# 真正的滚动容器：墙挂在页面内部那个 overflow-y-auto 的 div 上，不是 window。
+# 从任一格反查（closest）而不是按 class 猜——侧栏里也有 overflow-y-auto。
+_SCROLLER = """(() => {
+  const cell = document.querySelector('[data-library-item-id], [data-gallery-tile-id]');
+  return (cell && cell.closest('.overflow-y-auto'))
+    || [...document.querySelectorAll('.overflow-y-auto')]
+         .sort((a, b) => b.scrollHeight - a.scrollHeight)[0];
+})"""
+
+
+def js(source: str) -> str:
+    """把片段里的 SCROLLER 换成上面那段查找逻辑（JS 里满是花括号，
+    用占位替换而不是 format/%）。"""
+    return source.replace("SCROLLER", _SCROLLER)
+
+
+async def wall_state(page) -> dict:
+    """这一屏的四件事：滚动位置、墙高、挂着的格数、首个可见格的片名。
+
+    首个可见格与 lib/library-wall-recall.ts 的 firstVisibleAnchorId 同一判据
+    （下边缘越过容器可视区顶边），断言里就能按「那一部」而不是像素说话。
+    """
+    return await page.evaluate(
+        js("""() => {
+          const box = SCROLLER();
+          const cells = [...document.querySelectorAll('[data-library-item-id]')];
+          const top = box.getBoundingClientRect().top;
+          const first = cells.find((c) => c.getBoundingClientRect().bottom > top);
+          // 认条目 id 而不是片名：id 是墙自己的位置锚点（data-library-item-id），
+          // 片名会被后台刮削改写，拿它当断言基准是在测网络
+          const id = (el) => el ? Number(el.getAttribute('data-library-item-id')) : null;
+          return {
+            scrollTop: Math.round(box.scrollTop),
+            scrollHeight: box.scrollHeight,
+            mounted: cells.length,
+            firstVisible: id(first),
+            top: id(cells[0]),
+          };
+        }"""),
+    )
+
+
+async def settled_wall_state(page, tries: int = 12) -> dict:
+    """等这一屏真的稳下来再量。
+
+    墙是虚拟化的：回位之后要等一次重新量测才会把这一屏的格子挂上来，中间有
+    几帧 DOM 里一个格子都没有。不等就量，量到的是那个空档而不是结果。
+    """
+    state = await wall_state(page)
+    for _ in range(tries):
+        if state["mounted"] > 0 and state["firstVisible"]:
+            return state
+        await page.wait_for_timeout(400)
+        state = await wall_state(page)
+    return state
+
+
+async def gallery_state(page) -> dict:
+    """图廊这一屏：首个可见瓦片是哪一张、它离可视区顶边多远。
+
+    这里**不能**按像素断言。图廊是瀑布流，返回时图片按各自的时序解码、上方
+    每一列的高度都会重排，同一张瓦片对应的 scrollTop 本来就不是同一个数。
+    lib/use-scroll-restoration.ts 对这种墙给的承诺也正是「同一张瓦片停在同一
+    处」（anchorAttribute: data-gallery-tile-id），断言就照这条来。
+    """
+    return await page.evaluate(
+        js("""() => {
+          const box = SCROLLER();
+          const top = box.getBoundingClientRect().top;
+          const tile = [...document.querySelectorAll('[data-gallery-tile-id]')]
+            .find((t) => t.getBoundingClientRect().bottom > top);
+          return {
+            scrollTop: Math.round(box.scrollTop),
+            tile: tile ? tile.getAttribute('data-gallery-tile-id') : null,
+            offset: tile ? Math.round(tile.getBoundingClientRect().top - top) : null,
+          };
+        }"""),
+    )
+
+
+async def scroll_to(page, top: int) -> None:
+    await page.evaluate(
+        js("(top) => SCROLLER().scrollTo({ top, behavior: 'instant' })"), top
+    )
+    await page.wait_for_timeout(500)
+
+
+async def scroll_by_screens(page, screens: int) -> None:
+    """一屏一屏往下滑，等分页哨兵把下一页接上来（模拟真人滑动）。"""
+    for _ in range(screens):
+        await page.evaluate(
+            js("() => { const b = SCROLLER();"
+               " b.scrollBy({ top: b.clientHeight * 0.9, behavior: 'instant' }); }"),
+        )
+        await page.wait_for_timeout(600)
+
+
+async def wait_until_quiet(page, quiet_ms: int = 1500, limit_ms: int = 12_000) -> None:
+    """等墙不再长高再走。
+
+    滚动加载的下一页可能还在路上：这时候离开，快照记下的是一个「半页」的窗口，
+    返回时整窗对账拿回来的页数与它对不上，墙高一变，按像素回位就会落到别处
+    （图廊尤其明显，一部作品十几张图，一页的高度差着好几屏）。真人滑到一处
+    总会停一下，这里把那一下补上。
+    """
+    height = -1
+    stable = 0
+    waited = 0
+    while waited < limit_ms:
+        now = await page.evaluate(js("() => SCROLLER().scrollHeight"))
+        stable = stable + 500 if now == height else 0
+        height = now
+        if stable >= quiet_ms:
+            return
+        await page.wait_for_timeout(500)
+        waited += 500
+
+
+async def open_first_visible(page) -> None:
+    """点开当前屏幕上第一个可见的那一格（用户从这一屏进详情就是这么点的）。"""
+    await page.evaluate(
+        js("""() => {
+          const box = SCROLLER();
+          const top = box.getBoundingClientRect().top;
+          const cell = [...document.querySelectorAll('[data-library-item-id]')]
+            .find((c) => c.getBoundingClientRect().bottom > top);
+          cell.querySelector('a').click();
+        }"""),
+    )
+    await page.wait_for_url("**/item/**", timeout=30_000)
+    await page.wait_for_timeout(1000)
+
+
+async def favorite_id_at(page, offset: int) -> int | None:
+    """服务端名单里第 offset 部是哪个条目（期望值从同一份数据来，不写死——
+    测试中途取消过收藏，名单会整体前移）。"""
+    return await page.evaluate(
+        """async (offset) => {
+          const r = await fetch(`/api/v1/playback/favorites?limit=1&offset=${offset}`);
+          const body = await r.json();
+          return body.data.items[0]?.media_item_id ?? null;
+        }""",
+        offset,
+    )
+
+
+async def login(page, web: str, user: str, password: str) -> None:
+    await page.goto(f"{web}/login", wait_until="domcontentloaded")
+    await page.fill("input[type='text']", user)
+    await page.fill("input[type='password']", password)
+    await page.click("button[type='submit']")
+    await page.wait_for_url(lambda url: "/login" not in url, timeout=30_000)
+
+
+async def run(web: str, user: str, password: str, headed: bool, shot_path: str) -> int:
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(
+            headless=not headed, executable_path=_chromium_path()
+        )
+        context = await browser.new_context(viewport={"width": 1280, "height": 900})
+        page = await context.new_page()
+        page.on("pageerror", lambda e: print(f"  ⚠ 页面异常：{e}"))
+        await login(page, web, user, password)
+
+        # —— A. 会话内：进详情再返回，位置与窗口都在 ——
+        print("\nA. 会话内返回（收藏墙 → 作品详情 → 返回）")
+        await page.goto(f"{web}/library/favorites", wait_until="domcontentloaded")
+        await page.wait_for_selector(CELL, timeout=30_000)
+        await scroll_by_screens(page, 6)
+        await wait_until_quiet(page)
+        before = await settled_wall_state(page)
+        print(f"     离开前：scrollTop={before['scrollTop']} 墙高={before['scrollHeight']} "
+              f"首个可见={before['firstVisible']}")
+        check(before["scrollTop"] > 2000, "先滑到足够深（越过第一页 60 格）",
+              f"scrollTop={before['scrollTop']}")
+
+        await open_first_visible(page)
+        await page.go_back()
+        await page.wait_for_selector(CELL, timeout=30_000)
+        await page.wait_for_timeout(2000)
+        after = await settled_wall_state(page)
+        print(f"     返回后：scrollTop={after['scrollTop']} 墙高={after['scrollHeight']} "
+              f"首个可见={after['firstVisible']}")
+        check(abs(after["scrollTop"] - before["scrollTop"]) <= 8, "滚动位置回到原处",
+              f"{before['scrollTop']} → {after['scrollTop']}")
+        check(after["firstVisible"] == before["firstVisible"], "首个可见的还是同一部",
+              f"{before['firstVisible']} → {after['firstVisible']}")
+        check(abs(after["scrollHeight"] - before["scrollHeight"]) <= 4,
+              "已加载的窗口整份接回来（墙没有缩回一页）",
+              f"墙高 {before['scrollHeight']} → {after['scrollHeight']}")
+
+        # —— B. 在详情页取消收藏，返回后那一部消失、位置仍在 ——
+        print("\nB. 在详情页取消收藏后返回")
+        target = after["firstVisible"]
+        await open_first_visible(page)
+        heart = page.locator("button[aria-label*='收藏']").first
+        await heart.wait_for(timeout=15_000)
+        await heart.click()
+        await page.wait_for_timeout(1500)
+        await page.go_back()
+        await page.wait_for_selector(CELL, timeout=30_000)
+        await page.wait_for_timeout(2500)
+        purged = await settled_wall_state(page)
+        on_wall = await page.evaluate(
+            "() => [...document.querySelectorAll('[data-library-item-id]')]"
+            ".map((c) => Number(c.getAttribute('data-library-item-id')))",
+        )
+        print(f"     返回后：scrollTop={purged['scrollTop']} 首个可见={purged['firstVisible']}")
+        check(target is not None and target not in on_wall,
+              "取消收藏的那一部已从墙上消失（返回时整窗对过账）", f"条目 #{target}")
+        check(abs(purged["scrollTop"] - after["scrollTop"]) <= 8, "位置没有因为对账而跳走",
+              f"{after['scrollTop']} → {purged['scrollTop']}")
+
+        # —— C. 跨会话：胶囊 —— #
+        print("\nC. 跨会话「回到上次浏览的位置」胶囊")
+        expected = await favorite_id_at(page, 200)
+        await page.evaluate(
+            """() => localStorage.setItem('movieclaw.wall-recall', JSON.stringify({
+                 'library:favorites': {
+                   offset: 200, view: 'favorites', updatedAt: Date.now() - 3600e3,
+                 },
+               }))""",
+        )
+        # 换一页再回来 = 组件重新挂载、没有会话快照，等同于「第二天再进来」
+        await page.goto(f"{web}/library", wait_until="domcontentloaded")
+        await page.goto(f"{web}/library/favorites", wait_until="domcontentloaded")
+        await page.wait_for_selector(CELL, timeout=30_000)
+        await page.wait_for_timeout(1200)
+        pill = page.locator("button:has-text('回到上次浏览的位置')")
+        appeared = await pill.count() > 0
+        check(appeared, "重新进入时弹出胶囊（会话内返回时不弹，见 A）")
+        jumped = None
+        if appeared:
+            await pill.click()
+            await page.wait_for_timeout(3000)
+            jumped = await settled_wall_state(page)
+            print(f"     跳转后：首个可见=条目 #{jumped['firstVisible']}（期望 #{expected}）")
+            check(jumped["firstVisible"] == expected,
+                  "跳到了记录里的那一部（服务端名单第 201 部）",
+                  f"{jumped['firstVisible']} vs {expected}")
+
+            # —— D. 跳过去之后往上滑，上文由墙顶哨兵补回来 ——
+            print("\nD. 跳转之后往上滑，墙顶把上文补回来")
+            head_id = jumped["top"]
+            for _ in range(8):
+                await scroll_to(page, 0)
+                await page.wait_for_timeout(900)
+                state = await wall_state(page)
+                if state["top"] == head_id:
+                    break
+                head_id = state["top"]
+            first_ever = await favorite_id_at(page, 0)
+            print(f"     一路上滑到墙顶：条目 #{head_id}（名单第一部是 #{first_ever}）")
+            check(head_id == first_ever,
+                  "一路上滑能回到墙首（跳转位置之上不是一堵墙）",
+                  f"墙顶=#{head_id} 期望=#{first_ever}")
+
+        # —— E. 图床浏览模式 ——
+        print("\nE. 图床浏览模式的返回")
+        await page.evaluate("() => localStorage.removeItem('movieclaw.wall-recall')")
+        await page.goto(f"{web}/library/favorites", wait_until="domcontentloaded")
+        await page.wait_for_selector(CELL, timeout=30_000)
+        await page.click("button[aria-label='图床浏览']")
+        await page.wait_for_selector("[data-gallery-tile-id]", timeout=30_000)
+        # 图廊要滑得比海报墙更深：一页只有二十几部作品但每部十几张图，滑浅了
+        # 「返回时只补第一页」也能勉强凑够高度，测不出差别
+        await scroll_by_screens(page, 12)
+        await wait_until_quiet(page)
+        gal_before = await gallery_state(page)
+        tiles_before = await page.evaluate(
+            "() => document.querySelectorAll('[data-gallery-item-id]').length")
+        print(f"     离开前：scrollTop={gal_before['scrollTop']} 首个可见瓦片={gal_before['tile']}")
+        check(gal_before["scrollTop"] > 1500, "图廊也先滑到足够深",
+              f"scrollTop={gal_before['scrollTop']}")
+        # 必须走站内跳转再返回：会话快照与滚动位置都只活在当前这次页面加载里，
+        # page.goto 是整页重载、等同于刷新——那本来就该从墙首开始，拿它测「返回」
+        # 会测出一个假失败。图廊里的站内落点是每组标题那条通往作品详情的链接
+        await page.evaluate(
+            js("""() => {
+              const box = SCROLLER();
+              const top = box.getBoundingClientRect().top;
+              const link = [...document.querySelectorAll('a[href*="/item/"]')]
+                .find((a) => a.getBoundingClientRect().bottom > top);
+              link.click();
+            }"""),
+        )
+        await page.wait_for_url("**/item/**", timeout=30_000)
+        await page.wait_for_timeout(1000)
+        await page.go_back()
+        await page.wait_for_selector("[data-gallery-tile-id]", timeout=30_000)
+        await page.wait_for_timeout(2500)
+        gal_after = await gallery_state(page)
+        print(f"     返回后：scrollTop={gal_after['scrollTop']} 首个可见瓦片={gal_after['tile']}")
+        check(gal_after["tile"] is not None and gal_after["tile"] == gal_before["tile"],
+              "图廊返回后还停在同一张瓦片上",
+              f"{gal_before['tile']} → {gal_after['tile']}")
+        drift = (abs(gal_after["offset"] - gal_before["offset"])
+                 if gal_after["offset"] is not None else None)
+        check(drift is not None and drift <= 40,
+              "那张瓦片还停在屏幕上的同一高度",
+              f"离顶边 {gal_before['offset']}px → {gal_after['offset']}px")
+        check(tiles_before > 0, "图廊窗口非空（每部作品的图都在）", f"{tiles_before} 组")
+
+        await page.screenshot(path=shot_path)
+        await browser.close()
+    return report()
+
+
+def report() -> int:
+    passed = sum(1 for ok, _, _ in RESULTS if ok)
+    print(f"\n{'=' * 62}\n通过 {passed}/{len(RESULTS)}")
+    for ok, name, detail in RESULTS:
+        if not ok:
+            print(f"  失败：{name} {detail}")
+    return 0 if passed == len(RESULTS) else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", action="store_true", help="只灌数据，不跑浏览器")
+    parser.add_argument("--db", default="data/movieclaw.db")
+    parser.add_argument("--assets", default="data/metadata/images",
+                        help="图片资产根目录（后端 METADATA_DIR 下的 images/）")
+    parser.add_argument("--web", default="http://127.0.0.1:3000")
+    parser.add_argument("--user", default="admin")
+    parser.add_argument("--password", default="movieclaw-e2e")
+    parser.add_argument("--headed", action="store_true")
+    parser.add_argument("--shot", default="e2e-favorites-final.png",
+                        help="最后一屏的截图落点")
+    args = parser.parse_args()
+    if args.seed:
+        seed(args.db, args.assets)
+        sys.exit(0)
+    sys.exit(asyncio.run(run(args.web, args.user, args.password, args.headed, args.shot)))


### PR DESCRIPTION
## 起因

用户反馈：「收藏的展开详情页好像没有滚动记忆，和访问其他媒体库为什么体验不一样」。

差别不在滚动代码 —— 两处用的是同一套 `lib/use-scroll-restoration.ts`，差在**返回时墙有多高**。单库页有会话快照（`lib/library-detail-snapshot.ts`）把离开时已加载的整个分页窗口带回来；收藏页没有，返回时只重拉第一页 60 格，容器矮到装不下离开时的滚动位置，恢复逻辑既找不到锚点又等不到高度，超时后放弃 —— 人被甩回墙首。`library-detail-view.tsx` 里那段 2026-09-07 的注释记的正是同一个 bug，当时只在单库页修了。

## 改了什么

**1. 会话内滚动记忆（`f779cb9`）**

给收藏页补上同口径的会话快照（一个账号只有一面收藏墙，模块级一份即可，不必按 id 存 Map）。海报墙与图廊都在首帧接回整个窗口，挂载后按已加载的页数整窗重拉、整体替换 —— 在详情页取消收藏的那部会跟着消失，但窗口不缩、位置不动；请求失败就留着旧窗口，下次返回再对账。

**2. 跨会话「回到上次浏览的位置」（`42a9b66`）**

- `wallRecallScope` 收一个 `"favorites"` 字面量，键写成 `library:favorites`。
- `WallRecallPill` / `WallLoadPrev` 从单库页文件导出，两页共用。
- 收藏页窗口起点从「恒为 0」改成可跳转（`wallStart` / `wallOffset`），墙尾追加按起点算，墙顶由哨兵向上补页并按长高量补偿 `scrollTop`；`jumpTo` / `jumpGalleryTo` 整体换掉窗口而不是一页页追过去。
- 首帧无快照或久别回归（iOS PWA 恢复应用不重载页面）算「重新进入」：这一次不自动回位，改由胶囊来问。

有意与单库页不同的一处：单库页两种墙排序不同，同一个 offset 不是同一部作品，必须分开记；收藏页只有一种排序、两种形态是同一份名单同一种分页，所以共用一条记录 —— 在图廊里看到哪，切回海报墙照样跳得回去。

**3. 抽掉几处照抄（`6b8992e`，纯搬运，无行为改动）**

- `lib/session-snapshot.ts`：「先 delete 再 set、超限淘汰队首」这段同样的 LRU 全站有三份（滚动位置 / 单库页快照 / 片单页快照），收成一份 `createSessionSnapshots<K, V>(capacity)`，上限各自不变（100 / 20 / 32）。
- `components/wall-chrome.tsx`：`WallLoadMore` / `WallLoadPrev` / `WallRecallPill` 原先长在单库页文件里，搬出来后两页平级引用，单库页少了 140 行。

按 offset 分页的窗口状态机（`loadMore` / `loadPrev` / `jumpTo` / `reload` 与补页的滚动补偿）两页仍是各一份，留给后续单独一个 PR 连 `docs/design/media-wall.md` 一起做。

## 验证

**端到端（`6d6b524`）**：新增 `scripts/perf/e2e_favorites_recall.py`，真实浏览器 + 真实全栈（FastAPI + Next.js 生产构建 + 预装 Chromium），自带数据集（1 个库 / 320 部作品 / 320 条收藏 / 640 张图片资产）。五段动线 13 条断言，按条目 id 与瓦片 id 断言而不按片名（进详情页会触发真实刮削，片名会被改写）。

改动前后都跑过：

| 动线 | 修复前 | 修复后 |
|---|---|---|
| A 滚到第 6 屏 → 进详情 → 返回 | ❌ scrollTop 4710 → 0，墙高 7941 → 4080 | ✅ 位置、首个可见条目、墙高都不变 |
| B 详情页取消收藏 → 返回 | ✅ | ✅ 那一部消失，位置不跳 |
| C 写一条旧记录 → 重新进入 | ❌ 不弹胶囊 | ✅ 弹出并跳到名单第 201 部 |
| D 跳转后一路上滑 | — | ✅ 墙顶补回墙首 |
| E 图廊返回 | ❌ 9132 → 0 | ✅ 仍停在同一张瓦片、同一高度 |

合计：修复前 5/11，修复后 13/13（连跑两次稳定）。

**其他**：`web:typecheck` / `web:lint`（新文件零问题）/ `ruff check` / `next build` 全通过；新增 `test/session-snapshot.test.mjs` 六条与 `library-wall-recall.test.mjs` 一条。

## 已知边界（pre-existing，不是本次引入）

图廊模式下，如果离开时还有一页图在路上，快照记的是个「半页」窗口，返回时整窗对账拿回的页数与它对不上，墙高一变按像素回位会偏（实测约 8200px，5 次偶发 1 次）。这个形状在单库页是同一份代码、同样存在。等墙不再长高再离开就稳定复现同一张瓦片，端到端脚本里对应 `wait_until_quiet`。收紧它（快照记下窗口是否完整、对账按快照页数取）建议放进后续那个 `useWallWindow` PR。

## 检查清单

- 未改动运行时依赖（pyproject / Node 大版本 / Dockerfile / entrypoint），无需 bump `docker/runtime-version`
- 无数据库迁移
- 未在 `data/` 下新增目录（脚本只写既有的 `data/metadata/images`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017M3BppQmfnJdRPJkx1DFDb

---
_Generated by [Claude Code](https://claude.ai/code/session_017M3BppQmfnJdRPJkx1DFDb)_