### PR TITLE
修复同名目录多种子致洗版任务卡「已完成」：入库来源戳逐文件判定 + 洗版任务活性兜底

### DIFF
--- a/src/movieclaw_api/services/download_progress.py
+++ b/src/movieclaw_api/services/download_progress.py
@@ -378,9 +378,13 @@ async def _observe_attempt(
             # 洗版 attempt 的目标单元本来就是 imported（工单不重开），下方
             # 缺口语义的"工单已闭合→退出观察"判据对它恒真，会在首个巡检
             # tick 把刚投递的洗版任务错误完结。洗版的完成/证伪由入库验证
-            # 裁决（verify_upgrades 置 IMPORTED/FAILED）；这里只做两件事：
-            # 单元全部退出范围时止损取消，否则继续心跳观察与死种换源
+            # 裁决（verify_upgrades 置 IMPORTED/FAILED）；这里只做三件事：
+            # 单元全部退出范围时止损取消；已完成却再也等不到验证裁决的收尾；
+            # 否则继续心跳观察与死种换源
             from movieclaw_api.services.subscription import upgrade_attempt_wanted_rows
+            from movieclaw_api.services.subscription.upgrade import (
+                settle_outdated_upgrade_attempt,
+            )
 
             tracked = await upgrade_attempt_wanted_rows(session, attempt, in_scope_only=False)
             if tracked and not any(row.in_scope for row in tracked):
@@ -392,6 +396,8 @@ async def _observe_attempt(
                 attempt.updated_at = utcnow()
                 session.add(attempt)
                 await session.commit()
+                return False
+            if await settle_outdated_upgrade_attempt(session, attempt):
                 return False
         elif not await _attempt_wanted_rows(session, attempt):
             if await _cancel_attempt_if_out_of_scope(session, attempt):

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -166,6 +166,7 @@ from movieclaw_db.models import (
     MediaItem,
     MediaSeason,
     NoticeSeverity,
+    SubscriptionDownloadAttempt,
     utcnow,
 )
 from movieclaw_db.models.manual_download_intent import MANUAL_DOWNLOAD_INTENT_TTL
@@ -1824,22 +1825,28 @@ async def _ingest_entry(
     # 来源戳：入库文件行必须带上 (site, torrent)，洗版验证的 _file_from_attempt
     # 才能精确匹配「文件 ↔ 投递」。缺了它只能退化到时间兜底——两个包在同一
     # 时间窗交错完成时，会把别家包的文件记到自己账上（NAS 实测 HDKWeb 包的
-    # 文件被记成 CHDWEB 投递，qb 里的 CHDWEB 任务白下、清理证据链也锚错）
-    prov_site: str | None = None
-    prov_torrent: str | None = None
-    prov_confidence: str | None = None
+    # 文件被记成 CHDWEB 投递，qb 里的 CHDWEB 任务白下、清理证据链也锚错）。
+    # 订阅投递按**文件**解析（同名目录可能挂着多颗种子，见 _DeliveryProvenance）；
+    # 手动下载的身份锚本就钉在单颗种子上，沿用条目级
+    manual_stamp: tuple[str | None, str | None] = (None, None)
+    delivery: _DeliveryProvenance | None = None
     if manual_intent is not None:
-        prov_site, prov_torrent = manual_intent.site_id, manual_intent.torrent_id
+        manual_stamp = (manual_intent.site_id, manual_intent.torrent_id)
     elif matched_hashes:
-        prov_site, prov_torrent, prov_confidence = await _delivery_provenance(
-            session, matched_hashes
-        )
+        delivery = await _load_delivery_provenance(session, entry, matched_hashes)
+
+    def provenance(
+        file: Path | None, unit: tuple[int, int] | None
+    ) -> tuple[str | None, str | None]:
+        """某个入库文件的来源戳 (site, torrent)。"""
+        return delivery.stamp(entry, file, unit) if delivery is not None else manual_stamp
+
     # 身份来源分档：这条入库记录的身份是怎么来的、有多可信。这一列此前在
     # 监听导入路径上恒为 NULL——连"用户亲手认领的"和"机器蒙的"都分不出来
     ledger_identity = _ledger_identity_source(
         forced=forced_item is not None,
         identity_source=identity_source,
-        confidence=prov_confidence,
+        confidence=delivery.confidence if delivery is not None else None,
     )
     # 时长体检（§8）：订阅按 info_hash 认领身份时会短路整条名称识别链，连带
     # 跳过 resolve.py 上那套佐证/反证机器；这里补上被跳过的那一次反证。
@@ -1980,6 +1987,7 @@ async def _ingest_entry(
             )
         assert dest_library is not None and dest_library.id is not None
         stat = final.stat()
+        disc_site, disc_torrent = provenance(None, None)
         await repo.upsert_by_path(
             LibraryFile(
                 library_id=dest_library.id,
@@ -2009,8 +2017,8 @@ async def _ingest_entry(
                 release_group=release_attrs.release_group,
                 source=FileSource.IMPORTED,
                 identity_source=ledger_identity,
-                site_id=prov_site,
-                torrent_id=prov_torrent,
+                site_id=disc_site,
+                torrent_id=disc_torrent,
                 added_batch_id=added_batch_id,
             )
         )
@@ -2266,6 +2274,9 @@ async def _ingest_entry(
                 doubt["expected_minutes"],
                 final.name,
             )
+        stamp_site, stamp_torrent = provenance(
+            file, None if kind is MediaKind.MOVIE else (season, episode)
+        )
         await repo.upsert_by_path(
             LibraryFile(
                 library_id=dest_library.id,
@@ -2293,8 +2304,8 @@ async def _ingest_entry(
                 source=FileSource.IMPORTED,
                 identity_source=ledger_identity,
                 identity_doubt=doubt,
-                site_id=prov_site,
-                torrent_id=prov_torrent,
+                site_id=stamp_site,
+                torrent_id=stamp_torrent,
                 added_batch_id=added_batch_id,
             )
         )
@@ -2766,29 +2777,99 @@ async def _expected_runtime_minutes(session, media_item_id: int) -> int | None:
     ).scalar_one_or_none()
 
 
-async def _delivery_provenance(
-    session, info_hashes: list[str]
-) -> tuple[str | None, str | None, str | None]:
-    """按 info_hash 反查订阅投递记录的来源戳与身份证据强度。
+@dataclass(frozen=True)
+class _DeliveryProvenance:
+    """监听条目内**逐文件**解析订阅投递的来源戳 (site, torrent)。
 
-    返回 ``(site_id, torrent_id, identity_confidence)``。条目匹配到的 hash 就是
-    这个种子本身，任何同 hash 的投递记录都是它的来源——与身份认领走哪条链无关。
-    证据强度用于给入库台账的 ``identity_source`` 分档（exact / guess）。
-    查不到（外部种子）返回 (None, None, None)。
+    不能按条目只取一个来源：逐集发布的单集种子（CMCTV 这类）在下载器里共用
+    同一个内容目录名，一个监听条目于是同时匹配多颗种子。旧实现对
+    ``info_hash IN (...)`` 不排序取第一条，把整批文件记到同一次投递名下（NAS
+    实测 5 部剧 31 个文件记错，《交锋》E12 被记成 E10 的种子），洗版验证
+    ``_file_from_attempt`` 精确比对失败，洗版任务永远停在「已完成」。
+
+    判定顺序。原则是宁可不记、不可记错：缺戳时洗版验证还能退化到时间关联
+    兜底，记错了连兜底都用不上。
+
+    1. 有下载器文件清单时，候选只留**真正写入该文件**的种子；清单在手却没有
+       任何种子写它 → 不是投递来的（外部种子或手工放入），不记；
+    2. 候选中投递单元声明了该集的优先，同一集投递过多次取最新一次；
+    3. 下载器确认写入、但没有投递声明该集（季包里的附带集）→ 取最新候选；
+    4. 没有文件证据时，候选只剩一个来源才记，多个来源无从区分 → 不记。
     """
-    from movieclaw_db.models import SubscriptionDownloadAttempt
 
+    attempts: tuple[SubscriptionDownloadAttempt, ...]  # 条目匹配到的、带站点来源的投递
+    file_hashes: dict[str, frozenset[str]]  # 条目内相对路径 → 下载器确认写入它的 hash
+
+    @property
+    def confidence(self) -> str | None:
+        """条目级身份证据强度：全部投递都是外部 ID 精确命中才算 exact，否则按猜测记。"""
+        if self.attempts and all(a.identity_confidence == "exact_id" for a in self.attempts):
+            return "exact_id"
+        return None
+
+    def stamp(
+        self, entry: Path, file: Path | None, unit: tuple[int, int] | None
+    ) -> tuple[str | None, str | None]:
+        """单个入库文件的来源戳；file 为 None（原盘目录）时不看文件证据。"""
+        candidates = list(self.attempts)
+        writers: frozenset[str] | None = None
+        if file is not None and self.file_hashes:
+            writers = self.file_hashes.get(_relative_entry_file(entry, file) or "", frozenset())
+            candidates = [a for a in candidates if a.info_hash.lower() in writers]
+        if unit is not None:
+            claiming = [
+                a
+                for a in candidates
+                if unit
+                in {(int(u[0]), int(u[1])) for u in a.units if isinstance(u, list) and len(u) == 2}
+            ]
+            if claiming:
+                newest = max(claiming, key=lambda a: a.id or 0)
+                return newest.site_id, newest.torrent_id
+        if writers and candidates:
+            newest = max(candidates, key=lambda a: a.id or 0)
+            return newest.site_id, newest.torrent_id
+        sources = {(a.site_id, a.torrent_id) for a in candidates}
+        return sources.pop() if len(sources) == 1 else (None, None)
+
+
+async def _load_delivery_provenance(
+    session, entry: Path, info_hashes: list[str]
+) -> _DeliveryProvenance:
+    """按条目匹配到的 hash 载入投递记录；确有投递时再向下载器取文件清单作逐文件证据。"""
+    hashes = sorted({h for value in info_hashes if value for h in (value, value.lower())})
     rows = (
         await session.execute(
             select(SubscriptionDownloadAttempt).where(
-                SubscriptionDownloadAttempt.info_hash.in_(info_hashes)  # type: ignore[union-attr]
+                SubscriptionDownloadAttempt.info_hash.in_(hashes)  # type: ignore[union-attr]
             )
         )
     ).scalars()
-    for attempt in rows:
-        if attempt.site_id:
-            return attempt.site_id, attempt.torrent_id, attempt.identity_confidence
-    return None, None, None
+    attempts = tuple(attempt for attempt in rows if attempt.site_id)
+    file_hashes = await _entry_file_hashes(entry) if attempts else {}
+    return _DeliveryProvenance(attempts=attempts, file_hashes=file_hashes)
+
+
+async def _entry_file_hashes(entry: Path) -> dict[str, frozenset[str]]:
+    """按下载器文件清单反推条目内每个文件由哪些种子写入；拿不到证据返回空表。"""
+    try:
+        matches = _match_briefs(entry.name, await _downloader_briefs())
+        details = await _matched_torrent_statuses(matches) if matches else None
+    except Exception as exc:  # noqa: BLE001 -- 来源戳是附加信息，下载器故障不能拖垮入库
+        logger.warning(
+            "读取下载器文件清单失败，「%s」的来源戳改按投递的集号推断：%s", entry.name, exc
+        )
+        return {}
+    writers: dict[str, set[str]] = {}
+    for downloader, status in details or []:
+        for torrent_file in status.files or ():
+            if not torrent_file.selected:
+                continue
+            source = _torrent_file_source(downloader, status, torrent_file)
+            relative = _relative_entry_file(entry, source) if source is not None else None
+            if relative is not None:
+                writers.setdefault(relative, set()).add(str(status.info_hash).lower())
+    return {path: frozenset(hashes) for path, hashes in writers.items()}
 
 
 async def _manual_download_identity(

--- a/src/movieclaw_api/services/subscription/upgrade.py
+++ b/src/movieclaw_api/services/subscription/upgrade.py
@@ -541,6 +541,74 @@ def _file_from_attempt(file: LibraryFile, attempt: SubscriptionDownloadAttempt) 
     )
 
 
+# 洗版任务下载完成后留给入库的宽限期：监听巡检从发现完成到建好入库作业通常
+# 只要几十秒，留足余量，避免抢在入库验证之前把任务收尾
+_SETTLE_GRACE = timedelta(minutes=30)
+
+
+async def settle_outdated_upgrade_attempt(
+    session: AsyncSession, attempt: SubscriptionDownloadAttempt
+) -> bool:
+    """已下载完成、结果却不再需要的洗版任务就地收尾；返回是否已收尾。
+
+    洗版任务原本只由入库验证 ``verify_upgrades`` 裁决完结，而验证靠文件来源戳
+    精确匹配任务。来源戳缺失或记错（历史数据、下载器证据缺失），或者单元被
+    其他来源抢先升级时，验证不会再为它跑第二次，任务就永远停在「已完成」、
+    一直挂在活动页（NAS 实测《交锋》E12）。这里是**不依赖来源戳**的活性兜底：
+
+    - 判据：它照看的所有在范围单元，当前基线都已**不低于**它的标称档位——
+      此后它的文件入库也不可能再构成升级（验证只认严格更优），继续等没有意义；
+    - 前置：下载完成已超过宽限期，且没有该种子的入库作业在排队或执行，
+      不抢在入库验证之前收尾；标称或基线档位未知时不判；
+    - 结论：CANCELLED 并保留下载器任务，与验证里「被抢先」的收口口径一致，
+      不碰库文件、不改工单关联。
+    """
+    from movieclaw_api.services import jobs
+    from movieclaw_db.models import DownloadAttemptStatus
+
+    if attempt.purpose != "upgrade" or attempt.status != DownloadAttemptStatus.COMPLETED:
+        return False
+    if not attempt.quality:
+        return False
+    now = utcnow()
+    completed_at = attempt.completed_at or attempt.updated_at
+    if completed_at is not None and now - completed_at < _SETTLE_GRACE:
+        return False
+    rows = await upgrade_attempt_wanted_rows(session, attempt)
+    if not rows or any(not row.quality for row in rows):
+        return False
+    spec = (await _specs_for_subscriptions(session, {attempt.subscription_id})).get(
+        attempt.subscription_id
+    )
+    if spec is None:
+        return False
+    claimed = QualitySnapshot.model_validate(attempt.quality)
+    if any(_better(claimed, QualitySnapshot.model_validate(row.quality), spec) for row in rows):
+        return False  # 至少一个单元仍能被它升级：继续等入库验证
+    info_hash = attempt.info_hash.lower()
+    ingest_jobs = await jobs.list_jobs_by_resource(
+        session,
+        resource_type="download",
+        resource_ids=[info_hash],
+        job_type="library.ingest",
+    )
+    if any(job.status in jobs.ACTIVE_JOB_STATUSES for job in ingest_jobs.get(info_hash, [])):
+        return False
+    attempt.status = DownloadAttemptStatus.CANCELLED
+    attempt.next_search_at = None
+    attempt.cleanup_note = (
+        "该洗版单元的在库版本已不低于本任务的标称档位，无需再等待入库；保留下载器任务"
+    )
+    attempt.updated_at = now
+    session.add(attempt)
+    await session.commit()
+    logger.info(
+        "洗版任务收尾：#%s 照看的单元在库版本已不低于其标称档位，不再等待入库（保留下载器任务）",
+        attempt.id,
+    )
+    return True
+
+
 async def verify_upgrades(session: AsyncSession, media_item_id: int) -> None:
     """洗版入库验证：对该条目在途洗版单元，用实测新快照裁决确认/证伪。
 

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -2391,6 +2391,148 @@ async def test_subscription_extra_same_tier_file_not_imported_as_new_version(
     assert (imported_row.site_id, imported_row.torrent_id) == ("mteam", "12345")
 
 
+async def _seed_episode_deliveries(db, item, library_id, deliveries):
+    """订阅 + 逐集 grabbed 工单 + 投递记录；deliveries: {集号: (info_hash, torrent_id)}。"""
+    from movieclaw_db.models import (
+        RuleSet,
+        Subscription,
+        SubscriptionDownloadAttempt,
+        WantedItem,
+        WantedStatus,
+    )
+
+    async with db.session() as session:
+        rule_set = RuleSet(name="默认", spec={})
+        session.add(rule_set)
+        await session.commit()
+        await session.refresh(rule_set)
+        sub = Subscription(
+            media_item_id=item.id, kind="tv", rule_set_id=rule_set.id, library_id=library_id
+        )
+        session.add(sub)
+        await session.commit()
+        await session.refresh(sub)
+        for episode, (info_hash, torrent_id) in deliveries.items():
+            session.add_all(
+                [
+                    WantedItem(
+                        subscription_id=sub.id,
+                        media_item_id=item.id,
+                        season_number=1,
+                        episode_number=episode,
+                        status=WantedStatus.GRABBED,
+                        info_hash=info_hash,
+                    ),
+                    SubscriptionDownloadAttempt(
+                        subscription_id=sub.id,
+                        info_hash=info_hash,
+                        site_id="ssd",
+                        torrent_id=torrent_id,
+                        units=[[1, episode]],
+                        last_progress_at=utcnow(),
+                    ),
+                ]
+            )
+        await session.commit()
+
+
+async def _ingest_shared_folder(db, tmp_path, monkeypatch, *, deliveries, torrents, statuses=None):
+    """同一内容目录被多颗种子共用的监听条目：跑一轮入库，返回 {集号: 来源戳}。
+
+    torrents: {info_hash: 该种子写入的文件名}；statuses 为 True 时向入库提供
+    下载器文件清单证据，否则模拟清单不可用。
+    """
+    from movieclaw_downloader import TorrentBrief
+
+    root, watch = tmp_path / "tv", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.TV, root=root)
+    item = await _make_item(db, kind=MediaKind.TV, title="测试剧集", year=2024)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+    _stub_unit(monkeypatch, lambda file: (1, int(file.stem.removeprefix("ep"))))
+
+    async def identify_none(session, kind, watch_root, main, spec):
+        return None
+
+    monkeypatch.setattr(ingest_mod, "_identify", identify_none)
+    await _seed_episode_deliveries(db, item, library_id, deliveries)
+
+    name = "测试剧集.S01.2160p.WEB-DL-CMCTV"
+    entry = watch / name
+    entry.mkdir()
+    for filename in torrents.values():
+        (entry / filename).write_bytes(f"content-{filename}".encode())
+
+    async def briefs():
+        return [
+            TorrentBrief(name=name, content_name=name, completed=True, info_hash=info_hash)
+            for info_hash in torrents
+        ]
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", briefs)
+    if statuses:
+
+        async def file_statuses(matches):
+            return [
+                (
+                    SimpleNamespace(path_mappings=None),
+                    SimpleNamespace(
+                        info_hash=info_hash,
+                        save_path=str(watch),
+                        completed=True,
+                        files=[SimpleNamespace(path=f"{name}/{filename}", selected=True)],
+                    ),
+                )
+                for info_hash, filename in torrents.items()
+            ]
+
+        monkeypatch.setattr(ingest_mod, "_matched_torrent_statuses", file_statuses)
+
+    library = await _get_library(db, library_id)
+    await ingest_mod._sweep_dir(
+        _fixed_rule(watch, library_id=library_id), library, execute_inline=True
+    )
+    async with db.session() as session:
+        rows = (await session.execute(select(LibraryFile))).scalars().all()
+    return {row.episode_number: (row.site_id, row.torrent_id) for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_shared_folder_torrents_stamp_each_file_by_delivered_unit(
+    db, tmp_path, monkeypatch
+):
+    """逐集发布的单集种子共用同一个内容目录名（CMCTV 这类）：一个监听条目同时
+    匹配多颗种子，来源戳必须逐文件记到声明该集的那次投递上。旧实现按条目对
+    ``info_hash IN (...)`` 取第一条，整批文件记到同一颗种子（NAS 实测《交锋》
+    E12 被记成 E10 的种子），洗版验证精确匹配失败、任务永远挂在「已完成」。
+    这里模拟下载器文件清单不可用，只能靠投递单元区分。"""
+    deliveries = {9: ("hash-e09", "t09"), 10: ("hash-a10", "t10"), 11: ("hash-e11", "t11")}
+    stamps = await _ingest_shared_folder(
+        db,
+        tmp_path,
+        monkeypatch,
+        deliveries=deliveries,
+        torrents={info_hash: f"ep{ep}.mkv" for ep, (info_hash, _t) in deliveries.items()},
+    )
+    assert stamps == {ep: ("ssd", torrent_id) for ep, (_h, torrent_id) in deliveries.items()}
+
+
+@pytest.mark.asyncio
+async def test_shared_folder_file_from_foreign_torrent_gets_no_stamp(db, tmp_path, monkeypatch):
+    """同目录里还有非订阅投递的种子（外部/手工添加）写入的文件：下载器文件清单
+    证明它不是任何投递写的，就不能沿用"只有一个投递来源"的推断记到别人名下
+    （NAS 实测《重器》E17~E33 全记在只投递了 E11~E12 的种子上）。宁可不记。"""
+    stamps = await _ingest_shared_folder(
+        db,
+        tmp_path,
+        monkeypatch,
+        deliveries={11: ("hash-e11", "t11")},
+        torrents={"hash-e11": "ep11.mkv", "hash-foreign": "ep12.mkv"},
+        statuses=True,
+    )
+    assert stamps == {11: ("ssd", "t11"), 12: (None, None)}
+
+
 @pytest.mark.asyncio
 async def test_explicit_e00_pilot_skipped_without_blocking(db, tmp_path, monkeypatch):
     """显式 E00（先导/特辑占位）不入库但也不阻塞：正片照常入库、结论 imported、

--- a/tests/api/test_upgrade_attempt_state.py
+++ b/tests/api/test_upgrade_attempt_state.py
@@ -8,6 +8,8 @@ status 在途``，对洗版 attempt 恒为空（工单不重开、info_hash 指�
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 import pytest_asyncio
 
@@ -222,3 +224,78 @@ async def test_task_center_relations_skip_completed_download_attempt(db):
     async with db.session() as session:
         subscriptions, _manual = await _relations(session)
         assert "newhash" not in subscriptions
+
+
+async def _complete_upgrade(db, attempt_id, wanted_id, *, baseline, completed_ago):
+    """洗版 attempt 下载完成，工单基线改为指定档位（模拟入库验证已跑过或尚未跑）。"""
+    async with db.session() as session:
+        attempt = await session.get(SubscriptionDownloadAttempt, attempt_id)
+        attempt.status = DownloadAttemptStatus.COMPLETED
+        attempt.completed_at = utcnow() - completed_ago
+        wanted = await session.get(WantedItem, wanted_id)
+        wanted.quality = baseline
+        await session.commit()
+
+
+async def _observe_offline(db, monkeypatch, attempt_id):
+    async def lookup_unknown(*args, **kwargs):
+        return progress_mod._TorrentLookup(match=None, reachable_count=0)
+
+    monkeypatch.setattr(progress_mod, "_lookup_torrent", lookup_unknown)
+    await progress_mod._observe_attempt(attempt_id, downloaders=[])
+    async with db.session() as session:
+        return await session.get(SubscriptionDownloadAttempt, attempt_id)
+
+
+@pytest.mark.asyncio
+async def test_observe_settles_completed_upgrade_whose_units_reached_claim(db, monkeypatch):
+    """洗版任务已下完、单元基线也已达到它的标称档位，入库验证却没把它记为已入库
+    （文件来源戳对不上，或被其他来源抢先）：验证不会再为它跑第二次，巡检必须
+    收尾，不能永远挂在「已完成」（NAS 实测《交锋》E12）。下载器任务保留。"""
+    _sub, attempt_id, wanted_id = await _seed(db)
+    await _complete_upgrade(
+        db, attempt_id, wanted_id, baseline=_REMUX, completed_ago=timedelta(hours=2)
+    )
+    attempt = await _observe_offline(db, monkeypatch, attempt_id)
+    assert attempt.status == DownloadAttemptStatus.CANCELLED
+    assert "不低于本任务的标称档位" in (attempt.cleanup_note or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("baseline", "completed_ago"),
+    [(_WEBDL, timedelta(hours=2)), (_REMUX, timedelta(minutes=5))],
+    ids=["claim-still-better", "within-grace"],
+)
+async def test_observe_keeps_completed_upgrade_awaiting_verification(
+    db, monkeypatch, baseline, completed_ago
+):
+    """仍能构成升级（文件还没入库）或刚下完仍在宽限期内：保持「已完成」等入库验证裁决。"""
+    _sub, attempt_id, wanted_id = await _seed(db)
+    await _complete_upgrade(
+        db, attempt_id, wanted_id, baseline=baseline, completed_ago=completed_ago
+    )
+    attempt = await _observe_offline(db, monkeypatch, attempt_id)
+    assert attempt.status == DownloadAttemptStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_observe_keeps_completed_upgrade_while_ingest_job_pending(db, monkeypatch):
+    """该种子的入库作业还在排队/执行：不抢在入库验证之前收尾。"""
+    from movieclaw_api.services import jobs
+
+    _sub, attempt_id, wanted_id = await _seed(db)
+    await _complete_upgrade(
+        db, attempt_id, wanted_id, baseline=_REMUX, completed_ago=timedelta(hours=2)
+    )
+    async with db.session() as session:
+        await jobs.create_job(
+            session,
+            job_type="library.ingest",
+            subject="T.S01E01.REMUX",
+            input_data={},
+            resources=[jobs.ResourceRef("download", "newhash", relation="source")],
+        )
+        await session.commit()
+    attempt = await _observe_offline(db, monkeypatch, attempt_id)
+    assert attempt.status == DownloadAttemptStatus.COMPLETED


### PR DESCRIPTION
## Summary

活动页里《交锋》S01E12 的洗版任务下载完成后一直停在「已完成」，永不收尾。实际上洗版本身已经成功（4K 已入库、旧 1080p 进回收站、推送了「已洗版」），只是任务没被记成已入库。

**根因**：CMCTV 这类逐集发布的单集种子，在 qBittorrent 里的内容目录名完全相同，一个监听条目于是同时匹配多颗种子。入库时来源戳（`library_file.site_id/torrent_id`）按**条目**取 `info_hash IN (...)` 的第一条，整批文件记到同一颗种子名下（E12 被记成 E10 的种子）→ 洗版验证 `_file_from_attempt` 精确比对失败 → 升级照样确认，但 attempt 不置 IMPORTED；而巡检对洗版任务只等验证裁决，验证又不会再跑第二次 → 永久挂起。

**规模**：线上实例查出 31 个库文件来源戳记错，涉及 5 部剧，19 组投递共用同一 download_name——不是偶发。另一种错法是同目录混着非订阅投递的种子，文件被整批记到唯一那次投递名下（《重器》E17~E33 记在只投递了 E11~E12 的种子上）。

## Changes

- **入库来源戳逐文件判定**（`ingest.py`，`_DeliveryProvenance` 取代 `_delivery_provenance`）。原则是宁可不记、不可记错（缺戳时洗版验证还有时间关联兜底，记错连兜底都用不上）：
  1. 下载器文件清单可用时，只在**真正写入该文件**的种子里挑；清单在手却无种子写它 → 不记
  2. 投递单元声明了该集的优先，同集多次投递取最新
  3. 下载器确认写入但无投递声明该集（季包附带集）→ 取最新候选
  4. 无文件证据时只剩一个来源才记，多来源无从区分 → 不记
  - 读下载器清单失败不影响入库，降级为按集号推断；条目级身份证据强度改为「全部投递都是 exact 才算 exact」
- **洗版任务活性兜底**（`upgrade.py` 新增 `settle_outdated_upgrade_attempt`，`download_progress.py` 巡检调用）：已完成的洗版任务，若所有在范围单元当前基线都已不低于它的标称档位（此后它的文件入库也不可能构成升级）、完成超 30 分钟、且该种子没有活跃入库作业 → 收尾为 CANCELLED，保留下载器任务、不碰库文件。与验证里「被抢先」的收口口径一致；已卡住的历史任务部署后下一轮巡检自愈
- 历史错戳不做数据修复：来源戳只被 `upgrade.py` 消费，错戳指向的都是已结束的 attempt，对后续洗版无影响

## Testing

- [x] 新增 5 个用例：同名目录多种子逐文件记戳、外部种子写入的文件不记戳、满足条件时收尾、仍可升级 / 宽限期内 / 入库作业在途时保持等待
- [x] 在未修复的 origin/main 上跑，其中 3 个（记戳 ×2、收尾 ×1）按预期失败
- [x] `test_library_ingest.py`、`test_upgrade_pipeline.py`、`test_subscription_replacement.py`、`test_download_rescue.py`、`test_subscription_pipeline.py`、`test_manual_upgrade.py`、`test_wanted_fulfillment.py`、`test_upgrade_verify.py`、`test_upgrade_attempt_state.py` 全绿
- [x] `ruff check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
