### PR TITLE
修复多个会话同时生成时，侧栏「最近会话」列表反复重排

### DIFF
--- a/apps/web/lib/agent-activity.ts
+++ b/apps/web/lib/agent-activity.ts
@@ -1,0 +1,34 @@
+/** 会话「最近活跃时间」的刷新口径。
+ *
+ * 单独成模块是为了能被 node --test 直接覆盖：这里的回归（侧栏列表抖动）
+ * 在代码评审里看不出来，只有跑起来才发现。
+ */
+
+import type { AgentConversation, AgentTurn } from "./agent-conversations";
+
+/**
+ * 用新的 turns 重建会话：running 由轮次派生，``updatedAt`` 只在运行状态翻转
+ * （开跑 / 落终态）时刷新一次。
+ *
+ * 为什么流式增量不算「活跃」：``updatedAt`` 是侧栏「最近会话」的排序键，而
+ * 流式产出每 80ms 就合并落一次状态。若每次产出都刷新，同时开着多个会话时，
+ * 谁先吐出下一段谁就被顶到列表最前，两个会话每秒能互相换位十几次，整个列表
+ * 在跑的时候一直抖。
+ *
+ * 口径与服务端一致：运行心跳不刷新 ``updated_at``，只有消息追加与运行起止
+ * 才算活跃（见 ``movieclaw_db/repositories/agent_session_repo.py``）。本地
+ * 跟住服务端，刷新页面前后的排序才不会跳变。
+ */
+export function applyTurns(
+  conversation: AgentConversation,
+  turns: AgentTurn[],
+  now: number = Date.now(),
+): AgentConversation {
+  const running = turns.some((turn) => turn.status === "running");
+  return {
+    ...conversation,
+    updatedAt: running === conversation.running ? conversation.updatedAt : now,
+    running,
+    turns,
+  };
+}

--- a/apps/web/lib/agent-conversations.tsx
+++ b/apps/web/lib/agent-conversations.tsx
@@ -41,6 +41,7 @@ import {
   stopSession,
   streamSession,
 } from "@/lib/api/agent";
+import { applyTurns } from "@/lib/agent-activity";
 import { parseSkillTokens, toTokenForm } from "@/lib/agent-skills";
 import { HttpError } from "@/lib/http";
 import { nanoid } from "nanoid";
@@ -129,6 +130,8 @@ export interface AgentConversation {
   /** 服务端会话 id（路由 /sessions/[id] 与所有会话动作都用它） */
   id: string;
   title: string;
+  /** 最近活跃时间（epoch ms），侧栏「最近会话」的排序键。只在用户提交一轮
+   *  与轮次落终态时刷新，流式产出不刷新（口径见 lib/agent-activity.ts） */
   updatedAt: number;
   /** 是否有存活的运行（列表摘要派生；详情加载后随本地 turn 状态刷新） */
   running: boolean;
@@ -624,7 +627,7 @@ export function AgentConversationsProvider({ children }: { children: React.React
       });
   }, [hasMore]);
 
-  /** 对某会话中某轮做不可变更新，并刷新 updatedAt 与派生的 running。 */
+  /** 对某会话中某轮做不可变更新；running 与 updatedAt 由 applyTurns 派生。 */
   const updateTurn = useCallback(
     (conversationId: string, turnId: string, patch: (turn: AgentTurn) => AgentTurn) => {
       setConversations((previous) =>
@@ -633,12 +636,7 @@ export function AgentConversationsProvider({ children }: { children: React.React
           const turns = conversation.turns.map((turn) =>
             turn.id === turnId ? patch(turn) : turn,
           );
-          return {
-            ...conversation,
-            updatedAt: Date.now(),
-            running: turns.some((turn) => turn.status === "running"),
-            turns,
-          };
+          return applyTurns(conversation, turns);
         }),
       );
     },
@@ -674,12 +672,7 @@ export function AgentConversationsProvider({ children }: { children: React.React
             turn.id === buffer.turnId ? buffer.events.reduce(applyAgentEvent, turn) : turn,
           );
         }
-        return {
-          ...conversation,
-          updatedAt: Date.now(),
-          running: turns.some((turn) => turn.status === "running"),
-          turns,
-        };
+        return applyTurns(conversation, turns);
       }),
     );
   }, []);

