### PR TITLE
删除后重订同一种子不再卡「已投递」+ 入库台账补外键防 id 复用错挂

### DIFF
--- a/alembic/versions/20260911_1400_e6b2d4f8a137_ingest_entry_media_item_fk.py
+++ b/alembic/versions/20260911_1400_e6b2d4f8a137_ingest_entry_media_item_fk.py
@@ -1,0 +1,64 @@
+"""ingest_entry.media_item_id 补外键（删除作品时置空）
+
+模型早就声明了 ``ForeignKey("media_item.id", ondelete="SET NULL")``，但加列的
+d1e4b8f30527 只建了普通整数列、漏建约束。后果：作品被删（孤儿清理）后台账仍
+指着旧 id；SQLite 的主键不带 AUTOINCREMENT，被删的最大 id 会复用给下一个新建
+作品，于是台账静默改挂到一部毫不相干的作品上（NAS 实测：《恶人传》的监听台账
+指向了一个 AV 条目）。
+
+升级分两步：
+
+1. 先清掉已经失效的引用——指向已不存在的作品；或指向的作品**建档晚于**这条台账
+   最后一次写入（台账写入 media_item_id 时作品必然已存在，建档更晚只能是 id 被
+   复用了）。media_item_id 只服务于清单汇总与诊断，置空的代价是那几行汇总不再
+   归到某部作品下，远好于归错；
+2. 再以 batch 模式重建表补上约束，此后删作品由数据库自动置空。
+
+向前兼容（CLAUDE.md 硬约束 3）：只收紧约束并把本就错误的引用置空，列本身不变；
+旧版本回退后读写这一列的方式完全一样。
+
+Revision ID: e6b2d4f8a137
+Revises: d9f3b6a2e814
+Create Date: 2026-09-11 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "e6b2d4f8a137"
+down_revision: str | None = "d9f3b6a2e814"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE ingest_entry
+        SET media_item_id = NULL
+        WHERE media_item_id IS NOT NULL
+          AND (
+            NOT EXISTS (SELECT 1 FROM media_item WHERE media_item.id = ingest_entry.media_item_id)
+            OR EXISTS (
+              SELECT 1 FROM media_item
+              WHERE media_item.id = ingest_entry.media_item_id
+                AND media_item.created_at > ingest_entry.updated_at
+            )
+          )
+        """
+    )
+    with op.batch_alter_table("ingest_entry", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            "fk_ingest_entry_media_item_id",
+            "media_item",
+            ["media_item_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("ingest_entry", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_ingest_entry_media_item_id", type_="foreignkey")

--- a/src/movieclaw_api/services/library/ingest.py
+++ b/src/movieclaw_api/services/library/ingest.py
@@ -1060,6 +1060,50 @@ async def _has_managed_download_claim(session, entry: Path) -> bool:
     )
 
 
