### PR TITLE
进度条把手不再探出控制条左缘：轨道两端各让出半个把手

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1714,6 +1714,29 @@ html:has(.player-root) {
    为什么不是「把轨道本身染黑」（上一版的做法）：那等于拿暗画面的可见性换
    亮画面的可见性——刚起播已播段宽度为 0，黑轨道压在黑画面上，用户会以为
    播放器没有进度条。 */
+/* 轨道自己往里让出半个把手。
+   把手是**居中**在轨道端点上的圆点，所以 0% / 100% 时它有半个身位探到轨道
+   之外；而上下的时间胶囊、功能键簇左缘都正好落在 .player-inset-x 上——那半
+   个身位就成了控制条左缘唯一一处不齐（真机截图反馈）。让轨道两端各缩进半个
+   把手，两端的把手边缘于是与胶囊边缘齐平。
+   收窄的是 .player-scrub-shade 这个盒子本身（margin 而非 padding）：轨道、
+   章节刻度、圆点、命中用的 <input> 全是它的绝对定位子元素，指针取值量的也是
+   它的 rect，一起收窄才不会让「圆点跟手」和「圆点对准已播段」这两条已经修过
+   的性质回退。
+   顺带把 .player-inset-x 那 28px 的本意补齐：那段注释要的是「0 进度的把手整个
+   落在 iOS 返回手势区外」，但此前落在 28px 上的是把手**中心**，左缘只到 19px、
+   仍压在手势带里；让出半个身位之后左缘正好是 28px。 */
+.player-scrub-shade {
+  /* 与 player-controls.tsx 里圆点的 size-[14px] / pointer-coarse:size-[18px] 同源 */
+  --player-thumb-r: 7px;
+  margin-inline: var(--player-thumb-r);
+}
+@media (pointer: coarse) {
+  .player-scrub-shade {
+    --player-thumb-r: 9px;
+  }
+}
+
 .player-scrub-shade::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## 现象

控制条左缘只有进度条那一行不齐——白圆点比上下两张胶囊探出去一截（真机截图反馈）。

```
时间胶囊 0:24 / 48:05   │←── 28px ──→│▓▓▓▓▓
进度条                  │←─ 19px ─→│●●●●●●●───────────
功能键簇 ♫ ⊟ ⋯          │←── 28px ──→│▓▓▓▓▓
```

## 原因

把手是**居中**在轨道端点上的圆点（`size-[14px]` / `pointer-coarse:size-[18px]`），所以 0% / 100% 时它有半个身位探到轨道之外。而时间胶囊与功能键簇的左缘都严格落在 `.player-inset-x` 上，于是只有这半个身位不齐。

## 改法

让轨道两端各缩进半个把手（`margin-inline: var(--player-thumb-r)`，7px / 触屏 9px，与组件里圆点尺寸同源）。0% 与 100% 时把手边缘就与胶囊边缘齐平。

关键是收窄 `.player-scrub-shade` **这个盒子本身**、用 `margin` 而不是 `padding`：轨道、章节刻度、圆点、命中用的 `<input>` 全是它的绝对定位子元素，指针取值量的也是它的 `getBoundingClientRect()`。一起收窄，此前修过的两条性质才不会回退——「拖动时圆点跟手」和「圆点对准已播段」。**`player-controls.tsx` 一行未动。**

## 顺带补齐了 28px 那条注释的本意

`.player-inset-x` 的注释写着 28px 是为了「0 进度的把手**整个**落在 iOS 返回手势区外」。但此前落在 28px 上的是把手**中心**，左缘只到 19px，仍压在系统 20–25px 的手势带里——那条注释想要的效果其实没拿到。让出半个身位之后左缘正好是 28px。

## 取舍

进度过半时，轨道那条细线的两端会比胶囊各内收 9px（给两端的圆点留位；0% 与 100% 时被圆点自己盖住）。判断依据：18px 的亮圆点探出去，比 3px 灰线内收 9px 显眼得多。

另一条可选路线是「轨道保持满宽、把圆点行程限制在轨道内」，代价是拖到两端时圆点会比手指慢半个身位——与既有的「圆点跟手」取向冲突，故未取。

## 验证

- `apps/web` 258 项测试全过，`pnpm --filter web lint` 0 错误
- 已部署 NAS 真机：curl 线上样式 chunk 确认两条规则都已生效

```css
.player-scrub-shade{--player-thumb-r:7px;margin-inline:var(--player-thumb-r)}
@media (pointer:coarse){.player-scrub-shade{--player-thumb-r:9px}}
```

纯样式改动，不动 API 面、依赖与迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)