--- a/apps/web/test/agent-activity.test.mjs
+++ b/apps/web/test/agent-activity.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyTurns } from "../lib/agent-activity.ts";
+
+/** 一个最小可用的会话壳（字段取 AgentConversation 的必填部分）。 */
+function conversation(overrides = {}) {
+  return {
+    id: "s1",
+    title: "会话",
+    updatedAt: 1000,
+    running: true,
+    turns: [],
+    loaded: true,
+    ...overrides,
+  };
+}
+
+const turn = (status) => ({ id: "t1", input: "问", status, segments: [], startedAt: 0 });
+
+test("流式产出不刷新活跃时间：多个会话同时生成时列表不会互相换位", () => {
+  const before = conversation({ running: true, turns: [turn("running")] });
+  // 模拟 80ms 一次的事件合并：轮次内容在变，但运行状态没翻转
+  let current = before;
+  for (const now of [2000, 2080, 2160]) {
+    current = applyTurns(current, [turn("running")], now);
+    assert.equal(current.updatedAt, 1000, "流式期间排序键必须保持不变");
+  }
+  assert.equal(current.running, true);
+});
+
+test("轮次落终态刷新一次活跃时间（与服务端 finish_run 同口径）", () => {
+  const before = conversation({ running: true, turns: [turn("running")] });
+  const after = applyTurns(before, [turn("done")], 9999);
+  assert.equal(after.updatedAt, 9999);
+  assert.equal(after.running, false);
+});
+
+test("出错同样是终态，一样刷新", () => {
+  const before = conversation({ running: true, turns: [turn("running")] });
+  const after = applyTurns(before, [turn("error")], 9999);
+  assert.equal(after.updatedAt, 9999);
+  assert.equal(after.running, false);
+});
+
+test("已结束的会话被重新跑起来时刷新活跃时间", () => {
+  const before = conversation({ running: false, turns: [turn("done")] });
+  const after = applyTurns(before, [turn("running")], 9999);
+  assert.equal(after.updatedAt, 9999);
+  assert.equal(after.running, true);
+});
+
+test("轮次内容更新但运行状态没变（如回填 messageId）不动排序", () => {
+  const before = conversation({ running: false, turns: [turn("done")] });
+  const after = applyTurns(before, [{ ...turn("done"), messageId: "m1" }], 9999);
+  assert.equal(after.updatedAt, 1000);
+  assert.equal(after.turns[0].messageId, "m1");
+});


### PR DESCRIPTION
## 问题

同时开着多个会话并且都在生成时，侧栏「最近会话」列表会疯狂重排。

## 根因

`updatedAt` 既是列表排序键（`agent-conversations.tsx` 的 `conversations` 按它倒序），又被流式产出当成「活跃时间」在刷：`flushEvents` 每 80ms 合并一批 SSE 事件落状态时无条件 `updatedAt: Date.now()`，而一次 flush 只覆盖这 80ms 内真正有事件的会话。于是 A、B 同时生成时，谁这一拍吐了 token 谁的时间戳就更新，两行每秒来回换十几次。

服务端本来不是这个口径：`AgentSessionRepository.heartbeat` 明确「不动 updated_at（心跳不是内容活跃）」，只有消息追加（`touch_after_append`）与运行起止（`mark_running` / `finish_run`）才刷新。前端多刷的这一层既造成抖动，也让刷新页面前后的顺序对不上。

## 改动

- 新增 `apps/web/lib/agent-activity.ts` 的 `applyTurns()`：`running` 仍由轮次派生，但 `updatedAt` **只在 running 翻转时**刷新一次——开跑、落终态（done/error/cancelled）刷新，纯流式增量不刷。
- `updateTurn` 与 `flushEvents` 都改走它，两处重复的「派生 running + 刷时间」合并掉。顺带修掉给 `messageId` 回填这类不改运行状态的更新也在动排序的问题。
- 用户主动提交的 `start` / `send` / `retry` 保持原样显式刷新 —— 那本来就该跳到列表最前。
- 单独成模块是为了能被 `node --test` 覆盖到：这类回归在代码评审里看不出来。

## 行为变化

生成过程中侧栏那行的相对时间不再每秒跳动，会停在本轮开始的时刻，直到这轮跑完才更新；运行状态由已有的 running 指示器表达。

## 测试

- 新增 `apps/web/test/agent-activity.test.mjs`（5 例）：连续三拍流式排序键不变、终态刷新一次、出错同样刷新、重新跑起来刷新、内容更新但状态没变不动排序。
- `npm test`（apps/web）478 pass；另有 3 个失败（`player-device`、`time`、`use-media-query`）在未改动的干净树上同样失败，与本 PR 无关。
- `tsc --noEmit` 无新增报错。

未触碰运行时依赖，不涉及 `docker/runtime-version` bump。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P8LS6oPo1vrYC7Wcequzq

---
_Generated by [Claude Code](https://claude.ai/code/session_011P8LS6oPo1vrYC7Wcequzq)_