+async def _redelivered_since(session, record: IngestEntry, info_hashes: list[str]) -> bool:
+    """台账下结论之后，订阅又把同一颗种子重新投递、且投递仍在途：旧结论已过时。
+
+    台账按「条目路径 + 指纹」幂等：已入库/已跳过且指纹没变就不再处理。但结论所
+    依据的现实会变——用户把入库的文件删了、作品随之被清掉，之后重新订阅，仍在
+    下载器里做种的同一颗种子被原样再投递一次。指纹没变，旧台账于是永远短路，新
+    工单停在「已投递」、投递停在「已完成」，谁也不报警（NAS 实测《恶人传》）。
+
+    判据刻意只认「晚于台账结论的在途投递」：重跑会刷新 ``attempted_at``，同一次
+    投递不会反复触发；正常流程里投递总是先于入库结论，也不会误触发。
+    """
+    from movieclaw_db.models import DownloadAttemptStatus, SubscriptionDownloadAttempt
+
+    if record.status not in (IngestStatus.IMPORTED, IngestStatus.SKIPPED) or not info_hashes:
+        return False
+    hashes = sorted({h for value in info_hashes if value for h in (value, value.lower())})
+    attempt_id = (
+        await session.execute(
+            select(SubscriptionDownloadAttempt.id)
+            .where(
+                SubscriptionDownloadAttempt.info_hash.in_(hashes),  # type: ignore[union-attr]
+                SubscriptionDownloadAttempt.status.in_(  # type: ignore[attr-defined]
+                    (
+                        DownloadAttemptStatus.ACTIVE,
+                        DownloadAttemptStatus.REPLACEMENT_PENDING,
+                        DownloadAttemptStatus.TRIAL,
+                        DownloadAttemptStatus.COMPLETED,
+                    )
+                ),
+                SubscriptionDownloadAttempt.created_at > record.attempted_at,  # type: ignore[operator]
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if attempt_id is None:
+        return False
+    logger.info(
+        "「%s」在上次入库结论之后又被订阅投递（投递 #%s），旧结论已过时，重新入库",
+        Path(record.entry_path).name,
+        attempt_id,
+    )
+    return True
+
+
 def _match_briefs(entry_name: str, briefs: list | None) -> list:
     """按名称把条目匹配到下载器种子。
 
@@ -1497,7 +1541,14 @@ async def _process_entry(
             return
 
         if record is not None and record.fingerprint == snap.fingerprint:
-            if record.status != IngestStatus.FAILED and not parser_retry and not disc_retry:
+            if (
+                record.status != IngestStatus.FAILED
+                and not parser_retry
+                and not disc_retry
+                and not await _redelivered_since(
+                    session, record, [b.info_hash for b in matches if b.info_hash]
+                )
+            ):
                 return  # 已处理且没变化（pending 等的是人工拍板，不是时间）
             if record.status == IngestStatus.FAILED:
                 elapsed = (utcnow() - record.attempted_at).total_seconds()
@@ -3780,6 +3831,7 @@ async def _execute_ingest_job(
                 record.status in {IngestStatus.IMPORTED, IngestStatus.SKIPPED}
                 and not parser_retry
                 and not disc_retry
+                and not await _redelivered_since(session, record, matched_hashes)
             ):
                 return {
                     "message": record.message or "监听条目已处理",

--- a/tests/api/test_ingest_entry_media_item_fk_migration.py
+++ b/tests/api/test_ingest_entry_media_item_fk_migration.py
@@ -1,0 +1,103 @@
+"""ingest_entry.media_item_id 补外键迁移（e6b2d4f8a137）的回归测试。"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from alembic import command
+
+from movieclaw_api.core.config import get_settings
+from movieclaw_db.migrations import _build_config
+
+_BEFORE = "d9f3b6a2e814"
+
+
+def _insert(connection: sqlite3.Connection, table: str, **values) -> None:
+    """插入一行，NOT NULL 且无默认值的列按类型补占位值——只关心被测的那几列。"""
+    for _cid, name, col_type, notnull, default, _pk in connection.execute(
+        f"PRAGMA table_info('{table}')"
+    ):
+        if name in values or not notnull or default is not None or name == "id":
+            continue
+        kind = (col_type or "").upper()
+        values[name] = 0 if "INT" in kind or "BOOL" in kind else "[]" if "JSON" in kind else "x"
+    columns = ", ".join(values)
+    marks = ", ".join("?" for _ in values)
+    connection.execute(f"INSERT INTO {table} ({columns}) VALUES ({marks})", list(values.values()))
+
+
+def test_fk_migration_clears_stale_references_and_nulls_on_delete(tmp_path, monkeypatch) -> None:
+    """升级前的失效引用被置空（作品已删 / id 被复用给更晚建档的作品），有效引用
+    保留；升级后删除作品由数据库自动置空。"""
+    database = tmp_path / "ingest-fk.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{database}")
+    get_settings.cache_clear()
+    config = _build_config()
+    command.upgrade(config, _BEFORE)
+
+    with sqlite3.connect(database) as connection:
+        early, reused_at = "2026-09-01 00:00:00", "2026-09-10 00:00:00"
+        anchor = {"source": "tmdb"}
+        _insert(
+            connection,
+            "media_item",
+            id=1,
+            kind="movie",
+            title="有效",
+            tmdb_id=1,
+            external_id="1",
+            created_at=early,
+            updated_at=early,
+            **anchor,
+        )
+        # id 2 被复用：作品建档时间晚于台账最后一次写入
+        _insert(
+            connection,
+            "media_item",
+            id=2,
+            kind="video",
+            title="复用",
+            tmdb_id=2,
+            external_id="2",
+            created_at=reused_at,
+            updated_at=reused_at,
+            **anchor,
+        )
+        written = "2026-09-09 00:00:00"
+        for path, media_item_id in (
+            ("/w/valid", 1),
+            ("/w/reused", 2),
+            ("/w/gone", 99),
+            ("/w/none", None),
+        ):
+            _insert(
+                connection,
+                "ingest_entry",
+                entry_path=path,
+                fingerprint="1:1:1",
+                status="imported",
+                media_item_id=media_item_id,
+                attempted_at=written,
+                created_at=written,
+                updated_at=written,
+            )
+        connection.commit()
+
+    command.upgrade(config, "head")
+
+    with sqlite3.connect(database) as connection:
+        refs = dict(connection.execute("SELECT entry_path, media_item_id FROM ingest_entry"))
+        assert refs == {"/w/valid": 1, "/w/reused": None, "/w/gone": None, "/w/none": None}
+        fks = {
+            row[3]: (row[2], row[6])
+            for row in connection.execute("PRAGMA foreign_key_list('ingest_entry')")
+        }
+        assert fks["media_item_id"] == ("media_item", "SET NULL")
+
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("DELETE FROM media_item WHERE id = 1")
+        connection.commit()
+        assert connection.execute(
+            "SELECT media_item_id FROM ingest_entry WHERE entry_path = '/w/valid'"
+        ).fetchone() == (None,)
+    get_settings.cache_clear()

--- a/tests/api/test_library_ingest.py
+++ b/tests/api/test_library_ingest.py
@@ -2070,6 +2070,161 @@ async def test_file_scoped_job_never_falls_back_to_whole_directory():
         )
 
 
+async def _seed_redelivered_movie(db, tmp_path, monkeypatch, *, attempt_created_after_ledger):
+    """两天前已入库的电影监听条目 + 同一颗种子的订阅投递（在途）。
+
+    模拟 NAS《恶人传》：入库后用户删了文件、作品被清掉，之后重新订阅，仍在下载器
+    里做种的同一颗种子被原样再投递；条目指纹没变，旧台账仍是 imported。
+    """
+    from movieclaw_db.models import (
+        DownloadAttemptStatus,
+        RuleSet,
+        Subscription,
+        SubscriptionDownloadAttempt,
+        WantedItem,
+        WantedStatus,
+    )
+    from movieclaw_downloader import TorrentBrief
+
+    root, watch = tmp_path / "movies", tmp_path / "watch"
+    watch.mkdir()
+    library_id = await _make_library(db, kind=MediaKind.MOVIE, root=root)
+    item = await _make_item(db, kind=MediaKind.MOVIE, title="重订电影", year=2019)
+    monkeypatch.setattr(ingest_mod, "probe_media", lambda _path: _FAKE_SPEC)
+
+    async def identify_none(session, kind, watch_root, main, spec):
+        return None
+
+    monkeypatch.setattr(ingest_mod, "_identify", identify_none)
+    entry = watch / "Redelivered.Movie.2019.1080p.mkv"
+    entry.write_bytes(b"redelivered-movie")
+    ledger_at = utcnow() - timedelta(days=2)
+    offset = timedelta(days=1) if attempt_created_after_ledger else -timedelta(days=1)
+    attempt_at = ledger_at + offset
+    async with db.session() as session:
+        rule_set = RuleSet(name="默认", spec={})
+        session.add(rule_set)
+        await session.commit()
+        await session.refresh(rule_set)
+        sub = Subscription(
+            media_item_id=item.id, kind="movie", rule_set_id=rule_set.id, library_id=library_id
+        )
+        session.add(sub)
+        await session.commit()
+        await session.refresh(sub)
+        session.add_all(
+            [
+                IngestEntry(
+                    library_id=library_id,
+                    entry_path=str(entry),
+                    fingerprint=ingest_mod._snapshot(entry).fingerprint,
+                    status=IngestStatus.IMPORTED,
+                    message="旧结论：已入库",
+                    imported_count=1,
+                    attempted_at=ledger_at,
+                ),
+                WantedItem(
+                    subscription_id=sub.id,
+                    media_item_id=item.id,
+                    season_number=0,
+                    episode_number=0,
+                    status=WantedStatus.GRABBED,
+                    info_hash="hash-redelivered",
+                ),
+                SubscriptionDownloadAttempt(
+                    subscription_id=sub.id,
+                    info_hash="hash-redelivered",
+                    site_id="mteam",
+                    torrent_id="1196414",
+                    units=[[0, 0]],
+                    status=DownloadAttemptStatus.COMPLETED,
+                    last_progress_at=attempt_at,
+                    created_at=attempt_at,
+                ),
+            ]
+        )
+        await session.commit()
+
+    async def briefs():
+        return [
+            TorrentBrief(
+                name=entry.name,
+                content_name=entry.name,
+                completed=True,
+                info_hash="hash-redelivered",
+            )
+        ]
+
+    monkeypatch.setattr(ingest_mod, "_downloader_briefs", briefs)
+    return watch, library_id
+
+
+@pytest.mark.asyncio
+async def test_redelivered_torrent_reingests_despite_unchanged_fingerprint(
+    db, tmp_path, monkeypatch
+):
+    """台账已入库、指纹没变，但结论之后订阅又投递了同一颗种子：旧结论已过时，
+    必须重新入库——否则新工单永远停在「已投递」（NAS 实测《恶人传》）。重跑后
+    同一次投递不再触发第二遍，不会每轮巡检反复入库。"""
+    watch, library_id = await _seed_redelivered_movie(
+        db, tmp_path, monkeypatch, attempt_created_after_ledger=True
+    )
+    rule = _fixed_rule(watch, library_id=library_id)
+    await ingest_mod._sweep_dir(rule, await _get_library(db, library_id), execute_inline=True)
+
+    async with db.session() as session:
+        files = list((await session.execute(select(LibraryFile))).scalars())
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+    assert len(files) == 1
+    assert record.message != "旧结论：已入库"
+
+    rerun: list[object] = []
+
+    async def spy(*args, **kwargs):
+        rerun.append(args)
+
+    monkeypatch.setattr(ingest_mod, "_ingest_entry", spy)
+    await ingest_mod._sweep_dir(rule, await _get_library(db, library_id), execute_inline=True)
+    assert rerun == []
+
+
+@pytest.mark.asyncio
+async def test_delivery_older_than_ledger_keeps_short_circuit(db, tmp_path, monkeypatch):
+    """投递早于台账结论（正常流程：先投递、后入库）：已入库且指纹没变照旧短路。"""
+    watch, library_id = await _seed_redelivered_movie(
+        db, tmp_path, monkeypatch, attempt_created_after_ledger=False
+    )
+    await ingest_mod._sweep_dir(
+        _fixed_rule(watch, library_id=library_id),
+        await _get_library(db, library_id),
+        execute_inline=True,
+    )
+    async with db.session() as session:
+        assert list((await session.execute(select(LibraryFile))).scalars()) == []
+        record = (await session.execute(select(IngestEntry))).scalar_one()
+    assert record.message == "旧结论：已入库"
+
+
+@pytest.mark.asyncio
+async def test_redelivered_torrent_reingests_through_job_executor(db, tmp_path, monkeypatch):
+    """生产路径走后台作业：作业执行器里的台账短路同样要认「结论之后的新投递」，
+    否则巡检放行建了作业，作业又原样返回旧结论，照样入不了库。"""
+    watch, library_id = await _seed_redelivered_movie(
+        db, tmp_path, monkeypatch, attempt_created_after_ledger=True
+    )
+    await _make_rule(db, library_id=library_id, source=watch)
+    async with db.session() as session:
+        rule = (await session.execute(select(ImportWatch))).scalar_one()
+    await jobs.init_job_dispatcher(max_parallel=1)
+    await ingest_mod._sweep_dir(rule, await _get_library(db, library_id))
+
+    async with db.session() as session:
+        job = (await session.execute(_ingest_jobs())).scalars().one()
+    await _wait_job_status(job.id, JobStatus.SUCCEEDED)
+    async with db.session() as session:
+        assert len(list((await session.execute(select(LibraryFile))).scalars())) == 1
+
+
 @pytest.mark.asyncio
 async def test_manual_download_identity_claim_via_info_hash(db, tmp_path, monkeypatch):
     """手动下载投到共享监听目录后，按提交时锚定的身份和库入库。"""
@@ -3630,12 +3785,17 @@ async def test_entry_stats_dedupes_works_across_seasons_and_versions(db, tmp_pat
     async with db.session() as session:
         rule = ImportWatch(source_path=str(watch), strategy="hardlink", kind="tv")
         session.add(rule)
+        # 台账的 media_item_id 有外键约束，必须指向真实作品
+        work_a = MediaItem(kind="tv", tmdb_id=301, title="剧A", original_title="剧A", year=2024)
+        work_b = MediaItem(kind="tv", tmdb_id=302, title="剧B", original_title="剧B", year=2024)
+        session.add_all([work_a, work_b])
+        await session.flush()
         for name, item_id, files in (
-            ("剧A.S01.CHDWEB", 1, 8),  # 同一部剧：两季 + S02 三个版本
-            ("剧A.S02.MWeb.DV", 1, 6),
-            ("剧A.S02.MWeb.HDR", 1, 6),
-            ("剧A.S02.CMCTV.DV", 1, 6),
-            ("剧B.S01", 2, 10),
+            ("剧A.S01.CHDWEB", work_a.id, 8),  # 同一部剧：两季 + S02 三个版本
+            ("剧A.S02.MWeb.DV", work_a.id, 6),
+            ("剧A.S02.MWeb.HDR", work_a.id, 6),
+            ("剧A.S02.CMCTV.DV", work_a.id, 6),
+            ("剧B.S01", work_b.id, 10),
             ("剧C.S01", None, 3),  # 老条目：未回填，单独计一部
             ("认不出的", None, 0),  # pending 不计入作品数
         ):

--- a/tests/api/test_schema_foreign_keys.py
+++ b/tests/api/test_schema_foreign_keys.py
@@ -1,0 +1,44 @@
+"""CI 守卫：模型声明的外键必须在迁移后的真实库里同样存在。
+
+模型（SQLModel）与迁移（alembic）是两份各自手写的真相。模型里写了
+``ForeignKey(..., ondelete="SET NULL")`` 不代表数据库里真有这条约束——
+``ingest_entry.media_item_id`` 就是加列迁移漏建了约束，作品删除后台账指向
+被复用的 id、静默改挂到无关作品上，直到线上出事才发现。测试库若用
+``create_all`` 建表会照模型把约束建出来，这类漂移永远测不到，所以这里必须
+走真实迁移链再逐条比对。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from alembic import command
+from sqlmodel import SQLModel
+
+import movieclaw_db.models  # noqa: F401 -- 注册全部表到 SQLModel.metadata
+from movieclaw_api.core.config import get_settings
+from movieclaw_db.migrations import _build_config
+
+
+def test_migrated_schema_has_every_model_foreign_key(tmp_path, monkeypatch) -> None:
+    database = tmp_path / "fk-drift.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{database}")
+    get_settings.cache_clear()
+    command.upgrade(_build_config(), "head")
+
+    drift: list[str] = []
+    with sqlite3.connect(database) as connection:
+        for table in SQLModel.metadata.sorted_tables:
+            actual = {
+                row[3]: (row[2], row[6].upper())
+                for row in connection.execute(f"PRAGMA foreign_key_list('{table.name}')")
+            }
+            for fk in table.foreign_keys:
+                expected = (fk.column.table.name, (fk.ondelete or "NO ACTION").upper())
+                got = actual.get(fk.parent.name)
+                if got != expected:
+                    drift.append(
+                        f"{table.name}.{fk.parent.name}: 模型 {expected}，迁移后 {got or '无约束'}"
+                    )
+    get_settings.cache_clear()
+    assert drift == [], "模型与迁移的外键不一致，请补迁移：\n" + "\n".join(drift)


### PR DESCRIPTION
## Summary

活动页里《恶人传》的订阅任务下载完成后一直停在「已完成」，工单停在「已投递」，永不入库。

**时间线**：9-09 第一次订阅，抓到的种子入库后用户发现有问题、从磁盘删除了条目（作品随孤儿清理被删）；9-11 重新订阅，搜到的是同一颗仍在 qBittorrent 做种的种子（「种子已存在，跳过提交」）。

**根因**（两处，本 PR 都修）：

1. **台账只进不退**：监听入库台账 `ingest_entry` 按「条目路径 + 指纹」幂等，已入库且指纹没变就永远短路。删除条目不会动台账、手动「恢复」接口也不接受 imported 记录，于是同一颗种子被重新投递后再也入不了库，也没有任何告警。
2. **模型声明的外键实际不存在**：`IngestEntry.media_item_id` 在模型里写着 `ForeignKey("media_item.id", ondelete="SET NULL")`，但加列迁移 `d1e4b8f30527` 只建了普通整数列。作品被删后台账仍指着旧 id；SQLite 主键不带 AUTOINCREMENT，被删的最大 id 会复用——线上这条台账现在指向了一个毫不相干的 AV 条目。对全部表逐条比对过，模型与真实库的外键不一致只有这一处。

> 假种为什么能通过「电影」规则、shadow 反证为什么没拦下，是另一个独立问题（P1），不在本 PR 范围。

## Changes

- **过时台账重新入库**（`ingest.py` 新增 `_redelivered_since`）：台账为已入库/已跳过且指纹未变时，若有同一种子（按条目匹配到的 info_hash）的**在途**订阅投递，且投递创建时间**晚于台账结论**，判定旧结论过时、重新入库。巡检 `_process_entry` 与作业执行 `_execute_ingest_job` 两处短路都接上（只改巡检的话，放行建出的作业仍会原样返回旧结论）。
  - 不会反复重跑：重跑刷新 `attempted_at`，同一次投递不再满足「晚于结论」
  - 不会误触发：正常流程投递总是先于入库结论
- **迁移 `e6b2d4f8a137`**：补 `fk_ingest_entry_media_item_id`（SET NULL）。建约束前先置空两类失效引用：指向已不存在的作品；指向的作品建档晚于台账最后一次写入（写入时作品必然已存在，建档更晚只能是 id 被复用）。只收紧约束 + 置空本就错误的引用，向前兼容；`media_item_id` 只服务清单汇总与诊断，置空的代价是汇总不再归到某部作品，远好于归错
- **CI 守卫** `tests/api/test_schema_foreign_keys.py`：走真实迁移链到 head，逐条比对模型声明的外键（目标表 + ondelete）与 `PRAGMA foreign_key_list`，防止同类漂移再次发生（测试库若用 `create_all` 建表会照模型建出约束，这类漂移原本测不到）

## Testing

- [x] 新增：重新投递后重新入库且不反复重跑、投递早于结论时照旧短路、作业执行路径同样重新入库、迁移清理失效引用并在删除作品时自动置空、外键一致性守卫
- [x] 在未修复的 origin/main 上，外键守卫与「重新投递后重新入库」按预期失败
- [x] `test_entry_stats_dedupes_works_across_seasons_and_versions` 原本用不存在的作品 id 造台账，外键生效后改为先建真实作品
- [x] 入库 / 监听导入 / 删除与孤儿清理 / 回收站 / 存储登记相关测试全绿；`test_library_item_detail.py` 两项失败在 origin/main 上同样复现，与本 PR 无关
- [x] `ruff check` 通过

## 部署注意

- 含迁移，DB 回退需用更新前的自动备份
- 不涉及依赖/镜像，无需 bump `docker/runtime-version`
- 线上《恶人传》那颗种子是 5 分钟的假种，部署后会被重新入库；建议先暂停该订阅并在 qB 删除该种子（假种拦截见后续 P1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
